### PR TITLE
feat(M-738): drag-and-drop entries + clearer subcategory rows

### DIFF
--- a/assets/js/components/BandSpace/Finance/EntryList.vue
+++ b/assets/js/components/BandSpace/Finance/EntryList.vue
@@ -1,77 +1,153 @@
 <template>
-  <div v-if="entries.length === 0" class="text-sm text-surface-400 italic py-1">
-    Aucune entrée
-  </div>
-  <div
-    v-for="entry in entries"
-    :key="entry.id"
-    class="group flex items-center gap-1.5 sm:gap-2 py-2 px-1 sm:px-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700 transition-colors cursor-pointer"
-    @click="canEdit(entry) && emit('edit', entry)"
-  >
-    <!-- Status indicator -->
-    <FinanceStatusDot :status="entry.status" />
-
-    <!-- Recurrence icon -->
-    <i
-      v-if="entry.recurrence_id"
-      class="pi pi-sync text-xs text-surface-400 flex-shrink-0"
-      title="Récurrence"
-    ></i>
-
-    <!-- Label -->
-    <span class="flex-1 text-sm truncate min-w-0">{{ entry.label }}</span>
-
-    <!-- Date (hidden on mobile) -->
-    <span class="hidden sm:inline text-xs text-surface-400 flex-shrink-0">{{ formatDateCompact(entry.date) }}</span>
-
-    <!-- Scope badge -->
-    <span
-      v-if="entry.scope === 'personal'"
-      class="text-xs font-medium px-1.5 py-0.5 rounded-full flex-shrink-0 bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400"
+  <div>
+    <VueDraggable
+      v-model="localEntries"
+      group="finance-entries"
+      :sort="false"
+      :disabled="financeStore.isSaving"
+      :animation="200"
+      handle=".finance-entry-drag-handle"
+      ghost-class="opacity-30"
+      :data-category-id="categoryId"
+      class="flex flex-col min-h-[1.75rem]"
+      @end="handleDragEnd"
     >
-      Perso
-    </span>
+      <div
+        v-for="entry in localEntries"
+        :key="entry.id"
+        :data-entry-id="entry.id"
+        class="group flex items-center gap-1.5 sm:gap-2 py-2 px-1 sm:px-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700 transition-colors cursor-pointer"
+        @click="canEdit(entry) && emit('edit', entry)"
+      >
+        <!-- Drag handle (editable, non-paid entries only) -->
+        <span
+          v-if="isDraggable(entry)"
+          class="finance-entry-drag-handle flex-shrink-0 cursor-grab active:cursor-grabbing touch-none text-surface-300 hover:text-surface-500 dark:text-surface-600 dark:hover:text-surface-400 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+          title="Déplacer vers une autre catégorie"
+          aria-label="Déplacer l'entrée"
+          @click.stop
+        >
+          <i class="pi pi-bars text-xs"></i>
+        </span>
+        <!-- Paid entries are locked (settled): editable via the drawer but not draggable until set
+             back to « Engagé ». Show a lock cue so the missing drag handle doesn't read as a bug. -->
+        <span
+          v-else-if="isPaidLocked(entry)"
+          class="flex-shrink-0 cursor-not-allowed text-surface-300 dark:text-surface-600 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+          title="Entrée payée : repassez-la en « Engagé » pour la déplacer"
+          aria-label="Entrée payée, non déplaçable"
+        >
+          <i class="pi pi-lock text-xs"></i>
+        </span>
 
-    <!-- Type badge (hidden on mobile) -->
-    <span
-      class="hidden sm:inline text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0"
-      :class="typeBadgeClass(entry.type)"
-    >
-      {{ entry.type === 'expense' ? 'Dépense' : 'Revenu' }}
-    </span>
+        <!-- Status indicator -->
+        <FinanceStatusDot :status="entry.status" />
 
-    <!-- Amount -->
-    <span class="text-sm font-medium tabular-nums flex-shrink-0 text-right w-20 sm:w-24">
-      {{ formatEntryAmount(entry) }}
-    </span>
+        <!-- Recurrence icon -->
+        <i
+          v-if="entry.recurrence_id"
+          class="pi pi-sync text-xs text-surface-400 flex-shrink-0"
+          title="Récurrence"
+        ></i>
 
-    <!-- Edit button (visible on hover for desktop, always visible on mobile) -->
-    <button
-      v-if="canEdit(entry)"
-      class="sm:opacity-0 sm:group-hover:opacity-100 transition-opacity text-surface-400 hover:text-primary flex-shrink-0 p-1"
-      title="Modifier"
-      @click.stop="emit('edit', entry)"
-    >
-      <i class="pi pi-pencil text-sm"></i>
-    </button>
+        <!-- Label -->
+        <span class="flex-1 text-sm truncate min-w-0">{{ entry.label }}</span>
+
+        <!-- Date (hidden on mobile) -->
+        <span class="hidden sm:inline text-xs text-surface-400 flex-shrink-0">{{ formatDateCompact(entry.date) }}</span>
+
+        <!-- Scope badge -->
+        <span
+          v-if="entry.scope === 'personal'"
+          class="text-xs font-medium px-1.5 py-0.5 rounded-full flex-shrink-0 bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400"
+        >
+          Perso
+        </span>
+
+        <!-- Type badge (hidden on mobile) -->
+        <span
+          class="hidden sm:inline text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0"
+          :class="typeBadgeClass(entry.type)"
+        >
+          {{ entry.type === 'expense' ? 'Dépense' : 'Revenu' }}
+        </span>
+
+        <!-- Amount -->
+        <span class="text-sm font-medium tabular-nums flex-shrink-0 text-right w-20 sm:w-24">
+          {{ formatEntryAmount(entry) }}
+        </span>
+
+        <!-- Edit button (visible on hover for desktop, always visible on mobile) -->
+        <button
+          v-if="canEdit(entry)"
+          class="sm:opacity-0 sm:group-hover:opacity-100 transition-opacity text-surface-400 hover:text-primary flex-shrink-0 p-1"
+          title="Modifier"
+          @click.stop="emit('edit', entry)"
+        >
+          <i class="pi pi-pencil text-sm"></i>
+        </button>
+      </div>
+    </VueDraggable>
+    <div v-if="localEntries.length === 0 && !hideEmptyState" class="text-sm text-surface-400 italic py-1">
+      Aucune entrée
+    </div>
   </div>
 </template>
 
 <script setup>
+import { ref, watch } from 'vue'
+import { VueDraggable } from 'vue-draggable-plus'
+import { useBandSpaceFinanceStore } from '../../../store/bandSpace/bandSpaceFinance.js'
 import { formatAmount } from '../../../utils/currency.js'
 import { formatDateCompact } from '../../../utils/date.js'
 import FinanceStatusDot from './FinanceStatusDot.vue'
 
 const props = defineProps({
   entries: { type: Array, required: true },
-  currentMembershipId: { type: String, default: null }
+  categoryId: { type: String, required: true },
+  currentMembershipId: { type: String, default: null },
+  // Pole-level lists of a pole that has subcategories hide the "Aucune entrée" text: the list still
+  // renders as a drop target, but the empty label would read as a bug next to filled subcategories.
+  hideEmptyState: { type: Boolean, default: false }
 })
 
-const emit = defineEmits(['edit'])
+const emit = defineEmits(['edit', 'move'])
+
+const financeStore = useBandSpaceFinanceStore()
+
+// VueDraggable needs a mutable model, but the store's entries are readonly. Keep a local copy and
+// re-sync whenever props change - after a move the store reloads, which is the authoritative state.
+const localEntries = ref([...props.entries])
+watch(
+  () => props.entries,
+  (value) => {
+    localEntries.value = [...value]
+  }
+)
 
 function canEdit(entry) {
   if (entry.scope !== 'personal') return true
   return entry.member_id === props.currentMembershipId
+}
+
+// Draggable requires edit rights AND a non-paid status: the backend rejects a category change on a
+// paid entry (422), so paid rows stay clickable-to-edit but cannot be dragged.
+function isDraggable(entry) {
+  return canEdit(entry) && entry.status !== 'paid'
+}
+
+// Editable entry that can't be dragged only because it's paid (settled). Drives the lock cue that
+// replaces the drag handle, hinting the entry must go back to « Engagé » before it can be moved.
+function isPaidLocked(entry) {
+  return canEdit(entry) && entry.status === 'paid'
+}
+
+function handleDragEnd(event) {
+  const entryId = event.item?.dataset?.entryId
+  const toCategoryId = event.to?.dataset?.categoryId
+  const fromCategoryId = event.from?.dataset?.categoryId
+  if (!entryId || !toCategoryId || fromCategoryId === toCategoryId) return
+  emit('move', entryId, toCategoryId)
 }
 
 function formatEntryAmount(entry) {
@@ -81,7 +157,7 @@ function formatEntryAmount(entry) {
   if (entry.amount_min != null && entry.amount_max != null) {
     return `${formatAmount(entry.amount_min)} - ${formatAmount(entry.amount_max)}`
   }
-  return '0,00 \u20AC'
+  return '0,00 €'
 }
 
 function typeBadgeClass(type) {

--- a/assets/js/components/BandSpace/Finance/FinancePoleAccordion.vue
+++ b/assets/js/components/BandSpace/Finance/FinancePoleAccordion.vue
@@ -32,12 +32,15 @@
           <p class="text-xs text-surface-500 dark:text-surface-400 mt-1">{{ progressPercent(pole) }}% payé</p>
         </div>
 
-        <!-- Entries at pole level -->
+        <!-- Entries at pole level (always rendered so the pole itself is a drop target, even when it
+             only holds subcategories) -->
         <EntryList
-          v-if="(entriesByCategory[pole.id] || []).length > 0 || pole.children.length === 0"
           :entries="entriesByCategory[pole.id] || []"
+          :categoryId="pole.id"
           :currentMembershipId="currentMembershipId"
+          :hideEmptyState="pole.children.length > 0"
           @edit="(entry) => emit('edit-entry', entry)"
+          @move="(entryId, toCategoryId) => emit('move-entry', entryId, toCategoryId)"
         />
 
         <!-- Child categories -->
@@ -78,8 +81,10 @@
             </div>
             <EntryList
               :entries="entriesByCategory[child.id] || []"
+              :categoryId="child.id"
               :currentMembershipId="currentMembershipId"
               @edit="(entry) => emit('edit-entry', entry)"
+              @move="(entryId, toCategoryId) => emit('move-entry', entryId, toCategoryId)"
             />
             <button
               class="mt-1 text-sm text-primary hover:underline flex items-center gap-1"
@@ -163,6 +168,7 @@ const props = defineProps({
 const emit = defineEmits([
   'add-entry',
   'edit-entry',
+  'move-entry',
   'add-category',
   'delete-category',
   'rename-category'

--- a/assets/js/components/BandSpace/Finance/FinancePoleAccordion.vue
+++ b/assets/js/components/BandSpace/Finance/FinancePoleAccordion.vue
@@ -43,56 +43,73 @@
           @move="(entryId, toCategoryId) => emit('move-entry', entryId, toCategoryId)"
         />
 
-        <!-- Child categories -->
+        <!-- Child categories, linked by a tree rail so they read clearly as nested under the pole -->
         <div v-if="pole.children.length > 0">
-          <div v-for="child in pole.children" :key="child.id" class="mb-4 group">
-            <div class="flex items-center justify-between mb-2 gap-2">
-              <template v-if="editingId === child.id">
-                <InputText
-                  v-model="editingName"
-                  class="flex-1 text-sm"
-                  size="small"
-                  @keydown.enter="saveRename(child)"
-                  @keydown.escape="cancelRename"
-                />
-                <Button icon="pi pi-check" aria-label="Valider" text rounded size="small" @click="saveRename(child)" />
-                <Button icon="pi pi-times" aria-label="Annuler" text rounded size="small" @click="cancelRename" />
-              </template>
-              <template v-else>
-                <h4 class="text-sm font-medium text-surface-700 dark:text-surface-300 flex-1 min-w-0 truncate">{{ child.name }}</h4>
-                <span class="text-sm tabular-nums text-surface-600 dark:text-surface-400 shrink-0">{{ formatAmount(categoryTotal(child.id)) }}</span>
-                <div class="flex items-center gap-1 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
-                  <button
-                    class="text-xs text-surface-400 hover:text-primary"
-                    title="Renommer la catégorie"
-                    @click="startRename(child)"
-                  >
-                    <i class="pi pi-pencil"></i>
-                  </button>
-                  <button
-                    class="text-xs text-red-500 hover:text-red-700"
-                    title="Supprimer la catégorie"
-                    @click="emit('delete-category', child.id)"
-                  >
-                    <i class="pi pi-trash"></i>
-                  </button>
-                </div>
-              </template>
+          <div
+            v-for="(child, index) in pole.children"
+            :key="child.id"
+            class="group flex"
+          >
+            <!-- Tree rail: a vertical line connecting the subcategories, with a tick into each row -->
+            <div class="relative w-5 shrink-0" aria-hidden="true">
+              <span
+                class="absolute left-2 top-0 w-px bg-surface-300 dark:bg-surface-600"
+                :class="index === pole.children.length - 1 ? 'h-3' : 'h-full'"
+              ></span>
+              <span class="absolute left-2 top-3 w-2 h-px bg-surface-300 dark:bg-surface-600"></span>
             </div>
-            <EntryList
-              :entries="entriesByCategory[child.id] || []"
-              :categoryId="child.id"
-              :currentMembershipId="currentMembershipId"
-              @edit="(entry) => emit('edit-entry', entry)"
-              @move="(entryId, toCategoryId) => emit('move-entry', entryId, toCategoryId)"
-            />
-            <button
-              class="mt-1 text-sm text-primary hover:underline flex items-center gap-1"
-              @click="emit('add-entry', child.id)"
-            >
-              <i class="pi pi-plus text-xs"></i>
-              Ajouter une entrée
-            </button>
+
+            <div class="min-w-0 flex-1 pb-4">
+              <div class="flex items-center gap-2 mb-2">
+                <template v-if="editingId === child.id">
+                  <InputText
+                    v-model="editingName"
+                    class="flex-1 text-sm"
+                    size="small"
+                    @keydown.enter="saveRename(child)"
+                    @keydown.escape="cancelRename"
+                  />
+                  <Button icon="pi pi-check" aria-label="Valider" text rounded size="small" @click="saveRename(child)" />
+                  <Button icon="pi pi-times" aria-label="Annuler" text rounded size="small" @click="cancelRename" />
+                </template>
+                <template v-else>
+                  <h4 class="text-sm font-medium text-surface-700 dark:text-surface-300 min-w-0 truncate">{{ child.name }}</h4>
+                  <div class="flex items-center gap-0.5 shrink-0 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
+                    <button
+                      class="p-1 text-surface-400 hover:text-primary"
+                      title="Renommer la sous-catégorie"
+                      aria-label="Renommer la sous-catégorie"
+                      @click="startRename(child)"
+                    >
+                      <i class="pi pi-pencil text-xs"></i>
+                    </button>
+                    <button
+                      class="p-1 text-red-500 hover:text-red-700"
+                      title="Supprimer la sous-catégorie"
+                      aria-label="Supprimer la sous-catégorie"
+                      @click="emit('delete-category', child.id)"
+                    >
+                      <i class="pi pi-trash text-xs"></i>
+                    </button>
+                  </div>
+                  <span class="text-sm tabular-nums text-surface-600 dark:text-surface-400 shrink-0 ml-auto">{{ formatAmount(categoryTotal(child.id)) }}</span>
+                </template>
+              </div>
+              <EntryList
+                :entries="entriesByCategory[child.id] || []"
+                :categoryId="child.id"
+                :currentMembershipId="currentMembershipId"
+                @edit="(entry) => emit('edit-entry', entry)"
+                @move="(entryId, toCategoryId) => emit('move-entry', entryId, toCategoryId)"
+              />
+              <button
+                class="mt-1 text-sm text-primary hover:underline flex items-center gap-1"
+                @click="emit('add-entry', child.id)"
+              >
+                <i class="pi pi-plus text-xs"></i>
+                Ajouter une entrée
+              </button>
+            </div>
           </div>
         </div>
 

--- a/assets/js/store/bandSpace/bandSpaceFinance.js
+++ b/assets/js/store/bandSpace/bandSpaceFinance.js
@@ -165,6 +165,7 @@ export const useBandSpaceFinanceStore = defineStore('bandSpaceFinance', () => {
   }
 
   function expandDateRangeIfNeeded(entryDate) {
+    if (!entryDate) return
     const date = typeof entryDate === 'string' ? parseISO(entryDate) : entryDate
     if (date < dateFrom.value) {
       dateFrom.value = startOfMonth(date)
@@ -230,6 +231,23 @@ export const useBandSpaceFinanceStore = defineStore('bandSpaceFinance', () => {
       return updated
     } finally {
       isSaving.value = false
+    }
+  }
+
+  // Move an entry to another category (drag-and-drop). Updates entries.value optimistically so the
+  // accordion header totals and the row lists stay in sync during the round-trip, then persists via
+  // updateEntry (which reloads the authoritative state). Rolls back on failure. Mirrors
+  // bandSpaceTasks.moveTaskToColumn.
+  async function moveEntryToCategory(bandSpaceId, entryId, categoryId) {
+    const snapshot = [...entries.value]
+    entries.value = entries.value.map((entry) =>
+      entry.id === entryId ? { ...entry, category_id: categoryId } : entry
+    )
+    try {
+      return await updateEntry(bandSpaceId, entryId, { category_id: categoryId })
+    } catch (error) {
+      entries.value = snapshot
+      throw error
     }
   }
 
@@ -358,6 +376,7 @@ export const useBandSpaceFinanceStore = defineStore('bandSpaceFinance', () => {
     deleteCategory,
     createEntry,
     updateEntry,
+    moveEntryToCategory,
     deleteEntry,
     createRecurrence,
     updateRecurrence,

--- a/assets/js/views/BandSpace/Finance.vue
+++ b/assets/js/views/BandSpace/Finance.vue
@@ -83,6 +83,7 @@
             :currentMembershipId="financeStore.summary?.current_membership_id"
             @add-entry="handleAddEntry"
             @edit-entry="handleEditEntry"
+            @move-entry="handleMoveEntry"
             @add-category="handleAddCategory"
             @delete-category="handleDeleteCategory"
             @rename-category="handleRenameCategory"
@@ -404,6 +405,21 @@ function handleEditEntry(entry) {
   editingEntry.value = entry
   drawerCategoryId.value = entry.category_id
   drawerVisible.value = true
+}
+
+async function handleMoveEntry(entryId, toCategoryId) {
+  try {
+    await financeStore.moveEntryToCategory(bandSpaceId, entryId, toCategoryId)
+    trackUmamiEvent('finance-entry-move')
+  } catch {
+    // moveEntryToCategory already rolled the optimistic move back in the store.
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: 'Impossible de déplacer cette entrée',
+      life: 5000
+    })
+  }
 }
 
 function handleAddCategory(parentId = null) {


### PR DESCRIPTION
## What

Two improvements to the band-space Finance **categories** (accordion) view:

1. **Drag-and-drop to recategorize an entry.** Grab an entry by its handle and drop it into another bucket - a sibling subcategory, another pole's subcategory, or a pole itself. On drop, the entry's `category_id` is PATCHed. Addresses the beta feedback in #738 ("drag and drop les dépenses facilement d'une sous-catégorie à l'autre"), extended so an entry can move to **any** category, not only between sibling subcategories.
2. **Clearer subcategory rows.** Subcategories now hang off a connecting tree rail (├ / └) so the nesting under the pole is obvious; their rename/delete controls sit right next to the title (hover on desktop, always on mobile); the amount is pushed to the far right.

## Commits

- `feat(M-738): drag-and-drop entries between finance categories`
- `feat(M-738): clearer subcategory rows (tree rail + inline controls)`

## How (drag-and-drop)

- **Frontend only.** The `PATCH .../finance/entries/{id}` endpoint already accepts a partial `{ category_id }`, re-validates the target category belongs to the band space, and logs an `EntryCategoryChanged` activity.
- Reuses `vue-draggable-plus` (already used by the Kanban `TaskColumn.vue`). Each per-bucket `EntryList` is a shared-group droppable (`group="finance-entries"`, `:sort="false"` so only cross-bucket moves count, `handle` gated to a grip icon).
- The optimistic move lives in the store (`moveEntryToCategory`, mirroring `moveTaskToColumn`): it mutates `entries` optimistically so the accordion header totals and the row lists update together, then persists via `updateEntry` and rolls back on failure.

## Behaviour / decisions

- **Every pole is a drop target**, including poles that only hold subcategories (they get a slim drop strip; the "Aucune entrée" label is hidden there via `hideEmptyState`).
- **Paid entries can't be moved** - the module-wide "paid = locked" rule (the backend 422s a `category_id` change on a paid entry, same as every other field). Rather than a silent missing handle, paid rows show a **lock icon** with a tooltip explaining you must set the entry back to « Engagé » first. No rule change.
- **Personal entries** you don't own stay read-only.
- Concurrent-move race gated by `:disabled="financeStore.isSaving"` (same pattern as the task board).
- The tree rail uses Tailwind spans (`bg-surface-300 dark:bg-surface-600`) - dark-mode-aware, no scoped CSS.
- DnD is in the categories view only (the chronological timeline has no buckets); both accordion panels must be expanded to drag between two poles.

## Known follow-up (out of scope)

No keyboard-accessible way to recategorize an existing entry yet (the drawer's category select only shows on create). Worth a fast-follow a11y issue.

## Testing

Frontend-only; no backend or JS test infra affected. `npm run build` and `npx biome check` are green. The drag-and-drop feature was code-reviewed over two passes (one blocker + two important findings fixed and re-verified); the subcategory-display change is presentational (best verified visually).

Refs #738
