### PR TITLE
feat(finance): per-category totals + all-time pie/top-10 charts

### DIFF
--- a/assets/js/components/BandSpace/Finance/FinancePieChart.vue
+++ b/assets/js/components/BandSpace/Finance/FinancePieChart.vue
@@ -1,0 +1,195 @@
+<template>
+  <div v-if="isLoading && entries.length === 0" class="flex justify-center py-16">
+    <ProgressSpinner style="width: 44px; height: 44px" />
+  </div>
+  <div v-else class="flex flex-col gap-6">
+    <!-- Doughnuts + per-category legend -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <section
+        v-for="chart in charts"
+        :key="chart.key"
+        class="bg-surface-0 dark:bg-surface-800 rounded-xl border border-surface-200 dark:border-surface-700 p-4"
+      >
+        <div class="flex items-center justify-between mb-3 gap-2">
+          <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-300">{{ chart.title }}</h3>
+          <span class="text-sm font-semibold tabular-nums">{{ formatAmount(chart.total) }}</span>
+        </div>
+
+        <template v-if="chart.rows.length > 0">
+          <Chart
+            type="doughnut"
+            :data="chart.data"
+            :options="chartOptions"
+            :canvas-props="{ role: 'img', 'aria-label': chart.title }"
+            class="h-64"
+          />
+          <ul class="mt-4 space-y-1.5">
+            <li v-for="row in chart.rows" :key="row.id" class="flex items-center gap-2 text-sm">
+              <span class="w-3 h-3 rounded-full shrink-0" :style="{ backgroundColor: row.color }" />
+              <span class="flex-1 min-w-0 truncate text-surface-700 dark:text-surface-300">{{ row.name }}</span>
+              <span class="tabular-nums text-surface-500 dark:text-surface-400 shrink-0">{{ percent(row.value, chart.total) }}%</span>
+              <span class="tabular-nums text-surface-600 dark:text-surface-300 shrink-0 w-24 text-right">{{ formatAmount(row.value) }}</span>
+            </li>
+          </ul>
+        </template>
+        <div v-else class="text-surface-400 dark:text-surface-500 italic text-center py-16">
+          {{ chart.emptyLabel }}
+        </div>
+      </section>
+    </div>
+
+    <!-- Top 10 biggest entries -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <section
+        v-for="top in topLists"
+        :key="top.key"
+        class="bg-surface-0 dark:bg-surface-800 rounded-xl border border-surface-200 dark:border-surface-700 p-4"
+      >
+        <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-300 mb-3">{{ top.title }}</h3>
+        <ol v-if="top.rows.length > 0" class="space-y-2">
+          <li v-for="(entry, index) in top.rows" :key="entry.id" class="flex items-center gap-3 text-sm">
+            <span class="text-xs font-semibold text-surface-400 dark:text-surface-500 w-5 shrink-0 tabular-nums">{{ index + 1 }}</span>
+            <div class="flex-1 min-w-0">
+              <div class="truncate font-medium text-surface-700 dark:text-surface-200">{{ entry.label }}</div>
+              <div class="text-xs text-surface-500 dark:text-surface-400 truncate">
+                {{ entry.categoryName }}<template v-if="entry.categoryName && entry.dateLabel"> · </template>{{ entry.dateLabel }}
+              </div>
+            </div>
+            <span class="tabular-nums font-semibold shrink-0">{{ formatAmount(entry.amount) }}</span>
+          </li>
+        </ol>
+        <div v-else class="text-surface-400 dark:text-surface-500 italic text-center py-8">
+          {{ top.emptyLabel }}
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { format, parseISO } from 'date-fns'
+import Chart from 'primevue/chart'
+import ProgressSpinner from 'primevue/progressspinner'
+import { computed } from 'vue'
+import { effectiveAmount, formatAmount } from '../../../utils/currency.js'
+
+const props = defineProps({
+  // All-time entries (finance entry resources) and the category tree (poles + children).
+  entries: { type: Array, required: true },
+  categoryTree: { type: Array, required: true },
+  isLoading: { type: Boolean, default: false }
+})
+
+const TOP_LIMIT = 10
+
+const PALETTE = [
+  '#3b82f6',
+  '#f59e0b',
+  '#10b981',
+  '#8b5cf6',
+  '#ef4444',
+  '#06b6d4',
+  '#ec4899',
+  '#84cc16',
+  '#f97316',
+  '#14b8a6'
+]
+
+// Map every category id (pole or child) to its owning pole + a stable colour (by pole index),
+// so a pole keeps the same colour in both charts.
+const poleByCategory = computed(() => {
+  const map = new Map()
+  props.categoryTree.forEach((pole, index) => {
+    const entry = { id: pole.id, name: pole.name, color: PALETTE[index % PALETTE.length] }
+    map.set(pole.id, entry)
+    for (const child of pole.children ?? []) {
+      map.set(child.id, entry)
+    }
+  })
+  return map
+})
+
+// Personal-scope entries are a member's own, not band finances - excluded, matching the accordion.
+const bandEntries = computed(() => props.entries.filter((entry) => entry.scope !== 'personal'))
+
+function buildChart(type, title, emptyLabel, key) {
+  const totals = new Map()
+  for (const entry of bandEntries.value) {
+    if (entry.type !== type) continue
+    const pole = poleByCategory.value.get(entry.category_id)
+    if (!pole) continue
+    const row = totals.get(pole.id) ?? { id: pole.id, name: pole.name, color: pole.color, value: 0 }
+    row.value += effectiveAmount(entry)
+    totals.set(pole.id, row)
+  }
+  // Iterate the tree order so colours/legend stay stable between charts.
+  const rows = props.categoryTree
+    .map((pole) => totals.get(pole.id))
+    .filter((row) => row && row.value > 0)
+  const total = rows.reduce((sum, row) => sum + row.value, 0)
+  return {
+    key,
+    title,
+    emptyLabel,
+    rows,
+    total,
+    data: {
+      labels: rows.map((row) => row.name),
+      datasets: [
+        {
+          data: rows.map((row) => row.value),
+          backgroundColor: rows.map((row) => row.color),
+          borderWidth: 0
+        }
+      ]
+    }
+  }
+}
+
+function buildTop(type, title, emptyLabel, key) {
+  const rows = bandEntries.value
+    .filter((entry) => entry.type === type)
+    .map((entry) => ({
+      id: entry.id,
+      label: entry.label,
+      amount: effectiveAmount(entry),
+      categoryName: poleByCategory.value.get(entry.category_id)?.name ?? '',
+      dateLabel: entry.date ? format(parseISO(entry.date), 'dd/MM/yyyy') : ''
+    }))
+    .filter((entry) => entry.amount > 0)
+    .sort((a, b) => b.amount - a.amount)
+    .slice(0, TOP_LIMIT)
+  return { key, title, emptyLabel, rows }
+}
+
+const charts = computed(() => [
+  buildChart('income', 'Revenus par catégorie', 'Aucun revenu enregistré', 'income'),
+  buildChart('expense', 'Dépenses par catégorie', 'Aucune dépense enregistrée', 'expense')
+])
+
+const topLists = computed(() => [
+  buildTop('income', 'Top 10 des revenus', 'Aucun revenu enregistré', 'income'),
+  buildTop('expense', 'Top 10 des dépenses', 'Aucune dépense enregistrée', 'expense')
+])
+
+function percent(value, total) {
+  if (!total) return 0
+  return Math.round((value / total) * 100)
+}
+
+// Legend is HTML (theme-aware); the canvas only draws the ring. chart.js tooltips default to a
+// dark background with light text, readable over any slice.
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  cutout: '62%',
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: (ctx) => ` ${ctx.label} : ${formatAmount(ctx.parsed)}`
+      }
+    }
+  }
+}
+</script>

--- a/assets/js/components/BandSpace/Finance/FinancePoleAccordion.vue
+++ b/assets/js/components/BandSpace/Finance/FinancePoleAccordion.vue
@@ -11,9 +11,12 @@
   <Accordion v-model:value="openPanels" multiple>
     <AccordionPanel v-for="pole in poles" :key="pole.id" :value="pole.id">
       <AccordionHeader>
-        <div class="flex items-center justify-between w-full pr-2">
-          <span class="font-semibold">{{ pole.name }}</span>
-          <span class="text-sm text-surface-500 dark:text-surface-400">{{ countEntries(pole) }} entrée{{ countEntries(pole) > 1 ? 's' : '' }}</span>
+        <div class="flex items-center justify-between w-full pr-2 gap-3">
+          <span class="font-semibold min-w-0 truncate">{{ pole.name }}</span>
+          <span class="flex items-baseline gap-2 sm:gap-3 shrink-0">
+            <span class="text-sm font-semibold tabular-nums">{{ formatAmount(poleTotal(pole)) }}</span>
+            <span class="text-xs text-surface-500 dark:text-surface-400">{{ countEntries(pole) }} entrée{{ countEntries(pole) > 1 ? 's' : '' }}</span>
+          </span>
         </div>
       </AccordionHeader>
       <AccordionContent>
@@ -54,6 +57,7 @@
               </template>
               <template v-else>
                 <h4 class="text-sm font-medium text-surface-700 dark:text-surface-300 flex-1 min-w-0 truncate">{{ child.name }}</h4>
+                <span class="text-sm tabular-nums text-surface-600 dark:text-surface-400 shrink-0">{{ formatAmount(categoryTotal(child.id)) }}</span>
                 <div class="flex items-center gap-1 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
                   <button
                     class="text-xs text-surface-400 hover:text-primary"
@@ -145,7 +149,7 @@ import Button from 'primevue/button'
 import InputText from 'primevue/inputtext'
 import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
-import { effectiveAmount } from '../../../utils/currency.js'
+import { effectiveAmount, formatAmount } from '../../../utils/currency.js'
 import EntryList from './EntryList.vue'
 
 const STORAGE_KEY_PREFIX = 'finance_open_panels_'
@@ -230,6 +234,14 @@ function countEntries(pole) {
 
 function poleTotal(pole) {
   return poleStats.value.get(pole.id)?.total ?? 0
+}
+
+// Gross total for a single category (used for subcategories); excludes personal-scope entries
+// to match poleStats. Pole-level totals use poleTotal (pole + its children).
+function categoryTotal(categoryId) {
+  return (props.entriesByCategory[categoryId] || [])
+    .filter((entry) => entry.scope !== 'personal')
+    .reduce((sum, entry) => sum + effectiveAmount(entry), 0)
 }
 
 function progressPercent(pole) {

--- a/assets/js/store/bandSpace/bandSpaceFinance.js
+++ b/assets/js/store/bandSpace/bandSpaceFinance.js
@@ -23,9 +23,14 @@ export const useBandSpaceFinanceStore = defineStore('bandSpaceFinance', () => {
   const dateFrom = ref(startOfYear(new Date()))
   const dateTo = ref(endOfYear(new Date()))
   const activeEntry = ref(null)
+  // All-time entries for the (non-time-filtered) chart view, loaded lazily. The per-category
+  // pie and the top-10 lists are both derived from these client-side.
+  const allTimeEntries = ref([])
+  const isLoadingAllTime = ref(false)
   let entriesRequestId = 0
   let summaryRequestId = 0
   let categoriesRequestId = 0
+  let allTimeRequestId = 0
 
   const categoryTree = computed(() => buildTree(categories.value))
 
@@ -130,6 +135,26 @@ export const useBandSpaceFinanceStore = defineStore('bandSpaceFinance', () => {
     } finally {
       if (requestId === summaryRequestId) {
         isLoadingSummary.value = false
+      }
+    }
+  }
+
+  // Loaded on demand when the chart view opens; ignores the page date range (all-time).
+  async function loadAllTimeEntries(bandSpaceId) {
+    const requestId = ++allTimeRequestId
+    isLoadingAllTime.value = true
+    try {
+      const result = await bandSpaceFinanceApi.getEntries(bandSpaceId)
+      if (requestId === allTimeRequestId) {
+        allTimeEntries.value = result ?? []
+      }
+    } catch {
+      if (requestId === allTimeRequestId) {
+        allTimeEntries.value = []
+      }
+    } finally {
+      if (requestId === allTimeRequestId) {
+        isLoadingAllTime.value = false
       }
     }
   }
@@ -298,6 +323,7 @@ export const useBandSpaceFinanceStore = defineStore('bandSpaceFinance', () => {
     summary.value = null
     loadError.value = null
     activeEntry.value = null
+    allTimeEntries.value = []
   }
 
   return {
@@ -316,12 +342,15 @@ export const useBandSpaceFinanceStore = defineStore('bandSpaceFinance', () => {
     dateFrom: readonly(dateFrom),
     dateTo: readonly(dateTo),
     activeEntry: readonly(activeEntry),
+    allTimeEntries: readonly(allTimeEntries),
+    isLoadingAllTime: readonly(isLoadingAllTime),
     categoryTree,
     entriesByDate,
     entriesByCategory,
     loadCategories,
     loadEntries,
     loadSummary,
+    loadAllTimeEntries,
     loadRecurrences,
     setDateRange,
     createCategory,

--- a/assets/js/views/BandSpace/Finance.vue
+++ b/assets/js/views/BandSpace/Finance.vue
@@ -30,11 +30,16 @@
     <div v-else>
       <div class="flex items-center justify-between mb-6">
         <DateRangePicker
+          v-if="viewMode !== 'chart'"
           :from="financeStore.dateFrom"
           :to="financeStore.dateTo"
           :presets="financePresets"
           @apply="handleDateRangeApply"
         />
+        <span v-else class="text-sm text-surface-500 dark:text-surface-400 flex items-center gap-2">
+          <i class="pi pi-clock" />
+          Toutes périodes
+        </span>
         <div class="flex items-center gap-1">
           <Button
             :icon="'pi pi-objects-column'"
@@ -54,9 +59,19 @@
             title="Vue chronologique"
             @click="viewMode = 'timeline'"
           />
+          <Button
+            :icon="'pi pi-chart-pie'"
+            size="small"
+            :severity="viewMode === 'chart' ? 'primary' : 'secondary'"
+            :outlined="viewMode !== 'chart'"
+            :text="viewMode !== 'chart'"
+            title="Vue graphique (toutes périodes)"
+            @click="viewMode = 'chart'"
+          />
         </div>
       </div>
 
+      <template v-if="viewMode !== 'chart'">
       <FinanceMetricCards :summary="financeStore.summary" class="mb-6" :class="{ 'opacity-50 pointer-events-none': isDateRangeLoading }" />
 
       <div class="flex flex-col lg:flex-row gap-6" :class="{ 'opacity-50 pointer-events-none': isDateRangeLoading }">
@@ -106,6 +121,14 @@
           />
         </div>
       </div>
+      </template>
+
+      <FinancePieChart
+        v-else
+        :entries="financeStore.allTimeEntries"
+        :categoryTree="financeStore.categoryTree"
+        :isLoading="financeStore.isLoadingAllTime"
+      />
     </div>
 
     <CreateCategoryDialog
@@ -161,6 +184,7 @@ import CreateCategoryDialog from '../../components/BandSpace/Finance/CreateCateg
 import FinanceBootstrap from '../../components/BandSpace/Finance/FinanceBootstrap.vue'
 import FinanceDrawer from '../../components/BandSpace/Finance/FinanceDrawer.vue'
 import FinanceMetricCards from '../../components/BandSpace/Finance/FinanceMetricCards.vue'
+import FinancePieChart from '../../components/BandSpace/Finance/FinancePieChart.vue'
 import FinancePoleAccordion from '../../components/BandSpace/Finance/FinancePoleAccordion.vue'
 import FinanceSidebar from '../../components/BandSpace/Finance/FinanceSidebar.vue'
 import FinanceTimeline from '../../components/BandSpace/Finance/FinanceTimeline.vue'
@@ -282,6 +306,11 @@ const viewMode = ref(localStorage.getItem(viewModeStorageKey) || 'categories')
 
 watch(viewMode, (value) => {
   localStorage.setItem(viewModeStorageKey, value)
+  // Refetch on each switch to chart (no cache) so it reflects edits made in the other views -
+  // matches how loadEntries/loadSummary behave.
+  if (value === 'chart') {
+    financeStore.loadAllTimeEntries(bandSpaceId)
+  }
 })
 
 const drawerVisible = ref(false)
@@ -298,6 +327,9 @@ onMounted(() => {
   financeStore.loadEntries(bandSpaceId)
   financeStore.loadSummary(bandSpaceId)
   financeStore.loadRecurrences(bandSpaceId)
+  if (viewMode.value === 'chart') {
+    financeStore.loadAllTimeEntries(bandSpaceId)
+  }
 })
 
 watch(


### PR DESCRIPTION
Implements #733 (finance totals per category) plus a requested all-time chart view.

## Commits
1. `feat(M-733): show totals per category` - gross euro total per category in the accordion (each pole header + each subcategory).
2. `feat(M-733): add all-time finance charts + top-10 entries` - a third "chart" view with two all-time doughnuts (revenus / dépenses par catégorie) and two "Top 10" lists (biggest income / expense entries).

## Notes
- The chart view is **all-time** (ignores the date picker) and **frontend-only**: it lazy-loads all entries once and aggregates client-side (per-pole for the doughnuts, biggest individual entries for the top-10). No backend change.
- Personal-scope entries are excluded; child-category entries roll up to their pole; amounts use the shared `effectiveAmount` helper.
- Both commits went through the code-review agent. The chart started as a backend `by_category` aggregation, but review found a pre-existing SQL join fan-out there, so it was reverted in favour of the client-side approach (immune to that bug).

## For your review (from the totals commit's review - interpretability calls, your shout)
- A pole with **both** direct entries and subcategories shows a header total greater than the sum of its visible subcategory totals (no "sans sous-catégorie" subtotal).
- The accordion header **count** includes personal-scope entries while the **total** excludes them.
- Accordion category totals blend income + expense (the chart view splits them).

## Verification
- `npm run build` + Biome clean. No PHP touched.

## To check manually
Categories view: per-pole + per-subcategory totals. Chart view: two doughnuts + legends + top-10 lists (light/dark), income/expense split, "Toutes périodes" (date picker hidden), empty states.

Refs #733.