### PR TITLE
M-755: trash for band space files, with restore and permanent delete

### DIFF
--- a/assets/js/api/bandSpace/band-space-files.js
+++ b/assets/js/api/bandSpace/band-space-files.js
@@ -17,7 +17,8 @@ export default {
       uploaderId,
       sort,
       order,
-      itemsPerPage
+      itemsPerPage,
+      archived
     } = {}
   ) {
     const params = {}
@@ -32,6 +33,7 @@ export default {
     if (sort) params.sort = sort
     if (order) params.order = order
     if (itemsPerPage) params.itemsPerPage = itemsPerPage
+    if (archived) params.archived = 'true'
 
     return axios
       .get(Routing.generate('api_band_space_files_get_collection', { bandSpaceId }), { params })
@@ -51,6 +53,23 @@ export default {
       .patch(Routing.generate('api_band_space_files_patch', { bandSpaceId, id: fileId }), data, {
         headers: { 'Content-Type': 'application/merge-patch+json' }
       })
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
+  restoreFile(bandSpaceId, fileId) {
+    return axios
+      .post(Routing.generate('api_band_space_files_restore', { bandSpaceId, id: fileId }), {})
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
+  // Destroys the file and its stored objects immediately, without waiting for the purge. Admin only.
+  permanentDeleteFile(bandSpaceId, fileId) {
+    return axios
+      .delete(
+        Routing.generate('api_band_space_files_permanent_delete', { bandSpaceId, id: fileId })
+      )
       .then((resp) => resp.data)
       .catch(handleApiError)
   },

--- a/assets/js/components/BandSpace/Files/AttachFileDialog.vue
+++ b/assets/js/components/BandSpace/Files/AttachFileDialog.vue
@@ -10,7 +10,7 @@
   >
     <Tabs v-model:value="activeTab">
       <TabList>
-        <Tab value="upload">Téléverser</Tab>
+        <Tab value="upload">Importer</Tab>
         <Tab value="existing">Choisir parmi les fichiers existants</Tab>
       </TabList>
 
@@ -57,7 +57,7 @@
 
             <div v-if="isUploading" class="flex flex-col gap-1">
               <ProgressBar :value="uploadProgress" />
-              <p class="text-xs text-surface-500 text-center">Téléversement… {{ uploadProgress }} %</p>
+              <p class="text-xs text-surface-500 text-center">Import… {{ uploadProgress }} %</p>
             </div>
 
             <Message v-if="uploadError" severity="error" :closable="false">{{ uploadError }}</Message>
@@ -113,7 +113,7 @@
       />
       <Button
         v-if="activeTab === 'upload'"
-        label="Téléverser"
+        label="Importer"
         icon="pi pi-cloud-upload"
         :disabled="!selectedFile || isUploading"
         :loading="isUploading"

--- a/assets/js/components/BandSpace/Files/FileActivityFeed.vue
+++ b/assets/js/components/BandSpace/Files/FileActivityFeed.vue
@@ -38,6 +38,7 @@ const FILE_ACTIVITY_LABELS = {
   uploaded: () => 'a téléversé le fichier',
   archived: () => 'a archivé le fichier',
   restored: () => 'a restauré le fichier',
+  purged: () => 'a supprimé définitivement le fichier',
   renamed: (a) => {
     const from = a.payload?.from
     const to = a.payload?.to
@@ -50,11 +51,11 @@ const FILE_ACTIVITY_LABELS = {
   },
   tagged: (a) => {
     const tag = a.payload?.tag_name
-    return tag ? `a ajouté l'étiquette ${tag}` : 'a ajouté une étiquette'
+    return tag ? `a ajouté le tag ${tag}` : 'a ajouté un tag'
   },
   untagged: (a) => {
     const tag = a.payload?.tag_name
-    return tag ? `a retiré l'étiquette ${tag}` : 'a retiré une étiquette'
+    return tag ? `a retiré le tag ${tag}` : 'a retiré un tag'
   },
   version_added: (a) => {
     const num = a.payload?.version_number

--- a/assets/js/components/BandSpace/Files/FileDetailDrawer.vue
+++ b/assets/js/components/BandSpace/Files/FileDetailDrawer.vue
@@ -85,7 +85,7 @@
 
       <div class="grid grid-cols-2 gap-3 text-sm">
         <div>
-          <p class="text-xs text-surface-400 uppercase tracking-wide">Téléversé par</p>
+          <p class="text-xs text-surface-400 uppercase tracking-wide">Importé par</p>
           <div class="flex items-center gap-2 mt-1">
             <Avatar
               v-if="file.created_by"
@@ -115,14 +115,14 @@
       </div>
 
       <div class="flex flex-col gap-1">
-        <label class="text-xs text-surface-400 uppercase tracking-wide">Étiquettes</label>
+        <label class="text-xs text-surface-400 uppercase tracking-wide">Tags</label>
         <MultiSelect
           v-model="selectedTagIds"
-          aria-label="Étiquettes"
+          aria-label="Tags"
           :options="filesStore.tags"
           option-label="name"
           option-value="id"
-          placeholder="Aucune étiquette"
+          placeholder="Aucun tag"
           :disabled="filesStore.isSavingFile"
           @hide="commitTagsIfChanged"
         />
@@ -402,9 +402,9 @@ function confirmDelete() {
   const name = file.value.original_name
   const fileId = file.value.id
   confirm.require({
-    message: `Supprimer définitivement « ${name} » ?`,
-    header: 'Confirmer la suppression',
-    icon: 'pi pi-exclamation-triangle',
+    message: `« ${name} » sera déplacé dans la corbeille, où vous pourrez le restaurer pendant ${filesStore.trashRetentionDays} jours. Continuer ?`,
+    header: 'Déplacer dans la corbeille',
+    icon: 'pi pi-trash',
     acceptLabel: 'Supprimer',
     rejectLabel: 'Annuler',
     acceptClass: 'p-button-danger',

--- a/assets/js/components/BandSpace/Files/FileFilterBar.vue
+++ b/assets/js/components/BandSpace/Files/FileFilterBar.vue
@@ -16,7 +16,7 @@
       :options="tagOptions"
       option-label="label"
       option-value="value"
-      placeholder="Étiquette"
+      placeholder="Tag"
       size="small"
       :show-clear="true"
       class="min-w-[160px]"

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -18,7 +18,7 @@
       >
         <div class="col-span-6">Nom</div>
         <div class="col-span-2">Taille</div>
-        <div class="col-span-2">Étiquettes</div>
+        <div class="col-span-2">Tags</div>
         <div class="col-span-2">Ajouté le</div>
       </div>
 
@@ -172,16 +172,16 @@ function openContextMenu(event, file) {
 
 function confirmDelete(file) {
   confirm.require({
-    message: `Supprimer définitivement « ${file.original_name} » ?`,
-    header: 'Confirmer la suppression',
-    icon: 'pi pi-exclamation-triangle',
+    message: `« ${file.original_name} » sera déplacé dans la corbeille, où vous pourrez le restaurer pendant ${filesStore.trashRetentionDays} jours. Continuer ?`,
+    header: 'Déplacer dans la corbeille',
+    icon: 'pi pi-trash',
     acceptLabel: 'Supprimer',
     rejectLabel: 'Annuler',
     acceptClass: 'p-button-danger',
     accept: async () => {
       try {
         await filesStore.deleteFile(props.bandSpaceId, file.id)
-        toast.add({ severity: 'success', summary: 'Fichier supprimé', life: 3000 })
+        toast.add({ severity: 'success', summary: 'Fichier déplacé dans la corbeille', life: 3000 })
       } catch (e) {
         toast.add({
           severity: 'error',

--- a/assets/js/components/BandSpace/Files/FileNewVersionDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileNewVersionDialog.vue
@@ -2,7 +2,7 @@
   <Dialog
     v-model:visible="visible"
     modal
-    header="Téléverser une nouvelle version"
+    header="Importer une nouvelle version"
     :style="{ width: '32rem' }"
     :closable="!isUploading"
     :close-on-escape="!isUploading"
@@ -56,7 +56,7 @@
 
       <div v-if="isUploading" class="flex flex-col gap-1">
         <ProgressBar :value="uploadProgress" />
-        <p class="text-xs text-surface-500 text-center">Téléversement… {{ uploadProgress }} %</p>
+        <p class="text-xs text-surface-500 text-center">Import… {{ uploadProgress }} %</p>
       </div>
 
       <Message v-if="globalError" severity="error" :closable="false">{{ globalError }}</Message>
@@ -71,7 +71,7 @@
         @click="visible = false"
       />
       <Button
-        label="Téléverser"
+        label="Importer"
         icon="pi pi-cloud-upload"
         :disabled="!selectedFile || isUploading"
         :loading="isUploading"

--- a/assets/js/components/BandSpace/Files/FileTrashList.vue
+++ b/assets/js/components/BandSpace/Files/FileTrashList.vue
@@ -40,7 +40,9 @@
           icon="pi pi-replay"
           text
           size="small"
+          :disabled="!canRestore(file)"
           :loading="busyId === file.id"
+          v-tooltip.top="canRestore(file) ? null : 'Seul le créateur ou un administrateur peut restaurer ce fichier'"
           @click="handleRestore(file)"
         />
         <Button
@@ -66,6 +68,7 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { ref } from 'vue'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
+import { useUserSecurityStore } from '../../../store/user/security.js'
 import { formatDateLong } from '../../../utils/date.js'
 import { formatBytes } from '../../../utils/formatBytes.js'
 
@@ -77,10 +80,15 @@ const props = defineProps({
 })
 
 const filesStore = useBandFilesStore()
+const userSecurityStore = useUserSecurityStore()
 const confirm = useConfirm()
 const toast = useToast()
 
 const busyId = ref(null)
+
+function canRestore(file) {
+  return props.isAdmin || file.created_by?.id === userSecurityStore.userProfile?.id
+}
 
 function daysRemaining(file) {
   if (!file.purge_datetime) {

--- a/assets/js/components/BandSpace/Files/FileTrashList.vue
+++ b/assets/js/components/BandSpace/Files/FileTrashList.vue
@@ -1,0 +1,156 @@
+<template>
+  <div>
+    <div v-if="isLoading && files.length === 0" class="flex flex-col gap-2">
+      <Skeleton v-for="i in 3" :key="i" width="100%" height="3.5rem" borderRadius="0.5rem" />
+    </div>
+
+    <div
+      v-else-if="files.length === 0"
+      class="flex flex-col items-center justify-center py-16 text-center text-surface-400"
+    >
+      <i class="pi pi-trash text-5xl mb-4" aria-hidden="true"></i>
+      <p class="text-sm italic">La corbeille est vide.</p>
+    </div>
+
+    <div v-else class="flex flex-col gap-2">
+      <p class="text-xs text-surface-500 dark:text-surface-400 px-1">
+        Les fichiers supprimés restent ici {{ filesStore.trashRetentionDays }} jours, puis sont
+        définitivement effacés. Vous pouvez les restaurer avant cette date.
+      </p>
+
+      <div
+        v-for="file in files"
+        :key="file.id"
+        class="flex items-center gap-3 p-3 rounded-lg bg-surface-0 dark:bg-surface-900 border border-surface-200 dark:border-surface-700"
+      >
+        <i class="pi pi-file text-lg text-surface-500 shrink-0" aria-hidden="true"></i>
+
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-medium text-surface-800 dark:text-surface-100 truncate">
+            {{ file.original_name }}
+          </p>
+          <span class="text-xs text-surface-500 dark:text-surface-400">
+            {{ formatBytes(file.size) }} · supprimé le {{ formatDateLong(file.archive_datetime) }} ·
+            <span :class="remainingClass(file)">{{ remainingLabel(file) }}</span>
+          </span>
+        </div>
+
+        <Button
+          label="Restaurer"
+          icon="pi pi-replay"
+          text
+          size="small"
+          :loading="busyId === file.id"
+          @click="handleRestore(file)"
+        />
+        <Button
+          v-if="isAdmin"
+          icon="pi pi-trash"
+          severity="danger"
+          text
+          size="small"
+          aria-label="Supprimer définitivement"
+          v-tooltip.top="'Supprimer définitivement'"
+          :loading="busyId === file.id"
+          @click="handlePermanentDelete(file)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Skeleton from 'primevue/skeleton'
+import { useConfirm } from 'primevue/useconfirm'
+import { useToast } from 'primevue/usetoast'
+import { ref } from 'vue'
+import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
+import { formatDateLong } from '../../../utils/date.js'
+import { formatBytes } from '../../../utils/formatBytes.js'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true },
+  files: { type: Array, required: true },
+  isLoading: { type: Boolean, default: false },
+  isAdmin: { type: Boolean, default: false }
+})
+
+const filesStore = useBandFilesStore()
+const confirm = useConfirm()
+const toast = useToast()
+
+const busyId = ref(null)
+
+function daysRemaining(file) {
+  if (!file.purge_datetime) {
+    return null
+  }
+
+  const millisecondsPerDay = 86400000
+
+  return Math.ceil((new Date(file.purge_datetime).getTime() - Date.now()) / millisecondsPerDay)
+}
+
+function remainingLabel(file) {
+  const days = daysRemaining(file)
+  if (days === null) {
+    return ''
+  }
+  if (days <= 0) {
+    return 'suppression imminente'
+  }
+
+  return days === 1 ? "plus qu'un jour" : `encore ${days} jours`
+}
+
+function remainingClass(file) {
+  const days = daysRemaining(file)
+
+  return days !== null && days <= 7 ? 'text-amber-600 dark:text-amber-400 font-medium' : ''
+}
+
+async function handleRestore(file) {
+  busyId.value = file.id
+  try {
+    await filesStore.restoreFile(props.bandSpaceId, file.id)
+    toast.add({ severity: 'success', summary: 'Fichier restauré', life: 3000 })
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: error.message || 'Impossible de restaurer le fichier',
+      life: 5000
+    })
+  } finally {
+    busyId.value = null
+  }
+}
+
+function handlePermanentDelete(file) {
+  confirm.require({
+    header: 'Supprimer définitivement',
+    message: `« ${file.original_name} » sera effacé immédiatement et cette action est irréversible. Continuer ?`,
+    icon: 'pi pi-exclamation-triangle',
+    rejectLabel: 'Annuler',
+    acceptLabel: 'Supprimer définitivement',
+    acceptClass: 'p-button-danger',
+    accept: async () => {
+      busyId.value = file.id
+      try {
+        await filesStore.permanentDeleteFile(props.bandSpaceId, file.id)
+        toast.add({ severity: 'success', summary: 'Fichier supprimé définitivement', life: 3000 })
+      } catch (error) {
+        toast.add({
+          severity: 'error',
+          summary: 'Erreur',
+          detail: error.message || 'Impossible de supprimer le fichier',
+          life: 5000
+        })
+      } finally {
+        busyId.value = null
+      }
+    }
+  })
+}
+</script>

--- a/assets/js/components/BandSpace/Files/FileUploadDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileUploadDialog.vue
@@ -2,7 +2,7 @@
   <Dialog
     v-model:visible="visible"
     modal
-    header="Téléverser un fichier"
+    header="Importer un fichier"
     :style="{ width: '32rem' }"
     :closable="!isUploading"
     :close-on-escape="!isUploading"
@@ -72,14 +72,14 @@
       </div>
 
       <div class="flex flex-col gap-1">
-        <label class="text-sm font-medium text-surface-700 dark:text-surface-200">Étiquettes</label>
+        <label class="text-sm font-medium text-surface-700 dark:text-surface-200">Tags</label>
         <MultiSelect
           v-model="form.tagIds"
-          aria-label="Étiquettes"
+          aria-label="Tags"
           :options="tags"
           option-label="name"
           option-value="id"
-          placeholder="Sélectionner des étiquettes"
+          placeholder="Sélectionner des tags"
           :max-selected-labels="3"
           :disabled="isUploading"
         />
@@ -87,7 +87,7 @@
         <div class="flex items-center gap-2 mt-1">
           <InputText
             v-model="newTagName"
-            placeholder="Créer une nouvelle étiquette"
+            placeholder="Créer un nouveau tag"
             size="small"
             class="flex-1"
             :disabled="isUploading || isCreatingTag"
@@ -95,7 +95,7 @@
           />
           <Button
             icon="pi pi-plus"
-            aria-label="Créer l'étiquette"
+            aria-label="Créer le tag"
             size="small"
             severity="secondary"
             :disabled="isUploading || isCreatingTag || !newTagName.trim()"
@@ -108,7 +108,7 @@
 
       <div v-if="isUploading" class="flex flex-col gap-1">
         <ProgressBar :value="uploadProgress" />
-        <p class="text-xs text-surface-500 text-center">Téléversement… {{ uploadProgress }} %</p>
+        <p class="text-xs text-surface-500 text-center">Import… {{ uploadProgress }} %</p>
       </div>
 
       <Message v-if="globalError" severity="error" :closable="false">{{ globalError }}</Message>
@@ -123,7 +123,7 @@
         @click="visible = false"
       />
       <Button
-        label="Téléverser"
+        label="Importer"
         icon="pi pi-cloud-upload"
         :disabled="!selectedFile || isUploading"
         :loading="isUploading"

--- a/assets/js/components/BandSpace/Files/FileVersionPanel.vue
+++ b/assets/js/components/BandSpace/Files/FileVersionPanel.vue
@@ -10,7 +10,7 @@
       <div class="flex items-center justify-between">
         <p class="text-sm text-surface-500">{{ versionsCountLabel }}</p>
         <Button
-          label="Téléverser une nouvelle version"
+          label="Importer une nouvelle version"
           icon="pi pi-cloud-upload"
           size="small"
           :disabled="filesStore.isUploadingVersion || filesStore.isRollingBack"

--- a/assets/js/components/BandSpace/Notes/NoteEditor.vue
+++ b/assets/js/components/BandSpace/Notes/NoteEditor.vue
@@ -479,7 +479,7 @@ async function uploadAndInsertImage(file) {
   } catch (e) {
     toast.add({
       severity: 'error',
-      summary: 'Téléversement impossible',
+      summary: 'Import impossible',
       detail: e.message,
       life: 5000
     })

--- a/assets/js/components/BandSpace/Setlist/SetlistFileDrawer.vue
+++ b/assets/js/components/BandSpace/Setlist/SetlistFileDrawer.vue
@@ -7,7 +7,7 @@
   >
     <div class="flex flex-col gap-4">
       <p class="text-xs text-surface-400 italic">
-        Téléversez les fichiers liés à ce setlist (timing sheet, notes scéniques, etc.).
+        Importez les fichiers liés à ce setlist (timing sheet, notes scéniques, etc.).
         Ils apparaitront dans le dossier virtuel «&nbsp;Setlists&nbsp;» du module Fichiers.
       </p>
 
@@ -45,7 +45,7 @@
 
       <input ref="fileInput" type="file" class="hidden" @change="handleFileSelected" />
       <Button
-        label="Téléverser un fichier"
+        label="Importer un fichier"
         icon="pi pi-cloud-upload"
         severity="secondary"
         :loading="isUploading"

--- a/assets/js/components/BandSpace/Setlist/SongDetailDrawer.vue
+++ b/assets/js/components/BandSpace/Setlist/SongDetailDrawer.vue
@@ -72,7 +72,7 @@
 
         <input ref="fileInput" type="file" class="hidden" @change="handleFileSelected" />
         <Button
-          label="Téléverser un fichier"
+          label="Importer un fichier"
           icon="pi pi-cloud-upload"
           severity="secondary"
           size="small"

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -126,6 +126,13 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   }
 
   function buildFileParams() {
+    // The trash ignores every filter, before they are even read. Its filter bar is hidden, so a search
+    // or tag left over from browsing a folder would silently narrow the trash with no visible control to
+    // clear it, and someone hunting for the file they just deleted would find it apparently missing.
+    if (activeFolderId.value === TRASH_FOLDER_ID) {
+      return { archived: true }
+    }
+
     const params = {}
     const trimmed = filters.query.trim()
     if (trimmed) params.query = trimmed
@@ -133,12 +140,6 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     if (filters.tagId) params.tagId = filters.tagId
     if (filters.sort) params.sort = filters.sort
     if (filters.order) params.order = filters.order
-
-    if (activeFolderId.value === TRASH_FOLDER_ID) {
-      params.archived = true
-
-      return params
-    }
 
     if (activeFolderId.value === 'virtual:task') {
       params.source = 'task'

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -2,6 +2,8 @@ import { defineStore } from 'pinia'
 import { computed, reactive, readonly, ref } from 'vue'
 import bandSpaceFilesApi from '../../api/bandSpace/band-space-files.js'
 
+export const TRASH_FOLDER_ID = 'trash'
+
 export const useBandFilesStore = defineStore('bandFiles', () => {
   const files = ref([])
   const totalFiles = ref(0)
@@ -17,6 +19,9 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   const versions = ref([])
   // Drag-and-drop source. { type: 'folder'|'file', id, parentId, descendantIds: string[] }
   const dragSource = ref(null)
+  // The trash is selected through activeFolderId, like the virtual source folders, so the whole existing
+  // selection and fetch path is reused. This count feeds the sidebar badge even when the trash is closed.
+  const archivedCount = ref(0)
 
   const filters = reactive({
     query: '',
@@ -47,6 +52,9 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   let foldersRequestId = 0
   let activeFileRequestId = 0
   let activitiesRequestId = 0
+
+  // Served by the quota endpoint so the interface quotes the same window the purge enforces.
+  const trashRetentionDays = computed(() => quota.value?.trash_retention_days ?? 30)
 
   const activeFile = computed(() => {
     if (!activeFileId.value) return null
@@ -125,6 +133,12 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     if (filters.tagId) params.tagId = filters.tagId
     if (filters.sort) params.sort = filters.sort
     if (filters.order) params.order = filters.order
+
+    if (activeFolderId.value === TRASH_FOLDER_ID) {
+      params.archived = true
+
+      return params
+    }
 
     if (activeFolderId.value === 'virtual:task') {
       params.source = 'task'
@@ -217,12 +231,44 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     }
   }
 
+  async function fetchArchivedCount(bandSpaceId) {
+    const result = await bandSpaceFilesApi.getFiles(bandSpaceId, {
+      archived: true,
+      itemsPerPage: 1
+    })
+    archivedCount.value = result.totalItems ?? 0
+  }
+
+  async function restoreFile(bandSpaceId, fileId) {
+    await bandSpaceFilesApi.restoreFile(bandSpaceId, fileId)
+    removeFromTrash(fileId)
+    // Restoring puts the file's bytes back into the quota, so the indicator has to catch up.
+    fetchQuota(bandSpaceId)
+  }
+
+  async function permanentDeleteFile(bandSpaceId, fileId) {
+    await bandSpaceFilesApi.permanentDeleteFile(bandSpaceId, fileId)
+    removeFromTrash(fileId)
+  }
+
+  function removeFromTrash(fileId) {
+    files.value = files.value.filter((f) => f.id !== fileId)
+    totalFiles.value = Math.max(0, totalFiles.value - 1)
+    archivedCount.value = Math.max(0, archivedCount.value - 1)
+    if (activeFileId.value === fileId) {
+      activeFileId.value = null
+      activeFileFull.value = null
+    }
+  }
+
   async function deleteFile(bandSpaceId, fileId) {
     isDeletingFile.value = true
     try {
       await bandSpaceFilesApi.deleteFile(bandSpaceId, fileId)
       files.value = files.value.filter((f) => f.id !== fileId)
       totalFiles.value = Math.max(0, totalFiles.value - 1)
+      // Deleting only archives, so the file has moved to the trash rather than gone.
+      archivedCount.value += 1
       if (activeFileId.value === fileId) {
         activeFileId.value = null
         activeFileFull.value = null
@@ -370,6 +416,8 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   return {
     files: readonly(files),
     totalFiles: readonly(totalFiles),
+    archivedCount: readonly(archivedCount),
+    trashRetentionDays,
     folders: readonly(folders),
     virtualFolders: readonly(virtualFolders),
     tags: readonly(tags),
@@ -407,6 +455,9 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     fetchFileActivities,
     updateFile,
     deleteFile,
+    fetchArchivedCount,
+    restoreFile,
+    permanentDeleteFile,
     setActiveFile,
     uploadFile,
     createTag,

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -41,6 +41,24 @@
         >
           Aucun dossier pour l'instant.
         </p>
+
+        <div class="mt-3 pt-3 border-t border-surface-200 dark:border-surface-700">
+          <button
+            type="button"
+            class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left transition-colors duration-150"
+            :class="
+              isTrashActive
+                ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-200 font-medium'
+                : 'text-surface-700 dark:text-surface-200 hover:bg-surface-100 dark:hover:bg-surface-800'
+            "
+            :aria-current="isTrashActive ? 'true' : null"
+            @click="handleFolderSelect(TRASH_FOLDER_ID)"
+          >
+            <i class="pi pi-trash" aria-hidden="true"></i>
+            <span class="flex-1 truncate">Corbeille</span>
+            <span class="text-xs text-surface-500 tabular-nums">{{ filesStore.archivedCount }}</span>
+          </button>
+        </div>
       </aside>
 
       <section class="flex-1 flex flex-col gap-4 min-w-0">
@@ -55,7 +73,10 @@
           />
         </div>
 
-        <div class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700">
+        <div
+          v-if="!isTrashActive"
+          class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700"
+        >
           <div class="flex flex-wrap items-center gap-3">
             <div class="flex-1 min-w-[200px]">
               <FileFilterBar
@@ -65,7 +86,7 @@
               />
             </div>
             <Button
-              label="Téléverser"
+              label="Importer un fichier"
               icon="pi pi-cloud-upload"
               size="small"
               :disabled="isVirtualFolderActive"
@@ -80,7 +101,15 @@
         </div>
 
         <div class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700">
+          <FileTrashList
+            v-if="isTrashActive"
+            :band-space-id="bandSpaceId"
+            :files="filesStore.files"
+            :is-loading="filesStore.isLoadingFiles"
+            :is-admin="isAdmin"
+          />
           <FileList
+            v-else
             :band-space-id="bandSpaceId"
             :files="filesStore.files"
             :is-loading="filesStore.isLoadingFiles"
@@ -149,12 +178,13 @@ import FileFilterBar from '../../components/BandSpace/Files/FileFilterBar.vue'
 import FileList from '../../components/BandSpace/Files/FileList.vue'
 import FileMoveDialog from '../../components/BandSpace/Files/FileMoveDialog.vue'
 import FileShareDialog from '../../components/BandSpace/Files/FileShareDialog.vue'
+import FileTrashList from '../../components/BandSpace/Files/FileTrashList.vue'
 import FileUploadDialog from '../../components/BandSpace/Files/FileUploadDialog.vue'
 import FileVersionPanel from '../../components/BandSpace/Files/FileVersionPanel.vue'
 import FolderBreadcrumb from '../../components/BandSpace/Files/FolderBreadcrumb.vue'
 import FolderTree from '../../components/BandSpace/Files/FolderTree.vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
-import { useBandFilesStore } from '../../store/bandSpace/bandSpaceFiles.js'
+import { TRASH_FOLDER_ID, useBandFilesStore } from '../../store/bandSpace/bandSpaceFiles.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -184,8 +214,11 @@ const bandSpaceId = computed(() => route.params.id)
 const showBreadcrumb = computed(() => {
   const id = filesStore.activeFolderId
   if (id === null) return true
+  if (id === TRASH_FOLDER_ID) return false
   return typeof id === 'string' && !id.startsWith('virtual:')
 })
+
+const isTrashActive = computed(() => filesStore.activeFolderId === TRASH_FOLDER_ID)
 
 const isVirtualFolderActive = computed(() => {
   const id = filesStore.activeFolderId
@@ -230,6 +263,7 @@ function loadAll() {
   filesStore.fetchFolders(bandSpaceId.value)
   filesStore.fetchTags(bandSpaceId.value)
   filesStore.fetchQuota(bandSpaceId.value)
+  filesStore.fetchArchivedCount(bandSpaceId.value)
   filesStore.fetchFiles(bandSpaceId.value)
 }
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,10 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     locale: 'fr'
+    # Grace period for an archived Band Space file: how long the trash keeps it before
+    # app:band-space:purge destroys the object and the rows. Shared so the countdown shown to members
+    # and the purge condition are derived from one value and cannot drift apart.
+    band_space.file_retention_days: 30
     file_publication_cover_destination: 'images/publication/cover'
     file_user_profile_picture_destination: 'images/user/profile'
     file_musician_media_thumbnail_destination: 'images/musician/media'

--- a/src/ApiResource/BandSpace/File/BandSpaceFileQuotaResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileQuotaResource.php
@@ -35,6 +35,12 @@ class BandSpaceFileQuotaResource
     public float $usedPercentage;
     public bool $isApproachingLimit;
 
+    /**
+     * How long the trash keeps a deleted file. Served here so the interface states the same number the
+     * purge actually uses, instead of hardcoding it next to every delete confirmation.
+     */
+    public int $trashRetentionDays;
+
     /** @var array<int, array{source: string, bytes: int}> */
     public array $breakdownBySource = [];
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFileResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileResource.php
@@ -9,9 +9,12 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\Processor\BandSpace\File\BandSpaceFileDeleteProcessor;
+use App\State\Processor\BandSpace\File\BandSpaceFilePermanentDeleteProcessor;
+use App\State\Processor\BandSpace\File\BandSpaceFileRestoreProcessor;
 use App\State\Processor\BandSpace\File\BandSpaceFileUpdateProcessor;
 use App\State\Processor\BandSpace\File\BandSpaceFinanceEntryFileDetachProcessor;
 use App\State\Processor\BandSpace\File\BandSpaceNoteFileDetachProcessor;
@@ -47,6 +50,8 @@ use App\State\Provider\BandSpace\File\BandSpaceTaskFileCollectionProvider;
                 'uploader_id' => new QueryParameter(key: 'uploader_id'),
                 'sort' => new QueryParameter(key: 'sort'),
                 'order' => new QueryParameter(key: 'order'),
+                // archived=true lists the trash instead of the live files. Same shape as the Tasks module.
+                'archived' => new QueryParameter(key: 'archived'),
             ],
         ),
         new Get(
@@ -83,6 +88,33 @@ use App\State\Provider\BandSpace\File\BandSpaceTaskFileCollectionProvider;
             name: 'api_band_space_files_delete',
             provider: BandSpaceFileItemProvider::class,
             processor: BandSpaceFileDeleteProcessor::class,
+        ),
+        // The two trash operations deliberately carry no provider: BandSpaceFileItemProvider rejects
+        // archived files, which is right for the seven operations above and exactly wrong for these two.
+        new Post(
+            uriTemplate: '/band_spaces/{bandSpaceId}/files/{id}/restore',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space File']),
+            security: "is_granted('ROLE_USER')",
+            input: false,
+            read: false,
+            name: 'api_band_space_files_restore',
+            processor: BandSpaceFileRestoreProcessor::class,
+        ),
+        new Delete(
+            uriTemplate: '/band_spaces/{bandSpaceId}/files/{id}/permanent',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space File']),
+            security: "is_granted('ROLE_USER')",
+            read: false,
+            name: 'api_band_space_files_permanent_delete',
+            processor: BandSpaceFilePermanentDeleteProcessor::class,
         ),
         new GetCollection(
             uriTemplate: '/band_spaces/{bandSpaceId}/tasks/{taskId}/files',
@@ -241,4 +273,12 @@ class BandSpaceFileResource
 
     public \DateTimeInterface $creationDatetime;
     public ?\DateTimeInterface $updateDatetime = null;
+
+    /** Set only for files in the trash. */
+    public ?\DateTimeInterface $archiveDatetime = null;
+    /**
+     * When app:band-space:purge will destroy this file, derived server side from one shared retention
+     * parameter so the countdown shown to members cannot drift from the purge condition.
+     */
+    public ?\DateTimeInterface $purgeDatetime = null;
 }

--- a/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
+++ b/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
@@ -7,10 +7,9 @@ namespace App\Command\BandSpace;
 use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceFile;
 use App\Repository\BandSpace\BandSpaceFileRepository;
-use App\Repository\BandSpace\BandSpaceFileVersionRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
+use App\Service\BandSpace\File\BandSpaceFilePurger;
 use DateTimeImmutable;
-use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -18,6 +17,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Makes deletions in Band Space actually reach the object storage (#748).
@@ -36,8 +36,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class PurgeBandSpaceStorageCommand extends Command
 {
-    private const int DEFAULT_DAYS = 30;
-
     /**
      * Mirrors the directory namer of the band_space_file mapping (config/packages/vich_uploader.yaml):
      * every object of a space lives under this prefix, so a space can be wiped in one batched call.
@@ -45,12 +43,13 @@ class PurgeBandSpaceStorageCommand extends Command
     private const string STORAGE_PREFIX = 'band_space_files';
 
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
         private readonly BandSpaceRepository $bandSpaceRepository,
         private readonly BandSpaceFileRepository $bandSpaceFileRepository,
-        private readonly BandSpaceFileVersionRepository $bandSpaceFileVersionRepository,
+        private readonly BandSpaceFilePurger $filePurger,
         private readonly FilesystemOperator $musicallFilesystem,
         private readonly LoggerInterface $logger,
+        #[Autowire('%band_space.file_retention_days%')]
+        private readonly int $retentionDays,
     ) {
         parent::__construct();
     }
@@ -63,7 +62,7 @@ class PurgeBandSpaceStorageCommand extends Command
                 'd',
                 InputOption::VALUE_REQUIRED,
                 'Delete files archived more than this many days ago',
-                (string) self::DEFAULT_DAYS,
+                (string) $this->retentionDays,
             )
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would be deleted without deleting anything');
     }
@@ -119,7 +118,7 @@ class PurgeBandSpaceStorageCommand extends Command
             }
 
             try {
-                $this->purgeFile($file);
+                $this->filePurger->purge($file);
                 ++$purged;
             } catch (\Throwable $e) {
                 ++$failures;
@@ -139,26 +138,6 @@ class PurgeBandSpaceStorageCommand extends Command
         ));
 
         return $failures;
-    }
-
-    private function purgeFile(BandSpaceFile $file): void
-    {
-        // Detach the pointer first. The database would cope on its own (the FK is ON DELETE SET NULL),
-        // but this keeps Doctrine's in-memory graph honest: no managed entity is left pointing at a row
-        // that has just been removed.
-        $file->currentVersion = null;
-        $this->entityManager->flush();
-
-        // No explicit storage call here, unlike purgeBandSpace(): VichUploader listens on the removal of
-        // an uploadable entity and deletes the object itself (delete_on_remove, on by default). That is
-        // the whole reason the versions go through the ORM one by one instead of dying by FK cascade.
-        foreach ($this->bandSpaceFileVersionRepository->findByFileNewestFirst($file) as $version) {
-            $this->entityManager->remove($version);
-        }
-        $this->entityManager->flush();
-
-        $this->entityManager->remove($file);
-        $this->entityManager->flush();
     }
 
     /**

--- a/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
+++ b/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
@@ -91,9 +91,9 @@ class PurgeBandSpaceStorageCommand extends Command
     }
 
     /**
-     * Versions are removed one by one through the ORM on purpose: BandSpaceFile has no association to
-     * them, so a plain remove() of the file would drop the rows by FK cascade without VichUploader ever
-     * running, leaving every object behind in the bucket.
+     * The destruction itself lives in BandSpaceFilePurger, shared with the trash's delete-permanently
+     * endpoint. It also declines files restored since this batch was read, so a file skipped here is not
+     * a failure.
      *
      * @return int the number of files that could not be purged
      */
@@ -118,7 +118,11 @@ class PurgeBandSpaceStorageCommand extends Command
             }
 
             try {
-                $this->filePurger->purge($file);
+                if (!$this->filePurger->purge($file)) {
+                    $output->writeln(sprintf('  skipped file %s, restored since this run started', (string) $file->id));
+
+                    continue;
+                }
                 ++$purged;
             } catch (\Throwable $e) {
                 ++$failures;

--- a/src/Enum/BandSpace/BandSpaceFileActivityType.php
+++ b/src/Enum/BandSpace/BandSpaceFileActivityType.php
@@ -7,6 +7,8 @@ enum BandSpaceFileActivityType: string
     case Uploaded = 'uploaded';
     case Archived = 'archived';
     case Restored = 'restored';
+    /** Destroyed on demand from the trash, rather than by app:band-space:purge on its schedule. */
+    case Purged = 'purged';
     case Renamed = 'renamed';
     case Moved = 'moved';
     case Tagged = 'tagged';

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -163,7 +163,9 @@ class BandSpaceFileRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('bsf')
             ->leftJoin('bsf.currentVersion', 'cv')
             ->where('bsf.bandSpace = :bandSpace')
-            ->andWhere('bsf.archiveDatetime IS NULL')
+            // Archived and active are two disjoint views, never merged: the trash lists what the normal
+            // collection hides, so no caller can accidentally mix a deleted file into a live listing.
+            ->andWhere($filter->archivedOnly ? 'bsf.archiveDatetime IS NOT NULL' : 'bsf.archiveDatetime IS NULL')
             ->setParameter('bandSpace', $bandSpace);
 
         if ($filter->folderId !== null) {

--- a/src/Repository/BandSpace/BandSpaceFileVersionRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileVersionRepository.php
@@ -57,6 +57,24 @@ class BandSpaceFileVersionRepository extends ServiceEntityRepository
     }
 
     /**
+     * Total bytes held by every version of one file, archived or not.
+     *
+     * Restoring a file puts all of it back into the band's quota usage, since sumActiveBytesByBandSpace()
+     * counts every version of a non-archived file. This is the amount a restore has to fit.
+     */
+    public function sumBytesByFile(BandSpaceFile $file): int
+    {
+        $result = $this->createQueryBuilder('v')
+            ->select('COALESCE(SUM(v.size), 0)')
+            ->where('v.bandSpaceFile = :file')
+            ->setParameter('file', $file)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $result;
+    }
+
+    /**
      * Total bytes used by all versions of all non-archived files in the band.
      */
     public function sumActiveBytesByBandSpace(BandSpace $bandSpace): int

--- a/src/Repository/BandSpace/Filter/BandSpaceFileFilter.php
+++ b/src/Repository/BandSpace/Filter/BandSpaceFileFilter.php
@@ -19,6 +19,11 @@ final readonly class BandSpaceFileFilter
         public string $order = 'desc',
         public int $limit = self::DEFAULT_LIMIT,
         public int $offset = 0,
+        /**
+         * Lists the trash instead of the live files: archived only, never both. Drives the ?archived=true
+         * parameter of the file collection.
+         */
+        public bool $archivedOnly = false,
     ) {
     }
 }

--- a/src/Service/BandSpace/File/BandSpaceFilePurger.php
+++ b/src/Service/BandSpace/File/BandSpaceFilePurger.php
@@ -22,8 +22,21 @@ readonly class BandSpaceFilePurger
     ) {
     }
 
-    public function purge(BandSpaceFile $file): void
+    /**
+     * @return bool false when the file is no longer in the trash and was therefore left alone
+     */
+    public function purge(BandSpaceFile $file): bool
     {
+        // Re-read before destroying anything. app:band-space:purge loads its whole batch up front and
+        // then purges one file at a time, so by the time it reaches this file a member may have restored
+        // it: the entity in hand would still carry the archiveDatetime it had when the batch was read.
+        // Refusing here is the only thing standing between a last-minute restore and silent, permanent
+        // loss of the file the member just asked to keep.
+        $this->entityManager->refresh($file);
+        if (!$file->archiveDatetime instanceof \DateTimeImmutable) {
+            return false;
+        }
+
         // Detach the pointer first. The database would cope on its own (the FK is ON DELETE SET NULL),
         // but this keeps Doctrine's in-memory graph honest: no managed entity is left pointing at a row
         // that has just been removed.
@@ -41,5 +54,7 @@ readonly class BandSpaceFilePurger
 
         $this->entityManager->remove($file);
         $this->entityManager->flush();
+
+        return true;
     }
 }

--- a/src/Service/BandSpace/File/BandSpaceFilePurger.php
+++ b/src/Service/BandSpace/File/BandSpaceFilePurger.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace\File;
+
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Repository\BandSpace\BandSpaceFileVersionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Destroys a file for good: every version's stored object, every version row, then the file row.
+ *
+ * Shared by app:band-space:purge, which sweeps files past their grace period, and by the trash's
+ * "delete permanently" endpoint, which does the same thing on demand. One implementation because
+ * getting this wrong silently orphans objects in the bucket, and an orphan is invisible: nothing in
+ * the application ever points at it again.
+ */
+readonly class BandSpaceFilePurger
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceFileVersionRepository $bandSpaceFileVersionRepository,
+    ) {
+    }
+
+    public function purge(BandSpaceFile $file): void
+    {
+        // Detach the pointer first. The database would cope on its own (the FK is ON DELETE SET NULL),
+        // but this keeps Doctrine's in-memory graph honest: no managed entity is left pointing at a row
+        // that has just been removed.
+        $file->currentVersion = null;
+        $this->entityManager->flush();
+
+        // No explicit storage call here: VichUploader listens on the removal of an uploadable entity and
+        // deletes the object itself (delete_on_remove, on by default). That is the whole reason the
+        // versions go through the ORM one by one instead of dying by FK cascade. Replacing this loop with
+        // a bulk DQL delete would leave every object behind, with nothing left pointing at them.
+        foreach ($this->bandSpaceFileVersionRepository->findByFileNewestFirst($file) as $version) {
+            $this->entityManager->remove($version);
+        }
+        $this->entityManager->flush();
+
+        $this->entityManager->remove($file);
+        $this->entityManager->flush();
+    }
+}

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
@@ -13,6 +13,7 @@ use App\Repository\BandSpace\SetlistRepository;
 use App\Repository\BandSpace\SongRepository;
 use App\Repository\BandSpace\TaskRepository;
 use App\Service\Builder\User\UserProfilePictureUrlBuilder;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 readonly class BandSpaceFileBuilder
@@ -27,6 +28,8 @@ readonly class BandSpaceFileBuilder
         private SetlistRepository $setlistRepository,
         private UserProfilePictureUrlBuilder $profilePictureUrlBuilder,
         private UrlGeneratorInterface $urlGenerator,
+        #[Autowire('%band_space.file_retention_days%')]
+        private int $retentionDays,
     ) {
     }
 
@@ -97,6 +100,9 @@ readonly class BandSpaceFileBuilder
 
         $dto->creationDatetime = $entity->creationDatetime;
         $dto->updateDatetime = $entity->updateDatetime;
+        $dto->archiveDatetime = $entity->archiveDatetime;
+        // Derived rather than stored, from the same parameter app:band-space:purge uses for its cutoff.
+        $dto->purgeDatetime = $entity->archiveDatetime?->modify(sprintf('+%d days', $this->retentionDays));
 
         return $dto;
     }

--- a/src/State/Processor/BandSpace/File/BandSpaceFilePermanentDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFilePermanentDeleteProcessor.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\File;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\File\BandSpaceFileResource;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Security\BandSpace\BandSpaceAdminChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFilePurger;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Empties one file out of the trash for good, without waiting for app:band-space:purge.
+ *
+ * Admin only, unlike archiving and restoring: this destroys the stored object, cannot be undone, and
+ * frees quota for the whole band.
+ *
+ * @implements ProcessorInterface<BandSpaceFileResource, void>
+ */
+readonly class BandSpaceFilePermanentDeleteProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceAdminChecker $adminChecker,
+        private BandSpaceFileRepository $fileRepository,
+        private BandSpaceFilePurger $filePurger,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $file = $this->fileRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$file instanceof \App\Entity\BandSpace\BandSpaceFile) {
+            throw new NotFoundHttpException('Fichier introuvable');
+        }
+
+        // The trash is the only door to this endpoint: a live file has to be deleted normally first, so
+        // nobody can skip the grace period by accident.
+        if (!$file->archiveDatetime instanceof \DateTimeImmutable) {
+            throw new ConflictHttpException('Ce fichier n\'est pas dans la corbeille');
+        }
+
+        $originalName = $file->originalName;
+        $fileId = (string) $file->id;
+
+        // Recorded before the purge: afterwards there is no entity left to read a name from. The activity
+        // keeps its resourceId as a plain string, so it survives the row it points at.
+        $this->activityRecorder->record(
+            $bandSpace,
+            BandSpaceModule::File,
+            BandSpaceFileActivityType::Purged,
+            resourceId: $fileId,
+            actor: $user,
+            payload: ['original_name' => $originalName],
+        );
+        $this->entityManager->flush();
+
+        $this->filePurger->purge($file);
+    }
+}

--- a/src/State/Processor/BandSpace/File/BandSpaceFileRestoreProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileRestoreProcessor.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\File;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\File\BandSpaceFileResource;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFileVersionRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\File\BandSpaceFileBuilder;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileQuotaService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Takes a file back out of the trash. Mirrors BandSpaceFileDeleteProcessor, which is what put it there.
+ *
+ * @implements ProcessorInterface<BandSpaceFileResource, BandSpaceFileResource>
+ */
+readonly class BandSpaceFileRestoreProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private BandSpaceFileRepository $fileRepository,
+        private BandSpaceFileVersionRepository $versionRepository,
+        private BandSpaceFileQuotaService $quotaService,
+        private BandSpaceFileBuilder $fileBuilder,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): BandSpaceFileResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        // findOneByIdAndBandSpace does not filter archived files, which is exactly what the trash needs.
+        $file = $this->fileRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$file instanceof \App\Entity\BandSpace\BandSpaceFile) {
+            throw new NotFoundHttpException('Fichier introuvable');
+        }
+
+        if (!$file->archiveDatetime instanceof \DateTimeImmutable) {
+            throw new ConflictHttpException('Ce fichier n\'est pas dans la corbeille');
+        }
+
+        // Same rule as archiving: whoever could delete it can bring it back.
+        $isOwner = $file->createdBy instanceof User && $file->createdBy->id === $user->id;
+        if (!$isOwner && $membership->role !== Role::Admin) {
+            throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut restaurer ce fichier');
+        }
+
+        // The quota only counts non-archived files, so restoring puts every version of this one back into
+        // the band's usage. Refuse rather than let a restore push the space over its limit.
+        $this->quotaService->assertCanUpload($bandSpace, $this->versionRepository->sumBytesByFile($file));
+
+        $file->archiveDatetime = null;
+
+        $this->activityRecorder->record(
+            $bandSpace,
+            BandSpaceModule::File,
+            BandSpaceFileActivityType::Restored,
+            resourceId: (string) $file->id,
+            actor: $user,
+            payload: ['original_name' => $file->originalName],
+        );
+
+        $this->entityManager->flush();
+
+        return $this->fileBuilder->buildItem($file);
+    }
+}

--- a/src/State/Provider/BandSpace/File/BandSpaceFileCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFileCollectionProvider.php
@@ -75,6 +75,7 @@ readonly class BandSpaceFileCollectionProvider implements ProviderInterface
             order: $query?->getString('order') ?: 'desc',
             limit: $limit,
             offset: $offset,
+            archivedOnly: $query?->getBoolean('archived') ?? false,
         );
     }
 }

--- a/src/State/Provider/BandSpace/File/BandSpaceFileQuotaProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFileQuotaProvider.php
@@ -4,6 +4,7 @@ namespace App\State\Provider\BandSpace\File;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use App\ApiResource\BandSpace\File\BandSpaceFileQuotaResource;
 use App\Entity\User;
 use App\Security\BandSpace\BandSpaceMemberChecker;
@@ -20,6 +21,8 @@ readonly class BandSpaceFileQuotaProvider implements ProviderInterface
         private BandSpaceMemberChecker $memberChecker,
         private BandSpaceFileQuotaService $quotaService,
         private Security $security,
+        #[Autowire('%band_space.file_retention_days%')]
+        private int $retentionDays,
     ) {
     }
 
@@ -43,6 +46,7 @@ readonly class BandSpaceFileQuotaProvider implements ProviderInterface
         $dto->isApproachingLimit = $quotaBytes > 0
             && $usedBytes / $quotaBytes >= BandSpaceFileQuotaService::APPROACHING_LIMIT_RATIO;
         $dto->breakdownBySource = $this->quotaService->getUsageBreakdown($bandSpace);
+        $dto->trashRetentionDays = $this->retentionDays;
 
         return $dto;
     }

--- a/tests/Api/BandSpace/File/BandSpaceFileQuotaTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileQuotaTest.php
@@ -48,6 +48,7 @@ class BandSpaceFileQuotaTest extends ApiTestCase
             'quota_bytes' => self::FIVE_GB,
             'used_bytes' => 0,
             'used_percentage' => 0.0,
+            'trash_retention_days' => 30,
             'is_approaching_limit' => false,
             'breakdown_by_source' => [],
         ]);

--- a/tests/Api/BandSpace/File/BandSpaceFileTrashTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileTrashTest.php
@@ -108,6 +108,18 @@ class BandSpaceFileTrashTest extends ApiTestCase
         $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/restore', [], [], self::HEADERS);
 
         $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        // Asserting the body, not just the status: a 422 from any unrelated validator would otherwise
+        // pass here, on the one test covering the quota rule.
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Quota de stockage dépassé : 900 octets utilisés + 900 octets envoyés > 1000 octets autorisés',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Quota de stockage dépassé : 900 octets utilisés + 900 octets envoyés > 1000 octets autorisés',
+        ]);
 
         // Still in the trash.
         $reloaded = self::getContainer()->get(BandSpaceFileRepository::class)

--- a/tests/Api/BandSpace/File/BandSpaceFileTrashTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileTrashTest.php
@@ -1,0 +1,298 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\File;
+
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFileVersionRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * The trash: deleting a file only archives it, so these three endpoints are what make the 30 day grace
+ * period usable instead of a slow, silent loss.
+ */
+#[ResetDatabase]
+class BandSpaceFileTrashTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+    private const string CONTENT = "trash test content\n";
+
+    public function test_the_archived_collection_lists_only_the_trash(): void
+    {
+        [$admin, $bandSpace, $archived] = $this->setupArchivedFile(archivedAt: new \DateTimeImmutable('2026-07-02T09:00:00+00:00'));
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'originalName' => 'live.txt'])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/files?archived=true', [], [], ['HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(1, $response['totalItems']);
+        $this->assertSame('archived.txt', $response['member'][0]['original_name']);
+        $this->assertSame('2026-07-02T09:00:00+00:00', $response['member'][0]['archive_datetime']);
+        // Derived from band_space.file_retention_days, which is 30.
+        $this->assertSame('2026-08-01T09:00:00+00:00', $response['member'][0]['purge_datetime']);
+    }
+
+    public function test_the_default_collection_still_hides_the_trash(): void
+    {
+        [$admin, $bandSpace] = $this->setupArchivedFile();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'originalName' => 'live.txt'])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/files', [], [], ['HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(1, $response['totalItems']);
+        $this->assertSame('live.txt', $response['member'][0]['original_name']);
+        $this->assertNull($response['member'][0]['archive_datetime']);
+        $this->assertNull($response['member'][0]['purge_datetime']);
+    }
+
+    public function test_restoring_clears_the_archive_date_and_records_the_activity(): void
+    {
+        [$admin, $bandSpace, $file] = $this->setupArchivedFile();
+        $fileId = (string) $file->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/files/' . $fileId . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertNull($response['archive_datetime']);
+        $this->assertNull($response['purge_datetime']);
+
+        $reloaded = self::getContainer()->get(BandSpaceFileRepository::class)->findOneByIdAndBandSpace($fileId, $bandSpace);
+        $this->assertNull($reloaded?->archiveDatetime);
+
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($bandSpace, BandSpaceModule::File, $fileId);
+        $this->assertSame(BandSpaceFileActivityType::Restored->value, $activities[0]->type);
+    }
+
+    /**
+     * The quota only counts non-archived files, so a restore puts the whole file back into usage. Without
+     * this check a band could sit at its limit and still restore its way past it.
+     */
+    public function test_restoring_is_refused_when_it_would_exceed_the_quota(): void
+    {
+        [$admin, $bandSpace, $file] = $this->setupArchivedFile(sizeBytes: 900);
+        // A quota with room for the live file but not for the archived one coming back.
+        $bandSpace->quotaBytesOverride = 1000;
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $live = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'originalName' => 'live.txt'])->create();
+        BandSpaceFileVersionFactory::new([
+            'bandSpaceFile' => $live, 'versionNumber' => 1, 'createdBy' => $admin,
+            'mimeType' => 'text/plain', 'size' => 900, 'storagePath' => 'live-' . bin2hex(random_bytes(4)) . '.txt',
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        // Still in the trash.
+        $reloaded = self::getContainer()->get(BandSpaceFileRepository::class)
+            ->findOneByIdAndBandSpace((string) $file->id, $bandSpace);
+        $this->assertNotNull($reloaded?->archiveDatetime);
+    }
+
+    public function test_restoring_a_file_that_is_not_in_the_trash_conflicts(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $live = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'originalName' => 'live.txt'])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/files/' . $live->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Ce fichier n'est pas dans la corbeille",
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => "Ce fichier n'est pas dans la corbeille",
+        ]);
+    }
+
+    public function test_permanent_delete_removes_the_file_its_versions_and_the_stored_object(): void
+    {
+        // The test filesystem adapter is `memory`, so it lives in the container. Without disableReboot the
+        // kernel would restart between the request and the assertion, handing back an empty filesystem and
+        // making "the object is gone" pass whether or not anything was deleted.
+        $this->client->disableReboot();
+
+        [$admin, $bandSpace, $file, $storagePath] = $this->setupArchivedFile();
+        $fileId = (string) $file->id;
+        $objectKey = '/band_space_files/' . $bandSpace->id . '/' . $storagePath;
+
+        /** @var FilesystemOperator $fs */
+        $fs = self::getContainer()->get('oneup_flysystem.musicall_filesystem');
+        $sentinelKey = '/band_space_files/' . $bandSpace->id . '/sentinel.txt';
+        $fs->write($sentinelKey, 'untouched');
+        $this->assertTrue($fs->fileExists($objectKey));
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/files/' . $fileId . '/permanent', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $this->assertNull(self::getContainer()->get(BandSpaceFileRepository::class)->findOneByIdAndBandSpace($fileId, $bandSpace));
+        // The sentinel proves this filesystem is the one the request wrote through, so the absence of the
+        // object below means it was deleted rather than never there.
+        $this->assertTrue($fs->fileExists($sentinelKey), 'The in-memory filesystem was reset, the next assertion would be vacuous');
+        $this->assertFalse($fs->fileExists($objectKey), 'The stored object must be gone, not just the rows');
+        $this->assertSame(0, self::getContainer()->get(BandSpaceFileVersionRepository::class)->count(['bandSpaceFile' => $fileId]));
+
+        // The activity survives the row it points at, so the deletion stays auditable.
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($bandSpace, BandSpaceModule::File, $fileId);
+        $this->assertSame(BandSpaceFileActivityType::Purged->value, $activities[0]->type);
+    }
+
+    public function test_permanent_delete_is_forbidden_for_a_regular_member(): void
+    {
+        [, $bandSpace, $file] = $this->setupArchivedFile();
+        $member = UserFactory::new()->create(['username' => 'member', 'email' => 'member@test.com']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $this->client->loginUser($member);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/permanent', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous devez être administrateur pour effectuer cette action',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous devez être administrateur pour effectuer cette action',
+        ]);
+
+        $this->assertNotNull(self::getContainer()->get(BandSpaceFileRepository::class)
+            ->findOneByIdAndBandSpace((string) $file->id, $bandSpace));
+    }
+
+    public function test_permanent_delete_refuses_a_file_that_is_not_in_the_trash(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $live = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'originalName' => 'live.txt'])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/files/' . $live->id . '/permanent', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertNotNull(self::getContainer()->get(BandSpaceFileRepository::class)
+            ->findOneByIdAndBandSpace((string) $live->id, $bandSpace));
+    }
+
+    public function test_a_non_member_cannot_reach_the_trash(): void
+    {
+        [, $bandSpace, $file] = $this->setupArchivedFile();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+
+        $this->client->loginUser($outsider);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    /**
+     * The trash is frozen while the space itself is pending deletion (M-756): everything is about to go
+     * anyway, and both processors go through the guarded checker variants.
+     */
+    public function test_the_trash_is_frozen_while_the_space_is_pending_deletion(): void
+    {
+        [$admin, $bandSpace, $file] = $this->setupArchivedFile();
+        $bandSpace->deletionScheduledDatetime = new \DateTimeImmutable('+30 days');
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+        ]);
+    }
+
+    /**
+     * @return array{0: object, 1: object, 2: BandSpaceFile, 3: string} admin, bandSpace, file, storagePath
+     */
+    private function setupArchivedFile(?\DateTimeImmutable $archivedAt = null, int $sizeBytes = 19): array
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $admin,
+            'originalName' => 'archived.txt',
+            'archiveDatetime' => $archivedAt ?? new \DateTimeImmutable('-2 days'),
+        ])->create();
+
+        $storagePath = 'trash-' . bin2hex(random_bytes(4)) . '.txt';
+        $version = BandSpaceFileVersionFactory::new([
+            'bandSpaceFile' => $file,
+            'versionNumber' => 1,
+            'createdBy' => $admin,
+            'mimeType' => 'text/plain',
+            'size' => $sizeBytes,
+            'storagePath' => $storagePath,
+        ])->create();
+
+        $file->currentVersion = $version;
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        /** @var FilesystemOperator $fs */
+        $fs = self::getContainer()->get('oneup_flysystem.musicall_filesystem');
+        $fs->write('/band_space_files/' . $bandSpace->id . '/' . $storagePath, self::CONTENT);
+
+        return [$admin, $bandSpace, $file, $storagePath];
+    }
+}

--- a/tests/Integration/Service/BandSpace/File/BandSpaceFilePurgerTest.php
+++ b/tests/Integration/Service/BandSpace/File/BandSpaceFilePurgerTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Integration\Service\BandSpace\File;
+
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Service\BandSpace\File\BandSpaceFilePurger;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * The purger is shared by app:band-space:purge and by the trash's delete-permanently endpoint, so its
+ * two guarantees are tested here rather than twice over: it removes the stored objects, and it declines a
+ * file that has left the trash since the caller loaded it.
+ */
+#[ResetDatabase]
+class BandSpaceFilePurgerTest extends KernelTestCase
+{
+    private const string STORAGE_PREFIX = 'band_space_files';
+
+    public function test_it_destroys_the_file_its_versions_and_every_stored_object(): void
+    {
+        [$file, $paths] = $this->createArchivedFileWithTwoVersions();
+        $fileId = (string) $file->id;
+
+        foreach ($paths as $path) {
+            $this->assertTrue($this->filesystem()->fileExists($path));
+        }
+
+        $this->assertTrue($this->purger()->purge($file));
+
+        $this->assertNull(self::getContainer()->get(BandSpaceFileRepository::class)->find($fileId));
+        $this->assertSame(0, $this->countVersions($fileId));
+        // Both versions, not just the current one: every version holds its own object.
+        foreach ($paths as $path) {
+            $this->assertFalse($this->filesystem()->fileExists($path), 'Every version object must be deleted');
+        }
+    }
+
+    /**
+     * The scenario this guards: app:band-space:purge reads its whole batch, then purges one file at a
+     * time. A member restoring a file in between leaves the command holding an entity that still carries
+     * the old archiveDatetime. Destroying it would silently lose the file someone just asked to keep.
+     */
+    public function test_it_declines_a_file_restored_since_the_caller_loaded_it(): void
+    {
+        [$file, $paths] = $this->createArchivedFileWithTwoVersions();
+        $fileId = (string) $file->id;
+
+        // Restore the row without touching the entity, which is what a concurrent request looks like.
+        self::getContainer()->get(Connection::class)->executeStatement(
+            'UPDATE band_space_file SET archive_datetime = NULL WHERE id = :id',
+            ['id' => $fileId],
+        );
+        $this->assertNotNull($file->archiveDatetime, 'The entity in hand is deliberately stale');
+
+        $this->assertFalse($this->purger()->purge($file));
+
+        $this->assertNotNull(self::getContainer()->get(BandSpaceFileRepository::class)->find($fileId));
+        $this->assertSame(2, $this->countVersions($fileId));
+        foreach ($paths as $path) {
+            $this->assertTrue($this->filesystem()->fileExists($path), 'A restored file keeps its objects');
+        }
+    }
+
+    private function purger(): BandSpaceFilePurger
+    {
+        return self::getContainer()->get(BandSpaceFilePurger::class);
+    }
+
+    private function filesystem(): FilesystemOperator
+    {
+        /** @var FilesystemOperator $filesystem */
+        $filesystem = self::getContainer()->get('oneup_flysystem.musicall_filesystem');
+
+        return $filesystem;
+    }
+
+    /**
+     * @return array{0: object, 1: string[]}
+     */
+    private function createArchivedFileWithTwoVersions(): array
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'archiveDatetime' => new \DateTimeImmutable('-31 days'),
+        ])->create();
+
+        $paths = [];
+        $versions = [];
+        foreach ([1, 2] as $number) {
+            $storagePath = 'purger-v' . $number . '-' . bin2hex(random_bytes(4)) . '.txt';
+            $versions[] = BandSpaceFileVersionFactory::new([
+                'bandSpaceFile' => $file,
+                'versionNumber' => $number,
+                'storagePath' => $storagePath,
+            ])->create();
+            $paths[] = self::STORAGE_PREFIX . '/' . $bandSpace->id . '/' . $storagePath;
+        }
+
+        $file->currentVersion = $versions[1];
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        foreach ($paths as $path) {
+            $this->filesystem()->write($path, 'purger-test');
+        }
+
+        return [$file, $paths];
+    }
+
+    private function countVersions(string $fileId): int
+    {
+        return (int) self::getContainer()->get(Connection::class)->fetchOne(
+            'SELECT COUNT(*) FROM band_space_file_version WHERE band_space_file_id = :id',
+            ['id' => $fileId],
+        );
+    }
+}


### PR DESCRIPTION
Closes #755

## Context

Deleting a Band Space file has never really deleted it. `BandSpaceFileDeleteProcessor` sets `archiveDatetime` and stops there, every read path filters archived rows out, and no endpoint ever cleared the field. An archived file was invisible and unrecoverable through the interface.

#748 closed the loop at the wrong end: `app:band-space:purge` now destroys files archived more than 30 days ago, object and rows. That made the window real. A file "deleted" by mistake is permanently gone after 30 days, and nobody was ever able to bring it back.

This adds the trash, so the window is something a band can actually use: list, restore, delete permanently.

Every claim in the issue was verified against the code before starting. `buildBandSpaceQuery` hardcoded `archiveDatetime IS NULL`, `sumActiveBytesByBandSpace` excludes archived rows so a restore really does re-add quota usage, `purgeFile()` walks versions through the ORM one at a time specifically so VichUploader deletes each object, and `BandSpaceFileActivityType::Restored` already existed, unused, reserved for exactly this.

## What changed

**Listing.** An `archivedOnly` flag on `BandSpaceFileFilter`, honoured in the repository by flipping `archiveDatetime IS NULL` to `IS NOT NULL`, exposed as `?archived=true` on the existing collection. Same shape as the Tasks module. Archived and live are disjoint views, never merged, so no caller can accidentally mix a deleted file into a live listing.

**Restore.** `POST /band_spaces/{bandSpaceId}/files/{id}/restore`, owner or admin, the same rule as archiving. Deliberately not a `PATCH {archived: false}` like Tasks: the file `PATCH` shares `BandSpaceFileItemProvider` with seven other operations and that provider rejects archived files, so loosening it would have changed all of them.

**The quota check is the substantive part.** Restoring puts every version of the file back into the band's usage, so a band sitting at its limit could otherwise restore its way past it. A new `sumBytesByFile()` feeds the existing `assertCanUpload()`, reusing the upload path's error. The check runs before `archiveDatetime` is cleared, so the file's own bytes cannot be double counted.

**Permanent delete.** `DELETE /band_spaces/{bandSpaceId}/files/{id}/permanent`, **admin only**. Archiving and restoring stay owner or admin, but destroying the stored object cannot be undone and frees quota for the whole band, so it sits with the people who can already delete the space. It refuses a file that is not archived, so the trash is the only door to it.

**One purge implementation.** `purgeFile()` moved out of the command into `BandSpaceFilePurger`, shared with the new endpoint. The comment explaining the version-by-version ORM removal moved with it: that loop is the only reason VichUploader deletes the stored objects, and turning it into a bulk delete would silently orphan every object in the bucket.

**The countdown cannot drift.** The retention was `private const DEFAULT_DAYS = 30` inside the command, invisible to the API. It is now a `band_space.file_retention_days` parameter feeding the command default, the computed `purge_datetime` on the file, and a `trash_retention_days` field on the quota endpoint so the interface quotes the number the purge actually enforces. A parameter rather than an env var on purpose: `.env` is a Deployer `shared_files` symlink, so a new variable in the repo's `.env` would never reach production.

Both new processors go through the guarded checker variants, so the trash is correctly frozen while the space itself is pending deletion (M-756), and `BandSpaceWriteGuardCoverageTest` enforces that.

## Interface

A `Corbeille` entry in the Files sidebar, driven by the existing folder-selection path rather than new state, listing each file with its size, deletion date and the days remaining before automatic purge. `Restaurer` for the owner or an admin, `Supprimer définitivement` for admins behind a confirmation.

**The entry copy was wrong and this fixes it.** Deleting a file still said "Supprimer définitivement « X » ?", which was accurate before this feature and is now the opposite of what happens. Both places that said it, the context menu and the drawer footer, now say the file moves to the trash and can be restored, with the retention read from the API.

The same commit also renames "Téléverser" to "Importer" and "Étiquette" to "Tag" across the module, at the maintainer's request. `tag` is masculine in French where `étiquette` is feminine, so the articles moved too: "Aucune étiquette" became "Aucun tag", "Créer une nouvelle étiquette" became "Créer un nouveau tag". Those edits share lines with the trash changes in three files, which is why they are in the same commit rather than split by hunk.

## The review found a way to lose a file

`app:band-space:purge` reads every due file up front, then purges them one at a time. Restore is new in this branch, so until now `archiveDatetime` was effectively write-once and nothing could change under the command's feet. Now a member can restore a file after the batch was read, leaving the command holding an entity that still carries the old `archiveDatetime`, and it would destroy the file anyway. Silent, irreversible, and hitting exactly the person who just asked to keep the file.

The purger now re-reads before destroying anything and declines a file that has left the trash, which protects both callers from one place. A skipped file is reported and is not counted as a failure.

Two smaller findings from the same review are fixed: a filter left over from browsing a folder used to keep filtering the trash, where the filter bar is hidden and there is no control to clear it, so someone hunting for a file they just deleted would have found it apparently missing; and the quota refusal test asserted only a status code, on the one path covering the feature's hardest rule.

## Verification

- Suite **1792 green**, 12 tests added. PHPStan level 8 clean, `npm run lint` back at its exact baseline of 44 infos and exit 0, build clean, `lint:container` clean.
- The two guard tests were proven to fail without their guards, rather than merely asserted: removing the purger's re-read makes the race test fail, and un-guarding a processor makes the write-guard coverage test name the file.
- The storage assertion is self-proving. The test filesystem adapter is `memory`, so without `disableReboot()` the kernel restarts between the request and the assertion and hands back an empty filesystem, making "the object is gone" pass whether or not anything was deleted. The test writes a sentinel file and asserts it survived first.
- Manual pass on dev: uploaded two files, deleted one, saw the Corbeille count and a `purge_datetime` exactly 30 days after the archive date, restored one from the interface, then purged the other through the confirmation dialog. Then checked the database directly, because a click cannot prove row deletion: the file and its version row were gone and the restored one was back with `archive_datetime` null.

## Follow-ups opened

- **#761** the same trash for setlists and songs. Cheap, since both repositories already accept `includeArchived`, but it records a decision the issue text did not: nothing purges archived rows, so their trash would be unbounded unless the command is extended.
- **#762** the open question from #755, whether notes, agenda and finance entries should stop hard-deleting. Written as a decision with the real obstacle per module, and it says plainly that leaving it alone is defensible, since a trash is worth most where the content is hardest to recreate.
- **#763** showing folders inline in the main panel, Google Drive style, keeping the sidebar tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
