### PR TITLE
M-763: show folders inline in the files panel, Drive style

### DIFF
--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -22,14 +22,21 @@
         <div class="col-span-2">Ajouté le</div>
       </div>
 
-      <!-- Folders first, in the same grid as the files, so the panel reads as one list. -->
+      <!-- Folders first, in the same grid as the files, so the panel reads as one list. Focusable and
+           operable from the keyboard: #688 established that a clickable div needs this, and unlike the
+           file row below it this one has no nested button to conflict with the button role. -->
       <div
         v-for="folder in folders"
         :key="folder.id"
-        class="flex items-center gap-2 px-3 py-2 text-sm border-b border-surface-100 dark:border-surface-800 hover:bg-surface-50 dark:hover:bg-surface-800/40 cursor-pointer"
+        role="button"
+        tabindex="0"
+        :aria-label="`Ouvrir le dossier ${folder.name}`"
+        class="flex items-center gap-2 px-3 py-2 text-sm border-b border-surface-100 dark:border-surface-800 hover:bg-surface-50 dark:hover:bg-surface-800/40 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary-500"
         :class="dropTargetId === folder.id ? 'bg-primary-100 dark:bg-primary-900/40 ring-2 ring-primary-400' : ''"
         :draggable="true"
         @click="emit('open-folder', folder.id)"
+        @keydown.enter.prevent="emit('open-folder', folder.id)"
+        @keydown.space.prevent="emit('open-folder', folder.id)"
         @dragstart="(event) => handleFolderDragStart(event, folder)"
         @dragend="handleDragEnd"
         @dragover.prevent="(event) => handleFolderDragOver(event, folder)"

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -5,7 +5,7 @@
     </div>
 
     <div
-      v-else-if="files.length === 0"
+      v-else-if="files.length === 0 && folders.length === 0"
       class="flex flex-col items-center justify-center py-16 text-center text-surface-400"
     >
       <i class="pi pi-folder-open text-5xl mb-4"></i>
@@ -20,6 +20,37 @@
         <div class="col-span-2">Taille</div>
         <div class="col-span-2">Tags</div>
         <div class="col-span-2">Ajouté le</div>
+      </div>
+
+      <!-- Folders first, in the same grid as the files, so the panel reads as one list. -->
+      <div
+        v-for="folder in folders"
+        :key="folder.id"
+        class="flex items-center gap-2 px-3 py-2 text-sm border-b border-surface-100 dark:border-surface-800 hover:bg-surface-50 dark:hover:bg-surface-800/40 cursor-pointer"
+        :class="dropTargetId === folder.id ? 'bg-primary-100 dark:bg-primary-900/40 ring-2 ring-primary-400' : ''"
+        :draggable="true"
+        @click="emit('open-folder', folder.id)"
+        @dragstart="(event) => handleFolderDragStart(event, folder)"
+        @dragend="handleDragEnd"
+        @dragover.prevent="(event) => handleFolderDragOver(event, folder)"
+        @dragleave="handleFolderDragLeave"
+        @drop.prevent="() => handleFolderDrop(folder)"
+      >
+        <div class="grid grid-cols-12 gap-2 flex-1 min-w-0 items-center">
+          <div class="col-span-12 md:col-span-6 flex items-center gap-2 min-w-0">
+            <i class="pi pi-folder text-lg text-primary-500 shrink-0" aria-hidden="true"></i>
+            <span class="truncate font-medium">{{ folder.name }}</span>
+          </div>
+
+          <div class="col-span-4 md:col-span-2 text-surface-400">—</div>
+          <div class="col-span-4 md:col-span-2"></div>
+
+          <div class="col-span-4 md:col-span-2 text-surface-600 dark:text-surface-300">
+            {{ formatDate(folder.creation_datetime) }}
+          </div>
+        </div>
+
+        <span class="shrink-0 w-7 h-7" aria-hidden="true"></span>
       </div>
 
       <div
@@ -80,6 +111,12 @@ import Tag from 'primevue/tag'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
+import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
+import {
+  applyMove,
+  canDrop,
+  collectFolderAndDescendants
+} from '../../../composables/useFolderDragDrop.js'
 import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
@@ -90,11 +127,20 @@ const props = defineProps({
   isLoading: { type: Boolean, default: false },
   emptyMessage: {
     type: String,
-    default: 'Aucun fichier dans ce dossier — commencez par en téléverser un.'
-  }
+    default: 'Aucun fichier dans ce dossier — commencez par en importer un.'
+  },
+  /** Direct subfolders of the folder being shown, rendered above the files. */
+  folders: { type: Array, default: () => [] }
 })
 
-const emit = defineEmits(['select', 'open-share', 'open-versions', 'open-rename', 'open-move'])
+const emit = defineEmits([
+  'select',
+  'open-share',
+  'open-versions',
+  'open-rename',
+  'open-move',
+  'open-folder'
+])
 
 const filesStore = useBandFilesStore()
 const userSecurityStore = useUserSecurityStore()
@@ -103,6 +149,8 @@ const confirm = useConfirm()
 const toast = useToast()
 
 const isAdmin = computed(() => bandSpaceStore.getById(props.bandSpaceId)?.role === 'admin')
+
+const dropTargetId = ref(null)
 
 const contextMenuRef = ref(null)
 const contextMenuFile = ref(null)
@@ -194,6 +242,43 @@ function confirmDelete(file) {
   })
 }
 
+function handleFolderDragStart(event, folder) {
+  filesStore.startDrag({
+    type: 'folder',
+    id: folder.id,
+    parentId: folder.parent_id ?? null,
+    // Without the descendants a folder could be dropped inside itself, which would orphan the subtree.
+    descendantIds: collectFolderAndDescendants(filesStore.folders, folder.id)
+  })
+  event.dataTransfer.effectAllowed = 'move'
+  event.dataTransfer.setData('text/plain', folder.id)
+}
+
+function handleFolderDragOver(event, folder) {
+  if (!filesStore.dragSource) return
+  if (!canDrop(filesStore.dragSource, folder.id)) {
+    event.dataTransfer.dropEffect = 'none'
+    return
+  }
+  event.dataTransfer.dropEffect = 'move'
+  dropTargetId.value = folder.id
+}
+
+function handleFolderDragLeave() {
+  dropTargetId.value = null
+}
+
+function handleFolderDrop(folder) {
+  dropTargetId.value = null
+  if (!filesStore.dragSource || !canDrop(filesStore.dragSource, folder.id)) return
+  applyMove(filesStore.dragSource, folder.id, {
+    bandSpaceId: props.bandSpaceId,
+    filesStore,
+    filesApi: bandSpaceFilesApi,
+    toast
+  })
+}
+
 function handleDragStart(event, file) {
   filesStore.startDrag({
     type: 'file',
@@ -205,6 +290,7 @@ function handleDragStart(event, file) {
 }
 
 function handleDragEnd() {
+  dropTargetId.value = null
   filesStore.endDrag()
 }
 

--- a/assets/js/components/BandSpace/Files/FolderTree.vue
+++ b/assets/js/components/BandSpace/Files/FolderTree.vue
@@ -82,7 +82,7 @@ import Button from 'primevue/button'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
 import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
-import { canDrop } from '../../../composables/useFolderDragDrop.js'
+import { applyMove, canDrop } from '../../../composables/useFolderDragDrop.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import FolderDeleteDialog from './FolderDeleteDialog.vue'
 import FolderEditDialog from './FolderEditDialog.vue'
@@ -132,44 +132,20 @@ function handleRootDragLeave() {
 function handleRootDrop() {
   isRootDropTarget.value = false
   if (!filesStore.dragSource || !canDrop(filesStore.dragSource, null)) return
-  applyMove(filesStore.dragSource, null)
+  move(filesStore.dragSource, null)
+}
+
+function move(source, targetFolderId) {
+  applyMove(source, targetFolderId, {
+    bandSpaceId: props.bandSpaceId,
+    filesStore,
+    filesApi: bandSpaceFilesApi,
+    toast
+  })
 }
 
 function handleDropOnFolder({ targetFolderId, source }) {
-  applyMove(source, targetFolderId)
-}
-
-async function applyMove(source, targetFolderId) {
-  if (!props.bandSpaceId) return
-  try {
-    if (source.type === 'folder') {
-      await filesStore.updateFolder(props.bandSpaceId, source.id, { parent_id: targetFolderId })
-      toast.add({
-        severity: 'success',
-        summary: 'Dossier déplacé',
-        life: 2500
-      })
-    } else if (source.type === 'file') {
-      await bandSpaceFilesApi.updateFile(props.bandSpaceId, source.id, {
-        folder_id: targetFolderId
-      })
-      filesStore.fetchFiles(props.bandSpaceId)
-      toast.add({
-        severity: 'success',
-        summary: 'Fichier déplacé',
-        life: 2500
-      })
-    }
-  } catch (e) {
-    toast.add({
-      severity: 'error',
-      summary: 'Déplacement impossible',
-      detail: e.message,
-      life: 5000
-    })
-  } finally {
-    filesStore.endDrag()
-  }
+  move(source, targetFolderId)
 }
 
 function openCreateRoot() {

--- a/assets/js/composables/useFolderDragDrop.js
+++ b/assets/js/composables/useFolderDragDrop.js
@@ -40,6 +40,36 @@ export function collectFolderAndDescendants(tree, folderId) {
 }
 
 /**
+ * The direct children of a folder in a nested tree, or the roots when at the top.
+ *
+ * The folder collection returns roots carrying their whole subtree under `children`, so the children of
+ * any folder are already in memory and need no request. Used to list folders inline in the file panel.
+ *
+ * @param {Array} tree
+ * @param {string|null} folderId  null = root level
+ * @returns {Array}
+ */
+export function directChildren(tree, folderId) {
+  if (!Array.isArray(tree)) return []
+  if (!folderId) return tree
+
+  const walk = (nodes) => {
+    for (const node of nodes) {
+      if (node.id === folderId) {
+        return Array.isArray(node.children) ? node.children : []
+      }
+      if (Array.isArray(node.children) && node.children.length > 0) {
+        const found = walk(node.children)
+        if (found !== null) return found
+      }
+    }
+    return null
+  }
+
+  return walk(tree) ?? []
+}
+
+/**
  * Whether a drop is allowed for the given source on the given target folder id.
  *
  * @param {object|null} source
@@ -64,4 +94,43 @@ export function canDrop(source, targetFolderId) {
   }
 
   return false
+}
+
+/**
+ * Perform a validated drop: reparent a folder, or move a file into a folder.
+ *
+ * Lives here rather than in a component because both drop surfaces need it, the sidebar tree and the
+ * folder rows in the file panel. Always ends the drag, including on failure, so a rejected move cannot
+ * leave the store thinking a drag is still in progress.
+ *
+ * @param {object} source
+ * @param {string|null} targetFolderId  null = root
+ * @param {{bandSpaceId: string, filesStore: object, filesApi: object, toast: object}} context
+ */
+export async function applyMove(
+  source,
+  targetFolderId,
+  { bandSpaceId, filesStore, filesApi, toast }
+) {
+  if (!bandSpaceId) return
+
+  try {
+    if (source.type === 'folder') {
+      await filesStore.updateFolder(bandSpaceId, source.id, { parent_id: targetFolderId })
+      toast.add({ severity: 'success', summary: 'Dossier déplacé', life: 2500 })
+    } else if (source.type === 'file') {
+      await filesApi.updateFile(bandSpaceId, source.id, { folder_id: targetFolderId })
+      filesStore.fetchFiles(bandSpaceId)
+      toast.add({ severity: 'success', summary: 'Fichier déplacé', life: 2500 })
+    }
+  } catch (e) {
+    toast.add({
+      severity: 'error',
+      summary: 'Déplacement impossible',
+      detail: e.message,
+      life: 5000
+    })
+  } finally {
+    filesStore.endDrag()
+  }
 }

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -250,13 +250,9 @@ const showBreadcrumb = computed(() => {
 const isTrashActive = computed(() => filesStore.activeFolderId === TRASH_FOLDER_ID)
 
 /**
- * The subfolders shown inline above the files. Derived from the tree already in the store, so descending
- * costs no request. Empty for the virtual source folders and the trash: neither is a real folder, so
- * neither has children.
- */
-/**
  * The folder the panel is actually inside, or null at the root. Virtual sources and the trash are not
- * folders, so a new folder created from there belongs at the root rather than inside them.
+ * folders, so a new folder created from there belongs at the root rather than inside them, and their id
+ * must never reach the API as a parent_id.
  */
 const activeRealFolderId = computed(() => {
   if (isTrashActive.value || isVirtualFolderActive.value) {
@@ -266,6 +262,11 @@ const activeRealFolderId = computed(() => {
   return filesStore.activeFolderId
 })
 
+/**
+ * The subfolders shown inline above the files. Derived from the tree already in the store, so descending
+ * costs no request. The guard cannot be folded into activeRealFolderId: that returns null for a virtual
+ * source, and a null id means "the root" here, which would list every root folder inside it.
+ */
 const inlineFolders = computed(() => {
   if (isTrashActive.value || isVirtualFolderActive.value) {
     return []

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -77,25 +77,41 @@
           v-if="!isTrashActive"
           class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700"
         >
-          <div class="flex flex-wrap items-center gap-3">
-            <div class="flex-1 min-w-[200px]">
-              <FileFilterBar
-                :filters="filesStore.filters"
-                :tags="filesStore.tags"
-                @update-filter="handleFilterUpdate"
+          <!-- Two rows on purpose: the four filters need about 700px and the two actions about 340px,
+               so a single row wraps on any laptop and leaves the sort control orphaned underneath. -->
+          <div class="flex flex-col gap-3">
+            <div class="flex flex-wrap items-center justify-end gap-2">
+              <Button
+                label="Nouveau dossier"
+                icon="pi pi-folder-plus"
+                size="small"
+                severity="secondary"
+                :disabled="isVirtualFolderActive"
+                v-tooltip.top="
+                  isVirtualFolderActive
+                    ? 'Les dossiers virtuels sont remplis automatiquement par les attachements.'
+                    : null
+                "
+                @click="createFolderDialogVisible = true"
+              />
+              <Button
+                label="Importer un fichier"
+                icon="pi pi-cloud-upload"
+                size="small"
+                :disabled="isVirtualFolderActive"
+                v-tooltip.top="
+                  isVirtualFolderActive
+                    ? 'Les dossiers virtuels sont remplis automatiquement par les attachements.'
+                    : null
+                "
+                @click="uploadDialogVisible = true"
               />
             </div>
-            <Button
-              label="Importer un fichier"
-              icon="pi pi-cloud-upload"
-              size="small"
-              :disabled="isVirtualFolderActive"
-              v-tooltip.top="
-                isVirtualFolderActive
-                  ? 'Les dossiers virtuels sont remplis automatiquement par les attachements.'
-                  : null
-              "
-              @click="uploadDialogVisible = true"
+
+            <FileFilterBar
+              :filters="filesStore.filters"
+              :tags="filesStore.tags"
+              @update-filter="handleFilterUpdate"
             />
           </div>
         </div>
@@ -110,6 +126,8 @@
           />
           <FileList
             v-else
+            :folders="inlineFolders"
+            @open-folder="handleFolderSelect"
             :band-space-id="bandSpaceId"
             :files="filesStore.files"
             :is-loading="filesStore.isLoadingFiles"
@@ -123,6 +141,14 @@
         </div>
       </section>
     </div>
+
+    <FolderEditDialog
+      v-if="bandSpaceId && createFolderDialogVisible"
+      v-model:visible="createFolderDialogVisible"
+      :band-space-id="bandSpaceId"
+      :mode="activeRealFolderId ? 'create-sub' : 'create-root'"
+      :parent-id="activeRealFolderId"
+    />
 
     <FileUploadDialog
       v-if="bandSpaceId"
@@ -182,8 +208,10 @@ import FileTrashList from '../../components/BandSpace/Files/FileTrashList.vue'
 import FileUploadDialog from '../../components/BandSpace/Files/FileUploadDialog.vue'
 import FileVersionPanel from '../../components/BandSpace/Files/FileVersionPanel.vue'
 import FolderBreadcrumb from '../../components/BandSpace/Files/FolderBreadcrumb.vue'
+import FolderEditDialog from '../../components/BandSpace/Files/FolderEditDialog.vue'
 import FolderTree from '../../components/BandSpace/Files/FolderTree.vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
+import { directChildren } from '../../composables/useFolderDragDrop.js'
 import { TRASH_FOLDER_ID, useBandFilesStore } from '../../store/bandSpace/bandSpaceFiles.js'
 
 const route = useRoute()
@@ -199,6 +227,7 @@ filesStore.clear()
 const isAdmin = computed(() => currentSpace.value?.role === 'admin')
 
 const uploadDialogVisible = ref(false)
+const createFolderDialogVisible = ref(false)
 const detailVisible = ref(false)
 const shareDialogVisible = ref(false)
 const shareDialogFileId = ref(null)
@@ -219,6 +248,31 @@ const showBreadcrumb = computed(() => {
 })
 
 const isTrashActive = computed(() => filesStore.activeFolderId === TRASH_FOLDER_ID)
+
+/**
+ * The subfolders shown inline above the files. Derived from the tree already in the store, so descending
+ * costs no request. Empty for the virtual source folders and the trash: neither is a real folder, so
+ * neither has children.
+ */
+/**
+ * The folder the panel is actually inside, or null at the root. Virtual sources and the trash are not
+ * folders, so a new folder created from there belongs at the root rather than inside them.
+ */
+const activeRealFolderId = computed(() => {
+  if (isTrashActive.value || isVirtualFolderActive.value) {
+    return null
+  }
+
+  return filesStore.activeFolderId
+})
+
+const inlineFolders = computed(() => {
+  if (isTrashActive.value || isVirtualFolderActive.value) {
+    return []
+  }
+
+  return directChildren(filesStore.folders, filesStore.activeFolderId)
+})
 
 const isVirtualFolderActive = computed(() => {
   const id = filesStore.activeFolderId
@@ -242,9 +296,9 @@ const emptyMessage = computed(() => {
     return 'Aucun fichier attaché à une setlist pour le moment.'
   }
   if (filesStore.activeFolderId !== null) {
-    return 'Aucun fichier dans ce dossier — commencez par en téléverser un.'
+    return 'Aucun fichier dans ce dossier — commencez par en importer un.'
   }
-  return 'Aucun fichier — commencez par en téléverser un.'
+  return 'Aucun fichier — commencez par en importer un.'
 })
 
 let queryDebounce = null


### PR DESCRIPTION
Closes #763

## Context

Folders lived only in the left sidebar. The main panel showed the files of the selected folder and never indicated that a folder was there at all, so a space with nested folders read as a flat list of files with a separate map beside it: to go into a subfolder you had to find it in the tree.

Folder rows now sit above the files in the same table, Drive style, and the sidebar tree is unchanged.

## The reference screenshot made this much smaller than the issue assumed

The issue text was written before seeing Drive side by side, and three of its assumptions turned out to be wrong:

- **Folders show a dash in the size column, not a file count.** So there is **no backend change at all**: no `countByFolderIds`, no new API field, nothing threaded through the nested `children` arrays, and nothing new to keep excluding trashed files.
- **There is no pagination UI in this panel**, no control and no load-more, and `totalFiles` is not even displayed, so folders cannot be "paginated away".
- **`useFolderDragDrop.js` already provided `canDrop` and `collectFolderAndDescendants`**, so drop validation was reuse rather than new logic.

What is left is four front-end files.

## What changed

**Deriving the folders costs nothing.** `filesStore.folders` already holds the whole tree, fetched once: root folders each carrying their subtree under `children`. A new `directChildren(tree, folderId)` walks it, so descending into a folder issues no request.

**A single click opens a folder**, deliberately not a double click. In this panel a single click on a file row already opens its drawer and a single click in the sidebar already navigates, so there is one gesture for the whole list. Drive uses double click because it has multi-select, which this list does not.

**`applyMove` moved out of `FolderTree.vue` into the composable**, whose docblock already scoped it to "the folder tree + file list". The inline rows need identical move behaviour, so both drop surfaces now call one implementation instead of two copies. Folder rows are drag sources and drop targets, reusing the existing validation.

**Folders are hidden where they do not apply.** The virtual source folders and the trash are not folders and have no children, so the list is empty for them. The empty-state block now also requires that there be no folders, so a folder holding only subfolders no longer claims "aucun fichier".

**A "Nouveau dossier" button** next to "Importer un fichier", which creates the folder where you currently are: a root folder at the root, a subfolder when you are inside one. It reuses the existing `FolderEditDialog` in its `create-root` and `create-sub` modes, so no new dialog and no duplicated validation, and it is disabled for the virtual sources like the upload button.

**The toolbar is two rows now**, actions right-aligned above the filters. Measured rather than guessed: the four filters need about 700px and the two buttons about 340px, so a single row wrapped on any laptop and left the sort control stranded beside the buttons. Two rows also puts the filters directly above the table they filter.

## Review findings, both fixed

**The folder row was a clickable div with no keyboard path.** #688 already treated exactly this pattern as a defect and fixed it elsewhere in the app, so new code reintroducing it is a regression against a standard this project has already set. The row is now `role="button"` with `tabindex="0"`, Enter and Space handlers, a visible focus ring and a French `aria-label`. Verified without a mouse: focus the row, press Enter, the panel descends.

The file row beside it has the same gap, but it predates this change and cannot take the same fix, because it contains a nested actions button and wrapping that in a button role is invalid. That needs a different approach and belongs in its own change.

**A docblock had drifted onto the wrong computed.** A scripted edit left the description of `inlineFolders` sitting above `activeRealFolderId`, so `inlineFolders` was undocumented and a reader would have attached the wrong meaning to the virtual and trash guard. Both now sit above what they describe, and the reason the two guards cannot be collapsed into one is written down: `activeRealFolderId` returns null for a virtual source, and a null id means "the root" to `directChildren`, which would list every root folder inside it.

The review also raised the literal em dash in the size column. Left as is on purpose: it is the established "no value" convention across this whole feature already, in `formatSize`, `formatDate`, `FileVersionPanel`, `QuotaIndicator` and others, and it is what Drive shows. Changing only the new row would make the table inconsistent, and the em dash rule is about prose reading machine-generated, not a placeholder glyph in a table cell.

## Verification

There is **no JS test runner** in this project, so this cannot be covered by automated tests and the verification was hands-on, in a real browser against seeded data:

- the root lists its folders above its files, each with a dash for size
- clicking a folder descends, and the breadcrumb and the sidebar selection both follow
- a folder holding only a subfolder shows it, with no misleading "aucun fichier"
- dragging a file onto an inline folder row moves it, confirmed through the API rather than by the toast, and the row highlights on a valid drag-over and clears on leave
- dropping a folder onto itself is refused and its `parent_id` is unchanged afterwards
- the virtual sources and the Corbeille show no folder rows
- "Nouveau dossier" creates a root folder at the root and a subfolder from inside a folder, both confirmed through the API
- keyboard only: focus a folder row, press Enter, the panel descends
- checked at 1440px, 1150px and 390px

Backend untouched and proven so: suite **1792 green**, PHPStan level 8 clean, lint back at its exact baseline of 44 infos and exit 0, build clean, nothing outside `assets/`.

## Left alone deliberately

- **No actions menu on folder rows.** Renaming, moving and deleting a folder already work in the sidebar one click away, and doing it inline means lifting two dialogs out of `FolderTree.vue` into shared state. Worth doing once the navigation is in use.
- **No grid view and no sortable columns**, both visible in the Drive reference and both larger than this change.
- **The root still lists every file in the space**, including files inside subfolders, so a folder and its contents both appear there. That is pre-existing and the "Tous les fichiers" label is honest, but it now reads oddly next to the folder rows. Scoping the root to unfiled files would redefine a view people may rely on as the only way to see everything at once, so it needs a decision rather than a quiet change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
