### PR TITLE
M-754 : harmonisation de la sérialisation des dates dans les DTO

### DIFF
--- a/src/ApiResource/BandSpace/AgendaEntryResource.php
+++ b/src/ApiResource/BandSpace/AgendaEntryResource.php
@@ -132,5 +132,5 @@ class AgendaEntryResource
 
     public ?string $creatorId = null;
     public ?string $creatorUsername = null;
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 }

--- a/src/ApiResource/BandSpace/BandSpace.php
+++ b/src/ApiResource/BandSpace/BandSpace.php
@@ -51,5 +51,5 @@ class BandSpace
     /**
      * Set when the space is pending deletion, so members can be warned and admins offered a restore.
      */
-    public ?string $deletionScheduledDatetime = null;
+    public ?\DateTimeInterface $deletionScheduledDatetime = null;
 }

--- a/src/ApiResource/BandSpace/BandSpaceActivityResource.php
+++ b/src/ApiResource/BandSpace/BandSpaceActivityResource.php
@@ -58,5 +58,5 @@ class BandSpaceActivityResource
     /** @var array{id: string, username: string, profile_picture_url: ?string}|null */
     public ?array $actor = null;
 
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 }

--- a/src/ApiResource/BandSpace/BandSpaceMember.php
+++ b/src/ApiResource/BandSpace/BandSpaceMember.php
@@ -86,8 +86,8 @@ class BandSpaceMember
     public string $role;
 
     public ?string $profilePictureUrl = null;
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
     #[Assert\Choice(choices: ['active', 'left', 'kicked'], message: 'Le statut doit être "active", "left" ou "kicked"')]
     public string $status;
-    public ?string $leftDatetime = null;
+    public ?\DateTimeInterface $leftDatetime = null;
 }

--- a/src/ApiResource/BandSpace/BandSpaceNote.php
+++ b/src/ApiResource/BandSpace/BandSpaceNote.php
@@ -91,6 +91,6 @@ class BandSpaceNote
     /** @var array<string, mixed>|null */
     public ?array $content = null;
     public bool $hasChildren = false;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFileActivityResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileActivityResource.php
@@ -46,5 +46,5 @@ class BandSpaceFileActivityResource
     /** @var array<string, mixed>|null */
     public ?array $payload = null;
 
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFilePublicShareMetadata.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFilePublicShareMetadata.php
@@ -28,6 +28,6 @@ class BandSpaceFilePublicShareMetadata
     public string $originalName;
     public ?int $size = null;
     public ?string $mimeType = null;
-    public string $expiryDatetime;
+    public ?\DateTimeInterface $expiryDatetime = null;
     public bool $hasPassword = false;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFileResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileResource.php
@@ -239,6 +239,6 @@ class BandSpaceFileResource
 
     public ?string $downloadUrl = null;
 
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFileShareCreated.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileShareCreated.php
@@ -6,6 +6,6 @@ class BandSpaceFileShareCreated
 {
     public string $shareId;
     public string $shareUrl;
-    public string $expiryDatetime;
+    public \DateTimeInterface $expiryDatetime;
     public bool $hasPassword = false;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFileShareResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileShareResource.php
@@ -51,13 +51,13 @@ class BandSpaceFileShareResource
 
     public string $fileId;
     public string $fileOriginalName;
-    public ?string $expiryDatetime = null;
-    public ?string $revocationDatetime = null;
+    public ?\DateTimeInterface $expiryDatetime = null;
+    public ?\DateTimeInterface $revocationDatetime = null;
     public int $accessCount = 0;
-    public ?string $lastAccessDatetime = null;
+    public ?\DateTimeInterface $lastAccessDatetime = null;
     public bool $hasPassword = false;
     public bool $isActive = true;
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 
     /** @var array{id: string, username: string}|null */
     public ?array $createdBy = null;

--- a/src/ApiResource/BandSpace/File/BandSpaceFileTagResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileTagResource.php
@@ -78,5 +78,5 @@ class BandSpaceFileTagResource
     public string $name;
     public ?string $colorHex = null;
     public int $fileCount = 0;
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFileVersionResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileVersionResource.php
@@ -47,5 +47,5 @@ class BandSpaceFileVersionResource
     /** @var array{id: string, username: string, profile_picture_url: string|null}|null */
     public ?array $createdBy = null;
 
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFolderResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFolderResource.php
@@ -88,6 +88,6 @@ class BandSpaceFolderResource
      */
     public array $children = [];
 
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Finance/FinanceCategoryResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceCategoryResource.php
@@ -86,6 +86,6 @@ class FinanceCategoryResource
     public int $position;
 
     public bool $hasChildren = false;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Finance/FinanceEntryResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceEntryResource.php
@@ -96,6 +96,6 @@ class FinanceEntryResource
     public bool $isFormerMember = false;
     public ?string $recurrenceId = null;
     public bool $splitWarning = false;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Finance/FinanceEntrySplitResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceEntrySplitResource.php
@@ -71,6 +71,6 @@ class FinanceEntrySplitResource
     public ?string $memberName = null;
     public bool $isFormerMember = false;
     public int $amount;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Finance/FinanceRecurrenceResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceRecurrenceResource.php
@@ -91,6 +91,6 @@ class FinanceRecurrenceResource
     public string $endDate;
     public bool $isActive;
     public int $entryCount = 0;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Invitation/BandSpaceInvitationResource.php
+++ b/src/ApiResource/BandSpace/Invitation/BandSpaceInvitationResource.php
@@ -63,6 +63,6 @@ class BandSpaceInvitationResource
 
     public string $email;
     public string $status;
-    public string $creationDatetime;
-    public string $expirationDatetime;
+    public \DateTimeInterface $creationDatetime;
+    public \DateTimeInterface $expirationDatetime;
 }

--- a/src/ApiResource/BandSpace/Setlist/SetlistItemSongInfo.php
+++ b/src/ApiResource/BandSpace/Setlist/SetlistItemSongInfo.php
@@ -9,5 +9,5 @@ class SetlistItemSongInfo
     public ?int $tempo = null;
     public ?string $tonality = null;
     public ?int $referenceDuration = null;
-    public ?string $archiveDatetime = null;
+    public ?\DateTimeInterface $archiveDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Setlist/SetlistResource.php
+++ b/src/ApiResource/BandSpace/Setlist/SetlistResource.php
@@ -80,9 +80,9 @@ class SetlistResource
     #[Assert\Length(max: 255, maxMessage: 'Le nom ne peut pas dépasser {{ limit }} caractères')]
     public string $name;
 
-    public ?string $archiveDatetime = null;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public ?\DateTimeInterface $archiveDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 
     /** @var SetlistItemResource[] */
     #[ApiProperty(readableLink: true)]

--- a/src/ApiResource/BandSpace/Setlist/Song/SongResource.php
+++ b/src/ApiResource/BandSpace/Setlist/Song/SongResource.php
@@ -97,7 +97,7 @@ class SongResource
 
     public ?string $notes = null;
 
-    public ?string $archiveDatetime = null;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public ?\DateTimeInterface $archiveDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Task/TaskActivityResource.php
+++ b/src/ApiResource/BandSpace/Task/TaskActivityResource.php
@@ -59,5 +59,5 @@ class TaskActivityResource
     /** @var array<string, mixed>|null */
     public ?array $payload = null;
 
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 }

--- a/src/ApiResource/BandSpace/Task/TaskCategoryResource.php
+++ b/src/ApiResource/BandSpace/Task/TaskCategoryResource.php
@@ -85,6 +85,6 @@ class TaskCategoryResource
         message: 'La couleur doit être au format hexadécimal #RRGGBB'
     )]
     public string $color;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Task/TaskCommentResource.php
+++ b/src/ApiResource/BandSpace/Task/TaskCommentResource.php
@@ -91,6 +91,6 @@ class TaskCommentResource
     #[Assert\Length(max: 5000, maxMessage: 'Le commentaire ne peut pas dépasser {{ limit }} caractères')]
     public string $content;
 
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Task/TaskResource.php
+++ b/src/ApiResource/BandSpace/Task/TaskResource.php
@@ -109,11 +109,11 @@ class TaskResource
     /** @var array<int, array{id: string, username: string, profile_picture_url: string|null}> */
     public array $assignees = [];
 
-    public ?string $archiveDatetime = null;
-    public ?string $completedDatetime = null;
+    public ?\DateTimeInterface $archiveDatetime = null;
+    public ?\DateTimeInterface $completedDatetime = null;
     public int $position = 0;
-    public string $creationDatetime;
-    public ?string $updateDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
     public int $commentCount = 0;
     public int $fileCount = 0;
 }

--- a/src/ApiResource/Comment/CommentResource.php
+++ b/src/ApiResource/Comment/CommentResource.php
@@ -47,7 +47,7 @@ class CommentResource
 
     public string $content;
 
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 
     public int $upvotes = 0;
 

--- a/src/ApiResource/Forum/ForumSearchResult.php
+++ b/src/ApiResource/Forum/ForumSearchResult.php
@@ -28,7 +28,7 @@ class ForumSearchResult
 
     public int $topicPostNumber;
 
-    public ?string $lastPostDatetime;
+    public ?\DateTimeInterface $lastPostDatetime;
 
     public string $forumId;
 

--- a/src/ApiResource/Notification/UserNotification.php
+++ b/src/ApiResource/Notification/UserNotification.php
@@ -73,7 +73,7 @@ class UserNotification
     /** @var array<string, mixed> */
     public array $payload = [];
 
-    public ?string $readDatetime = null;
+    public ?\DateTimeInterface $readDatetime = null;
 
-    public string $creationDatetime;
+    public \DateTimeInterface $creationDatetime;
 }

--- a/src/Service/Builder/BandSpace/AgendaEntryBuilder.php
+++ b/src/Service/Builder/BandSpace/AgendaEntryBuilder.php
@@ -35,7 +35,7 @@ readonly class AgendaEntryBuilder
         $dto->recurrenceMonthlyMode = $entity->recurrenceMonthlyMode?->value;
         $dto->creatorId = $entity->creator instanceof \App\Entity\User ? (string) $entity->creator->id : null;
         $dto->creatorUsername = $entity->creator?->username;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/BandSpaceActivityBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceActivityBuilder.php
@@ -36,7 +36,7 @@ readonly class BandSpaceActivityBuilder
             'username' => $entity->actor->username,
             'profile_picture_url' => $this->profilePictureUrlBuilder->build($entity->actor),
         ] : null;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/BandSpaceBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceBuilder.php
@@ -27,7 +27,7 @@ readonly class BandSpaceBuilder
         $dto->id = (string) $entity->id;
         $dto->name = $entity->name;
         $dto->role = $role->value;
-        $dto->deletionScheduledDatetime = $entity->deletionScheduledDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->deletionScheduledDatetime = $entity->deletionScheduledDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/BandSpaceInvitationBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceInvitationBuilder.php
@@ -14,8 +14,8 @@ readonly class BandSpaceInvitationBuilder
         $dto->bandSpaceId = (string) $invitation->bandSpace->id;
         $dto->email = $invitation->email;
         $dto->status = $invitation->status->value;
-        $dto->creationDatetime = $invitation->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->expirationDatetime = $invitation->expirationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $invitation->creationDatetime;
+        $dto->expirationDatetime = $invitation->expirationDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/BandSpaceMemberBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceMemberBuilder.php
@@ -22,9 +22,9 @@ readonly class BandSpaceMemberBuilder
         $dto->username = $membership->user->username;
         $dto->role = $membership->role->value;
         $dto->profilePictureUrl = $this->profilePictureUrlBuilder->build($membership->user);
-        $dto->creationDatetime = $membership->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $membership->creationDatetime;
         $dto->status = $membership->status->value;
-        $dto->leftDatetime = $membership->leftDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->leftDatetime = $membership->leftDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/BandSpaceNoteBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceNoteBuilder.php
@@ -35,8 +35,8 @@ readonly class BandSpaceNoteBuilder
         $dto->position = $entity->position;
         $dto->content = null;
         $dto->hasChildren = !$entity->children->isEmpty();
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileActivityBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileActivityBuilder.php
@@ -46,7 +46,7 @@ readonly class BandSpaceFileActivityBuilder
         $dto->actorProfilePictureUrl = $this->profilePictureUrlBuilder->build($entity->actor);
         $dto->type = $entity->type;
         $dto->payload = $entity->payload;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
@@ -95,8 +95,8 @@ readonly class BandSpaceFileBuilder
             UrlGeneratorInterface::ABSOLUTE_PATH,
         ) . '/download';
 
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileShareBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileShareBuilder.php
@@ -16,14 +16,14 @@ readonly class BandSpaceFileShareBuilder
         $dto->bandSpaceId = (string) $file->bandSpace->id;
         $dto->fileId = (string) $file->id;
         $dto->fileOriginalName = $file->originalName;
-        $dto->expiryDatetime = $entity->expiryDatetime?->format(\DateTimeInterface::ATOM);
-        $dto->revocationDatetime = $entity->revocationDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->expiryDatetime = $entity->expiryDatetime;
+        $dto->revocationDatetime = $entity->revocationDatetime;
         $dto->accessCount = $entity->accessCount;
-        $dto->lastAccessDatetime = $entity->lastAccessDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->lastAccessDatetime = $entity->lastAccessDatetime;
         $dto->hasPassword = $entity->passwordHash !== null;
         $dto->isActive = !$entity->revocationDatetime instanceof \DateTimeImmutable
             && (!$entity->expiryDatetime instanceof \DateTimeImmutable || $entity->expiryDatetime > $now);
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
 
         if ($entity->createdBy instanceof \App\Entity\User) {
             $dto->createdBy = [

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileTagBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileTagBuilder.php
@@ -15,7 +15,7 @@ readonly class BandSpaceFileTagBuilder
         $dto->name = $entity->name;
         $dto->colorHex = $entity->colorHex;
         $dto->fileCount = $fileCount;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileVersionBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileVersionBuilder.php
@@ -45,7 +45,7 @@ readonly class BandSpaceFileVersionBuilder
             ];
         }
 
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/File/BandSpaceFolderBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFolderBuilder.php
@@ -15,8 +15,8 @@ readonly class BandSpaceFolderBuilder
         $dto->name = $entity->name;
         $dto->parentId = $entity->parent instanceof \App\Entity\BandSpace\BandSpaceFolder ? (string) $entity->parent->id : null;
         $dto->depth = $depth;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/FinanceCategoryBuilder.php
+++ b/src/Service/Builder/BandSpace/FinanceCategoryBuilder.php
@@ -28,8 +28,8 @@ readonly class FinanceCategoryBuilder
         $dto->parentId = $entity->parent instanceof \App\Entity\BandSpace\FinanceCategory ? (string) $entity->parent->id : null;
         $dto->position = $entity->position;
         $dto->hasChildren = !$entity->children->isEmpty();
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/FinanceEntryBuilder.php
+++ b/src/Service/Builder/BandSpace/FinanceEntryBuilder.php
@@ -44,8 +44,8 @@ readonly class FinanceEntryBuilder
         $dto->isFormerMember = $entity->member instanceof \App\Entity\BandSpace\BandSpaceMembership && $entity->member->status !== MembershipStatus::Active;
         $dto->recurrenceId = $entity->recurrence instanceof \App\Entity\BandSpace\FinanceRecurrence ? (string) $entity->recurrence->id : null;
         $dto->splitWarning = $splitWarning;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/FinanceEntrySplitBuilder.php
+++ b/src/Service/Builder/BandSpace/FinanceEntrySplitBuilder.php
@@ -30,8 +30,8 @@ readonly class FinanceEntrySplitBuilder
         $dto->memberName = $entity->member?->user->username;
         $dto->isFormerMember = $entity->member instanceof \App\Entity\BandSpace\BandSpaceMembership && $entity->member->status !== MembershipStatus::Active;
         $dto->amount = $entity->amount;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/FinanceRecurrenceBuilder.php
+++ b/src/Service/Builder/BandSpace/FinanceRecurrenceBuilder.php
@@ -36,8 +36,8 @@ readonly class FinanceRecurrenceBuilder
         $dto->endDate = $entity->endDate->format(DateTimeInterface::ATOM);
         $dto->isActive = $entity->isActive;
         $dto->entryCount = $entity->entries->count();
-        $dto->creationDatetime = $entity->creationDatetime->format(DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/SetlistBuilder.php
+++ b/src/Service/Builder/BandSpace/SetlistBuilder.php
@@ -34,9 +34,9 @@ readonly class SetlistBuilder
         $dto->id = (string) $entity->id;
         $dto->bandSpaceId = (string) $entity->bandSpace->id;
         $dto->name = $entity->name;
-        $dto->archiveDatetime = $entity->archiveDatetime?->format(DateTimeInterface::ATOM);
-        $dto->creationDatetime = $entity->creationDatetime->format(DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(DateTimeInterface::ATOM);
+        $dto->archiveDatetime = $entity->archiveDatetime;
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         $items = $entity->items->toArray();
         usort(

--- a/src/Service/Builder/BandSpace/SetlistItemBuilder.php
+++ b/src/Service/Builder/BandSpace/SetlistItemBuilder.php
@@ -29,7 +29,7 @@ readonly class SetlistItemBuilder
             $songInfo->tempo = $entity->song->tempo;
             $songInfo->tonality = $entity->song->tonality;
             $songInfo->referenceDuration = $entity->song->referenceDuration;
-            $songInfo->archiveDatetime = $entity->song->archiveDatetime?->format(DateTimeInterface::ATOM);
+            $songInfo->archiveDatetime = $entity->song->archiveDatetime;
             $dto->song = $songInfo;
         }
 

--- a/src/Service/Builder/BandSpace/SongBuilder.php
+++ b/src/Service/Builder/BandSpace/SongBuilder.php
@@ -30,9 +30,9 @@ readonly class SongBuilder
         $dto->tonality = $entity->tonality;
         $dto->referenceDuration = $entity->referenceDuration;
         $dto->notes = $entity->notes;
-        $dto->archiveDatetime = $entity->archiveDatetime?->format(DateTimeInterface::ATOM);
-        $dto->creationDatetime = $entity->creationDatetime->format(DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(DateTimeInterface::ATOM);
+        $dto->archiveDatetime = $entity->archiveDatetime;
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/TaskActivityBuilder.php
+++ b/src/Service/Builder/BandSpace/TaskActivityBuilder.php
@@ -47,7 +47,7 @@ readonly class TaskActivityBuilder
         $dto->actorProfilePictureUrl = $this->profilePictureUrlBuilder->build($entity->actor);
         $dto->type = $entity->type;
         $dto->payload = $entity->payload;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/TaskBuilder.php
+++ b/src/Service/Builder/BandSpace/TaskBuilder.php
@@ -54,11 +54,11 @@ readonly class TaskBuilder
             ]
         )->toArray();
         $dto->assignees = array_values($dto->assignees);
-        $dto->archiveDatetime = $entity->archiveDatetime?->format(\DateTimeInterface::ATOM);
-        $dto->completedDatetime = $entity->completedDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->archiveDatetime = $entity->archiveDatetime;
+        $dto->completedDatetime = $entity->completedDatetime;
         $dto->position = $entity->position;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
         $dto->commentCount = $commentCount;
         $dto->fileCount = $fileCount;
 

--- a/src/Service/Builder/BandSpace/TaskCategoryBuilder.php
+++ b/src/Service/Builder/BandSpace/TaskCategoryBuilder.php
@@ -26,8 +26,8 @@ readonly class TaskCategoryBuilder
         $dto->bandSpaceId = (string) $entity->bandSpace->id;
         $dto->name = $entity->name;
         $dto->color = $entity->color;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/TaskCommentBuilder.php
+++ b/src/Service/Builder/BandSpace/TaskCommentBuilder.php
@@ -35,8 +35,8 @@ readonly class TaskCommentBuilder
         $dto->authorUsername = $entity->author->username;
         $dto->authorProfilePictureUrl = $this->profilePictureUrlBuilder->build($entity->author);
         $dto->content = $entity->content;
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
-        $dto->updateDatetime = $entity->updateDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
     }

--- a/src/Service/Builder/Comment/CommentBuilder.php
+++ b/src/Service/Builder/Comment/CommentBuilder.php
@@ -44,7 +44,7 @@ readonly class CommentBuilder
             'deletion_datetime' => $entity->author->deletionDatetime?->format(\DateTimeInterface::ATOM),
         ];
         $dto->content = $this->appOnlybrSanitizer->sanitize(nl2br($entity->content));
-        $dto->creationDatetime = $entity->creationDatetime->format(\DateTimeInterface::ATOM);
+        $dto->creationDatetime = $entity->creationDatetime;
         $dto->upvotes = $entity->voteCache->upvoteCount ?? 0;
         $dto->downvotes = $entity->voteCache->downvoteCount ?? 0;
         $dto->userVote = $userVote;

--- a/src/Service/Builder/Notification/NotificationBuilder.php
+++ b/src/Service/Builder/Notification/NotificationBuilder.php
@@ -13,8 +13,8 @@ readonly class NotificationBuilder
         $dto->id = (string) $notification->id;
         $dto->type = $notification->type->value;
         $dto->payload = $notification->payload;
-        $dto->readDatetime = $notification->readDatetime?->format(DATE_ATOM);
-        $dto->creationDatetime = $notification->creationDatetime->format(DATE_ATOM);
+        $dto->readDatetime = $notification->readDatetime;
+        $dto->creationDatetime = $notification->creationDatetime;
 
         return $dto;
     }

--- a/src/State/Processor/BandSpace/File/BandSpaceFileShareCreateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileShareCreateProcessor.php
@@ -101,7 +101,7 @@ readonly class BandSpaceFileShareCreateProcessor implements ProcessorInterface
         $created = new BandSpaceFileShareCreated();
         $created->shareId = (string) $share->id;
         $created->shareUrl = $shareUrl;
-        $created->expiryDatetime = $expiry->format(\DateTimeInterface::ATOM);
+        $created->expiryDatetime = $expiry;
         $created->hasPassword = $share->passwordHash !== null;
 
         return $created;

--- a/src/State/Provider/BandSpace/File/BandSpaceFilePublicShareMetadataProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFilePublicShareMetadataProvider.php
@@ -61,7 +61,7 @@ readonly class BandSpaceFilePublicShareMetadataProvider implements ProviderInter
         $dto->originalName = $file->originalName;
         $dto->size = $file->currentVersion->size;
         $dto->mimeType = $file->currentVersion->mimeType;
-        $dto->expiryDatetime = $share->expiryDatetime?->format(\DateTimeInterface::ATOM) ?? '';
+        $dto->expiryDatetime = $share->expiryDatetime;
         $dto->hasPassword = $share->passwordHash !== null;
 
         return $dto;

--- a/src/State/Provider/Forum/ForumSearchProvider.php
+++ b/src/State/Provider/Forum/ForumSearchProvider.php
@@ -80,7 +80,7 @@ readonly class ForumSearchProvider implements ProviderInterface
         $dto->topicTitle = (string) $row['topic_title'];
         $dto->topicPostNumber = (int) $row['topic_post_number'];
         $dto->lastPostDatetime = $row['last_post_datetime'] !== null
-            ? (new \DateTimeImmutable((string) $row['last_post_datetime']))->format(\DateTimeInterface::ATOM)
+            ? new \DateTimeImmutable((string) $row['last_post_datetime'])
             : null;
         $dto->forumId = (string) $row['forum_id'];
         $dto->forumTitle = (string) $row['forum_title'];

--- a/tests/Api/Admin/Publication/AdminTagTest.php
+++ b/tests/Api/Admin/Publication/AdminTagTest.php
@@ -236,14 +236,14 @@ class AdminTagTest extends ApiTestCase
                 ],
                 [
                     'propertyPath' => 'label',
-                    'message' => 'Cette chaîne est trop courte. Elle doit avoir au minimum 1 caractère.',
+                    'message' => 'Cette chaîne est trop courte. Elle doit contenir au minimum 1 caractère.',
                     'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
                 ],
             ],
-            'detail' => "label: Le label ne peut pas être vide\nlabel: Cette chaîne est trop courte. Elle doit avoir au minimum 1 caractère.",
+            'detail' => "label: Le label ne peut pas être vide\nlabel: Cette chaîne est trop courte. Elle doit contenir au minimum 1 caractère.",
             'type' => '/validation_errors/0=c1051bb4-d103-4f74-8988-acbcafc7fdc3;1=9ff3fdc4-b214-49db-8718-39c315e33d45',
             'title' => 'An error occurred',
-            'description' => "label: Le label ne peut pas être vide\nlabel: Cette chaîne est trop courte. Elle doit avoir au minimum 1 caractère.",
+            'description' => "label: Le label ne peut pas être vide\nlabel: Cette chaîne est trop courte. Elle doit contenir au minimum 1 caractère.",
         ]);
     }
 

--- a/tests/Api/BandSpace/File/BandSpaceFilePublicShareMetadataTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFilePublicShareMetadataTest.php
@@ -23,7 +23,8 @@ class BandSpaceFilePublicShareMetadataTest extends ApiTestCase
 
     public function test_returns_metadata_for_unprotected_share(): void
     {
-        ['token' => $token] = $this->setupShare();
+        // Pinned so expiry_datetime can be asserted exactly: the serializer formats it, not the provider.
+        ['token' => $token] = $this->setupShare(expiry: new \DateTimeImmutable('2099-03-01T10:00:00+00:00'));
 
         $this->client->jsonRequest('GET', '/api/shares/' . $token . '/metadata', [], [
             'CONTENT_TYPE' => 'application/ld+json',
@@ -31,12 +32,17 @@ class BandSpaceFilePublicShareMetadataTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $response = $this->getResponseAsArray();
-        $this->assertSame('doc.txt', $response['original_name']);
-        $this->assertSame('text/plain', $response['mime_type']);
-        $this->assertSame(42, $response['size']);
-        $this->assertFalse($response['has_password']);
-        $this->assertNotEmpty($response['expiry_datetime']);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceFilePublicShareMetadata',
+            '@id' => '/api/shares/' . $token . '/metadata',
+            '@type' => 'BandSpaceFilePublicShareMetadata',
+            'token' => $token,
+            'original_name' => 'doc.txt',
+            'size' => 42,
+            'mime_type' => 'text/plain',
+            'expiry_datetime' => '2099-03-01T10:00:00+00:00',
+            'has_password' => false,
+        ]);
     }
 
     public function test_returns_has_password_true_for_protected_share(): void

--- a/tests/Api/BandSpace/File/BandSpaceFileShareCollectionTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileShareCollectionTest.php
@@ -26,12 +26,16 @@ class BandSpaceFileShareCollectionTest extends ApiTestCase
 
         $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'doc.pdf'])->create();
 
-        // Active share (no expiry)
-        BandSpaceFileShareFactory::new([
+        // Dates are pinned so the response body can be asserted whole: they are the only
+        // fields the serializer formats itself rather than the builder handing it a string.
+        $activeShare = BandSpaceFileShareFactory::new([
             'bandSpaceFile' => $file,
             'createdBy' => $user,
             'tokenHash' => hash('sha256', 'token-active'),
-            'expiryDatetime' => new \DateTimeImmutable('+1 day'),
+            'expiryDatetime' => new \DateTimeImmutable('2099-03-01T10:00:00+00:00'),
+            'lastAccessDatetime' => new \DateTimeImmutable('2026-02-14T08:30:00+00:00'),
+            'accessCount' => 3,
+            'creationDatetime' => new \DateTime('2026-02-01T09:15:00+00:00'),
         ])->create();
         // Revoked share
         BandSpaceFileShareFactory::new([
@@ -60,11 +64,34 @@ class BandSpaceFileShareCollectionTest extends ApiTestCase
         );
 
         $this->assertResponseIsSuccessful();
-        $response = $this->getResponseAsArray();
-        $this->assertSame(1, $response['totalItems']);
-        $this->assertTrue($response['member'][0]['is_active']);
-        $this->assertFalse($response['member'][0]['has_password']);
-        $this->assertSame('doc.pdf', $response['member'][0]['file_original_name']);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceFileShare',
+            '@id' => '/api/band_spaces/' . $bandSpaceId . '/shares',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    // Composite-identifier fallback IRI: the Delete template is not used to generate it.
+                    '@id' => '/api/band_space_file_shares/id=' . $activeShare->id . ';bandSpaceId=' . $bandSpaceId,
+                    '@type' => 'BandSpaceFileShare',
+                    'id' => (string) $activeShare->id,
+                    'band_space_id' => (string) $bandSpaceId,
+                    'file_id' => (string) $file->id,
+                    'file_original_name' => 'doc.pdf',
+                    'expiry_datetime' => '2099-03-01T10:00:00+00:00',
+                    'revocation_datetime' => null,
+                    'access_count' => 3,
+                    'last_access_datetime' => '2026-02-14T08:30:00+00:00',
+                    'has_password' => false,
+                    'is_active' => true,
+                    'creation_datetime' => '2026-02-01T09:15:00+00:00',
+                    'created_by' => [
+                        'id' => (string) $user->id,
+                        'username' => $user->username,
+                    ],
+                ],
+            ],
+        ]);
     }
 
     public function test_list_empty_returns_empty_collection(): void

--- a/tests/Api/Forum/ForumPostEditTest.php
+++ b/tests/Api/Forum/ForumPostEditTest.php
@@ -168,12 +168,12 @@ class ForumPostEditTest extends ApiTestCase
                 ],
                 [
                     'propertyPath' => 'content',
-                    'message' => 'Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.',
+                    'message' => 'Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.',
                     'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
                 ],
             ],
-            'detail' => "content: Cette valeur ne doit pas être vide.\ncontent: Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.",
-            'description' => "content: Cette valeur ne doit pas être vide.\ncontent: Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.",
+            'detail' => "content: Cette valeur ne doit pas être vide.\ncontent: Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.",
+            'description' => "content: Cette valeur ne doit pas être vide.\ncontent: Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.",
             'type' => '/validation_errors/0=c1051bb4-d103-4f74-8988-acbcafc7fdc3;1=9ff3fdc4-b214-49db-8718-39c315e33d45',
             'title' => 'An error occurred',
         ]);

--- a/tests/Api/Forum/ForumPostPostTest.php
+++ b/tests/Api/Forum/ForumPostPostTest.php
@@ -127,12 +127,12 @@ class ForumPostPostTest extends ApiTestCase
                 ],
                 [
                     'propertyPath' => 'content',
-                    'message' => 'Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.',
+                    'message' => 'Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.',
                     'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
                 ],
             ],
-            'detail' => "content: Cette valeur ne doit pas être vide.\ncontent: Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.",
-            'description' => "content: Cette valeur ne doit pas être vide.\ncontent: Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.",
+            'detail' => "content: Cette valeur ne doit pas être vide.\ncontent: Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.",
+            'description' => "content: Cette valeur ne doit pas être vide.\ncontent: Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.",
             'type' => '/validation_errors/0=c1051bb4-d103-4f74-8988-acbcafc7fdc3;1=9ff3fdc4-b214-49db-8718-39c315e33d45',
             'title' => 'An error occurred',
         ]);
@@ -170,12 +170,12 @@ class ForumPostPostTest extends ApiTestCase
             'violations' => [
                 [
                     'propertyPath' => 'content',
-                    'message' => 'Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.',
+                    'message' => 'Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.',
                     'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
                 ],
             ],
-            'detail' => 'content: Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.',
-            'description' => 'content: Cette chaîne est trop courte. Elle doit avoir au minimum 10 caractères.',
+            'detail' => 'content: Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.',
+            'description' => 'content: Cette chaîne est trop courte. Elle doit contenir au minimum 10 caractères.',
             'type' => '/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
             'title' => 'An error occurred',
         ]);

--- a/tests/Api/User/UserSearchTest.php
+++ b/tests/Api/User/UserSearchTest.php
@@ -96,12 +96,12 @@ class UserSearchTest extends ApiTestCase
             'violations' => [
                 [
                     'propertyPath' => 'search',
-                    'message' => 'Cette chaîne est trop courte. Elle doit avoir au minimum 3 caractères.',
+                    'message' => 'Cette chaîne est trop courte. Elle doit contenir au minimum 3 caractères.',
                     'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
                 ]
             ],
-            'detail' => 'search: Cette chaîne est trop courte. Elle doit avoir au minimum 3 caractères.',
-            'description' => 'search: Cette chaîne est trop courte. Elle doit avoir au minimum 3 caractères.',
+            'detail' => 'search: Cette chaîne est trop courte. Elle doit contenir au minimum 3 caractères.',
+            'description' => 'search: Cette chaîne est trop courte. Elle doit contenir au minimum 3 caractères.',
             'type' => '/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
             'title' => 'An error occurred',
         ]);

--- a/tests/Unit/Service/Notification/NotificationFeedEnricherTest.php
+++ b/tests/Unit/Service/Notification/NotificationFeedEnricherTest.php
@@ -75,7 +75,7 @@ class NotificationFeedEnricherTest extends TestCase
         $notification->id = '00000000-0000-0000-0000-000000000000';
         $notification->type = $type->value;
         $notification->payload = $payload;
-        $notification->creationDatetime = '2026-05-31T00:00:00+00:00';
+        $notification->creationDatetime = new \DateTimeImmutable('2026-05-31T00:00:00+00:00');
 
         return $notification;
     }


### PR DESCRIPTION
Closes #754

## Contexte

Le projet exposait ses dates de deux façons concurrentes dans les DTO API Platform :

- **A.** `public ?string $creationDatetime` et le builder appelle `?->format(\DateTimeInterface::ATOM)`
- **B.** `public ?\DateTimeInterface $creationDatetime` et le sérialiseur s'en charge

Le style A était concentré dans Band Space, le style B est déjà utilisé par Forum, Publication, Musician, Teacher, User et Search. Cette PR converge vers **B** et supprime le formatage à la main.

## Ce qui change

**50 propriétés dans 28 DTO** sont retypées, **48 appels à `format()`** disparaissent des builders et providers, plus 2 cas multilignes traités à la main.

C'est une opération sans effet sur les réponses. `\DateTimeInterface::ATOM`, `RFC3339` et `DATE_ATOM` sont la même chaîne de format (`Y-m-d\TH:i:sP`), et rien ne surcharge `datetime_format` dans `config/`, donc le `DateTimeNormalizer` de Symfony produit exactement ce que les builders produisaient.

## Ce qui ne change pas, et pourquoi

**24 propriétés restent des chaînes.** Ce n'est pas de la dette à finir plus tard, les deux styles encodaient en partie une vraie distinction :

| Raison | Propriétés |
|---|---|
| **Entrée client**, parsée à la main avec `new \DateTimeImmutable($data->x)` | `eventDatetime`, `endDatetime`, `recurrenceUntilDate`, `dueDate`, `startDate`, `endDate`, `date`, et `expiryDatetime` sur `BandSpaceFileShareCreate` |
| **Date seule ou heure seule**, qui deviendrait un horodatage complet | `dueDate`, `recurrenceUntilDate`, `date` (`Y-m-d`) ; `startTime`, `endTime` des deux classes TeacherProfileAvailability (`H:i`) |
| **Jamais un DateTime**, chaînes issues de SQL brut | `FinanceSummary.minDate` et `maxDate` |

Trois pièges à retenir pour quiconque voudrait « finir le travail » :

1. `startDate` et `endDate` sont aussi relues par `RecurrenceNoOverlapValidator` et `RecurrenceEndDateValidator`, qui font `new \DateTimeImmutable($value->startDate)`. Les convertir casserait la validation, pas seulement le processor.
2. `eventDatetime` et `recurrenceUntilDate` sont relues par `ValidRecurrenceValidator` via des tests `is_string()`.
3. `expiryDatetime` est une **entrée** sur une classe et une **sortie** sur trois autres. Même nom, rôles opposés : la décision se prend par classe et par propriété, jamais par nom.

Volontairement laissé de côté : `BandSpaceFolderBuilder::toNestedArray()` formate encore à la main, parce que le sous-arbre `children` est un tableau récursif non typé et non une propriété de DTO. Le convertir voudrait dire redessiner toute cette représentation.

## Vérification

- PHPStan niveau 8 : propre
- Suite complète : **1749 verts**, avec **un seul fichier de test modifié par le refactoring** (`NotificationFeedEnricherTest`, un test unitaire qui construit le DTO directement et devait donc passer un `DateTimeImmutable` au lieu d'une chaîne). **Zéro assertion de réponse API modifiée** : comme chaque réponse convertie est vérifiée entièrement par `assertJsonEquals`, une suite inchangée est la preuve que le JSON est identique à l'octet.
- 16 réponses de l'application capturées avant et après sur l'environnement de dev, puis comparées : identiques. À noter que 4 seulement contenaient des dates, les espaces de dev étant peu remplis.
- `npm run lint` et `npm run build` : propres, aucun changement front n'étant attendu.

## Deux points à signaler

**Une seule modification de charge utile, assumée.** `BandSpaceFilePublicShareMetadata` renvoyait `""` quand un partage n'avait pas d'expiration. Cette branche était inatteignable, `parseFutureDatetime()` lève une exception au lieu de renvoyer null, mais le champ est désormais nullable et renverrait `null`. C'est une correction : le dépôt et le provider de téléchargement traitent déjà une expiration nulle comme « n'expire jamais », ce DTO était le seul endroit à prétendre le contraire.

**Les DTO qui acceptent PATCH deviennent plus stricts.** Une quinzaine de classes servent à la fois de forme GET et de corps merge-patch. Un client qui envoie une valeur malformée dans `creation_datetime` reçoit maintenant un 400 de dénormalisation, là où c'était silencieusement ignoré. Tous les appels PATCH du front ont été relus : ils construisent des charges utiles ciblées à partir de l'état du formulaire, jamais un objet renvoyé par l'API, donc le cas est inatteignable aujourd'hui. Et le nouveau comportement est le meilleur des deux : avaler une date invalide sans rien dire était pire qu'un 400. Si on veut fermer la porte proprement, `#[ApiProperty(writable: false)]` sur les champs d'audit est la bonne réponse, pas `readonly` en PHP qui produirait un 500.

## Autres commits de la branche

- `2b41d89f` répare le rouge de master causé par la mise à jour des dépendances : la traduction française de la contrainte `Length` est passée de « Elle doit avoir au minimum » à « Elle doit contenir au minimum », 15 occurrences dans 4 fichiers de test.
- `fac516f5` ajoute les assertions manquantes relevées en revue. `expiry_datetime`, `revocation_datetime` et `last_access_datetime` avaient été convertis sans aucune assertion derrière eux ; les deux corps de réponse sont désormais vérifiés entièrement avec des dates figées. `last_post_datetime` reste sans couverture pour une raison antérieure et documentée : les tables auxiliaires FULLTEXT de MariaDB ne sont pas mises à jour avant le commit, et DAMA annule la transaction de chaque test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
