### PR TITLE
M-748 : suppression d'un Band Space avec délai de grâce de 30 jours + purge du stockage

### DIFF
--- a/assets/js/api/bandSpace/band-space-settings.js
+++ b/assets/js/api/bandSpace/band-space-settings.js
@@ -39,6 +39,23 @@ export default {
       .catch(handleApiError)
   },
 
+  // Schedules the deletion 30 days out, it does not delete: restoreBandSpace cancels it until then.
+  scheduleBandSpaceDeletion(bandSpaceId) {
+    return axios
+      .delete(Routing.generate('api_band_spaces_delete', { id: bandSpaceId }))
+      .catch(handleApiError)
+  },
+
+  restoreBandSpace(bandSpaceId) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_restore', { bandSpaceId }),
+        {},
+        { headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' } }
+      )
+      .catch(handleApiError)
+  },
+
   getInvitations(bandSpaceId) {
     return axios
       .get(Routing.generate('api_band_space_invitations_get_collection', { bandSpaceId }))

--- a/assets/js/components/AppBandLayout.vue
+++ b/assets/js/components/AppBandLayout.vue
@@ -30,6 +30,26 @@
         </aside>
         <main id="main-content" tabindex="-1" class="flex-1 min-w-0 bg-surface-200 dark:bg-surface-950">
           <div class="px-6 py-8 md:px-12 lg:pl-8 lg:pr-20 flex flex-col gap-8">
+            <!-- Pending deletion is shown on every module, not only in the settings: the grace period is
+                 the members' window to retrieve their files, so they have to see it wherever they are. -->
+            <div
+              v-if="deletionScheduledFor"
+              role="alert"
+              class="flex items-start gap-3 rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-300"
+            >
+              <i class="pi pi-exclamation-triangle mt-0.5" aria-hidden="true" />
+              <p class="flex-1 min-w-0">
+                Cet espace sera définitivement supprimé le
+                <strong>{{ formatDateLong(deletionScheduledFor) }}</strong>. Pensez à récupérer vos
+                fichiers.
+                <RouterLink
+                  :to="{ name: BAND_SPACE_ROUTES.PARAMETERS, params: { id: route.params.id }, query: { section: 'danger' } }"
+                  class="underline"
+                >
+                  Gérer la suppression
+                </RouterLink>
+              </p>
+            </div>
             <!-- Force remount on space switch so module views never retain
                  another space's bandSpaceId or store state. -->
             <router-view :key="route.params.id" />
@@ -144,6 +164,7 @@ import { BAND_SPACE_ROUTES, SECTION_NAMES } from '../constants/bandSpace.js'
 import { useBandSpaceStore } from '../store/bandSpace/bandSpace.js'
 import { useNotificationStore } from '../store/notification/notification.js'
 import { useUserSecurityStore } from '../store/user/security.js'
+import { formatDateLong } from '../utils/date.js'
 import MenuBand from '../views/Global/MenuBand.vue'
 import BandSidebar from './BandSpace/BandSidebar.vue'
 import BandSpaceSelector from './BandSpace/BandSpaceSelector.vue'
@@ -225,6 +246,8 @@ function handleUserMenuClick(entry) {
 
 const { currentSpace, setLastSpaceId, handleRedirect, validateCurrentSpace } =
   useBandSpaceNavigation()
+
+const deletionScheduledFor = computed(() => currentSpace.value?.deletion_scheduled_datetime ?? null)
 
 const isLoading = ref(true)
 const hasError = ref(false)

--- a/assets/js/components/BandSpace/Settings/DangerZoneSection.vue
+++ b/assets/js/components/BandSpace/Settings/DangerZoneSection.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="flex flex-col gap-6">
+    <!-- Pending deletion: only an admin can call it off -->
+    <div
+      v-if="scheduledFor"
+      class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-6 border border-amber-500/40"
+    >
+      <div class="flex items-start gap-3">
+        <i class="pi pi-exclamation-triangle text-amber-600 dark:text-amber-400 mt-1" aria-hidden="true" />
+        <div class="flex-1 min-w-0">
+          <h3 class="text-base font-semibold text-surface-800 dark:text-surface-100">
+            Suppression programmée
+          </h3>
+          <p class="text-sm text-surface-600 dark:text-surface-300 mt-1">
+            Cet espace et tous ses contenus seront définitivement supprimés le
+            <strong>{{ formatDateLong(scheduledFor) }}</strong>. D'ici là, les membres peuvent encore
+            récupérer leurs fichiers.
+          </p>
+        </div>
+        <Button
+          v-if="isAdmin"
+          label="Restaurer"
+          icon="pi pi-undo"
+          outlined
+          class="shrink-0"
+          :loading="settingsStore.isRestoring"
+          @click="handleRestore"
+        />
+      </div>
+    </div>
+
+    <!-- Delete the space -->
+    <div v-if="isAdmin && !scheduledFor" class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-6">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0">
+          <h3 class="text-base font-semibold text-surface-800 dark:text-surface-100">
+            Supprimer ce Band Space
+          </h3>
+          <p class="text-xs text-surface-500 dark:text-surface-400 mt-1">
+            L'espace, ses fichiers, son agenda, ses notes, ses tâches, ses setlists et ses finances
+            seront supprimés après un délai de {{ GRACE_PERIOD_DAYS }} jours, pendant lequel un
+            administrateur peut annuler la suppression.
+          </p>
+        </div>
+        <Button
+          label="Supprimer"
+          icon="pi pi-trash"
+          severity="danger"
+          outlined
+          class="shrink-0 self-start sm:self-auto"
+          @click="isDeleteDialogOpen = true"
+        />
+      </div>
+    </div>
+
+    <div
+      v-else-if="!isAdmin && !scheduledFor"
+      class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-6"
+    >
+      <p class="text-sm text-surface-500 dark:text-surface-400">
+        Seul un administrateur peut supprimer cet espace. Vous pouvez le quitter depuis la section
+        « Membres ».
+      </p>
+    </div>
+
+    <Dialog
+      v-model:visible="isDeleteDialogOpen"
+      modal
+      header="Supprimer ce Band Space ?"
+      :style="{ width: '32rem' }"
+      @hide="resetDialog"
+    >
+      <div class="flex flex-col gap-4">
+        <p class="text-sm">
+          Vous êtes sur le point de programmer la suppression de
+          <span class="font-medium">« {{ currentSpace?.name }} »</span>.
+        </p>
+
+        <ul class="list-disc list-inside text-sm text-surface-600 dark:text-surface-300 space-y-1">
+          <li>
+            L'espace reste accessible {{ GRACE_PERIOD_DAYS }} jours, le temps que chacun récupère ses
+            fichiers.
+          </li>
+          <li>Les autres membres sont prévenus immédiatement.</li>
+          <li>Un administrateur peut annuler jusqu'à l'échéance.</li>
+          <li>Passé ce délai, tout est supprimé définitivement et rien ne peut être récupéré.</li>
+        </ul>
+
+        <div class="flex flex-col gap-2">
+          <label for="delete-confirmation" class="text-sm text-surface-700 dark:text-surface-200">
+            Pour confirmer, tapez <strong>{{ CONFIRMATION_WORD }}</strong> ci-dessous.
+          </label>
+          <InputText
+            id="delete-confirmation"
+            v-model="confirmation"
+            autocomplete="off"
+            :placeholder="CONFIRMATION_WORD"
+            @keyup.enter="handleDelete"
+          />
+        </div>
+
+        <Message v-if="globalError" severity="error" :closable="false">{{ globalError }}</Message>
+      </div>
+
+      <template #footer>
+        <Button
+          label="Annuler"
+          severity="secondary"
+          text
+          :disabled="settingsStore.isSchedulingDeletion"
+          @click="isDeleteDialogOpen = false"
+        />
+        <Button
+          label="Supprimer"
+          severity="danger"
+          :disabled="!isConfirmed"
+          :loading="settingsStore.isSchedulingDeletion"
+          @click="handleDelete"
+        />
+      </template>
+    </Dialog>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import { useToast } from 'primevue/usetoast'
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
+import { useBandSpaceSettingsStore } from '../../../store/bandSpace/bandSpaceSettings.js'
+import { formatDateLong } from '../../../utils/date.js'
+
+// Mirrors BandSpaceDeleteProcessor::GRACE_PERIOD_DAYS; shown so the admin knows what they are agreeing
+// to before the space reports its own scheduled date.
+const GRACE_PERIOD_DAYS = 30
+
+const CONFIRMATION_WORD = 'Supprimer'
+
+const route = useRoute()
+const toast = useToast()
+const settingsStore = useBandSpaceSettingsStore()
+const { currentSpace } = useBandSpaceNavigation()
+
+const bandSpaceId = route.params.id
+
+const isDeleteDialogOpen = ref(false)
+const confirmation = ref('')
+const globalError = ref(null)
+
+const isAdmin = computed(() => currentSpace.value?.role === 'admin')
+const scheduledFor = computed(() => currentSpace.value?.deletion_scheduled_datetime ?? null)
+
+// Case-insensitive so a stray capital does not stand between an admin and their own space, but the word
+// still has to be typed out: that deliberate keystroke is the point of the confirmation.
+const isConfirmed = computed(
+  () => confirmation.value.trim().toLowerCase() === CONFIRMATION_WORD.toLowerCase()
+)
+
+async function handleDelete() {
+  if (!isConfirmed.value) return
+
+  globalError.value = null
+  try {
+    await settingsStore.scheduleDeletion(bandSpaceId)
+    isDeleteDialogOpen.value = false
+    toast.add({ severity: 'warn', summary: 'Suppression programmée', life: 4000 })
+  } catch (e) {
+    globalError.value = e.message
+  }
+}
+
+async function handleRestore() {
+  try {
+    await settingsStore.restore(bandSpaceId)
+    toast.add({ severity: 'success', summary: 'Suppression annulée', life: 3000 })
+  } catch (e) {
+    toast.add({ severity: 'error', summary: e.message, life: 5000 })
+  }
+}
+
+function resetDialog() {
+  confirmation.value = ''
+  globalError.value = null
+}
+</script>

--- a/assets/js/components/BandSpace/Settings/activitySentences.js
+++ b/assets/js/components/BandSpace/Settings/activitySentences.js
@@ -1,3 +1,5 @@
+import { formatDateLong } from '../../../utils/date.js'
+
 const TASK_STATUS_LABELS = {
   todo: 'À faire',
   in_progress: 'En cours',
@@ -162,7 +164,14 @@ const SENTENCES = {
   'settings.invitation_declined': (a) => `a refusé l'invitation pour ${a.payload?.email}`,
   'settings.invitation_revoked': (a) => `a annulé l'invitation pour ${a.payload?.email}`,
   'settings.invitation_expired': (a) =>
-    `l'invitation pour ${a.payload?.email ?? 'un utilisateur'} a expiré`
+    `l'invitation pour ${a.payload?.email ?? 'un utilisateur'} a expiré`,
+
+  // Settings — suppression de l'espace
+  'settings.deletion_scheduled': (a) =>
+    a.payload?.scheduled_for
+      ? `a programmé la suppression du Band Space pour le ${formatDateLong(a.payload.scheduled_for)}`
+      : 'a programmé la suppression du Band Space',
+  'settings.deletion_cancelled': () => 'a annulé la suppression du Band Space'
 }
 
 export function activitySentence(activity) {

--- a/assets/js/components/Notification/NotificationItem.vue
+++ b/assets/js/components/Notification/NotificationItem.vue
@@ -63,8 +63,6 @@
 </template>
 
 <script setup>
-import { format } from 'date-fns'
-import { fr } from 'date-fns/locale'
 import Button from 'primevue/button'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
@@ -73,6 +71,7 @@ import bandSpaceSettingsApi from '../../api/bandSpace/band-space-settings.js'
 import { BAND_SPACE_ROUTES } from '../../constants/bandSpace.js'
 import relativeDate from '../../helper/date/relative-date.js'
 import { useUserNotificationStore } from '../../store/notification/userNotification.js'
+import { formatDateLong } from '../../utils/date.js'
 
 const props = defineProps({
   notification: { type: Object, required: true }
@@ -93,11 +92,6 @@ const isUnread = computed(() => props.notification.read_datetime === null)
 function publicationTarget(payload) {
   const name = payload.is_course ? 'app_course_show' : 'app_publication_show'
   return { name, params: { slug: payload.publication_slug } }
-}
-
-// Agenda has no per-entry deep-link; show the (read-time-refreshed) event date inline.
-function formatEventDate(iso) {
-  return format(new Date(iso), 'd MMMM yyyy', { locale: fr })
 }
 
 // type -> row rendering. Each future producer adds its branch here.
@@ -231,7 +225,7 @@ const TYPE_CONFIG = {
     icon: 'pi pi-calendar-plus',
     avatarClass: 'bg-sky-100 text-sky-600 dark:bg-sky-500/20 dark:text-sky-300',
     title: payload.actor_username,
-    preview: `a ajouté l'événement « ${payload.entry_title} » le ${formatEventDate(payload.event_datetime)}`,
+    preview: `a ajouté l'événement « ${payload.entry_title} » le ${formatDateLong(payload.event_datetime)}`,
     actions: null,
     target: { name: BAND_SPACE_ROUTES.AGENDA, params: { id: payload.band_space_id } }
   }),
@@ -242,6 +236,24 @@ const TYPE_CONFIG = {
     preview: `vous a attribué une dépense sur « ${payload.entry_label} »`,
     actions: null,
     target: { name: BAND_SPACE_ROUTES.FINANCE, params: { id: payload.band_space_id } }
+  }),
+  band_space_deletion_scheduled: (payload) => ({
+    icon: 'pi pi-trash',
+    avatarClass: 'bg-rose-100 text-rose-600 dark:bg-rose-500/20 dark:text-rose-300',
+    title: payload.actor_username,
+    preview: payload.scheduled_for
+      ? `a programmé la suppression de « ${payload.band_space_name} » le ${formatDateLong(payload.scheduled_for)}`
+      : `a programmé la suppression de « ${payload.band_space_name} »`,
+    actions: null,
+    target: { name: BAND_SPACE_ROUTES.DASHBOARD, params: { id: payload.band_space_id } }
+  }),
+  band_space_deletion_cancelled: (payload) => ({
+    icon: 'pi pi-undo',
+    avatarClass: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300',
+    title: payload.actor_username,
+    preview: `a annulé la suppression de « ${payload.band_space_name} »`,
+    actions: null,
+    target: { name: BAND_SPACE_ROUTES.DASHBOARD, params: { id: payload.band_space_id } }
   })
 }
 

--- a/assets/js/store/bandSpace/bandSpaceSettings.js
+++ b/assets/js/store/bandSpace/bandSpaceSettings.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { readonly, ref } from 'vue'
 import bandSpaceSettingsApi from '../../api/bandSpace/band-space-settings.js'
+import { useBandSpaceStore } from './bandSpace.js'
 
 export const useBandSpaceSettingsStore = defineStore('bandSpaceSettings', () => {
   const members = ref([])
@@ -12,6 +13,8 @@ export const useBandSpaceSettingsStore = defineStore('bandSpaceSettings', () => 
   const isKicking = ref(false)
   const isLeaving = ref(false)
   const isCancellingInvitation = ref(false)
+  const isSchedulingDeletion = ref(false)
+  const isRestoring = ref(false)
 
   // Monotonic tokens to prevent stale members/invitations from a previous
   // bandSpace overwriting the current view when the user switches spaces
@@ -103,6 +106,38 @@ export const useBandSpaceSettingsStore = defineStore('bandSpaceSettings', () => 
     }
   }
 
+  // Both reload the space list so the banner and the « Zone de danger » reflect the new state without
+  // a page refresh. The refresh is deliberately not allowed to fail the call: the mutation has already
+  // been committed server-side, and surfacing a refresh blip as an error would tell the user their
+  // deletion did not happen when it did. The state is correct again on the next load either way.
+  async function refreshSpacesQuietly() {
+    try {
+      await useBandSpaceStore().loadMyBandSpaces()
+    } catch {
+      // Intentionally swallowed, see above.
+    }
+  }
+
+  async function scheduleDeletion(bandSpaceId) {
+    isSchedulingDeletion.value = true
+    try {
+      await bandSpaceSettingsApi.scheduleBandSpaceDeletion(bandSpaceId)
+      await refreshSpacesQuietly()
+    } finally {
+      isSchedulingDeletion.value = false
+    }
+  }
+
+  async function restore(bandSpaceId) {
+    isRestoring.value = true
+    try {
+      await bandSpaceSettingsApi.restoreBandSpace(bandSpaceId)
+      await refreshSpacesQuietly()
+    } finally {
+      isRestoring.value = false
+    }
+  }
+
   function clear() {
     members.value = []
     invitations.value = []
@@ -118,6 +153,8 @@ export const useBandSpaceSettingsStore = defineStore('bandSpaceSettings', () => 
     isKicking: readonly(isKicking),
     isLeaving: readonly(isLeaving),
     isCancellingInvitation: readonly(isCancellingInvitation),
+    isSchedulingDeletion: readonly(isSchedulingDeletion),
+    isRestoring: readonly(isRestoring),
     loadMembers,
     loadInvitations,
     invite,
@@ -125,6 +162,8 @@ export const useBandSpaceSettingsStore = defineStore('bandSpaceSettings', () => 
     updateRole,
     kickMember,
     leave,
+    scheduleDeletion,
+    restore,
     clear
   }
 })

--- a/assets/js/utils/date.js
+++ b/assets/js/utils/date.js
@@ -1,4 +1,5 @@
 import { format, parseISO } from 'date-fns'
+import { fr } from 'date-fns/locale'
 
 export function formatDate(dateString) {
   return format(parseISO(dateString), 'dd/MM/yyyy HH:mm')
@@ -18,4 +19,10 @@ export function formatDateCompactWithYear(dateString) {
   if (!dateString) return ''
   const date = parseISO(dateString)
   return date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+// Spelled-out date, for copy that has to read as a sentence: « supprimé le 29 août 2026 ».
+export function formatDateLong(dateString) {
+  if (!dateString) return ''
+  return format(parseISO(dateString), 'd MMMM yyyy', { locale: fr })
 }

--- a/assets/js/views/BandSpace/Settings.vue
+++ b/assets/js/views/BandSpace/Settings.vue
@@ -33,6 +33,7 @@
             <ActivitySection v-else-if="activeSection === 'activity'" />
             <ActiveSharesSection v-else-if="activeSection === 'shares'" />
             <QuotaIndicator v-else-if="activeSection === 'storage'" />
+            <DangerZoneSection v-else-if="activeSection === 'danger'" />
             <ComingSoonSection v-else :title="activeSectionLabel" />
           </div>
         </div>
@@ -48,6 +49,7 @@ import QuotaIndicator from '../../components/BandSpace/Files/QuotaIndicator.vue'
 import ActiveSharesSection from '../../components/BandSpace/Settings/ActiveSharesSection.vue'
 import ActivitySection from '../../components/BandSpace/Settings/ActivitySection.vue'
 import ComingSoonSection from '../../components/BandSpace/Settings/ComingSoonSection.vue'
+import DangerZoneSection from '../../components/BandSpace/Settings/DangerZoneSection.vue'
 import MembersSection from '../../components/BandSpace/Settings/MembersSection.vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
 
@@ -71,6 +73,19 @@ const activeSection = ref(allSections.find((s) => s.key === route.query.section)
 
 const activeSectionLabel = computed(
   () => allSections.find((s) => s.key === activeSection.value)?.label ?? ''
+)
+
+// The deletion banner links here with ?section=danger, and it is shown on the settings page too. Vue
+// Router reuses this instance on a query-only change, so without re-reading the query the URL would
+// update while the visible section stayed put.
+watch(
+  () => route.query.section,
+  (section) => {
+    const match = allSections.find((s) => s.key === section)
+    if (match) {
+      activeSection.value = match.key
+    }
+  }
 )
 
 watch(visibleSections, (sections) => {

--- a/assets/js/views/Legal/MentionsLegales.vue
+++ b/assets/js/views/Legal/MentionsLegales.vue
@@ -5,18 +5,32 @@
         Mentions légales
       </h1>
 
+      <p class="text-surface-600 dark:text-surface-300 mb-6">
+        Dernière mise à jour : {{ lastUpdate }}
+      </p>
+
       <div class="prose dark:prose-invert max-w-none space-y-8">
+        <!--
+          No postal address is published because the site currently has zero economic activity,
+          which is what triggers the CDE art. III.74 / XII.6 obligation. A geographic address
+          becomes mandatory as soon as any revenue exists (ads, affiliation, paid storage) or as
+          soon as the project is moved into a legal entity (ASBL, indépendant complémentaire,
+          société).
+        -->
         <section>
           <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
             1. Éditeur du site
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            Le site MusicAll est édité par Jérémy, personne physique.
+            Le site MusicAll est édité par Jérémy Tonneau, personne physique.
           </p>
           <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2 mt-4">
-            <li><strong>Email :</strong> <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a></li>
-            <li><strong>Directeur de la publication :</strong> Jérémy</li>
+            <li><strong>Contact :</strong> <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a></li>
+            <li><strong>Directeur de la publication :</strong> Jérémy Tonneau</li>
           </ul>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            MusicAll est un projet personnel à but non lucratif. Le site ne génère aucun revenu : ni publicité, ni affiliation, ni service payant.
+          </p>
         </section>
 
         <section>
@@ -24,7 +38,7 @@
             2. Hébergement
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            Le site est hébergé par :
+            Serveurs applicatifs et stockage des fichiers :
           </p>
           <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2 mt-4">
             <li><strong>Scaleway SAS</strong></li>
@@ -32,6 +46,9 @@
             <li>75008 Paris, France</li>
             <li><a href="https://www.scaleway.com" class="text-primary hover:text-primary-emphasis" target="_blank" rel="noopener">www.scaleway.com</a></li>
           </ul>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Les serveurs et le stockage objet (région fr-par, Paris) sont situés dans l'Union européenne.
+          </p>
         </section>
 
         <section>
@@ -39,10 +56,10 @@
             3. Propriété intellectuelle
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            L'ensemble du contenu de ce site (textes, images, vidéos, logos, design) est protégé par le droit d'auteur. Toute reproduction, représentation, modification ou exploitation non autorisée est interdite.
+            Le site MusicAll, son design, son code source, ses logos et son contenu éditorial sont protégés par le droit d'auteur. Toute reproduction, représentation, modification ou exploitation non autorisée est interdite.
           </p>
           <p class="text-surface-600 dark:text-surface-300 mt-4">
-            Les contenus publiés par les utilisateurs restent leur propriété. En les publiant sur MusicAll, ils accordent une licence d'utilisation non exclusive pour leur affichage sur la plateforme.
+            Les contenus publiés par les utilisateurs restent leur propriété. En les publiant sur MusicAll, ils accordent une licence non exclusive et gratuite permettant leur affichage et leur diffusion dans le cadre du fonctionnement de la plateforme.
           </p>
         </section>
 
@@ -51,36 +68,64 @@
             4. Données personnelles
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            Pour toute information concernant la collecte et le traitement de vos données personnelles, veuillez consulter notre
+            Pour toute information concernant la collecte et le traitement de vos données personnelles, consultez notre
             <RouterLink :to="{ name: 'app_privacy' }" class="text-primary hover:text-primary-emphasis">politique de confidentialité</RouterLink>.
           </p>
         </section>
 
         <section>
           <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            5. Cookies
+            5. Cookies et mesure d'audience
           </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Ce site utilise uniquement des cookies essentiels nécessaires à son fonctionnement (session de connexion). Aucun cookie publicitaire ou de suivi n'est utilisé. Pour plus d'informations, consultez notre
+          <p class="text-surface-600 dark:text-surface-300 mb-4">
+            Le site dépose uniquement les cookies nécessaires à son fonctionnement :
+          </p>
+          <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2">
+            <li><strong>jwt_hp</strong> et <strong>jwt_s</strong> : maintien de votre session de connexion (1 heure)</li>
+            <li><strong>refresh_token</strong> : renouvellement de votre session sans nouvelle saisie de mot de passe (30 jours)</li>
+            <li><strong>PHPSESSID</strong> : session technique du serveur (durée de votre navigation)</li>
+            <li><strong>is_dark_mode</strong> : mémorisation du thème clair ou sombre que vous avez choisi (1 an)</li>
+          </ul>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Aucun cookie publicitaire, de profilage ou de suivi entre sites n'est déposé par MusicAll. Il n'y a sur le site ni publicité, ni régie, ni suivi de conversion.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            La mesure d'audience est assurée par Umami, une solution auto-hébergée qui ne dépose pas de cookie et produit des statistiques agrégées.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            En revanche, certaines pages affichent des contenus fournis par des plateformes externes : vidéos YouTube, lecteurs Spotify et SoundCloud, et polices de caractères Google Fonts. Lorsque ces contenus sont chargés, votre navigateur communique directement avec ces plateformes, qui peuvent déposer leurs propres cookies. Le détail figure dans notre
             <RouterLink :to="{ name: 'app_privacy' }" class="text-primary hover:text-primary-emphasis">politique de confidentialité</RouterLink>.
           </p>
         </section>
 
         <section>
           <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            6. Mesure d'audience
+            6. Signalement d'un contenu illicite
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            Ce site utilise une solution de mesure d'audience auto-hébergée et respectueuse de la vie privée. Les données collectées sont anonymisées, ne nécessitent aucun cookie et sont utilisées uniquement pour améliorer le site. Aucune donnée n'est partagée avec des tiers.
+            Conformément au règlement (UE) 2022/2065 sur les services numériques, tout utilisateur ou toute entité peut signaler un contenu qu'il estime illicite en écrivant à
+            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Merci d'indiquer l'adresse (URL) du contenu concerné, la nature du problème et les motifs de votre signalement. Chaque signalement fait l'objet d'un accusé de réception, d'un examen, et d'une décision motivée communiquée à son auteur.
           </p>
         </section>
 
         <section>
           <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            7. Contact
+            7. Droit applicable
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            Pour toute question ou réclamation, vous pouvez nous contacter à l'adresse
+            Le site est édité et exploité depuis la Belgique. Il est soumis au droit belge.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            8. Contact
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            Pour toute question ou réclamation :
             <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.
           </p>
         </section>
@@ -93,4 +138,6 @@
 import { useTitle } from '@vueuse/core'
 
 useTitle('Mentions légales - MusicAll')
+
+const lastUpdate = '29 juillet 2026'
 </script>

--- a/assets/js/views/Legal/Privacy.vue
+++ b/assets/js/views/Legal/Privacy.vue
@@ -78,7 +78,8 @@
             <li>Les données déposées dans un Band Space ne sont ni revendues, ni exploitées à des fins publicitaires, ni utilisées pour du profilage. Elles ne sont consultées par l'éditeur que lorsque c'est strictement nécessaire au fonctionnement ou à la sécurité du service, ou pour répondre à une obligation légale.</li>
             <li>Lorsque vous quittez un espace, les contenus que vous y avez déposés y restent, afin que le travail du groupe reste cohérent. Vos entrées financières personnelles récurrentes sont désactivées et leurs échéances futures encore prévues sont supprimées.</li>
             <li>Lorsque vous supprimez votre compte, vos contenus Band Space restent également en place et votre appartenance à l'espace est conservée, mais votre nom d'utilisateur est remplacé par un identifiant anonyme.</li>
-            <li>L'application ne permet pas aujourd'hui de supprimer un Band Space. Les fichiers supprimés depuis l'application sont retirés de l'espace et ne sont plus accessibles à ses membres, mais restent stockés chez notre hébergeur. Pour demander la suppression complète d'un espace et de ses fichiers, écrivez à <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.</li>
+            <li>Un administrateur peut supprimer un Band Space. La suppression n'est pas immédiate : l'espace reste accessible pendant 30 jours, afin que chaque membre puisse récupérer ses fichiers, et un administrateur peut l'annuler pendant ce délai. Passé les 30 jours, l'espace et l'ensemble de ses contenus, fichiers compris, sont définitivement supprimés. Les membres sont informés dès qu'une suppression est programmée ou annulée.</li>
+            <li>Un fichier supprimé depuis un Band Space est immédiatement retiré de l'espace et n'est plus accessible à ses membres. Il est définitivement effacé de nos serveurs 30 jours plus tard.</li>
           </ul>
         </section>
 
@@ -129,7 +130,8 @@
             <li><strong>Journaux applicatifs :</strong> 10 jours</li>
             <li><strong>Sauvegardes :</strong> 1 an</li>
             <li><strong>Versions remplacées d'un fichier Band Space :</strong> 30 jours</li>
-            <li><strong>Fichiers Band Space supprimés depuis l'application :</strong> retirés de l'espace et rendus inaccessibles à ses membres, mais conservés chez l'hébergeur, aucune suppression automatique n'étant en place à ce jour</li>
+            <li><strong>Fichiers Band Space supprimés :</strong> 30 jours, puis effacement définitif</li>
+            <li><strong>Band Space supprimé :</strong> 30 jours, puis effacement définitif de l'espace et de tous ses contenus</li>
             <li><strong>Statistiques d'audience :</strong> conservées sous forme agrégée et non nominative</li>
           </ul>
         </section>
@@ -222,5 +224,5 @@ import { useTitle } from '@vueuse/core'
 
 useTitle('Politique de confidentialité - MusicAll')
 
-const lastUpdate = '29 juillet 2026'
+const lastUpdate = '31 juillet 2026'
 </script>

--- a/assets/js/views/Legal/Privacy.vue
+++ b/assets/js/views/Legal/Privacy.vue
@@ -15,149 +15,201 @@
             1. Responsable du traitement
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            Le site MusicAll est édité par Jérémy. Pour toute question relative à la protection de vos données personnelles, vous pouvez nous contacter à l'adresse :
-            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            2. Données collectées
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Nous collectons les données suivantes :
-          </p>
-          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li><strong>Données de compte</strong> : adresse email, nom d'utilisateur</li>
-            <li><strong>Données de profil</strong> : photo de profil (optionnelle), informations musicales que vous choisissez de partager (profil musicien, profil professeur, instruments, styles, localisation)</li>
-            <li><strong>Données de connexion</strong> : identifiants OAuth (Google, Facebook) si vous utilisez ces méthodes de connexion</li>
-            <li><strong>Données d'usage anonymisées</strong> : statistiques de visite (pages consultées, actions effectuées) collectées de manière anonyme sans cookies de suivi</li>
-            <li><strong>Données d'interaction</strong> : votes sur les publications, commentaires, messages privés, annonces</li>
-            <li><strong>Données techniques</strong> : informations sur les erreurs pour améliorer le service (via Sentry)</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            3. Finalités du traitement
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Vos données sont utilisées pour :
-          </p>
-          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li>Créer et gérer votre compte utilisateur</li>
-            <li>Vous permettre de vous connecter via Google ou Facebook</li>
-            <li>Vous permettre de publier du contenu et d'interagir avec la communauté</li>
-            <li>Analyser l'utilisation du site pour l'améliorer</li>
-            <li>Détecter et corriger les erreurs techniques</li>
-            <li>Vous envoyer des notifications liées à votre compte (si vous l'avez autorisé)</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            4. Base légale
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Le traitement de vos données repose sur votre consentement (lors de l'inscription) et sur l'exécution du contrat (fourniture du service MusicAll).
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            5. Services tiers
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Nous utilisons les services tiers suivants :
-          </p>
-          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li><strong>Google OAuth / Facebook Login</strong> : pour vous permettre de vous connecter avec vos comptes existants</li>
-            <li><strong>Sentry</strong> : pour détecter et corriger les erreurs techniques</li>
-          </ul>
-          <p class="text-surface-600 dark:text-surface-300 mt-4">
-            Ces services peuvent collecter des données conformément à leurs propres politiques de confidentialité.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            6. Mesure d'audience
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Nous utilisons Umami, une solution de mesure d'audience auto-hébergée sur nos propres serveurs. Cette solution respecte votre vie privée :
-          </p>
-          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li>Aucun cookie de suivi n'est déposé sur votre appareil</li>
-            <li>Les données sont anonymisées et ne permettent pas de vous identifier personnellement</li>
-            <li>Aucune donnée n'est partagée avec des tiers</li>
-            <li>Les données restent hébergées sur nos serveurs en Europe</li>
-          </ul>
-          <p class="text-surface-600 dark:text-surface-300 mt-4">
-            Ces statistiques sont utilisées uniquement pour comprendre comment le site est utilisé et l'améliorer.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            7. Cookies
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Nous utilisons uniquement des cookies essentiels nécessaires au fonctionnement du site, notamment pour maintenir votre session de connexion. Nous n'utilisons aucun cookie publicitaire ou de suivi.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            8. Durée de conservation
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Vos données sont conservées tant que votre compte est actif. Vous pouvez supprimer votre compte à tout moment depuis les paramètres de votre profil.
-          </p>
-          <p class="text-surface-600 dark:text-surface-300">
-            Lors de la suppression de votre compte, vos données personnelles (nom d'utilisateur, adresse email, mot de passe, photo de profil, comptes OAuth associés) sont anonymisées immédiatement. Vos publications, commentaires, messages et contributions au forum restent visibles sur la plateforme mais sont associés à un profil anonyme (« Utilisateur supprimé »).
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            9. Vos droits
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Conformément au RGPD, vous disposez des droits suivants :
-          </p>
-          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li><strong>Droit d'accès</strong> : obtenir une copie de vos données personnelles</li>
-            <li><strong>Droit de rectification</strong> : corriger vos données inexactes</li>
-            <li><strong>Droit à l'effacement</strong> : supprimer votre compte directement depuis les paramètres de votre profil, ou nous en faire la demande</li>
-            <li><strong>Droit à la portabilité</strong> : recevoir vos données dans un format structuré</li>
-            <li><strong>Droit d'opposition</strong> : vous opposer au traitement de vos données</li>
-            <li><strong>Droit de retirer votre consentement</strong> : à tout moment</li>
-          </ul>
-          <p class="text-surface-600 dark:text-surface-300 mt-4">
-            Pour exercer ces droits, contactez-nous à
-            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            10. Sécurité
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Nous mettons en place des mesures techniques et organisationnelles appropriées pour protéger vos données personnelles contre tout accès non autorisé, modification, divulgation ou destruction.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            11. Contact
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Pour toute question concernant cette politique de confidentialité ou vos données personnelles, contactez-nous à
-            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.
+            Le responsable du traitement de vos données personnelles est Jérémy Tonneau, éditeur du site MusicAll.
           </p>
           <p class="text-surface-600 dark:text-surface-300 mt-4">
-            Vous avez également le droit d'introduire une réclamation auprès de la CNIL (Commission Nationale de l'Informatique et des Libertés) si vous estimez que le traitement de vos données n'est pas conforme à la réglementation.
+            Contact : <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Aucun délégué à la protection des données n'a été désigné, cette désignation n'étant pas requise au vu de la nature et du volume des traitements réalisés.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            2. Données que nous traitons
+          </h2>
+          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
+            <li><strong>Compte</strong> : adresse email, nom d'utilisateur, mot de passe (stocké sous forme hachée)</li>
+            <li><strong>Connexion via Google</strong> (si vous choisissez ce mode de connexion) : identifiant de compte Google et adresse email associée</li>
+            <li><strong>Profil</strong> : photo de profil, image de couverture, biographie, instruments, styles musicaux, localisation, liens vers vos réseaux, fiches annuaire musicien et professeur</li>
+            <li><strong>Contenus publics</strong> : publications, cours, galeries, commentaires, messages du forum, annonces, votes et compteurs de vues</li>
+            <li><strong>Messages privés</strong> échangés avec d'autres utilisateurs</li>
+            <li><strong>Band Space</strong> : notes, tâches et leurs commentaires, entrées d'agenda, setlists, fichiers déposés, entrées financières (libellés, montants, catégories, échéances, répartitions), invitations, appartenances et journal d'activité de l'espace</li>
+            <li><strong>Notifications</strong> et préférences d'envoi d'emails</li>
+            <li><strong>Recherche assistée de musiciens</strong> : le texte libre que vous saisissez dans cette recherche</li>
+            <li><strong>Données techniques</strong> : adresse IP, journaux du serveur, rapports d'erreur applicative</li>
+            <li><strong>Mesure d'audience</strong> : statistiques de visite agrégées, sans cookie</li>
+          </ul>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Votre adresse IP sert à sécuriser le service et à limiter le débit des requêtes, et figure dans les journaux du serveur. Elle n'est pas conservée en base de données : les votes et les compteurs de vues reposent sur un identifiant haché qui ne permet pas de remonter à votre adresse.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            3. Finalités et bases légales
+          </h2>
+          <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2">
+            <li>Créer et gérer votre compte, vous permettre d'utiliser le site et Band Space : <strong>exécution du contrat</strong> (art. 6.1.b RGPD)</li>
+            <li>Vous permettre de vous connecter avec votre compte Google : <strong>exécution du contrat</strong></li>
+            <li>Sécuriser le service, prévenir les abus et le spam, limiter le débit des requêtes : <strong>intérêt légitime</strong> (art. 6.1.f)</li>
+            <li>Détecter et corriger les erreurs techniques : <strong>intérêt légitime</strong></li>
+            <li>Mesurer l'audience du site de façon agrégée afin de l'améliorer : <strong>intérêt légitime</strong></li>
+            <li>Interpréter votre recherche de musiciens en langage naturel pour la convertir en filtres : <strong>intérêt légitime</strong></li>
+            <li>Vous envoyer les emails nécessaires au fonctionnement de votre compte (validation d'adresse, réinitialisation de mot de passe, invitations) : <strong>exécution du contrat</strong></li>
+            <li>Vous envoyer les emails de suivi de votre activité (réponses, commentaires, messages reçus, récapitulatifs, actualités du site), que vous pouvez désactiver à tout moment depuis vos paramètres : <strong>intérêt légitime</strong></li>
+            <li>Vous envoyer des emails à caractère promotionnel : <strong>consentement</strong> (art. 6.1.a), désactivé par défaut et retirable à tout moment</li>
+            <li>Traiter les signalements de contenu et documenter les décisions de modération : <strong>obligation légale</strong></li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            4. Band Space, espace partagé
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300 mb-4">
+            Un Band Space est un espace de travail privé, partagé entre les membres d'un même groupe.
+          </p>
+          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
+            <li>Tout contenu déposé dans un Band Space est accessible à l'ensemble des membres de cet espace. En rejoignant un espace, vous acceptez cette visibilité.</li>
+            <li>L'administrateur de l'espace a accès à l'ensemble des contenus et gère les membres et les invitations.</li>
+            <li>Les entrées financières marquées comme personnelles sont visibles par tous les membres de l'espace. Elles sont seulement exclues des totaux et des graphiques du groupe, et ne peuvent être modifiées que par leur auteur. Ne saisissez donc pas dans ce module une information que vous ne souhaitez pas partager avec les autres membres.</li>
+            <li>Les données déposées dans un Band Space ne sont ni revendues, ni exploitées à des fins publicitaires, ni utilisées pour du profilage. Elles ne sont consultées par l'éditeur que lorsque c'est strictement nécessaire au fonctionnement ou à la sécurité du service, ou pour répondre à une obligation légale.</li>
+            <li>Lorsque vous quittez un espace, les contenus que vous y avez déposés y restent, afin que le travail du groupe reste cohérent. Vos entrées financières personnelles récurrentes sont désactivées et leurs échéances futures encore prévues sont supprimées.</li>
+            <li>Lorsque vous supprimez votre compte, vos contenus Band Space restent également en place et votre appartenance à l'espace est conservée, mais votre nom d'utilisateur est remplacé par un identifiant anonyme.</li>
+            <li>L'application ne permet pas aujourd'hui de supprimer un Band Space. Les fichiers supprimés depuis l'application sont retirés de l'espace et ne sont plus accessibles à ses membres, mais restent stockés chez notre hébergeur. Pour demander la suppression complète d'un espace et de ses fichiers, écrivez à <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            5. Destinataires et sous-traitants
+          </h2>
+          <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2">
+            <li><strong>Scaleway SAS</strong> : hébergement des serveurs et stockage des fichiers, France (UE)</li>
+            <li><strong>Amazon Web Services</strong> : stockage des sauvegardes chiffrées, région Europe (Paris), France (UE)</li>
+            <li><strong>Brevo</strong> : envoi des emails transactionnels, France (UE)</li>
+            <li><strong>Sentry</strong> : détection des erreurs applicatives</li>
+            <li><strong>Google Ireland Limited</strong> : connexion via compte Google, si vous l'utilisez, Irlande (UE)</li>
+            <li><strong>OpenAI</strong> : interprétation du texte libre de la recherche assistée de musiciens, États-Unis</li>
+            <li><strong>Komoot GmbH</strong> : suggestion de villes lorsque vous saisissez une localisation, Allemagne (UE)</li>
+            <li><strong>Google / YouTube</strong>, <strong>Spotify</strong> et <strong>SoundCloud</strong> : lecture des vidéos et des morceaux intégrés dans certaines pages</li>
+            <li><strong>Google Fonts</strong> : fourniture des polices de caractères du site</li>
+          </ul>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Les lecteurs Spotify et SoundCloud, ainsi que les vidéos YouTube affichées sur les profils de musiciens et de professeurs, ne sont chargés qu'au moment où vous cliquez pour les lancer. En revanche, les vidéos des publications de type vidéo et celles insérées dans le corps d'un article sont chargées dès l'ouverture de la page, comme les polices Google Fonts : votre navigateur transmet alors votre adresse IP à ces plateformes sans action de votre part.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Aucune donnée personnelle n'est vendue, louée ou cédée à des tiers à des fins publicitaires ou commerciales.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            6. Transferts en dehors de l'Union européenne
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            Vos données de compte, vos contenus et vos fichiers sont hébergés et sauvegardés dans l'Union européenne : les serveurs et les fichiers chez Scaleway en France, les sauvegardes chez Amazon Web Services en région Europe (Paris). Les sauvegardes sont chiffrées avant leur transmission : l'hébergeur n'a accès qu'à des données illisibles.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Deux traitements sortent de ce cadre. Le texte que vous saisissez dans la recherche assistée de musiciens est transmis à OpenAI, dont les serveurs sont situés aux États-Unis, afin d'être converti en filtres de recherche. Et lorsqu'une vidéo, un lecteur audio ou une police de caractères externe est chargé, votre navigateur communique directement avec Google, Spotify ou SoundCloud, dont les serveurs peuvent être situés en dehors de l'Union européenne.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            7. Durées de conservation
+          </h2>
+          <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2">
+            <li><strong>Compte et contenus associés :</strong> conservés tant que votre compte est actif</li>
+            <li><strong>Après suppression de votre compte :</strong> vos données personnelles sont anonymisées immédiatement, et l'enregistrement anonymisé est conservé afin de préserver la cohérence des contenus publics et des espaces de groupe</li>
+            <li><strong>Journaux d'accès au serveur web :</strong> 52 jours</li>
+            <li><strong>Journaux système :</strong> 90 jours au maximum</li>
+            <li><strong>Journaux applicatifs :</strong> 10 jours</li>
+            <li><strong>Sauvegardes :</strong> 1 an</li>
+            <li><strong>Versions remplacées d'un fichier Band Space :</strong> 30 jours</li>
+            <li><strong>Fichiers Band Space supprimés depuis l'application :</strong> retirés de l'espace et rendus inaccessibles à ses membres, mais conservés chez l'hébergeur, aucune suppression automatique n'étant en place à ce jour</li>
+            <li><strong>Statistiques d'audience :</strong> conservées sous forme agrégée et non nominative</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            8. Vos droits
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            Conformément au RGPD, vous disposez d'un droit d'accès, de rectification, d'effacement, de limitation, d'opposition et de portabilité, ainsi que du droit de retirer votre consentement à tout moment pour les traitements qui en dépendent.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Vous pouvez supprimer votre compte directement depuis les paramètres de votre profil. Pour tout autre droit, y compris pour obtenir une copie de vos données, écrivez à
+            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a> : ces demandes sont traitées manuellement, aucun export automatique n'étant disponible à ce jour. Nous répondons dans un délai d'un mois.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            9. Cookies
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300 mb-4">
+            MusicAll dépose uniquement les cookies nécessaires à son fonctionnement :
+          </p>
+          <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2">
+            <li><strong>jwt_hp</strong> et <strong>jwt_s</strong> : maintien de votre session de connexion (1 heure)</li>
+            <li><strong>refresh_token</strong> : renouvellement de votre session sans nouvelle saisie de mot de passe (30 jours)</li>
+            <li><strong>PHPSESSID</strong> : session technique du serveur (durée de votre navigation)</li>
+            <li><strong>is_dark_mode</strong> : mémorisation du thème clair ou sombre que vous avez choisi (1 an)</li>
+          </ul>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Aucun cookie publicitaire, de profilage ou de suivi entre sites n'est déposé par MusicAll, et la mesure d'audience fonctionne sans cookie. Les contenus externes décrits à la section 5 peuvent en revanche déposer leurs propres cookies lorsqu'ils sont chargés.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            10. Âge minimum
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            L'inscription à MusicAll est réservée aux personnes âgées de 15 ans ou plus.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            11. Sécurité
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            Les échanges avec le site sont chiffrés (HTTPS). Les mots de passe sont stockés sous forme hachée. L'accès aux contenus d'un Band Space est restreint à ses membres. La base de données fait l'objet de sauvegardes quotidiennes chiffrées, et les fichiers déposés bénéficient d'un mécanisme de versionnement.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Aucun système n'étant infaillible, nous vous recommandons d'utiliser un mot de passe unique pour votre compte MusicAll.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            12. Réclamation
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300 mb-4">
+            Si vous estimez que le traitement de vos données n'est pas conforme à la réglementation, vous pouvez introduire une réclamation auprès de l'Autorité de protection des données :
+          </p>
+          <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2">
+            <li><strong>Autorité de protection des données (APD)</strong></li>
+            <li>Rue de la Presse 35, 1000 Bruxelles, Belgique</li>
+            <li><a href="mailto:contact@apd-gba.be" class="text-primary hover:text-primary-emphasis">contact@apd-gba.be</a></li>
+            <li><a href="https://www.autoriteprotectiondonnees.be" class="text-primary hover:text-primary-emphasis" target="_blank" rel="noopener">www.autoriteprotectiondonnees.be</a></li>
+          </ul>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Si vous résidez dans un autre État membre de l'Union européenne, vous pouvez également saisir l'autorité de contrôle de votre pays de résidence.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            13. Contact
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>
           </p>
         </section>
       </div>
@@ -170,5 +222,5 @@ import { useTitle } from '@vueuse/core'
 
 useTitle('Politique de confidentialité - MusicAll')
 
-const lastUpdate = '8 février 2026'
+const lastUpdate = '29 juillet 2026'
 </script>

--- a/assets/js/views/Legal/Terms.vue
+++ b/assets/js/views/Legal/Terms.vue
@@ -84,8 +84,7 @@
             <strong>5.4 Départ d'un espace et suppression de compte.</strong> Lorsque vous quittez un espace, les contenus que vous y avez déposés y restent disponibles pour les autres membres, afin que le travail du groupe reste cohérent. Vos entrées financières personnelles récurrentes sont désactivées et leurs échéances futures encore prévues sont supprimées. Si vous supprimez votre compte, ces contenus restent également en place et votre appartenance à l'espace est conservée, mais votre nom d'utilisateur est remplacé par un identifiant anonyme.
           </p>
           <p class="text-surface-600 dark:text-surface-300 mt-4">
-            <strong>5.5 Suppression d'un espace.</strong> L'application ne permet pas aujourd'hui de supprimer un Band Space, et aucun délai de grâce n'est donc prévu. Les membres peuvent quitter l'espace individuellement. Pour demander la suppression complète d'un espace et de ses fichiers, écrivez à
-            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.
+            <strong>5.5 Suppression d'un espace.</strong> Seul un administrateur de l'espace peut le supprimer. La suppression est programmée et non immédiate : l'espace reste accessible pendant 30 jours, de sorte que chaque membre puisse récupérer ses fichiers, et tout administrateur peut annuler la suppression pendant ce délai. Les membres sont informés dès qu'une suppression est programmée ou annulée. À l'issue des 30 jours, l'espace et l'ensemble de ses contenus, fichiers compris, sont définitivement supprimés et ne peuvent plus être récupérés. Un fichier supprimé individuellement suit le même délai de 30 jours avant son effacement définitif.
           </p>
           <p class="text-surface-600 dark:text-surface-300 mt-4">
             <strong>5.6 Stockage.</strong> Chaque espace dispose d'un quota de stockage de 5 Go. Ce quota peut évoluer. Band Space n'est pas un service d'hébergement de fichiers à usage général : son utilisation doit rester liée à l'activité du groupe.
@@ -255,5 +254,5 @@ import { useTitle } from '@vueuse/core'
 
 useTitle("Conditions générales d'utilisation - MusicAll")
 
-const lastUpdate = '29 juillet 2026'
+const lastUpdate = '31 juillet 2026'
 </script>

--- a/assets/js/views/Legal/Terms.vue
+++ b/assets/js/views/Legal/Terms.vue
@@ -12,13 +12,13 @@
       <div class="prose dark:prose-invert max-w-none space-y-8">
         <section>
           <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            1. Présentation du site
+            1. Objet et éditeur
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            MusicAll est une plateforme communautaire dédiée aux musiciens et passionnés de musique. Le site permet de publier des articles, tutoriels, cours, et de mettre en relation des musiciens via des annonces.
+            MusicAll est une plateforme communautaire dédiée aux musiciens et aux passionnés de musique. Elle permet de publier des articles, tutoriels et cours, de participer à un forum, de déposer des annonces, de consulter des annuaires de musiciens et de professeurs, et de gérer un espace de travail de groupe (Band Space).
           </p>
           <p class="text-surface-600 dark:text-surface-300 mt-4">
-            Le site est édité par Jérémy. Pour toute question, vous pouvez nous contacter à l'adresse :
+            Le site est édité par Jérémy Tonneau. Contact :
             <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.
           </p>
         </section>
@@ -28,144 +28,221 @@
             2. Acceptation des conditions
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            L'utilisation du site MusicAll implique l'acceptation pleine et entière des présentes conditions générales d'utilisation. Si vous n'acceptez pas ces conditions, veuillez ne pas utiliser le site.
+            L'utilisation de MusicAll implique l'acceptation des présentes conditions. Si vous ne les acceptez pas, n'utilisez pas le site.
           </p>
         </section>
 
         <section>
           <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            3. Inscription et compte utilisateur
+            3. Inscription et compte
           </h2>
           <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Pour accéder à certaines fonctionnalités, vous devez créer un compte. Lors de l'inscription, vous vous engagez à :
+            La création d'un compte est nécessaire pour accéder à certaines fonctionnalités. Elle est réservée aux personnes âgées de 15 ans ou plus. Vous pouvez vous inscrire avec votre adresse email ou via votre compte Google.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mb-4">
+            En créant un compte, vous vous engagez à :
           </p>
           <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li>Fournir des informations exactes et à jour</li>
-            <li>Maintenir la confidentialité de vos identifiants de connexion</li>
-            <li>Être responsable de toutes les activités effectuées depuis votre compte</li>
-            <li>Nous informer immédiatement de toute utilisation non autorisée de votre compte</li>
+            <li>Fournir des informations exactes</li>
+            <li>Préserver la confidentialité de vos identifiants et ne pas les partager</li>
+            <li>Nous signaler sans délai toute utilisation non autorisée de votre compte</li>
           </ul>
           <p class="text-surface-600 dark:text-surface-300 mt-4">
-            Vous pouvez vous inscrire avec votre email ou via Google/Facebook. Vous devez avoir au moins 15 ans pour créer un compte (conformément au RGPD en France).
+            Vous êtes responsable des activités réalisées depuis votre compte.
           </p>
         </section>
 
         <section>
           <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            4. Contenu utilisateur
+            4. Contenus publiés sur la partie publique
           </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            En publiant du contenu sur MusicAll (articles, commentaires, annonces, images, etc.), vous :
+          <p class="text-surface-600 dark:text-surface-300">
+            En publiant du contenu sur MusicAll (articles, commentaires, messages du forum, annonces, images), vous garantissez en être l'auteur ou détenir les droits nécessaires.
           </p>
-          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li>Garantissez être l'auteur ou détenir les droits nécessaires sur ce contenu</li>
-            <li>Accordez à MusicAll une licence non exclusive pour afficher et distribuer ce contenu sur la plateforme</li>
-            <li>Restez propriétaire de vos contenus et pouvez les supprimer à tout moment</li>
-            <li>Acceptez qu'en cas de suppression de votre compte, vos contenus (publications, commentaires, messages, contributions au forum) restent visibles sur la plateforme mais soient associés à un profil anonyme</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            5. Comportement interdit
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Il est strictement interdit de :
-          </p>
-          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li>Publier du contenu illégal, diffamatoire, discriminatoire, haineux ou pornographique</li>
-            <li>Harceler, menacer ou intimider d'autres utilisateurs</li>
-            <li>Usurper l'identité d'une autre personne</li>
-            <li>Publier du spam ou du contenu promotionnel non autorisé</li>
-            <li>Tenter de pirater le site ou de nuire à son fonctionnement</li>
-            <li>Collecter des données personnelles d'autres utilisateurs sans leur consentement</li>
-            <li>Violer les droits de propriété intellectuelle de tiers</li>
-          </ul>
           <p class="text-surface-600 dark:text-surface-300 mt-4">
-            Tout manquement à ces règles peut entraîner la suspension ou la suppression de votre compte, sans préavis.
+            Vous conservez la propriété de vos contenus et accordez à MusicAll une licence non exclusive et gratuite permettant leur affichage et leur diffusion dans le cadre du fonctionnement du site.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            En cas de suppression de votre compte, vos contenus publics restent visibles mais sont rattachés à un profil anonyme. Vos profils public, musicien et professeur ne sont plus accessibles.
           </p>
         </section>
 
         <section>
           <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            6. Modération
+            5. Band Space
           </h2>
           <p class="text-surface-600 dark:text-surface-300">
-            Nous nous réservons le droit de modérer, modifier ou supprimer tout contenu qui ne respecterait pas les présentes conditions, sans obligation de justification. Les décisions de modération sont prises à notre seule discrétion.
+            <strong>5.1 Nature du service.</strong> Band Space est un espace de travail privé et gratuit mis à disposition des groupes. Il permet de gérer un agenda, des notes, des tâches, des setlists, des fichiers et un suivi financier prévisionnel.
           </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            7. Propriété intellectuelle
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Le site MusicAll, son design, son code source, ses logos et son contenu éditorial sont protégés par le droit de la propriété intellectuelle. Toute reproduction, distribution ou utilisation non autorisée est interdite.
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>5.2 Rôles et visibilité.</strong> L'espace est créé par un utilisateur qui en devient administrateur. Tout contenu déposé dans un espace est accessible à l'ensemble de ses membres. En rejoignant un espace, vous acceptez que les contenus que vous y déposez soient visibles par les autres membres.
           </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            8. Limitation de responsabilité
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            MusicAll est fourni "tel quel", sans garantie d'aucune sorte. Nous ne pouvons être tenus responsables :
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>5.3 Contenus déposés.</strong> Vous restez propriétaire des contenus que vous déposez et garantissez détenir les droits nécessaires sur les fichiers que vous téléversez.
           </p>
-          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
-            <li>Des contenus publiés par les utilisateurs</li>
-            <li>Des interruptions temporaires du service</li>
-            <li>Des pertes de données</li>
-            <li>Des dommages indirects liés à l'utilisation du site</li>
-            <li>Des relations entre utilisateurs (annonces, rencontres musicales, etc.)</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            9. Liens externes
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Le site peut contenir des liens vers des sites tiers. Nous n'avons aucun contrôle sur ces sites et déclinons toute responsabilité quant à leur contenu ou leurs pratiques.
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>5.4 Départ d'un espace et suppression de compte.</strong> Lorsque vous quittez un espace, les contenus que vous y avez déposés y restent disponibles pour les autres membres, afin que le travail du groupe reste cohérent. Vos entrées financières personnelles récurrentes sont désactivées et leurs échéances futures encore prévues sont supprimées. Si vous supprimez votre compte, ces contenus restent également en place et votre appartenance à l'espace est conservée, mais votre nom d'utilisateur est remplacé par un identifiant anonyme.
           </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            10. Modification des conditions
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Nous nous réservons le droit de modifier ces conditions à tout moment. Les utilisateurs seront informés des modifications importantes. La continuation de l'utilisation du site après modification vaut acceptation des nouvelles conditions.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            11. Résiliation
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300 mb-4">
-            Vous pouvez supprimer votre compte à tout moment depuis les paramètres de votre profil. Nous nous réservons également le droit de suspendre ou supprimer votre compte en cas de violation des présentes conditions.
-          </p>
-          <p class="text-surface-600 dark:text-surface-300">
-            Lors de la suppression, vos données personnelles sont anonymisées immédiatement. Vos publications, commentaires, messages et contributions au forum restent visibles mais sont associés à un profil anonyme (« Utilisateur supprimé »). Votre profil public, profil musicien et profil professeur ne seront plus accessibles.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            12. Droit applicable
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Les présentes conditions sont régies par le droit français. En cas de litige, une solution amiable sera recherchée avant toute action judiciaire. À défaut, les tribunaux français seront seuls compétents.
-          </p>
-        </section>
-
-        <section>
-          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
-            13. Contact
-          </h2>
-          <p class="text-surface-600 dark:text-surface-300">
-            Pour toute question concernant ces conditions d'utilisation, contactez-nous à
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>5.5 Suppression d'un espace.</strong> L'application ne permet pas aujourd'hui de supprimer un Band Space, et aucun délai de grâce n'est donc prévu. Les membres peuvent quitter l'espace individuellement. Pour demander la suppression complète d'un espace et de ses fichiers, écrivez à
             <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>5.6 Stockage.</strong> Chaque espace dispose d'un quota de stockage de 5 Go. Ce quota peut évoluer. Band Space n'est pas un service d'hébergement de fichiers à usage général : son utilisation doit rester liée à l'activité du groupe.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>5.7 Module Finances.</strong> Le module Finances est un outil de suivi et de prévision à usage interne. Il ne constitue ni un outil de comptabilité, ni un outil de facturation, ni un outil de déclaration fiscale, et ne se substitue pas aux obligations légales du groupe ou de ses membres. Les montants saisis relèvent de la seule responsabilité des utilisateurs. Les entrées marquées comme personnelles restent visibles par tous les membres de l'espace : elles sont seulement exclues des totaux du groupe et ne peuvent être modifiées que par leur auteur.
+          </p>
+          <!--
+            The word "sauvegarde" is deliberately avoided here. The restic backup covers /srv/www and
+            the MariaDB dumps only - Band Space files live in object storage and are NOT backed up.
+            Bucket versioning is an undo mechanism, not a backup: same provider, same account, same
+            bucket. Do not upgrade this wording to "des sauvegardes sont réalisées" until an off-site
+            copy of the bucket exists.
+          -->
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>5.8 Protection et conservation de vos fichiers.</strong> Les fichiers déposés dans un Band Space sont stockés sur un service disposant d'un mécanisme de versionnement : lorsqu'un fichier est remplacé par une nouvelle version, la version précédente reste récupérable pendant 30 jours. Ce mécanisme ne constitue pas une sauvegarde indépendante et ne protège pas contre tous les scénarios de perte. Nous vous recommandons de conserver vos propres copies des documents importants.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            6. Comportements interdits
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300 mb-4">
+            Il est interdit de :
+          </p>
+          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
+            <li>publier un contenu illicite, diffamatoire, discriminatoire, haineux, violent ou pornographique ;</li>
+            <li>harceler, menacer ou intimider d'autres utilisateurs ;</li>
+            <li>usurper l'identité d'une autre personne ;</li>
+            <li>publier du spam ou du contenu promotionnel non sollicité ;</li>
+            <li>tenter de porter atteinte à la sécurité ou au fonctionnement du site ;</li>
+            <li>collecter les données personnelles d'autres utilisateurs sans leur consentement ;</li>
+            <li>violer les droits de propriété intellectuelle de tiers ;</li>
+            <li>utiliser Band Space comme espace de stockage de fichiers sans lien avec l'activité d'un groupe ;</li>
+            <li>contourner les quotas ou les limitations techniques du service.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            7. Modération, signalement et recours
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            <strong>7.1 Signalement.</strong> Conformément au règlement (UE) 2022/2065, vous pouvez signaler tout contenu que vous estimez illicite en écrivant à
+            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>, en indiquant l'URL concernée, la nature du problème et les motifs du signalement. Vous recevrez un accusé de réception et serez informé de la suite donnée.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>7.2 Moyens de modération.</strong> La modération est assurée humainement, après signalement ou lors de l'examen des publications et galeries soumises à validation. Le site applique par ailleurs des mesures techniques automatiques qui limitent le nombre de contenus pouvant être créés sur une période donnée, et un filtrage du code HTML des contenus publiés afin d'écarter les éléments dangereux. Ces mesures techniques n'entraînent ni la suppression d'un contenu, ni la restriction d'un compte : aucune décision de modération n'est prise sur une base purement automatisée.
+          </p>
+          <!--
+            7.3 describes a behaviour that is only partly implemented: the author is notified when a
+            publication or gallery is approved or rejected (PublicationModerationListener /
+            GalleryModerationListener), but the notification carries no reason, no legal basis and no
+            remedy. The rest is a legal commitment honoured manually until the statement-of-reasons
+            flow is built.
+          -->
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>7.3 Décision motivée.</strong> Lorsqu'un contenu est retiré ou rendu inaccessible, ou lorsqu'un compte est suspendu ou supprimé pour un motif de modération, l'utilisateur concerné est informé du motif de la décision, du fondement invoqué (disposition légale ou clause des présentes conditions), des faits pris en compte et des voies de recours à sa disposition.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            <strong>7.4 Recours.</strong> Vous pouvez contester une décision de modération en écrivant à
+            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>. Vous conservez la possibilité de saisir les juridictions compétentes.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            8. Disponibilité du service
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            MusicAll est fourni gratuitement, en l'état et selon sa disponibilité, sans engagement de niveau de service. Le service peut être interrompu temporairement, notamment pour maintenance.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Les fonctionnalités peuvent évoluer, être modifiées ou supprimées. En cas d'arrêt définitif d'un service comportant des données utilisateur, un préavis raisonnable sera donné afin de permettre leur récupération.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            9. Rôle d'intermédiaire
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            MusicAll met en relation des utilisateurs (annonces de musiciens, cours, groupes) mais n'est pas partie aux relations, accords ou transactions qui en découlent. Nous ne vérifions ni l'identité, ni les qualifications, ni les intentions des personnes inscrites. Il vous appartient de faire preuve de prudence dans vos échanges et vos rencontres.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            10. Propriété intellectuelle
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            Le site MusicAll, son design, son code source, ses logos et son contenu éditorial sont protégés par le droit d'auteur. Toute reproduction ou utilisation non autorisée est interdite.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            11. Responsabilité
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300 mb-4">
+            Dans les limites permises par la loi :
+          </p>
+          <ul class="list-disc list-inside text-surface-600 dark:text-surface-300 space-y-2">
+            <li>MusicAll n'est pas responsable des contenus publiés par les utilisateurs, dans les conditions prévues par le règlement (UE) 2022/2065 ;</li>
+            <li>MusicAll n'est pas responsable des relations nouées entre utilisateurs ;</li>
+            <li>MusicAll n'est pas responsable des dommages indirects résultant de l'utilisation du service ;</li>
+            <li>MusicAll met en œuvre des moyens raisonnables pour préserver les données mais ne garantit pas l'absence de perte ou d'altération.</li>
+          </ul>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Ces limitations ne s'appliquent pas en cas de dol ou de faute lourde, ni en cas de dommage résultant d'une atteinte à la vie ou à l'intégrité physique. Elles ne portent pas atteinte aux droits impératifs dont bénéficient les consommateurs en vertu de la loi applicable.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            12. Modification des conditions
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            Les présentes conditions peuvent être modifiées. En cas de modification substantielle, les utilisateurs inscrits en sont informés avant son entrée en vigueur. La poursuite de l'utilisation du service après cette date vaut acceptation.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            13. Résiliation
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            Vous pouvez supprimer votre compte à tout moment depuis les paramètres de votre profil.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Nous pouvons suspendre ou supprimer un compte en cas de violation des présentes conditions, dans les conditions prévues à l'article 7.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            Lors de la suppression, vos données personnelles sont anonymisées immédiatement : nom d'utilisateur, adresse email, mot de passe, photo de profil, image de couverture, biographie, localisation, liens sociaux et compte Google associé. Vos contenus publics et vos contenus Band Space restent en place, rattachés à un profil anonyme, comme décrit aux articles 4 et 5.4.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            14. Droit applicable et litiges
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            Le service est édité et exploité depuis la Belgique. Les présentes conditions sont régies par le droit belge, sans préjudice des dispositions impératives de protection des consommateurs applicables dans le pays de résidence habituelle de l'utilisateur.
+          </p>
+          <p class="text-surface-600 dark:text-surface-300 mt-4">
+            En cas de litige, une solution amiable sera recherchée en priorité en écrivant à
+            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>. À défaut, les juridictions compétentes seront déterminées conformément aux règles applicables, l'utilisateur ayant la qualité de consommateur conservant la faculté de saisir les juridictions de son lieu de résidence.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 mb-4">
+            15. Contact
+          </h2>
+          <p class="text-surface-600 dark:text-surface-300">
+            <a href="mailto:contact@musicall.com" class="text-primary hover:text-primary-emphasis">contact@musicall.com</a>
           </p>
         </section>
       </div>
@@ -178,5 +255,5 @@ import { useTitle } from '@vueuse/core'
 
 useTitle("Conditions générales d'utilisation - MusicAll")
 
-const lastUpdate = '8 février 2026'
+const lastUpdate = '29 juillet 2026'
 </script>

--- a/migrations/2026/07/Version20260730073334.php
+++ b/migrations/2026/07/Version20260730073334.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260730073334 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add band_space.deletion_scheduled_datetime for the 30-day deletion grace period (#748)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space ADD deletion_scheduled_datetime DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space DROP deletion_scheduled_datetime');
+    }
+}

--- a/src/ApiResource/BandSpace/BandSpace.php
+++ b/src/ApiResource/BandSpace/BandSpace.php
@@ -4,9 +4,11 @@ namespace App\ApiResource\BandSpace;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\BandSpaceDeleteProcessor;
 use App\State\Provider\BandSpace\BandSpaceCollectionProvider;
 use App\State\Provider\BandSpace\BandSpaceItemProvider;
 
@@ -27,11 +29,27 @@ use App\State\Provider\BandSpace\BandSpaceItemProvider;
             name: 'api_band_spaces_get_item',
             provider: BandSpaceItemProvider::class,
         ),
-    ]
+        // Schedules the deletion, it does not delete: app:band-space:purge removes the space and its
+        // files once deletionScheduledDatetime has passed. Restore with api_band_space_restore.
+        new Delete(
+            uriTemplate: '/band_spaces/{id}',
+            openapi: new Operation(tags: ['Band Space']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_spaces_delete',
+            provider: BandSpaceItemProvider::class,
+            processor: BandSpaceDeleteProcessor::class,
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
 )]
 class BandSpace
 {
     public string $id;
     public string $name;
     public string $role;
+
+    /**
+     * Set when the space is pending deletion, so members can be warned and admins offered a restore.
+     */
+    public ?string $deletionScheduledDatetime = null;
 }

--- a/src/ApiResource/BandSpace/BandSpaceCreate.php
+++ b/src/ApiResource/BandSpace/BandSpaceCreate.php
@@ -12,6 +12,9 @@ use Symfony\Component\Validator\Constraints as Assert;
     openapi: new Operation(tags: ['Band Space']),
     security: 'is_granted("ROLE_USER")',
     output: BandSpace::class,
+    // Same context as the BandSpace resource itself: the front-end merges this response into the list
+    // fed by GET /band_spaces, so both have to serialise the DTO identically, nulls included.
+    normalizationContext: ['skip_null_values' => false],
     name: 'api_band_spaces_post_collection',
     processor: BandSpaceCreateProcessor::class,
 )]

--- a/src/ApiResource/BandSpace/BandSpaceRestore.php
+++ b/src/ApiResource/BandSpace/BandSpaceRestore.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\BandSpaceRestoreProcessor;
+
+#[ApiResource(
+    operations: [
+        new Post(
+            uriTemplate: '/band_spaces/{bandSpaceId}/restore',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            status: 204,
+            openapi: new Operation(tags: ['Band Space']),
+            security: "is_granted('ROLE_USER')",
+            input: false,
+            output: false,
+            name: 'api_band_space_restore',
+            processor: BandSpaceRestoreProcessor::class,
+        ),
+    ],
+)]
+class BandSpaceRestore
+{
+    #[ApiProperty(identifier: true)]
+    public string $bandSpaceId;
+}

--- a/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
+++ b/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFileVersionRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Makes deletions in Band Space actually reach the object storage (#748).
+ *
+ * Deleting a file only sets archiveDatetime, and deleting a space only sets deletionScheduledDatetime;
+ * neither removes anything from storage. Worse, the storage objects cannot be reclaimed by the bucket
+ * lifecycle rule either, because that rule expires *non-current* versions and only ever fires on a real
+ * DELETE. Without this command the bucket grows forever.
+ *
+ * Storage is always deleted before the rows: if storage fails, the rows survive and the next run retries.
+ * The reverse order would lose the only pointer to the object and orphan it permanently.
+ */
+#[AsCommand(
+    name: 'app:band-space:purge',
+    description: 'Delete archived Band Space files and spaces past their grace period, from the database and from object storage',
+)]
+class PurgeBandSpaceStorageCommand extends Command
+{
+    private const int DEFAULT_DAYS = 30;
+
+    /**
+     * Mirrors the directory namer of the band_space_file mapping (config/packages/vich_uploader.yaml):
+     * every object of a space lives under this prefix, so a space can be wiped in one batched call.
+     */
+    private const string STORAGE_PREFIX = 'band_space_files';
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly BandSpaceRepository $bandSpaceRepository,
+        private readonly BandSpaceFileRepository $bandSpaceFileRepository,
+        private readonly BandSpaceFileVersionRepository $bandSpaceFileVersionRepository,
+        private readonly FilesystemOperator $musicallFilesystem,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'days',
+                'd',
+                InputOption::VALUE_REQUIRED,
+                'Delete files archived more than this many days ago',
+                (string) self::DEFAULT_DAYS,
+            )
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would be deleted without deleting anything');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $days = (int) $input->getOption('days');
+        if ($days < 0) {
+            $output->writeln('<error>Option --days cannot be negative</error>');
+
+            return Command::FAILURE;
+        }
+
+        $isDryRun = (bool) $input->getOption('dry-run');
+        if ($isDryRun) {
+            $output->writeln('<comment>Dry run: nothing will be deleted</comment>');
+        }
+
+        $now = new DateTimeImmutable();
+        $cutoff = $now->modify(sprintf('-%d days', $days));
+
+        $failures = $this->purgeArchivedFiles($output, $cutoff, $isDryRun);
+        $failures += $this->purgeScheduledBandSpaces($output, $now, $isDryRun);
+
+        return $failures === 0 ? Command::SUCCESS : Command::FAILURE;
+    }
+
+    /**
+     * Versions are removed one by one through the ORM on purpose: BandSpaceFile has no association to
+     * them, so a plain remove() of the file would drop the rows by FK cascade without VichUploader ever
+     * running, leaving every object behind in the bucket.
+     *
+     * @return int the number of files that could not be purged
+     */
+    private function purgeArchivedFiles(OutputInterface $output, DateTimeImmutable $cutoff, bool $isDryRun): int
+    {
+        $files = $this->bandSpaceFileRepository->findArchivedOlderThan($cutoff);
+        if ($files === []) {
+            $output->writeln(sprintf('<info>No archived file older than %s</info>', $cutoff->format('Y-m-d H:i:s')));
+
+            return 0;
+        }
+
+        $purged = 0;
+        $failures = 0;
+
+        foreach ($files as $file) {
+            if ($isDryRun) {
+                $output->writeln(sprintf('  would delete file %s (%s)', (string) $file->id, $file->originalName));
+                ++$purged;
+
+                continue;
+            }
+
+            try {
+                $this->purgeFile($file);
+                ++$purged;
+            } catch (\Throwable $e) {
+                ++$failures;
+                $this->logger->error('Failed to purge archived band space file', [
+                    'band_space_file_id' => (string) $file->id,
+                    'exception' => $e,
+                ]);
+                $output->writeln(sprintf('<error>Failed to purge file %s: %s</error>', (string) $file->id, $e->getMessage()));
+            }
+        }
+
+        $output->writeln(sprintf(
+            '<info>%s %d archived file(s) older than %s</info>',
+            $isDryRun ? 'Would delete' : 'Deleted',
+            $purged,
+            $cutoff->format('Y-m-d H:i:s'),
+        ));
+
+        return $failures;
+    }
+
+    private function purgeFile(BandSpaceFile $file): void
+    {
+        // Detach the pointer first. The database would cope on its own (the FK is ON DELETE SET NULL),
+        // but this keeps Doctrine's in-memory graph honest: no managed entity is left pointing at a row
+        // that has just been removed.
+        $file->currentVersion = null;
+        $this->entityManager->flush();
+
+        // No explicit storage call here, unlike purgeBandSpace(): VichUploader listens on the removal of
+        // an uploadable entity and deletes the object itself (delete_on_remove, on by default). That is
+        // the whole reason the versions go through the ORM one by one instead of dying by FK cascade.
+        foreach ($this->bandSpaceFileVersionRepository->findByFileNewestFirst($file) as $version) {
+            $this->entityManager->remove($version);
+        }
+        $this->entityManager->flush();
+
+        $this->entityManager->remove($file);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @return int the number of spaces that could not be purged
+     */
+    private function purgeScheduledBandSpaces(OutputInterface $output, DateTimeImmutable $now, bool $isDryRun): int
+    {
+        $bandSpaces = $this->bandSpaceRepository->findScheduledForDeletion($now);
+        if ($bandSpaces === []) {
+            $output->writeln('<info>No band space past its deletion grace period</info>');
+
+            return 0;
+        }
+
+        $purged = 0;
+        $failures = 0;
+
+        foreach ($bandSpaces as $bandSpace) {
+            if ($isDryRun) {
+                $output->writeln(sprintf('  would delete band space %s (%s)', (string) $bandSpace->id, $bandSpace->name));
+                ++$purged;
+
+                continue;
+            }
+
+            try {
+                $this->purgeBandSpace($bandSpace);
+                ++$purged;
+            } catch (\Throwable $e) {
+                ++$failures;
+                $this->logger->error('Failed to purge band space', [
+                    'band_space_id' => (string) $bandSpace->id,
+                    'exception' => $e,
+                ]);
+                $output->writeln(sprintf('<error>Failed to purge band space %s: %s</error>', (string) $bandSpace->id, $e->getMessage()));
+            }
+        }
+
+        $output->writeln(sprintf(
+            '<info>%s %d band space(s) past their grace period</info>',
+            $isDryRun ? 'Would delete' : 'Deleted',
+            $purged,
+        ));
+
+        return $failures;
+    }
+
+    /**
+     * Objects first, then the rows: deleteById() drops every child row by FK cascade, and a cascade at
+     * database level never reaches VichUploader, so the storage prefix has to go on its own.
+     */
+    private function purgeBandSpace(BandSpace $bandSpace): void
+    {
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->musicallFilesystem->deleteDirectory(self::STORAGE_PREFIX . '/' . $bandSpaceId);
+
+        $this->bandSpaceRepository->deleteById($bandSpaceId);
+    }
+}

--- a/src/Entity/BandSpace/BandSpace.php
+++ b/src/Entity/BandSpace/BandSpace.php
@@ -4,6 +4,7 @@ namespace App\Entity\BandSpace;
 
 use App\Repository\BandSpace\BandSpaceRepository;
 use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -33,6 +34,14 @@ class BandSpace
 
     #[ORM\Column(type: Types::BIGINT, nullable: true)]
     public ?int $quotaBytesOverride = null;
+
+    /**
+     * When set, the space is pending deletion and app:band-space:purge removes it once this date has
+     * passed. The due date is stored rather than the request date so the date shown to members and the
+     * purge condition can never drift apart.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    public ?DateTimeImmutable $deletionScheduledDatetime = null;
 
     /**
      * @var Collection<int, BandSpaceMembership>

--- a/src/Enum/BandSpace/BandSpaceSettingsActivityType.php
+++ b/src/Enum/BandSpace/BandSpaceSettingsActivityType.php
@@ -13,4 +13,6 @@ enum BandSpaceSettingsActivityType: string
     case InvitationDeclined = 'invitation_declined';
     case InvitationRevoked = 'invitation_revoked';
     case InvitationExpired = 'invitation_expired';
+    case DeletionScheduled = 'deletion_scheduled';
+    case DeletionCancelled = 'deletion_cancelled';
 }

--- a/src/Enum/Notification/NotificationType.php
+++ b/src/Enum/Notification/NotificationType.php
@@ -23,4 +23,6 @@ enum NotificationType: string
     case BandSpaceMemberRemoved = 'band_space_member_removed';
     case BandSpaceAgendaEntryCreated = 'band_space_agenda_entry_created';
     case BandSpaceFinanceSplitAssigned = 'band_space_finance_split_assigned';
+    case BandSpaceDeletionScheduled = 'band_space_deletion_scheduled';
+    case BandSpaceDeletionCancelled = 'band_space_deletion_cancelled';
 }

--- a/src/Event/BandSpaceDeletionStateChangedEvent.php
+++ b/src/Event/BandSpaceDeletionStateChangedEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\User;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BandSpaceDeletionStateChangedEvent extends Event
+{
+    /**
+     * @param bool $scheduled true when the deletion was just scheduled, false when it was cancelled
+     *                        (the discriminator the listener maps to a notification type)
+     */
+    public function __construct(
+        public readonly BandSpace $bandSpace,
+        public readonly User $actor,
+        public readonly bool $scheduled,
+    ) {
+    }
+}

--- a/src/EventSubscriber/BandSpaceDeletionStateChangedListener.php
+++ b/src/EventSubscriber/BandSpaceDeletionStateChangedListener.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\User;
+use App\Enum\Notification\NotificationType;
+use App\Event\BandSpaceDeletionStateChangedEvent;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Service\Notification\NotificationCreator;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * Notifies the active members when an admin schedules a band space for deletion or cancels it (#748).
+ * A grace period is worthless if nobody is told, so this is what gives the other members their 30 days
+ * to retrieve their files or ask an admin to restore the space.
+ *
+ * One listener for both outcomes, discriminated by the event flag - same shape as
+ * BandSpaceInvitationRespondedListener. Best-effort per the epic #689 resilience contract: dispatched
+ * after the commit, and the whole body (including the member-resolution query) is wrapped so it can
+ * never roll back or 500 the action. The actor is excluded; createForRecipients dedupes by user id.
+ *
+ * No enricher: band_space_name is a point-in-time label, and once the purge has run there is nothing
+ * left to deep-link to anyway.
+ */
+#[AsEventListener]
+readonly class BandSpaceDeletionStateChangedListener
+{
+    public function __construct(
+        private NotificationCreator $notificationCreator,
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(BandSpaceDeletionStateChangedEvent $event): void
+    {
+        $bandSpace = $event->bandSpace;
+        $actor = $event->actor;
+        $actorId = (string) $actor->id;
+
+        try {
+            $memberships = $this->bandSpaceMembershipRepository->findByBandSpace($bandSpace);
+            $recipients = array_filter(
+                array_map(static fn (BandSpaceMembership $membership): User => $membership->user, $memberships),
+                static fn (User $user): bool => (string) $user->id !== $actorId,
+            );
+            if ($recipients === []) {
+                return;
+            }
+
+            $type = $event->scheduled
+                ? NotificationType::BandSpaceDeletionScheduled
+                : NotificationType::BandSpaceDeletionCancelled;
+
+            $this->notificationCreator->createForRecipients($recipients, $type, [
+                'band_space_id' => (string) $bandSpace->id,
+                'band_space_name' => $bandSpace->name,
+                'scheduled_for' => $bandSpace->deletionScheduledDatetime?->format(\DateTimeInterface::ATOM),
+                'actor_id' => $actorId,
+                'actor_username' => $actor->username,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to create band space deletion notifications', [
+                'band_space_id' => (string) $bandSpace->id,
+                'scheduled' => $event->scheduled,
+                'exception' => $e,
+            ]);
+        }
+    }
+}

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -47,6 +47,24 @@ class BandSpaceFileRepository extends ServiceEntityRepository
         return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
+    /**
+     * Files archived before the cutoff, for app:band-space:purge. Deliberately not scoped to a band
+     * space: the command sweeps the whole table. Unbounded on purpose - the daily run only ever sees
+     * one day's worth of newly-due files; add a limit here if that stops being true.
+     *
+     * @return BandSpaceFile[]
+     */
+    public function findArchivedOlderThan(\DateTimeImmutable $cutoff): array
+    {
+        return $this->createQueryBuilder('bsf')
+            ->where('bsf.archiveDatetime IS NOT NULL')
+            ->andWhere('bsf.archiveDatetime <= :cutoff')
+            ->setParameter('cutoff', $cutoff)
+            ->orderBy('bsf.archiveDatetime', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?BandSpaceFile
     {
         return $this->createQueryBuilder('bsf')

--- a/src/Repository/BandSpace/BandSpaceRepository.php
+++ b/src/Repository/BandSpace/BandSpaceRepository.php
@@ -38,6 +38,40 @@ class BandSpaceRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Spaces whose grace period has elapsed, for app:band-space:purge.
+     *
+     * @return BandSpace[]
+     */
+    public function findScheduledForDeletion(\DateTimeImmutable $now): array
+    {
+        return $this->createQueryBuilder('bs')
+            ->where('bs.deletionScheduledDatetime IS NOT NULL')
+            ->andWhere('bs.deletionScheduledDatetime <= :now')
+            ->setParameter('now', $now)
+            ->orderBy('bs.deletionScheduledDatetime', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Hard-deletes a space in one statement, for app:band-space:purge. Deliberately a bulk DQL delete
+     * rather than an ORM remove(): hydrating a whole space and its children just to delete them would be
+     * pointless work, and every child table cascades from band_space at database level anyway.
+     *
+     * Two consequences the caller has to know about. A bulk delete never fires lifecycle events, so
+     * VichUploader does not run and the stored objects must be removed separately - which is exactly why
+     * app:band-space:purge deletes the storage prefix first. And the entities stay in Doctrine's identity
+     * map, so anything that re-reads them in the same process sees rows that no longer exist.
+     */
+    public function deleteById(string $id): void
+    {
+        $this->getEntityManager()
+            ->createQuery('DELETE FROM App\Entity\BandSpace\BandSpace bs WHERE bs.id = :id')
+            ->setParameter('id', $id)
+            ->execute();
+    }
+
     public function countAdminByUser(User $user): int
     {
         return (int) $this->createQueryBuilder('bs')

--- a/src/Service/Builder/BandSpace/BandSpaceBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceBuilder.php
@@ -27,6 +27,7 @@ readonly class BandSpaceBuilder
         $dto->id = (string) $entity->id;
         $dto->name = $entity->name;
         $dto->role = $role->value;
+        $dto->deletionScheduledDatetime = $entity->deletionScheduledDatetime?->format(\DateTimeInterface::ATOM);
 
         return $dto;
     }

--- a/src/State/Processor/BandSpace/BandSpaceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceDeleteProcessor.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\BandSpace as BandSpaceResource;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceSettingsActivityType;
+use App\Event\BandSpaceDeletionStateChangedEvent;
+use App\Security\BandSpace\BandSpaceAdminChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Schedules a band space for deletion instead of deleting it. The space stays listed and usable during
+ * the grace period so members can still download their files; app:band-space:purge removes the rows and
+ * the stored objects once the due date has passed, and BandSpaceRestoreProcessor cancels it before then.
+ *
+ * @implements ProcessorInterface<BandSpaceResource, void>
+ */
+readonly class BandSpaceDeleteProcessor implements ProcessorInterface
+{
+    /**
+     * Kept in sync with the durations announced in the privacy policy and the terms.
+     */
+    private const int GRACE_PERIOD_DAYS = 30;
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceAdminChecker $adminChecker,
+        private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private Security $security,
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    /**
+     * @param BandSpaceResource $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['id'], $user);
+
+        if ($bandSpace->deletionScheduledDatetime instanceof DateTimeImmutable) {
+            throw new ConflictHttpException('La suppression de cet espace est déjà programmée');
+        }
+
+        $scheduledFor = new DateTimeImmutable(sprintf('+%d days', self::GRACE_PERIOD_DAYS));
+        $bandSpace->deletionScheduledDatetime = $scheduledFor;
+
+        $this->bandSpaceActivityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Settings,
+            type: BandSpaceSettingsActivityType::DeletionScheduled,
+            resourceId: (string) $bandSpace->id,
+            actor: $user,
+            payload: ['scheduled_for' => $scheduledFor->format(DateTimeInterface::ATOM)],
+        );
+
+        $this->entityManager->flush();
+
+        // Best-effort notification dispatched after the commit (epic #689 contract).
+        $this->eventDispatcher->dispatch(new BandSpaceDeletionStateChangedEvent($bandSpace, $user, true));
+    }
+}

--- a/src/State/Processor/BandSpace/BandSpaceRestoreProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceRestoreProcessor.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceSettingsActivityType;
+use App\Event\BandSpaceDeletionStateChangedEvent;
+use App\Security\BandSpace\BandSpaceAdminChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Cancels a scheduled deletion, as long as app:band-space:purge has not run yet.
+ *
+ * @implements ProcessorInterface<mixed, void>
+ */
+readonly class BandSpaceRestoreProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceAdminChecker $adminChecker,
+        private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private Security $security,
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
+
+        if (!$bandSpace->deletionScheduledDatetime instanceof DateTimeImmutable) {
+            throw new ConflictHttpException('La suppression de cet espace n\'est pas programmée');
+        }
+
+        $bandSpace->deletionScheduledDatetime = null;
+
+        $this->bandSpaceActivityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Settings,
+            type: BandSpaceSettingsActivityType::DeletionCancelled,
+            resourceId: (string) $bandSpace->id,
+            actor: $user,
+            payload: [],
+        );
+
+        $this->entityManager->flush();
+
+        // Best-effort notification dispatched after the commit (epic #689 contract).
+        $this->eventDispatcher->dispatch(new BandSpaceDeletionStateChangedEvent($bandSpace, $user, false));
+    }
+}

--- a/tests/Api/BandSpace/BandSpaceCreateTest.php
+++ b/tests/Api/BandSpace/BandSpaceCreateTest.php
@@ -57,6 +57,7 @@ class BandSpaceCreateTest extends ApiTestCase
             'id' => $bandSpace->id,
             'name' => 'The Rockers',
             'role' => 'admin',
+            'deletion_scheduled_datetime' => null,
         ]);
 
         $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);

--- a/tests/Api/BandSpace/BandSpaceDeleteTest.php
+++ b/tests/Api/BandSpace/BandSpaceDeleteTest.php
@@ -1,0 +1,178 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Enum\Notification\NotificationType;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\Notification\NotificationRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BandSpaceDeleteTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_admin_schedules_the_deletion(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpaceId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // The space is only flagged: app:band-space:purge is what actually deletes it.
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships($bandSpaceId);
+        $this->assertNotNull($reloaded);
+        $this->assertNotNull($reloaded->deletionScheduledDatetime);
+        $this->assertSame(
+            (new \DateTimeImmutable('+30 days'))->format('Y-m-d'),
+            $reloaded->deletionScheduledDatetime->format('Y-m-d'),
+        );
+
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($bandSpace, BandSpaceModule::Settings, $bandSpaceId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('deletion_scheduled', $activities[0]->type);
+        $this->assertSame($admin->id, $activities[0]->actor?->id);
+    }
+
+    public function test_scheduling_the_deletion_notifies_the_other_members(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $adminId = (string) $admin->id;
+        $adminUsername = $admin->username;
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpaceId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+        $notifications = $notificationRepository->findForRecipient($member, 10, 0);
+        $this->assertCount(1, $notifications);
+        $this->assertSame(NotificationType::BandSpaceDeletionScheduled, $notifications[0]->type);
+
+        $scheduledFor = self::getContainer()->get(BandSpaceRepository::class)
+            ->findOneByIdWithMemberships($bandSpaceId)
+            ?->deletionScheduledDatetime;
+        $this->assertNotNull($scheduledFor);
+        $this->assertSame([
+            'band_space_id' => $bandSpaceId,
+            'band_space_name' => 'Mon groupe',
+            'scheduled_for' => $scheduledFor->format(\DateTimeInterface::ATOM),
+            'actor_id' => $adminId,
+            'actor_username' => $adminUsername,
+        ], $notifications[0]->payload);
+
+        // The admin who asked for the deletion is never notified.
+        $this->assertCount(0, $notificationRepository->findForRecipient($admin, 10, 0));
+    }
+
+    public function test_regular_member_cannot_schedule_the_deletion(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $this->client->loginUser($member);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous devez être administrateur pour effectuer cette action',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous devez être administrateur pour effectuer cette action',
+        ]);
+
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships((string) $bandSpace->id);
+        $this->assertNull($reloaded?->deletionScheduledDatetime);
+    }
+
+    public function test_non_member_cannot_schedule_the_deletion(): void
+    {
+        $outsider = UserFactory::new()->asBaseUser()->create();
+        $admin = UserFactory::new()->create(['username' => 'admin_user', 'email' => 'admin@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id);
+
+        // The provider runs before the processor, so a non-member is rejected by the membership check.
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'You are not a member of this band space',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'You are not a member of this band space',
+        ]);
+    }
+
+    public function test_scheduling_twice_conflicts(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+10 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'La suppression de cet espace est déjà programmée',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'La suppression de cet espace est déjà programmée',
+        ]);
+    }
+
+    public function test_anonymous_cannot_schedule_the_deletion(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/BandSpaceGetCollectionTest.php
+++ b/tests/Api/BandSpace/BandSpaceGetCollectionTest.php
@@ -49,6 +49,7 @@ class BandSpaceGetCollectionTest extends ApiTestCase
                     'id' => $bandSpace2->id,
                     'name' => 'Jazz Ensemble',
                     'role' => 'user',
+                    'deletion_scheduled_datetime' => null,
                 ],
                 [
                     '@id' => '/api/band_spaces/' . $bandSpace1->id,
@@ -56,6 +57,7 @@ class BandSpaceGetCollectionTest extends ApiTestCase
                     'id' => $bandSpace1->id,
                     'name' => 'The Rockers',
                     'role' => 'user',
+                    'deletion_scheduled_datetime' => null,
                 ],
             ],
             'totalItems' => 2,
@@ -105,6 +107,7 @@ class BandSpaceGetCollectionTest extends ApiTestCase
                     'id' => $userBandSpace->id,
                     'name' => 'My Band',
                     'role' => 'user',
+                    'deletion_scheduled_datetime' => null,
                 ],
             ],
             'totalItems' => 1,

--- a/tests/Api/BandSpace/BandSpaceGetTest.php
+++ b/tests/Api/BandSpace/BandSpaceGetTest.php
@@ -36,6 +36,7 @@ class BandSpaceGetTest extends ApiTestCase
             'id' => $bandSpace->id,
             'name' => 'The Rockers',
             'role' => 'user',
+            'deletion_scheduled_datetime' => null,
         ]);
     }
 

--- a/tests/Api/BandSpace/BandSpaceRestoreTest.php
+++ b/tests/Api/BandSpace/BandSpaceRestoreTest.php
@@ -1,0 +1,185 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Enum\Notification\NotificationType;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\Notification\NotificationRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BandSpaceRestoreTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = [
+        'CONTENT_TYPE' => 'application/ld+json',
+        'HTTP_ACCEPT' => 'application/ld+json',
+    ];
+
+    public function test_admin_cancels_a_scheduled_deletion(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create([
+            'name' => 'Mon groupe',
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+10 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpaceId . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships($bandSpaceId);
+        $this->assertNotNull($reloaded);
+        $this->assertNull($reloaded->deletionScheduledDatetime);
+
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($bandSpace, BandSpaceModule::Settings, $bandSpaceId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('deletion_cancelled', $activities[0]->type);
+        $this->assertSame($admin->id, $activities[0]->actor?->id);
+    }
+
+    public function test_cancelling_notifies_the_other_members(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create([
+            'name' => 'Mon groupe',
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+10 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $adminId = (string) $admin->id;
+        $adminUsername = $admin->username;
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpaceId . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+        $notifications = $notificationRepository->findForRecipient($member, 10, 0);
+        $this->assertCount(1, $notifications);
+        $this->assertSame(NotificationType::BandSpaceDeletionCancelled, $notifications[0]->type);
+        // scheduled_for is null: the payload is built after the column was cleared.
+        $this->assertSame([
+            'band_space_id' => $bandSpaceId,
+            'band_space_name' => 'Mon groupe',
+            'scheduled_for' => null,
+            'actor_id' => $adminId,
+            'actor_username' => $adminUsername,
+        ], $notifications[0]->payload);
+
+        $this->assertCount(0, $notificationRepository->findForRecipient($admin, 10, 0));
+    }
+
+    public function test_cancelling_when_nothing_is_scheduled_conflicts(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'La suppression de cet espace n\'est pas programmée',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'La suppression de cet espace n\'est pas programmée',
+        ]);
+    }
+
+    public function test_regular_member_cannot_cancel(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+10 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $this->client->loginUser($member);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous devez être administrateur pour effectuer cette action',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous devez être administrateur pour effectuer cette action',
+        ]);
+
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships((string) $bandSpace->id);
+        $this->assertNotNull($reloaded?->deletionScheduledDatetime);
+    }
+
+    public function test_non_member_cannot_cancel(): void
+    {
+        $outsider = UserFactory::new()->asBaseUser()->create();
+        $admin = UserFactory::new()->create(['username' => 'admin_user', 'email' => 'admin@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+10 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+        ]);
+
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships((string) $bandSpace->id);
+        $this->assertNotNull($reloaded?->deletionScheduledDatetime);
+    }
+
+    public function test_anonymous_cannot_cancel(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+10 days'),
+        ]);
+
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+}

--- a/tests/Integration/Command/BandSpace/PurgeBandSpaceStorageCommandTest.php
+++ b/tests/Integration/Command/BandSpace/PurgeBandSpaceStorageCommandTest.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Command\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToDeleteDirectory;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * The point of #748: a Band Space deletion must actually reach the object storage. These tests assert on
+ * the filesystem, not only on the rows, because the rows were already going away by FK cascade while the
+ * objects stayed behind forever.
+ */
+#[ResetDatabase]
+class PurgeBandSpaceStorageCommandTest extends KernelTestCase
+{
+    private const string STORAGE_PREFIX = 'band_space_files';
+
+    private ?CommandTester $tester = null;
+
+    private ?FilesystemOperator $realFilesystem = null;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        parent::setUp();
+    }
+
+    /**
+     * Both the command and the filesystem are resolved on first use rather than in setUp: the container
+     * refuses to replace an already-initialised service, and the failure test has to swap the filesystem
+     * out before anything touches it.
+     */
+    private function filesystem(): FilesystemOperator
+    {
+        if (!$this->realFilesystem instanceof FilesystemOperator) {
+            /** @var FilesystemOperator $filesystem */
+            $filesystem = self::getContainer()->get('oneup_flysystem.musicall_filesystem');
+            $this->realFilesystem = $filesystem;
+        }
+
+        return $this->realFilesystem;
+    }
+
+    private function commandTester(): CommandTester
+    {
+        if (!$this->tester instanceof CommandTester) {
+            $application = new Application(self::$kernel);
+            $this->tester = new CommandTester($application->find('app:band-space:purge'));
+        }
+
+        return $this->tester;
+    }
+
+    public function test_it_deletes_archived_files_and_their_objects_past_the_cutoff(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        [$oldFile, $oldPath] = $this->createFileWithObject($bandSpace, new DateTimeImmutable('-40 days'));
+        [$recentFile, $recentPath] = $this->createFileWithObject($bandSpace, new DateTimeImmutable('-5 days'));
+        [$liveFile, $livePath] = $this->createFileWithObject($bandSpace, null);
+
+        $oldFileId = (string) $oldFile->id;
+        $recentFileId = (string) $recentFile->id;
+        $liveFileId = (string) $liveFile->id;
+
+        $this->commandTester()->execute([]);
+        $this->commandTester()->assertCommandIsSuccessful();
+
+        // Archived long enough ago: object and rows are gone.
+        $this->assertFalse($this->filesystem()->fileExists($oldPath));
+        $this->assertNull($this->findFile($oldFileId));
+
+        // Archived recently: still inside the 30-day window.
+        $this->assertTrue($this->filesystem()->fileExists($recentPath));
+        $this->assertNotNull($this->findFile($recentFileId));
+
+        // Never archived: untouched.
+        $this->assertTrue($this->filesystem()->fileExists($livePath));
+        $this->assertNotNull($this->findFile($liveFileId));
+    }
+
+    public function test_it_deletes_a_band_space_past_its_grace_period_with_all_its_objects(): void
+    {
+        $dueSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('-1 day'),
+        ]);
+        $pendingSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('+10 days'),
+        ]);
+        $keptSpace = BandSpaceFactory::new()->create();
+
+        // A live file in the doomed space: the purge must not care whether it was archived.
+        [, $duePath] = $this->createFileWithObject($dueSpace, null);
+        [, $pendingPath] = $this->createFileWithObject($pendingSpace, null);
+        [, $keptPath] = $this->createFileWithObject($keptSpace, null);
+
+        $dueSpaceId = (string) $dueSpace->id;
+        $pendingSpaceId = (string) $pendingSpace->id;
+        $keptSpaceId = (string) $keptSpace->id;
+
+        $this->commandTester()->execute([]);
+        $this->commandTester()->assertCommandIsSuccessful();
+
+        $this->assertSame(0, $this->countBandSpaceRows($dueSpaceId));
+        $this->assertFalse($this->filesystem()->fileExists($duePath));
+        $this->assertFalse($this->filesystem()->directoryExists(self::STORAGE_PREFIX . '/' . $dueSpaceId));
+
+        // The space is removed with a bulk DQL delete, which performs no ORM cascade: the children only
+        // disappear because every child table declares ON DELETE CASCADE on band_space. Asserted here so
+        // that guarantee cannot be lost silently by a mapping change.
+        $this->assertSame(0, $this->countRows('band_space_file', 'band_space_id', $dueSpaceId));
+        $this->assertSame(0, $this->countRows('band_space_membership', 'band_space_id', $dueSpaceId));
+
+        $this->assertSame(1, $this->countBandSpaceRows($pendingSpaceId));
+        $this->assertTrue($this->filesystem()->fileExists($pendingPath));
+
+        $this->assertSame(1, $this->countBandSpaceRows($keptSpaceId));
+        $this->assertTrue($this->filesystem()->fileExists($keptPath));
+    }
+
+    public function test_dry_run_changes_nothing(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('-1 day'),
+        ]);
+        [$file, $path] = $this->createFileWithObject($bandSpace, new DateTimeImmutable('-40 days'));
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $fileId = (string) $file->id;
+
+        $this->commandTester()->execute(['--dry-run' => true]);
+        $this->commandTester()->assertCommandIsSuccessful();
+
+        $this->assertTrue($this->filesystem()->fileExists($path));
+        $this->assertNotNull($this->findFile($fileId));
+        $this->assertSame(1, $this->countBandSpaceRows($bandSpaceId));
+
+        $output = $this->commandTester()->getDisplay();
+        $this->assertStringContainsString('Dry run', $output);
+        $this->assertStringContainsString('would delete file ' . $fileId, $output);
+        $this->assertStringContainsString('would delete band space ' . $bandSpaceId, $output);
+    }
+
+    public function test_days_option_narrows_the_cutoff(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+        [$file, $path] = $this->createFileWithObject($bandSpace, new DateTimeImmutable('-5 days'));
+
+        $fileId = (string) $file->id;
+
+        // Default 30 days would keep it; --days=1 makes it due.
+        $this->commandTester()->execute(['--days' => '1']);
+        $this->commandTester()->assertCommandIsSuccessful();
+
+        $this->assertFalse($this->filesystem()->fileExists($path));
+        $this->assertNull($this->findFile($fileId));
+    }
+
+    public function test_negative_days_is_rejected(): void
+    {
+        $exitCode = $this->commandTester()->execute(['--days' => '-1']);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('cannot be negative', $this->commandTester()->getDisplay());
+    }
+
+    /**
+     * Locks in the command's core safety property: storage is deleted before the rows, so a storage
+     * failure must leave the row in place for the next run to retry. Deleting the row first would lose
+     * the only pointer to the object and orphan it for good.
+     */
+    public function test_a_storage_failure_keeps_the_row_and_does_not_affect_the_other_spaces(): void
+    {
+        $failingSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('-2 days'),
+        ]);
+        $healthySpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('-1 day'),
+        ]);
+
+        $failingSpaceId = (string) $failingSpace->id;
+        $healthySpaceId = (string) $healthySpace->id;
+
+        // Swapped in before anything resolves the real service. Only deleteDirectory is stubbed: it is the
+        // single filesystem call the space purge makes, and no file is seeded here, so the archived-file
+        // phase never needs storage either.
+        $failingFilesystem = $this->createStub(FilesystemOperator::class);
+        $failingFilesystem
+            ->method('deleteDirectory')
+            ->willReturnCallback(static function (string $location) use ($failingSpaceId): void {
+                if (str_contains($location, $failingSpaceId)) {
+                    throw UnableToDeleteDirectory::atLocation($location, 'storage unavailable');
+                }
+            });
+        self::getContainer()->set('oneup_flysystem.musicall_filesystem', $failingFilesystem);
+
+        $exitCode = $this->commandTester()->execute([]);
+
+        // Reported as a failure so the cron alerts, but the healthy space is still purged.
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Failed to purge band space ' . $failingSpaceId, $this->commandTester()->getDisplay());
+
+        // The row survived, so the next run retries and the object is never orphaned.
+        $this->assertSame(1, $this->countBandSpaceRows($failingSpaceId));
+        $this->assertSame(0, $this->countBandSpaceRows($healthySpaceId));
+    }
+
+    /**
+     * Both phases in one run, against the same space: the archived file is purged first, then the space
+     * itself. Makes the phase ordering explicit so a future refactor cannot silently invert it.
+     */
+    public function test_it_purges_an_archived_file_and_its_space_in_the_same_run(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('-1 day'),
+        ]);
+
+        [$archivedFile, $archivedPath] = $this->createFileWithObject($bandSpace, new DateTimeImmutable('-40 days'));
+        [, $livePath] = $this->createFileWithObject($bandSpace, null);
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $archivedFileId = (string) $archivedFile->id;
+
+        $this->commandTester()->execute([]);
+        $this->commandTester()->assertCommandIsSuccessful();
+
+        $this->assertNull($this->findFile($archivedFileId));
+        $this->assertSame(0, $this->countBandSpaceRows($bandSpaceId));
+        $this->assertFalse($this->filesystem()->fileExists($archivedPath));
+        $this->assertFalse($this->filesystem()->fileExists($livePath));
+        $this->assertFalse($this->filesystem()->directoryExists(self::STORAGE_PREFIX . '/' . $bandSpaceId));
+    }
+
+    /**
+     * @return array{BandSpaceFile, string} the file and the storage path of its only version
+     */
+    private function createFileWithObject(BandSpace $bandSpace, ?DateTimeImmutable $archivedAt): array
+    {
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'archiveDatetime' => $archivedAt,
+        ])->create();
+
+        $storagePath = bin2hex(random_bytes(8)) . '.pdf';
+        $version = BandSpaceFileVersionFactory::new([
+            'bandSpaceFile' => $file,
+            'versionNumber' => 1,
+            'storagePath' => $storagePath,
+        ])->create();
+
+        $file->currentVersion = $version;
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->flush();
+
+        $path = self::STORAGE_PREFIX . '/' . $bandSpace->id . '/' . $storagePath;
+        $this->filesystem()->write($path, 'purge-test');
+
+        return [$file, $path];
+    }
+
+    private function findFile(string $id): ?BandSpaceFile
+    {
+        return self::getContainer()->get(BandSpaceFileRepository::class)->find($id);
+    }
+
+    /**
+     * Queried through DBAL on purpose: the command removes a space with a bulk DQL delete (the FK cascade
+     * does the rest), which never touches Doctrine's identity map, so find() would happily return an
+     * entity whose row is already gone.
+     */
+    private function countBandSpaceRows(string $id): int
+    {
+        return $this->countRows('band_space', 'id', $id);
+    }
+
+    private function countRows(string $table, string $column, string $value): int
+    {
+        return (int) self::getContainer()->get(Connection::class)->fetchOne(
+            sprintf('SELECT COUNT(*) FROM %s WHERE %s = :value', $table, $column),
+            ['value' => $value],
+        );
+    }
+}


### PR DESCRIPTION
Closes #748.

## Le problème

Deux manques constatés en réécrivant les pages légales :

1. **Un Band Space ne pouvait pas être supprimé du tout.** `src/ApiResource/BandSpace/BandSpace.php` n’exposait que `GetCollection` et `Get`.
2. **Supprimer un fichier ne touchait jamais le stockage objet.** `BandSpaceFileDeleteProcessor` ne faisait que renseigner `archiveDatetime`. La règle de cycle de vie du bucket ne pouvait rien récupérer non plus : elle expire les versions *non courantes* et ne se déclenche que sur un vrai `DELETE`. Les fichiers « supprimés » restaient donc indéfiniment et le bucket grossissait sans limite.

## Ce que fait cette PR

`DELETE /api/band_spaces/{id}` (administrateur uniquement) programme la suppression à 30 jours ; `POST /api/band_spaces/{id}/restore` l’annule. `app:band-space:purge` (`--days`, `--dry-run`) effectue la suppression réelle.

**Pourquoi un délai, alors que les notes, l’agenda, les finances et les tâches sont supprimés immédiatement ?** Parce qu’un espace est *partagé* : le clic d’un seul administrateur détruirait sinon les fichiers, les finances et l’agenda de tous les autres membres, sans recours, et le bucket n’est pas couvert par la sauvegarde restic (#752). C’est aussi ce que font Notion, Slack, Google Drive partagé et Linear pour un conteneur partagé. L’espace reste volontairement accessible et utilisable pendant la fenêtre : c’est précisément ce qui donne aux membres leurs 30 jours pour récupérer leurs fichiers.

La date d’échéance est stockée, et non la date de demande, pour que la date annoncée aux membres et la condition de purge ne puissent pas diverger.

### Deux pièges qui auraient silencieusement orphelinné chaque objet

- `BandSpaceFile` n’a **aucune association ORM vers ses versions**, seulement un `ManyToOne currentVersion`. Supprimer un fichier fait donc disparaître les lignes de version par cascade FK **sans que VichUploader ne s’exécute**. La commande charge les versions et les retire une par une via l’ORM.
- `DELETE FROM band_space` cascade toutes les lignes filles sans que Doctrine hydrate quoi que ce soit. La purge d’un espace supprime donc le préfixe `band_space_files/{id}/` séparément, en un seul `deleteDirectory()`.

**Le stockage est toujours supprimé avant les lignes** : si le stockage échoue, les lignes subsistent et la prochaine exécution réessaie. L’ordre inverse perdrait le seul pointeur vers l’objet.

Les membres sont notifiés dès qu’une suppression est programmée ou annulée (contrat de l’épopée #689) : un délai de grâce dont personne n’est informé ne sert à rien.

La section « Zone de danger » des paramètres était un `ComingSoonSection` ; elle porte maintenant les actions de suppression et de restauration, et un bandeau rappelle l’échéance sur chaque module.

## Vérifications

- Suite complète **1749 tests verts**, PHPStan niveau 8 sans erreur, Biome à son niveau de référence, build OK.
- Migration testée **up → down → up** sur la base de migration (pas la base Foundry).
- `deleteDirectory` vérifié **contre le vrai bucket Scaleway**, clés imbriquées comprises : l’adaptateur en mémoire des tests l’implémente très différemment (S3 fait `ListObjectsV2` puis des `DeleteObjects` par lots), donc le test d’intégration seul ne pouvait pas le prouver.
- La cascade FK vers les lignes filles est désormais assertée, et non plus supposée.
- Deux relectures par agent, dont une portant spécifiquement sur les correctifs de la première.

## ⚠️ Avant de déployer

Le second commit met les pages légales à jour et annonce **30 jours**. Cette durée n’est vraie que si `app:band-space:purge` est effectivement planifié sur le serveur. **Ne pas déployer avant que le cron existe**, sinon les pages annoncent une conservation que rien n’applique, ce qui est exactement le défaut que #748 corrige.

## Hors périmètre, suivi séparément

- #755 corbeille par module, fichiers d’abord (une purge à 30 jours ferme désormais définitivement la porte, alors qu’aucune interface ne permet de restaurer)
- #756 bloquer les écritures dans un espace en attente de suppression
- #754 harmonisation de la sérialisation des dates dans les DTO

🤖 Generated with [Claude Code](https://claude.com/claude-code)