### PR TITLE
M-756 : un espace en attente de suppression devient en lecture seule

### DIFF
--- a/assets/js/components/AppBandLayout.vue
+++ b/assets/js/components/AppBandLayout.vue
@@ -40,8 +40,8 @@
               <i class="pi pi-exclamation-triangle mt-0.5" aria-hidden="true" />
               <p class="flex-1 min-w-0">
                 Cet espace sera définitivement supprimé le
-                <strong>{{ formatDateLong(deletionScheduledFor) }}</strong>. Pensez à récupérer vos
-                fichiers.
+                <strong>{{ formatDateLong(deletionScheduledFor) }}</strong>. Les modifications sont
+                désactivées, mais vous pouvez toujours consulter et télécharger vos fichiers.
                 <RouterLink
                   :to="{ name: BAND_SPACE_ROUTES.PARAMETERS, params: { id: route.params.id }, query: { section: 'danger' } }"
                   class="underline"

--- a/assets/js/views/BandSpace/Notes.vue
+++ b/assets/js/views/BandSpace/Notes.vue
@@ -138,11 +138,11 @@ async function handleCreateNote({ title, parentId }) {
       life: 3000
     })
     notesStore.selectNote(bandSpaceId, newNote.id)
-  } catch {
+  } catch (error) {
     toast.add({
       severity: 'error',
       summary: 'Erreur',
-      detail: 'Impossible de créer la note',
+      detail: error.message || 'Impossible de créer la note',
       life: 5000
     })
   }
@@ -181,11 +181,11 @@ function handleDelete(noteId) {
           summary: 'Note supprimée',
           life: 3000
         })
-      } catch {
+      } catch (error) {
         toast.add({
           severity: 'error',
           summary: 'Erreur',
-          detail: 'Impossible de supprimer la note',
+          detail: error.message || 'Impossible de supprimer la note',
           life: 5000
         })
       }

--- a/src/Entity/BandSpace/BandSpace.php
+++ b/src/Entity/BandSpace/BandSpace.php
@@ -54,4 +54,9 @@ class BandSpace
         $this->creationDatetime = new DateTime();
         $this->memberships = new ArrayCollection();
     }
+
+    public function isPendingDeletion(): bool
+    {
+        return $this->deletionScheduledDatetime instanceof DateTimeImmutable;
+    }
 }

--- a/src/EventSubscriber/BandSpaceInvitationAutoAcceptListener.php
+++ b/src/EventSubscriber/BandSpaceInvitationAutoAcceptListener.php
@@ -44,6 +44,13 @@ readonly class BandSpaceInvitationAutoAcceptListener
                 continue;
             }
 
+            // Symmetry with BandSpaceInvitationAcceptProcessor, which rejects joining a condemned space.
+            // Skipped silently rather than thrown: this runs inside registration and must never break it.
+            // The invitation stays pending and gets purged with the space.
+            if ($invitation->bandSpace->isPendingDeletion()) {
+                continue;
+            }
+
             $existingMembership = $this->membershipRepository->findMembershipIncludingInactive($invitation->bandSpace, $user);
 
             if ($existingMembership instanceof \App\Entity\BandSpace\BandSpaceMembership) {

--- a/src/Security/BandSpace/BandSpaceAdminChecker.php
+++ b/src/Security/BandSpace/BandSpaceAdminChecker.php
@@ -16,7 +16,25 @@ readonly class BandSpaceAdminChecker
     public function __construct(
         private BandSpaceRepository $bandSpaceRepository,
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private BandSpaceWriteGuard $writeGuard,
     ) {
+    }
+
+    /**
+     * Same as checkAdmin(), and additionally rejects a space pending deletion. Processors use this one,
+     * providers keep checkAdmin() so reads stay open during the grace period.
+     *
+     * BandSpaceDeleteProcessor and BandSpaceRestoreProcessor deliberately stay on checkAdmin(): the first
+     * carries its own more precise conflict message, the second is how the deletion gets cancelled.
+     *
+     * @return array{BandSpace, BandSpaceMembership}
+     */
+    public function checkAdminForWrite(string $bandSpaceId, User $user): array
+    {
+        $result = $this->checkAdmin($bandSpaceId, $user);
+        $this->writeGuard->assertWritable($result[0]);
+
+        return $result;
     }
 
     /**

--- a/src/Security/BandSpace/BandSpaceMemberChecker.php
+++ b/src/Security/BandSpace/BandSpaceMemberChecker.php
@@ -15,7 +15,25 @@ readonly class BandSpaceMemberChecker
     public function __construct(
         private BandSpaceRepository $bandSpaceRepository,
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private BandSpaceWriteGuard $writeGuard,
     ) {
+    }
+
+    /**
+     * Same as checkMember(), and additionally rejects a space pending deletion. Processors use this one,
+     * providers keep checkMember() so reads and downloads stay open during the grace period.
+     *
+     * Membership is verified first on purpose: a non-member must get a 403 rather than learn from a 409
+     * that the space is pending deletion.
+     *
+     * @return array{BandSpace, BandSpaceMembership}
+     */
+    public function checkMemberForWrite(string $bandSpaceId, User $user): array
+    {
+        $result = $this->checkMember($bandSpaceId, $user);
+        $this->writeGuard->assertWritable($result[0]);
+
+        return $result;
     }
 
     /**

--- a/src/Security/BandSpace/BandSpaceWriteGuard.php
+++ b/src/Security/BandSpace/BandSpaceWriteGuard.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+/**
+ * A space pending deletion is read only for the whole grace period: the window exists so members can
+ * retrieve their files, so reads and downloads stay open while every write is rejected.
+ *
+ * Deliberately separate from the two checkers, which both delegate here, because
+ * BandSpaceInvitationAcceptProcessor needs the same rule and has no checker to hang it on.
+ */
+readonly class BandSpaceWriteGuard
+{
+    public function assertWritable(BandSpace $bandSpace): void
+    {
+        if ($bandSpace->isPendingDeletion()) {
+            throw new ConflictHttpException('Cet espace est en attente de suppression, les modifications sont désactivées');
+        }
+    }
+}

--- a/src/State/Processor/BandSpace/AgendaEntryCreateProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryCreateProcessor.php
@@ -48,7 +48,7 @@ readonly class AgendaEntryCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         try {
             $eventDatetime = new DateTimeImmutable($data->eventDatetime);

--- a/src/State/Processor/BandSpace/AgendaEntryDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryDeleteProcessor.php
@@ -40,7 +40,7 @@ readonly class AgendaEntryDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->agendaEntryRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$entry instanceof \App\Entity\BandSpace\AgendaEntry) {

--- a/src/State/Processor/BandSpace/AgendaEntryFromOccurrenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryFromOccurrenceDeleteProcessor.php
@@ -52,7 +52,7 @@ readonly class AgendaEntryFromOccurrenceDeleteProcessor implements ProcessorInte
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->agendaEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$entry instanceof AgendaEntry) {

--- a/src/State/Processor/BandSpace/AgendaEntryOccurrenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryOccurrenceDeleteProcessor.php
@@ -55,7 +55,7 @@ readonly class AgendaEntryOccurrenceDeleteProcessor implements ProcessorInterfac
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->agendaEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$entry instanceof AgendaEntry) {

--- a/src/State/Processor/BandSpace/AgendaEntryUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryUpdateProcessor.php
@@ -50,7 +50,7 @@ readonly class AgendaEntryUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->agendaEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$entry instanceof \App\Entity\BandSpace\AgendaEntry) {

--- a/src/State/Processor/BandSpace/BandSpaceInvitationAcceptProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceInvitationAcceptProcessor.php
@@ -61,6 +61,12 @@ readonly class BandSpaceInvitationAcceptProcessor implements ProcessorInterface
             throw new ConflictHttpException('Vous êtes déjà membre de ce Band Space');
         }
 
+        // No checker to hang the write guard on here, the space comes from the invitation rather than a URI
+        // variable, and joining deserves a clearer message than the generic one.
+        if ($invitation->bandSpace->isPendingDeletion()) {
+            throw new ConflictHttpException('Cet espace est en attente de suppression, vous ne pouvez pas le rejoindre');
+        }
+
         $existingMembership = $this->bandSpaceMembershipRepository->findMembershipIncludingInactive($invitation->bandSpace, $user);
 
         if ($existingMembership instanceof \App\Entity\BandSpace\BandSpaceMembership) {

--- a/src/State/Processor/BandSpace/BandSpaceInvitationCreateProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceInvitationCreateProcessor.php
@@ -63,7 +63,7 @@ readonly class BandSpaceInvitationCreateProcessor implements ProcessorInterface
 
         $identifier = trim($data->identifier);
 
-        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $currentUser);
+        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $currentUser);
 
         $isEmail = str_contains($identifier, '@');
 

--- a/src/State/Processor/BandSpace/BandSpaceInvitationDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceInvitationDeleteProcessor.php
@@ -38,7 +38,7 @@ readonly class BandSpaceInvitationDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $invitation = $this->bandSpaceInvitationRepository->findOneByIdAndBandSpace(
             (string) $uriVariables['id'],

--- a/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
@@ -48,7 +48,7 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $membership = $this->bandSpaceMembershipRepository->findOneByIdAndBandSpace(
             (string) $uriVariables['id'],

--- a/src/State/Processor/BandSpace/BandSpaceMemberUpdateRoleProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceMemberUpdateRoleProcessor.php
@@ -47,6 +47,9 @@ readonly class BandSpaceMemberUpdateRoleProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
+        // Deliberately the read-only checker: role changes stay possible while a deletion is pending.
+        // Leaving requires promoting a successor first, so guarding this would trap the sole admin, and
+        // letting them leave instead would strand the space with nobody able to restore it.
         [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
 
         $membership = $this->bandSpaceMembershipRepository->findOneByIdAndBandSpace(

--- a/src/State/Processor/BandSpace/BandSpaceNoteCreateProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceNoteCreateProcessor.php
@@ -10,14 +10,12 @@ use App\Entity\BandSpace\BandSpaceNote;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceNoteActivityType;
-use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
-use App\Repository\BandSpace\BandSpaceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\BandSpaceNoteBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -27,8 +25,7 @@ readonly class BandSpaceNoteCreateProcessor implements ProcessorInterface
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private BandSpaceRepository $bandSpaceRepository,
-        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private BandSpaceMemberChecker $memberChecker,
         private BandSpaceNoteRepository $bandSpaceNoteRepository,
         private BandSpaceNoteBuilder $bandSpaceNoteBuilder,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
@@ -44,14 +41,7 @@ readonly class BandSpaceNoteCreateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        $bandSpace = $this->bandSpaceRepository->findOneByIdWithMemberships((string) $uriVariables['bandSpaceId']);
-        if (!$bandSpace instanceof \App\Entity\BandSpace\BandSpace) {
-            throw new NotFoundHttpException('Band space not found');
-        }
-
-        if (!$this->bandSpaceMembershipRepository->isMember($bandSpace, $user)) {
-            throw new AccessDeniedHttpException('You are not a member of this band space');
-        }
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $parent = null;
         if ($data->parentId !== null) {

--- a/src/State/Processor/BandSpace/BandSpaceNoteDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceNoteDeleteProcessor.php
@@ -8,13 +8,11 @@ use App\ApiResource\BandSpace\BandSpaceNote;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceNoteActivityType;
-use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
-use App\Repository\BandSpace\BandSpaceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -24,8 +22,7 @@ readonly class BandSpaceNoteDeleteProcessor implements ProcessorInterface
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private BandSpaceRepository $bandSpaceRepository,
-        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private BandSpaceMemberChecker $memberChecker,
         private BandSpaceNoteRepository $bandSpaceNoteRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
@@ -40,14 +37,7 @@ readonly class BandSpaceNoteDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        $bandSpace = $this->bandSpaceRepository->findOneByIdWithMemberships((string) $uriVariables['bandSpaceId']);
-        if (!$bandSpace instanceof \App\Entity\BandSpace\BandSpace) {
-            throw new NotFoundHttpException('Band space not found');
-        }
-
-        if (!$this->bandSpaceMembershipRepository->isMember($bandSpace, $user)) {
-            throw new AccessDeniedHttpException('You are not a member of this band space');
-        }
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $note = $this->bandSpaceNoteRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$note instanceof \App\Entity\BandSpace\BandSpaceNote) {

--- a/src/State/Processor/BandSpace/BandSpaceNoteUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceNoteUpdateProcessor.php
@@ -8,16 +8,14 @@ use App\ApiResource\BandSpace\BandSpaceNote as BandSpaceNoteDTO;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceNoteActivityType;
-use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
-use App\Repository\BandSpace\BandSpaceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\BandSpaceNoteBuilder;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -27,8 +25,7 @@ readonly class BandSpaceNoteUpdateProcessor implements ProcessorInterface
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private BandSpaceRepository $bandSpaceRepository,
-        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private BandSpaceMemberChecker $memberChecker,
         private BandSpaceNoteRepository $bandSpaceNoteRepository,
         private BandSpaceNoteBuilder $bandSpaceNoteBuilder,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
@@ -45,14 +42,7 @@ readonly class BandSpaceNoteUpdateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        $bandSpace = $this->bandSpaceRepository->findOneByIdWithMemberships((string) $uriVariables['bandSpaceId']);
-        if (!$bandSpace instanceof \App\Entity\BandSpace\BandSpace) {
-            throw new NotFoundHttpException('Band space not found');
-        }
-
-        if (!$this->bandSpaceMembershipRepository->isMember($bandSpace, $user)) {
-            throw new AccessDeniedHttpException('You are not a member of this band space');
-        }
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $note = $this->bandSpaceNoteRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$note instanceof \App\Entity\BandSpace\BandSpaceNote) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileAttachProcessor.php
@@ -58,7 +58,7 @@ readonly class BandSpaceFileAttachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $file = $this->fileRepository->findOneByIdAndBandSpace((string) $uriVariables['fileId'], $bandSpace);
         if (!$file instanceof \App\Entity\BandSpace\BandSpaceFile || $file->archiveDatetime instanceof \DateTimeImmutable) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileDeleteProcessor.php
@@ -42,7 +42,7 @@ readonly class BandSpaceFileDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [, $membership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $file = $this->fileRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $membership->bandSpace);
         if (!$file instanceof \App\Entity\BandSpace\BandSpaceFile || $file->archiveDatetime instanceof \DateTimeImmutable) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileRollbackProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileRollbackProcessor.php
@@ -38,7 +38,7 @@ readonly class BandSpaceFileRollbackProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $file = $this->fileRepository->findOneByIdAndBandSpace((string) $uriVariables['fileId'], $bandSpace);
         if (!$file instanceof \App\Entity\BandSpace\BandSpaceFile || $file->archiveDatetime instanceof \DateTimeImmutable) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileShareCreateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileShareCreateProcessor.php
@@ -53,7 +53,7 @@ readonly class BandSpaceFileShareCreateProcessor implements ProcessorInterface
 
         $this->shareCreateLimiter->create($user->id)->consume()->ensureAccepted();
 
-        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $file = $this->fileRepository->findOneByIdAndBandSpace((string) $uriVariables['fileId'], $bandSpace);
         if (!$file instanceof \App\Entity\BandSpace\BandSpaceFile || $file->archiveDatetime instanceof \DateTimeImmutable) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileShareDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileShareDeleteProcessor.php
@@ -37,7 +37,7 @@ readonly class BandSpaceFileShareDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $share = $this->shareRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$share instanceof \App\Entity\BandSpace\BandSpaceFileShare) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileTagCreateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileTagCreateProcessor.php
@@ -38,7 +38,7 @@ readonly class BandSpaceFileTagCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $name = trim($data->name);
         if ($this->tagRepository->nameExists($bandSpace, $name)) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileTagDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileTagDeleteProcessor.php
@@ -33,7 +33,7 @@ readonly class BandSpaceFileTagDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $tag = $this->tagRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$tag instanceof \App\Entity\BandSpace\BandSpaceFileTag) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileTagUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileTagUpdateProcessor.php
@@ -43,7 +43,7 @@ readonly class BandSpaceFileTagUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $tag = $this->tagRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$tag instanceof \App\Entity\BandSpace\BandSpaceFileTag) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileUpdateProcessor.php
@@ -38,7 +38,7 @@ readonly class BandSpaceFileUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $file = $this->fileRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$file instanceof \App\Entity\BandSpace\BandSpaceFile || $file->archiveDatetime instanceof \DateTimeImmutable) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileUploadProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileUploadProcessor.php
@@ -68,7 +68,7 @@ readonly class BandSpaceFileUploadProcessor implements ProcessorInterface
 
         $this->uploadLimiter->create($user->id)->consume()->ensureAccepted();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $upload = $data->uploadedFile;
         if ($upload === null) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFileVersionUploadProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileVersionUploadProcessor.php
@@ -58,7 +58,7 @@ readonly class BandSpaceFileVersionUploadProcessor implements ProcessorInterface
 
         $this->uploadLimiter->create($user->id)->consume()->ensureAccepted();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $file = $this->fileRepository->findOneByIdAndBandSpace((string) $uriVariables['fileId'], $bandSpace);
         if (!$file instanceof \App\Entity\BandSpace\BandSpaceFile || $file->archiveDatetime instanceof \DateTimeImmutable) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFinanceEntryFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFinanceEntryFileAttachProcessor.php
@@ -59,7 +59,7 @@ readonly class BandSpaceFinanceEntryFileAttachProcessor implements ProcessorInte
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->financeEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['entryId'], $bandSpace);
         if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFinanceEntryFileDetachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFinanceEntryFileDetachProcessor.php
@@ -45,7 +45,7 @@ readonly class BandSpaceFinanceEntryFileDetachProcessor implements ProcessorInte
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->financeEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['entryId'], $bandSpace);
         if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderCreateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderCreateProcessor.php
@@ -45,7 +45,7 @@ readonly class BandSpaceFolderCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $parent = null;
         if ($data->parentId !== null && $data->parentId !== '') {

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
@@ -44,7 +44,7 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [, $membership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $folder = $this->folderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $membership->bandSpace);
         if (!$folder instanceof \App\Entity\BandSpace\BandSpaceFolder) {

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderUpdateProcessor.php
@@ -46,7 +46,7 @@ readonly class BandSpaceFolderUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace, $membership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $folder = $this->folderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$folder instanceof \App\Entity\BandSpace\BandSpaceFolder) {

--- a/src/State/Processor/BandSpace/File/BandSpaceNoteFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceNoteFileAttachProcessor.php
@@ -55,7 +55,7 @@ readonly class BandSpaceNoteFileAttachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $note = $this->noteRepository->findOneByIdAndBandSpace((string) $uriVariables['noteId'], $bandSpace);
         if (!$note instanceof \App\Entity\BandSpace\BandSpaceNote) {

--- a/src/State/Processor/BandSpace/File/BandSpaceNoteFileDetachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceNoteFileDetachProcessor.php
@@ -44,7 +44,7 @@ readonly class BandSpaceNoteFileDetachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $note = $this->noteRepository->findOneByIdAndBandSpace((string) $uriVariables['noteId'], $bandSpace);
         if (!$note instanceof \App\Entity\BandSpace\BandSpaceNote) {

--- a/src/State/Processor/BandSpace/File/BandSpaceSetlistFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceSetlistFileAttachProcessor.php
@@ -59,7 +59,7 @@ readonly class BandSpaceSetlistFileAttachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['setlistId'], $bandSpace);
         if (!$setlist instanceof \App\Entity\BandSpace\Setlist) {

--- a/src/State/Processor/BandSpace/File/BandSpaceSetlistFileDetachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceSetlistFileDetachProcessor.php
@@ -45,7 +45,7 @@ readonly class BandSpaceSetlistFileDetachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['setlistId'], $bandSpace);
         if (!$setlist instanceof \App\Entity\BandSpace\Setlist) {

--- a/src/State/Processor/BandSpace/File/BandSpaceSongFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceSongFileAttachProcessor.php
@@ -59,7 +59,7 @@ readonly class BandSpaceSongFileAttachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $song = $this->songRepository->findOneByIdAndBandSpace((string) $uriVariables['songId'], $bandSpace);
         if (!$song instanceof \App\Entity\BandSpace\Song) {

--- a/src/State/Processor/BandSpace/File/BandSpaceSongFileDetachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceSongFileDetachProcessor.php
@@ -45,7 +45,7 @@ readonly class BandSpaceSongFileDetachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $song = $this->songRepository->findOneByIdAndBandSpace((string) $uriVariables['songId'], $bandSpace);
         if (!$song instanceof \App\Entity\BandSpace\Song) {

--- a/src/State/Processor/BandSpace/File/BandSpaceTaskFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceTaskFileAttachProcessor.php
@@ -58,7 +58,7 @@ readonly class BandSpaceTaskFileAttachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $task = $this->taskRepository->findOneByIdAndBandSpace((string) $uriVariables['taskId'], $bandSpace);
         if (!$task instanceof \App\Entity\BandSpace\Task) {

--- a/src/State/Processor/BandSpace/File/BandSpaceTaskFileDetachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceTaskFileDetachProcessor.php
@@ -44,7 +44,7 @@ readonly class BandSpaceTaskFileDetachProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $task = $this->taskRepository->findOneByIdAndBandSpace((string) $uriVariables['taskId'], $bandSpace);
         if (!$task instanceof \App\Entity\BandSpace\Task) {

--- a/src/State/Processor/BandSpace/FinanceBootstrapProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceBootstrapProcessor.php
@@ -52,7 +52,7 @@ readonly class FinanceBootstrapProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         if ($this->financeCategoryRepository->existsByBandSpace($bandSpace)) {
             $categories = $this->financeCategoryRepository->findByBandSpace($bandSpace);

--- a/src/State/Processor/BandSpace/FinanceCategoryCreateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceCategoryCreateProcessor.php
@@ -41,7 +41,7 @@ readonly class FinanceCategoryCreateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $parent = null;
         if ($data->parentId !== null) {

--- a/src/State/Processor/BandSpace/FinanceCategoryDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceCategoryDeleteProcessor.php
@@ -37,7 +37,7 @@ readonly class FinanceCategoryDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $category = $this->financeCategoryRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$category instanceof \App\Entity\BandSpace\FinanceCategory) {

--- a/src/State/Processor/BandSpace/FinanceCategoryUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceCategoryUpdateProcessor.php
@@ -43,7 +43,7 @@ readonly class FinanceCategoryUpdateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $category = $this->financeCategoryRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$category instanceof \App\Entity\BandSpace\FinanceCategory) {

--- a/src/State/Processor/BandSpace/FinanceEntryCreateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntryCreateProcessor.php
@@ -46,7 +46,7 @@ readonly class FinanceEntryCreateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace, $currentMembership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $currentMembership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $category = $this->financeCategoryRepository->findOneByIdAndBandSpace($data->categoryId, $bandSpace);
         if (!$category instanceof \App\Entity\BandSpace\FinanceCategory) {

--- a/src/State/Processor/BandSpace/FinanceEntryDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntryDeleteProcessor.php
@@ -41,7 +41,7 @@ readonly class FinanceEntryDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->financeEntryRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry) {

--- a/src/State/Processor/BandSpace/FinanceEntrySplitCreateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntrySplitCreateProcessor.php
@@ -50,7 +50,7 @@ readonly class FinanceEntrySplitCreateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->financeEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['entryId'], $bandSpace);
         if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry) {

--- a/src/State/Processor/BandSpace/FinanceEntrySplitDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntrySplitDeleteProcessor.php
@@ -41,7 +41,7 @@ readonly class FinanceEntrySplitDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->financeEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['entryId'], $bandSpace);
         if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry) {

--- a/src/State/Processor/BandSpace/FinanceEntryUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntryUpdateProcessor.php
@@ -55,7 +55,7 @@ readonly class FinanceEntryUpdateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace, $currentMembership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $currentMembership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->financeEntryRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry) {

--- a/src/State/Processor/BandSpace/FinanceRecurrenceCreateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceCreateProcessor.php
@@ -46,7 +46,7 @@ readonly class FinanceRecurrenceCreateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace, $currentMembership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $currentMembership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $category = $this->financeCategoryRepository->findOneByIdAndBandSpace($data->categoryId, $bandSpace);
         if (!$category instanceof \App\Entity\BandSpace\FinanceCategory) {

--- a/src/State/Processor/BandSpace/FinanceRecurrenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceDeleteProcessor.php
@@ -38,7 +38,7 @@ readonly class FinanceRecurrenceDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $recurrence = $this->financeRecurrenceRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$recurrence instanceof \App\Entity\BandSpace\FinanceRecurrence) {

--- a/src/State/Processor/BandSpace/FinanceRecurrenceUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceUpdateProcessor.php
@@ -49,7 +49,7 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace, $currentMembership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $currentMembership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $recurrence = $this->financeRecurrenceRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$recurrence instanceof \App\Entity\BandSpace\FinanceRecurrence) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistCreateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistCreateProcessor.php
@@ -41,7 +41,7 @@ readonly class SetlistCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = new Setlist();
         $setlist->bandSpace = $bandSpace;

--- a/src/State/Processor/BandSpace/Setlist/SetlistDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistDeleteProcessor.php
@@ -44,7 +44,7 @@ readonly class SetlistDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$setlist instanceof Setlist) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistDuplicateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistDuplicateProcessor.php
@@ -41,7 +41,7 @@ readonly class SetlistDuplicateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $source = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$source instanceof Setlist) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistItemCreateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistItemCreateProcessor.php
@@ -50,7 +50,7 @@ readonly class SetlistItemCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['setlistId'], $bandSpace);
         if (!$setlist instanceof Setlist) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistItemDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistItemDeleteProcessor.php
@@ -47,7 +47,7 @@ readonly class SetlistItemDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['setlistId'], $bandSpace);
         if (!$setlist instanceof Setlist) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistItemUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistItemUpdateProcessor.php
@@ -51,7 +51,7 @@ readonly class SetlistItemUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['setlistId'], $bandSpace);
         if (!$setlist instanceof Setlist) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistReorderProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistReorderProcessor.php
@@ -46,7 +46,7 @@ readonly class SetlistReorderProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$setlist instanceof Setlist) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistUpdateProcessor.php
@@ -48,7 +48,7 @@ readonly class SetlistUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$setlist instanceof Setlist) {

--- a/src/State/Processor/BandSpace/Setlist/Song/SongCreateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/Song/SongCreateProcessor.php
@@ -41,7 +41,7 @@ readonly class SongCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $song = new Song();
         $song->bandSpace = $bandSpace;

--- a/src/State/Processor/BandSpace/Setlist/Song/SongDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/Song/SongDeleteProcessor.php
@@ -45,7 +45,7 @@ readonly class SongDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $song = $this->songRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$song instanceof Song) {

--- a/src/State/Processor/BandSpace/Setlist/Song/SongUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/Song/SongUpdateProcessor.php
@@ -44,7 +44,7 @@ readonly class SongUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $song = $this->songRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$song instanceof Song) {

--- a/src/State/Processor/BandSpace/TaskBulkDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/TaskBulkDeleteProcessor.php
@@ -33,7 +33,7 @@ readonly class TaskBulkDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace, $membership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $this->taskBulkDeleteProcedure->delete($bandSpace, $membership, $data->taskIds, $user);
     }

--- a/src/State/Processor/BandSpace/TaskBulkPatchProcessor.php
+++ b/src/State/Processor/BandSpace/TaskBulkPatchProcessor.php
@@ -37,7 +37,7 @@ readonly class TaskBulkPatchProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $payload = $this->requestStack->getCurrentRequest()?->toArray() ?? [];
         $patchPayload = array_intersect_key($payload, array_flip(self::ALLOWED_KEYS));

--- a/src/State/Processor/BandSpace/TaskCategoryCreateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCategoryCreateProcessor.php
@@ -41,7 +41,7 @@ readonly class TaskCategoryCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $usedColors = $this->taskCategoryRepository->findColorsByBandSpace($bandSpace);
 

--- a/src/State/Processor/BandSpace/TaskCategoryDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCategoryDeleteProcessor.php
@@ -36,7 +36,7 @@ readonly class TaskCategoryDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $category = $this->taskCategoryRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$category instanceof \App\Entity\BandSpace\TaskCategory) {

--- a/src/State/Processor/BandSpace/TaskCategoryUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCategoryUpdateProcessor.php
@@ -41,7 +41,7 @@ readonly class TaskCategoryUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $category = $this->taskCategoryRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$category instanceof \App\Entity\BandSpace\TaskCategory) {

--- a/src/State/Processor/BandSpace/TaskCommentCreateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCommentCreateProcessor.php
@@ -52,7 +52,7 @@ readonly class TaskCommentCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $task = $this->taskRepository->findOneByIdAndBandSpace((string) $uriVariables['taskId'], $bandSpace);
         if (!$task instanceof \App\Entity\BandSpace\Task) {

--- a/src/State/Processor/BandSpace/TaskCommentDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCommentDeleteProcessor.php
@@ -43,7 +43,7 @@ readonly class TaskCommentDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [, $membership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $task = $this->taskRepository->findOneByIdAndBandSpace((string) $uriVariables['taskId'], $membership->bandSpace);
         if (!$task instanceof \App\Entity\BandSpace\Task) {

--- a/src/State/Processor/BandSpace/TaskCommentUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCommentUpdateProcessor.php
@@ -45,7 +45,7 @@ readonly class TaskCommentUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $task = $this->taskRepository->findOneByIdAndBandSpace((string) $uriVariables['taskId'], $bandSpace);
         if (!$task instanceof \App\Entity\BandSpace\Task) {

--- a/src/State/Processor/BandSpace/TaskCreateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCreateProcessor.php
@@ -54,7 +54,7 @@ readonly class TaskCreateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $task = new Task();
         $task->bandSpace = $bandSpace;

--- a/src/State/Processor/BandSpace/TaskDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/TaskDeleteProcessor.php
@@ -37,7 +37,7 @@ readonly class TaskDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [, $membership] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $task = $this->taskRepository->findOneByIdAndBandSpace($data->id, $membership->bandSpace);
         if (!$task instanceof \App\Entity\BandSpace\Task) {

--- a/src/State/Processor/BandSpace/TaskMoveProcessor.php
+++ b/src/State/Processor/BandSpace/TaskMoveProcessor.php
@@ -40,7 +40,7 @@ readonly class TaskMoveProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         /** @var array<int, array{id: string, position: int}> $positions */
         $positions = $data->positions;

--- a/src/State/Processor/BandSpace/TaskReorderProcessor.php
+++ b/src/State/Processor/BandSpace/TaskReorderProcessor.php
@@ -36,7 +36,7 @@ readonly class TaskReorderProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $requestedIds = array_column($data->positions, 'id');
         $foundTasks = $this->taskRepository->findByIdsAndBandSpace($requestedIds, $bandSpace);

--- a/src/State/Processor/BandSpace/TaskUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskUpdateProcessor.php
@@ -44,7 +44,7 @@ readonly class TaskUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $task = $this->taskRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$task instanceof \App\Entity\BandSpace\Task) {

--- a/src/State/Provider/BandSpace/BandSpaceNoteCollectionProvider.php
+++ b/src/State/Provider/BandSpace/BandSpaceNoteCollectionProvider.php
@@ -5,13 +5,11 @@ namespace App\State\Provider\BandSpace;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\User;
-use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
-use App\Repository\BandSpace\BandSpaceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\Builder\BandSpace\BandSpaceNoteBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @implements ProviderInterface<object>
@@ -19,8 +17,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 readonly class BandSpaceNoteCollectionProvider implements ProviderInterface
 {
     public function __construct(
-        private BandSpaceRepository $bandSpaceRepository,
-        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private BandSpaceMemberChecker $memberChecker,
         private BandSpaceNoteRepository $bandSpaceNoteRepository,
         private BandSpaceNoteBuilder $bandSpaceNoteBuilder,
         private Security $security,
@@ -34,14 +31,8 @@ readonly class BandSpaceNoteCollectionProvider implements ProviderInterface
             throw new AccessDeniedHttpException();
         }
 
-        $bandSpace = $this->bandSpaceRepository->findOneByIdWithMemberships((string) $uriVariables['bandSpaceId']);
-        if (!$bandSpace instanceof \App\Entity\BandSpace\BandSpace) {
-            throw new NotFoundHttpException('Band space not found');
-        }
-
-        if (!$this->bandSpaceMembershipRepository->isMember($bandSpace, $user)) {
-            throw new AccessDeniedHttpException('You are not a member of this band space');
-        }
+        // The read-only variant: notes stay readable while a deletion is pending.
+        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
         $notes = $this->bandSpaceNoteRepository->findByBandSpace($bandSpace);
 

--- a/src/State/Provider/BandSpace/BandSpaceNoteItemProvider.php
+++ b/src/State/Provider/BandSpace/BandSpaceNoteItemProvider.php
@@ -5,9 +5,8 @@ namespace App\State\Provider\BandSpace;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\User;
-use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
-use App\Repository\BandSpace\BandSpaceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\Builder\BandSpace\BandSpaceNoteBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -19,8 +18,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 readonly class BandSpaceNoteItemProvider implements ProviderInterface
 {
     public function __construct(
-        private BandSpaceRepository $bandSpaceRepository,
-        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private BandSpaceMemberChecker $memberChecker,
         private BandSpaceNoteRepository $bandSpaceNoteRepository,
         private BandSpaceNoteBuilder $bandSpaceNoteBuilder,
         private Security $security,
@@ -34,14 +32,9 @@ readonly class BandSpaceNoteItemProvider implements ProviderInterface
             throw new AccessDeniedHttpException();
         }
 
-        $bandSpace = $this->bandSpaceRepository->findOneByIdWithMemberships((string) $uriVariables['bandSpaceId']);
-        if (!$bandSpace instanceof \App\Entity\BandSpace\BandSpace) {
-            throw new NotFoundHttpException('Band space not found');
-        }
-
-        if (!$this->bandSpaceMembershipRepository->isMember($bandSpace, $user)) {
-            throw new AccessDeniedHttpException('You are not a member of this band space');
-        }
+        // The read-only variant: notes stay readable while a deletion is pending, and this provider also
+        // runs before the update and delete processors, which carry the write guard themselves.
+        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
         $note = $this->bandSpaceNoteRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$note instanceof \App\Entity\BandSpace\BandSpaceNote) {

--- a/tests/Api/BandSpace/BandSpaceNoteCreateTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteCreateTest.php
@@ -183,6 +183,41 @@ class BandSpaceNoteCreateTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    public function test_create_note_unknown_band_space(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/8f1b0d2a-0000-4000-8000-000000000000/notes',
+            ['title' => 'Note nulle part'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Band Space introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Band Space introuvable',
+        ]);
     }
 
     public function test_create_note_inactive_member(): void

--- a/tests/Api/BandSpace/BandSpaceNoteDeleteTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteDeleteTest.php
@@ -111,6 +111,16 @@ class BandSpaceNoteDeleteTest extends ApiTestCase
         $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id);
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
     }
 
     public function test_delete_inactive_member(): void

--- a/tests/Api/BandSpace/BandSpaceNoteGetCollectionTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteGetCollectionTest.php
@@ -111,6 +111,16 @@ class BandSpaceNoteGetCollectionTest extends ApiTestCase
         $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/notes');
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
     }
 
     public function test_get_collection_inactive_member(): void

--- a/tests/Api/BandSpace/BandSpaceNoteGetTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteGetTest.php
@@ -90,6 +90,16 @@ class BandSpaceNoteGetTest extends ApiTestCase
         $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id);
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
     }
 
     public function test_get_item_inactive_member(): void

--- a/tests/Api/BandSpace/BandSpaceNoteUpdateTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteUpdateTest.php
@@ -528,6 +528,16 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
     }
 
     public function test_update_inactive_member(): void

--- a/tests/Api/BandSpace/BandSpacePendingDeletionWriteBlockTest.php
+++ b/tests/Api/BandSpace/BandSpacePendingDeletionWriteBlockTest.php
@@ -1,0 +1,349 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\User;
+use App\Enum\BandSpace\InvitationStatus;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceInvitationRepository;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Repository\BandSpace\BandSpaceNoteRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceInvitationFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * A space pending deletion is read only for the whole grace period.
+ *
+ * The rule reaches roughly 75 processors through BandSpaceMemberChecker::checkMemberForWrite() and
+ * BandSpaceAdminChecker::checkAdminForWrite(), so this covers one representative per wiring rather than
+ * every endpoint. BandSpaceWriteGuardCoverageTest is what proves no processor escapes the wiring.
+ */
+#[ResetDatabase]
+class BandSpacePendingDeletionWriteBlockTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    private const array EXPECTED_CONFLICT = [
+        '@context' => '/api/contexts/Error',
+        '@id' => '/api/errors/409',
+        '@type' => 'Error',
+        'title' => 'An error occurred',
+        'detail' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+        'status' => 409,
+        'type' => '/errors/409',
+        'description' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+    ];
+
+    /**
+     * Representative of the 61 processors on checkMemberForWrite().
+     */
+    public function test_a_member_cannot_create_a_task(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks',
+            ['title' => 'Répéter le nouveau morceau'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals(self::EXPECTED_CONFLICT);
+    }
+
+    /**
+     * Representative of the 8 processors on checkAdminForWrite().
+     */
+    public function test_an_admin_cannot_invite_anyone(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/invitations',
+            ['identifier' => 'newuser@example.com'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals(self::EXPECTED_CONFLICT);
+
+        $this->assertCount(
+            0,
+            self::getContainer()->get(BandSpaceInvitationRepository::class)->findBy(['bandSpace' => $bandSpace->id]),
+        );
+    }
+
+    /**
+     * The three note processors used to inline their own membership check and bypass the checkers entirely.
+     */
+    public function test_a_member_cannot_create_a_note(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/notes',
+            ['title' => 'Idées pour le prochain album'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals(self::EXPECTED_CONFLICT);
+
+        $this->assertCount(0, self::getContainer()->get(BandSpaceNoteRepository::class)->findByBandSpace($bandSpace));
+    }
+
+    /**
+     * Joining a condemned space is pointless, and this processor has no checker to hang the guard on, so it
+     * gets its own message.
+     */
+    public function test_an_invitee_cannot_accept_an_invitation_to_a_condemned_space(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+        $invitee = UserFactory::new()->create(['username' => 'invitee', 'email' => 'invitee@example.com']);
+
+        $invitation = BandSpaceInvitationFactory::new([
+            'bandSpace' => $bandSpace,
+            'invitedBy' => $admin,
+            'email' => 'invitee@example.com',
+            'existingUser' => $invitee,
+            'expirationDatetime' => (new \DateTime())->modify('+7 days'),
+        ])->create();
+
+        $this->client->loginUser($invitee);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/invitations/' . $invitation->token . '/accept',
+            [],
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cet espace est en attente de suppression, vous ne pouvez pas le rejoindre',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cet espace est en attente de suppression, vous ne pouvez pas le rejoindre',
+        ]);
+
+        $this->assertFalse(
+            self::getContainer()->get(BandSpaceMembershipRepository::class)->isMember($bandSpace, $invitee),
+        );
+    }
+
+    /**
+     * The guard runs after the membership check on purpose. A stranger must not be able to learn that a
+     * space is pending deletion by probing a write endpoint.
+     */
+    public function test_a_non_member_still_gets_403_and_never_learns_the_space_is_condemned(): void
+    {
+        [, $bandSpace] = $this->pendingDeletionSpace();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@example.com']);
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks',
+            ['title' => 'Sonder cet espace'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function readableModuleProvider(): iterable
+    {
+        yield 'tasks' => ['tasks'];
+        yield 'notes' => ['notes'];
+        yield 'files' => ['files'];
+        yield 'agenda' => ['agenda-entries'];
+        yield 'setlists' => ['setlists'];
+        yield 'finance categories' => ['finance/categories'];
+    }
+
+    /**
+     * The window exists so members can retrieve their work, so reads stay open. One test per module because
+     * loginUser() only survives a single request. The download path has its own case in
+     * BandSpaceFileDownloadTest, where the storage fixtures live.
+     */
+    #[DataProvider('readableModuleProvider')]
+    public function test_reads_stay_open(string $module): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+
+        $this->client->loginUser($admin);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/' . $module,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function test_an_admin_can_still_cancel_the_deletion(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertNull(
+            self::getContainer()->get(BandSpaceRepository::class)
+                ->findOneByIdWithMemberships((string) $bandSpace->id)
+                ?->deletionScheduledDatetime,
+        );
+    }
+
+    /**
+     * Leaving refuses to strand a space without an admin, so the sole admin has to promote a successor first.
+     * Blocking role changes during the grace period would trap them: unable to promote, unable to leave. And
+     * letting them leave without a successor is not the alternative, that would strand the space with nobody
+     * able to cancel the deletion.
+     *
+     * This half proves the promotion is still allowed. The next one proves the departure that follows it.
+     */
+    public function test_the_sole_admin_can_still_promote_a_successor(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+        $member = UserFactory::new()->create(['username' => 'successor', 'email' => 'successor@example.com']);
+        $membership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $member,
+            'role' => Role::User,
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/members/' . $membership->id,
+            ['role' => 'admin'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            Role::Admin,
+            self::getContainer()->get(BandSpaceMembershipRepository::class)->findMembership($bandSpace, $member)?->role,
+        );
+    }
+
+    public function test_the_departing_admin_can_leave_once_a_successor_exists(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+        $successor = UserFactory::new()->create(['username' => 'successor', 'email' => 'successor@example.com']);
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $successor,
+            'role' => Role::Admin,
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/leave', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // An admin remains, so the deletion stays cancellable.
+        $membershipRepository = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $this->assertFalse($membershipRepository->isMember($bandSpace, $admin));
+        $this->assertSame(Role::Admin, $membershipRepository->findMembership($bandSpace, $successor)?->role);
+    }
+
+    public function test_a_member_can_still_leave(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+        $member = UserFactory::new()->create(['username' => 'member', 'email' => 'member@example.com']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $this->client->loginUser($member);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/leave', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $membershipRepository = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $this->assertFalse($membershipRepository->isMember($bandSpace, $member));
+        // The admin is untouched, only the leaving member's own membership changed.
+        $this->assertTrue($membershipRepository->isMember($bandSpace, $admin));
+    }
+
+    public function test_an_invitee_can_still_decline(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+        $invitee = UserFactory::new()->create(['username' => 'invitee', 'email' => 'invitee@example.com']);
+
+        $invitation = BandSpaceInvitationFactory::new([
+            'bandSpace' => $bandSpace,
+            'invitedBy' => $admin,
+            'email' => 'invitee@example.com',
+            'existingUser' => $invitee,
+            'expirationDatetime' => (new \DateTime())->modify('+7 days'),
+        ])->create();
+
+        $this->client->loginUser($invitee);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/invitations/' . $invitation->token . '/decline',
+            [],
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertSame(
+            InvitationStatus::Declined,
+            self::getContainer()->get(BandSpaceInvitationRepository::class)->find($invitation->id)?->status,
+        );
+    }
+
+    /**
+     * @return array{User, BandSpace}
+     */
+    private function pendingDeletionSpace(): array
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create([
+            'name' => 'Groupe condamné',
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+30 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        return [$admin, $bandSpace];
+    }
+}

--- a/tests/Api/BandSpace/File/BandSpaceFileDownloadTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileDownloadTest.php
@@ -44,6 +44,28 @@ class BandSpaceFileDownloadTest extends ApiTestCase
         $this->assertSame(self::V2_CONTENT, $this->getStreamedBody());
     }
 
+    /**
+     * The grace period exists so members can retrieve their files, so the write block introduced for a
+     * space pending deletion must never reach the download path.
+     */
+    public function test_download_still_works_while_the_space_is_pending_deletion(): void
+    {
+        $this->client->disableReboot();
+        [$user, $bandSpace, $file, , ] = $this->setupFileWithTwoVersions(currentVersionNumber: 2);
+
+        $bandSpace->deletionScheduledDatetime = new \DateTimeImmutable('+30 days');
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/download',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(self::V2_CONTENT, $this->getStreamedBody());
+    }
+
     public function test_download_specific_old_version_returns_v1_bytes(): void
     {
         $this->client->disableReboot();

--- a/tests/Integration/EventSubscriber/BandSpaceInvitationAutoAcceptListenerTest.php
+++ b/tests/Integration/EventSubscriber/BandSpaceInvitationAutoAcceptListenerTest.php
@@ -128,6 +128,57 @@ class BandSpaceInvitationAutoAcceptListenerTest extends KernelTestCase
         $this->assertFalse($membershipRepo->isMember($bandSpace, $newUser));
     }
 
+    /**
+     * Symmetry with the explicit accept endpoint, which rejects joining a space pending deletion. Skipped
+     * silently rather than thrown: this runs inside registration and must never break it.
+     */
+    public function test_skips_invitations_to_a_space_pending_deletion(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $condemned = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+30 days'),
+        ]);
+        $healthy = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $condemned, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $healthy, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $condemnedInvitation = BandSpaceInvitationFactory::new([
+            'bandSpace' => $condemned,
+            'invitedBy' => $admin,
+            'email' => 'newuser@example.com',
+            'expirationDatetime' => (new \DateTime())->modify('+7 days'),
+        ])->create();
+        BandSpaceInvitationFactory::new([
+            'bandSpace' => $healthy,
+            'invitedBy' => $admin,
+            'email' => 'newuser@example.com',
+            'expirationDatetime' => (new \DateTime())->modify('+7 days'),
+        ])->create();
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $newUser = new User();
+        $newUser->username = 'newuser';
+        $newUser->email = 'newuser@example.com';
+        $newUser->password = 'hashed';
+        $newUser->profile = new UserProfile();
+        $em->persist($newUser);
+        $em->flush();
+
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->dispatch(new UserRegisteredEvent($newUser));
+
+        $membershipRepo = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $this->assertFalse($membershipRepo->isMember($condemned, $newUser));
+        // Skipping one invitation must not abort the loop: the healthy space still gets its member.
+        $this->assertTrue($membershipRepo->isMember($healthy, $newUser));
+
+        // The skipped invitation stays pending and gets purged along with the space.
+        $this->assertSame(
+            InvitationStatus::Pending,
+            self::getContainer()->get(BandSpaceInvitationRepository::class)->find($condemnedInvitation->id)?->status,
+        );
+    }
+
     public function test_no_pending_invitations(): void
     {
         $em = self::getContainer()->get(EntityManagerInterface::class);

--- a/tests/Unit/Security/BandSpace/BandSpaceWriteGuardCoverageTest.php
+++ b/tests/Unit/Security/BandSpace/BandSpaceWriteGuardCoverageTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security\BandSpace;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A space pending deletion must be read only, and that rule lives in roughly 75 processors. Enumerating
+ * them in API tests is not realistic, so this asserts the wiring instead: every processor either goes
+ * through a guarded checker variant, guards itself, or is on the allow-list below with its reason.
+ *
+ * The point is processor number 79. Without this, a new write path silently reopens the hole and no test
+ * fails.
+ */
+class BandSpaceWriteGuardCoverageTest extends TestCase
+{
+    private const string PROCESSOR_DIR = 'src/State/Processor/BandSpace';
+
+    /**
+     * Either of these means the processor is covered: the two guarded checker variants, or the entity
+     * predicate for BandSpaceInvitationAcceptProcessor, which has no checker to hang the guard on because
+     * its space comes from the invitation rather than from a URI variable.
+     */
+    private const array GUARD_MARKERS = [
+        'checkMemberForWrite(',
+        'checkAdminForWrite(',
+        'isPendingDeletion(',
+    ];
+
+    /**
+     * Writes that must keep working while a deletion is pending. Any addition here is a deliberate hole
+     * and needs a reason.
+     *
+     * @var array<string, string>
+     */
+    private const array ALLOWED_UNGUARDED = [
+        'BandSpaceCreateProcessor.php' => 'Creates the space, so there is none to be pending deletion.',
+        'BandSpaceDeleteProcessor.php' => 'Schedules the deletion, and carries its own more precise conflict message.',
+        'BandSpaceRestoreProcessor.php' => 'Cancels the deletion. Guarding it would make the deletion unrecoverable.',
+        'BandSpaceLeaveProcessor.php' => 'A member must be able to walk away from a condemned space.',
+        'BandSpaceInvitationDeclineProcessor.php' => 'Declining is the invitee cleaning up their own state.',
+        'BandSpaceMemberUpdateRoleProcessor.php' => 'Leaving requires promoting a successor first, so guarding '
+            . 'this would trap the sole admin of a condemned space. Letting them leave without a successor is '
+            . 'not the alternative: it would strand the space with nobody able to restore it.',
+    ];
+
+    public function test_every_band_space_write_processor_is_guarded_or_explicitly_allowed(): void
+    {
+        $unguarded = [];
+        foreach ($this->processorFiles() as $relativePath => $source) {
+            $basename = basename($relativePath);
+            if (isset(self::ALLOWED_UNGUARDED[$basename])) {
+                continue;
+            }
+
+            $isGuarded = array_filter(
+                self::GUARD_MARKERS,
+                static fn(string $marker): bool => str_contains($source, $marker),
+            ) !== [];
+
+            if (!$isGuarded) {
+                $unguarded[] = $relativePath;
+            }
+        }
+
+        self::assertSame([], $unguarded, sprintf(
+            "These processors write to a band space without the pending-deletion guard.\n"
+            . "Use checkMemberForWrite() or checkAdminForWrite() instead of the read-only variants, or add the\n"
+            . "file to ALLOWED_UNGUARDED in %s with a reason.\n",
+            self::class,
+        ));
+    }
+
+    public function test_the_allow_list_has_no_stale_entries(): void
+    {
+        $existing = array_map('basename', array_keys($this->processorFiles()));
+
+        foreach (array_keys(self::ALLOWED_UNGUARDED) as $allowed) {
+            self::assertContains($allowed, $existing, sprintf(
+                '%s is allow-listed but no longer exists. Remove the entry.',
+                $allowed,
+            ));
+        }
+    }
+
+    /**
+     * Guards against the glob silently matching nothing, which would make the test above pass vacuously.
+     */
+    public function test_the_scan_actually_finds_the_processors(): void
+    {
+        self::assertGreaterThan(70, count($this->processorFiles()));
+    }
+
+    /**
+     * @return array<string, string> relative path => file contents
+     */
+    private function processorFiles(): array
+    {
+        // tests/Unit/Security/BandSpace -> project root
+        $directory = \dirname(__DIR__, 4) . '/' . self::PROCESSOR_DIR;
+        self::assertDirectoryExists($directory);
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory));
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $source = file_get_contents($file->getPathname());
+            self::assertIsString($source);
+            // Keyed by sub-path, not basename: two processors with the same name in different
+            // subdirectories would otherwise overwrite each other and drop out of the scan unnoticed.
+            $files[self::PROCESSOR_DIR . '/' . $iterator->getSubPathname()] = $source;
+        }
+
+        ksort($files);
+
+        return $files;
+    }
+}

--- a/tests/Unit/Security/BandSpace/BandSpaceWriteGuardTest.php
+++ b/tests/Unit/Security/BandSpace/BandSpaceWriteGuardTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Security\BandSpace\BandSpaceWriteGuard;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+class BandSpaceWriteGuardTest extends TestCase
+{
+    public function test_a_space_pending_deletion_rejects_writes_with_a_conflict(): void
+    {
+        $bandSpace = new BandSpace();
+        $bandSpace->deletionScheduledDatetime = new \DateTimeImmutable('+30 days');
+
+        try {
+            (new BandSpaceWriteGuard())->assertWritable($bandSpace);
+            self::fail('Expected a ConflictHttpException');
+        } catch (ConflictHttpException $exception) {
+            self::assertSame(Response::HTTP_CONFLICT, $exception->getStatusCode());
+            self::assertSame(
+                'Cet espace est en attente de suppression, les modifications sont désactivées',
+                $exception->getMessage(),
+            );
+        }
+    }
+
+    public function test_an_ordinary_space_is_writable(): void
+    {
+        $bandSpace = new BandSpace();
+
+        (new BandSpaceWriteGuard())->assertWritable($bandSpace);
+
+        self::assertFalse($bandSpace->isPendingDeletion());
+    }
+
+    /**
+     * The purge command deletes a space once the due date has passed, but until it runs the space is still
+     * there. A past due date must stay blocked rather than flip back to writable.
+     */
+    public function test_a_space_whose_due_date_has_passed_is_still_blocked(): void
+    {
+        $bandSpace = new BandSpace();
+        $bandSpace->deletionScheduledDatetime = new \DateTimeImmutable('-1 day');
+
+        $this->expectException(ConflictHttpException::class);
+
+        (new BandSpaceWriteGuard())->assertWritable($bandSpace);
+    }
+}


### PR DESCRIPTION
Closes #756

## Contexte

Depuis #748, un administrateur peut programmer la suppression d'un espace, ce qui renseigne `deletionScheduledDatetime` et ouvre un délai de grâce de 30 jours avant que `app:band-space:purge` ne détruise le stockage et les lignes.

Pendant ces 30 jours l'espace restait **entièrement modifiable**. Les membres pouvaient encore téléverser des fichiers, créer des notes, des tâches, des entrées financières, tout cela promis à la destruction sans avertissement supplémentaire. Rien ne cassait techniquement, puisque tout est purgé de toute façon, mais un espace condamné qui accepte encore du travail est déroutant. #748 avait écarté le sujet parce que le resserrer suppose d'atteindre tous les points d'écriture du module.

Désormais, pendant le délai de grâce, l'espace passe **en lecture seule** : toutes les lectures continuent de fonctionner, parce que la fenêtre existe précisément pour que les membres récupèrent leurs fichiers, et toute écriture répond **409 Conflict** avec un message clair.

## Pourquoi la garde vit dans les checkers

Un listener sur `kernel.request` aurait été une toute petite modification au lieu de 75. C'est pourtant le mauvais choix, pour deux raisons vérifiées :

1. **Cela divulguerait l'état de l'espace.** Un listener s'exécute avant les providers et les processeurs, il ne peut donc pas savoir si l'appelant est membre. Un non-membre sondant `POST /api/band_spaces/{id}/tasks` recevrait 409 « en attente de suppression » au lieu de 403, apprenant l'état d'un espace qu'il ne peut pas voir. Dans les checkers, l'ordre reste correct : appartenance d'abord, état de suppression ensuite.
2. **Toutes les écritures ne sont pas des écritures.** `BandSpaceFilePublicShareDownloadProvider` incrémente `accessCount` et `lastAccessDatetime` puis flush, sur un `GET`. Une règle fondée sur la méthode HTTP devrait le traiter à part. La garde placée dans les checkers ne le voit jamais.

## Ce qui change

- `BandSpaceWriteGuard::assertWritable()`, et `BandSpace::isPendingDeletion()` pour que la condition se lise comme une intention.
- `BandSpaceMemberChecker::checkMemberForWrite()` et `BandSpaceAdminChecker::checkAdminForWrite()`, qui délèguent à la méthode de lecture existante puis appellent la garde. Les règles d'appartenance et de rôle restent à un seul endroit.
- **73 processeurs sur 78** passent par les variantes gardées : 61 renommages `checkMember`, 8 renommages `checkAdmin`, les 3 processeurs de notes migrés depuis leur contrôle d'appartenance recopié à la main, et `BandSpaceInvitationAcceptProcessor` gardé directement, son espace venant de l'invitation et non d'une variable d'URI.
- `BandSpaceInvitationAutoAcceptListener` ignore désormais les invitations vers un espace condamné. Silencieusement : ce code s'exécute dans l'inscription et ne doit jamais la casser.
- Les **48 providers** conservent volontairement les méthodes de lecture inchangées.

Côté interface, seule la formulation du bandeau existant change, dans `AppBandLayout.vue`. Il s'affiche déjà sur tous les modules et indique maintenant que les modifications sont désactivées mais que la consultation et le téléchargement restent possibles. Les boutons restent actifs : `handleApiError` lit déjà `data.detail`, donc le message du 409 remonte dans les retours existants.

## Les six écritures qui restent autorisées

| Processeur | Raison |
|---|---|
| `BandSpaceRestoreProcessor` | Le garder rendrait la suppression irréversible. |
| `BandSpaceDeleteProcessor` | Porte déjà son propre 409, plus précis : « La suppression de cet espace est déjà programmée ». |
| `BandSpaceLeaveProcessor` | Un membre doit pouvoir quitter un espace condamné. |
| `BandSpaceInvitationDeclineProcessor` | Refuser une invitation, c'est l'invité qui range son propre état. |
| `BandSpaceMemberUpdateRoleProcessor` | Voir ci-dessous, cette exemption vient de la relecture. |
| `BandSpaceCreateProcessor` | Aucun espace n'existe encore. |

Créer un lien de partage public **reste bloqué**, pour une règle uniforme. Le téléchargement direct reste disponible pour tous les membres et les liens existants continuent de fonctionner, les fichiers ne sont donc pas piégés.

**L'exemption des changements de rôle corrige un blocage mutuel** trouvé en relecture. Quitter un espace refuse de le laisser sans administrateur, donc l'unique administrateur doit d'abord promouvoir un successeur. Avec la promotion bloquée, il se retrouvait piégé : ni promouvoir, ni partir. Laisser partir l'unique administrateur sans successeur n'était pas la solution de rechange, cela aurait laissé l'espace sans personne pour annuler la suppression, ce qui est exactement ce que l'exemption de `BandSpaceRestoreProcessor` cherche à éviter. Les contrôles existants garantissent toujours qu'un administrateur subsiste.

## Le test qui rend la règle durable

La règle porte sur environ 75 fichiers, et l'inquiétude explicite de l'issue était cette dispersion. `BandSpaceWriteGuardCoverageTest` parcourt donc chaque processeur du module et exige qu'il passe par une variante gardée, se garde lui-même, ou figure sur une liste d'exemptions accompagnée de sa raison. C'est ce qui empêche le soixante-dix-neuvième processeur de rouvrir la porte sans qu'aucun test ne tombe.

Un test dont le seul rôle est d'échouer ne vaut rien tant qu'on n'a pas prouvé qu'il échoue : `TaskCreateProcessor` a été dégardé volontairement, le test a bien nommé le fichier avec un message actionnable, puis le fichier a été remis en état.

## Vérification

- Suite complète : **1773 verts**, 24 tests ajoutés, et **aucun test existant cassé**. Ce dernier point confirme que rien dans le code n'écrivait dans un espace en attente de suppression.
- PHPStan niveau 8 sans baseline, Biome et `npm run build` : propres.
- Le renommage mécanique fait exactement +1/-1 par fichier, et le diff dédupliqué ne contient que le changement de nom de méthode. Aucun fichier de `src/State/Provider/` n'est touché.
- Passage manuel sur l'application de développement : 5 écritures réparties sur 4 modules et sur les deux variantes répondent 409 avec le message attendu, les 8 endpoints de lecture répondent 200, et le 409 s'affiche bien dans l'interface. Surtout, un fichier a été téléversé pendant que l'espace était sain, l'espace a été condamné, puis le téléversement a répondu **409** tandis que le téléchargement de ce fichier a répondu **200** avec les octets exacts et le bon `Content-Disposition`. C'est la garantie qui compte : le délai de grâce sert à récupérer ses fichiers.
- Le test d'ordre est celui à conserver s'il ne devait en rester qu'un : un non-membre reçoit toujours 403 et jamais 409, personne n'apprend donc de l'extérieur qu'un espace est condamné.

## À signaler

La migration des 3 processeurs de notes fait passer leurs messages 403 et 404 de l'anglais au français des checkers. Aucun test ne les vérifiait, rien ne casse, et le français est correct pour cette application, mais c'est un changement visible par l'utilisateur.

## Volontairement hors périmètre

- **Désactiver les boutons d'écriture dans l'interface.** Bien fait, cela demande un composable `useBandSpaceWritable()` propagé dans une vingtaine de composants sur 8 modules, avec sa propre passe de vérification. Le bandeau explique déjà la situation là où elle se produit. À ouvrir en suivi.
- **Le contrôle d'appartenance recopié dans `BandSpaceLeaveProcessor`.** Vraie duplication de `checkMember()`, mais refactorer un processeur exempté au milieu de ce changement mélangerait deux sujets.
- **Les messages d'erreur en anglais des providers Get et Delete de l'espace**, vérifiés par `BandSpaceGetTest` et `BandSpaceDeleteTest`. Même incohérence que les notes, mais ce sont des chemins de lecture que ce changement ne touche pas.
---

## Suite de la relecture : le module Notes

Deux points relevés après la première passe.

**Correction de ce qui avait été annoncé.** Il avait été écrit que la migration des 3 processeurs de notes faisait passer leurs messages 403 et 404 de l'anglais au français. C'était trop large. `PATCH` et `DELETE` passent par `BandSpaceNoteItemProvider` **avant** le processeur, donc pour ces deux endpoints le message venu du provider, en anglais, court-circuitait le processeur : leurs réponses n'avaient pas changé. Seul `POST /notes`, qui n'a pas de provider, était réellement passé au français. Le résultat était une incohérence au sein d'un même module : `POST` en français, `GET` / `PATCH` / `DELETE` en anglais.

Les deux providers de notes passent donc à leur tour par `checkMember()`, la variante en lecture seule. Le module entier parle maintenant français, et c'est une duplication de moins : ces providers recopiaient eux aussi le chargement et le contrôle d'appartenance à la main.

**Les messages sont désormais verrouillés par des tests.** Les cinq tests « non membre » des notes se contentaient d'un code de statut, ce que `CLAUDE.md` déconseille explicitement. Ils vérifient maintenant le corps complet avec `assertJsonEquals`, ce qui fige la chaîne française et corrige au passage l'écart de convention. Le 404 « Band Space introuvable » n'avait quant à lui aucune couverture, les 404 existants portant tous sur la note introuvable et non sur l'espace : un test a été ajouté.

**Le message générique du module Notes.** Créer une note dans un espace condamné affichait « Impossible de créer la note » là où les autres modules affichent la vraie raison. `Notes.vue` écrivait `catch {` sans lier l'erreur, jetant donc le message. Les deux gestionnaires concernés, création et suppression, suivent maintenant le motif majoritaire du projet, `error.message || 'repli'`. Vérifié dans l'interface : la création affiche désormais « Cet espace est en attente de suppression, les modifications sont désactivées ».

L'indicateur d'enregistrement automatique de l'éditeur de notes continue d'afficher un « Erreur » laconique, sans raison. C'est un statut en ligne dans l'en-tête, volontairement bref, et le bandeau explique déjà la situation juste au-dessus. Laissé tel quel.

Suite complète : **1774 verts**. PHPStan niveau 8, Biome et `npm run build` : propres.


🤖 Generated with [Claude Code](https://claude.com/claude-code)