### PR TITLE
M-766: tech rider core entity, CRUD API and activity feed

### DIFF
--- a/assets/js/components/BandSpace/Settings/activitySentences.js
+++ b/assets/js/components/BandSpace/Settings/activitySentences.js
@@ -147,6 +147,12 @@ const SENTENCES = {
   'setlist.setlist_file_detached': (a) =>
     `a détaché le fichier « ${a.payload?.original_name ?? '—'} » d'une setlist`,
 
+  // Tech riders
+  'rider.rider_created': (a) => `a créé le tech rider « ${a.payload?.name ?? '—'} »`,
+  'rider.rider_renamed': (a) => `a renommé le tech rider en « ${a.payload?.name ?? '—'} »`,
+  'rider.rider_archived': (a) => `a archivé le tech rider « ${a.payload?.name ?? '—'} »`,
+  'rider.rider_unarchived': (a) => `a réintégré le tech rider « ${a.payload?.name ?? '—'} »`,
+
   // Settings — band
   'settings.band_created': (a) => `a créé le Band Space « ${a.payload?.name ?? '—'} »`,
 

--- a/migrations/2026/08/Version20260802081656.php
+++ b/migrations/2026/08/Version20260802081656.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260802081656 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create band_space_tech_rider (Tech Rider module core entity)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE band_space_tech_rider (id CHAR(36) NOT NULL, name VARCHAR(255) NOT NULL, archive_datetime DATETIME DEFAULT NULL, creation_datetime DATETIME NOT NULL, update_datetime DATETIME DEFAULT NULL, band_space_id CHAR(36) NOT NULL, created_by_id CHAR(36) DEFAULT NULL, INDEX IDX_C4F3158FE31C124A (band_space_id), INDEX IDX_C4F3158FB03A8386 (created_by_id), INDEX idx_tech_rider_band_archive (band_space_id, archive_datetime), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE band_space_tech_rider ADD CONSTRAINT FK_C4F3158FE31C124A FOREIGN KEY (band_space_id) REFERENCES band_space (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE band_space_tech_rider ADD CONSTRAINT FK_C4F3158FB03A8386 FOREIGN KEY (created_by_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space_tech_rider DROP FOREIGN KEY FK_C4F3158FE31C124A');
+        $this->addSql('ALTER TABLE band_space_tech_rider DROP FOREIGN KEY FK_C4F3158FB03A8386');
+        $this->addSql('DROP TABLE band_space_tech_rider');
+    }
+}

--- a/src/ApiResource/BandSpace/TechRider/TechRiderCreate.php
+++ b/src/ApiResource/BandSpace/TechRider/TechRiderCreate.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\TechRider\TechRiderCreateProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: TechRiderResource::class, identifiers: ['bandSpaceId']),
+    ],
+    openapi: new Operation(tags: ['Band Space Tech Rider']),
+    security: "is_granted('ROLE_USER')",
+    normalizationContext: ['skip_null_values' => false],
+    output: TechRiderResource::class,
+    name: 'api_band_space_tech_riders_post',
+    processor: TechRiderCreateProcessor::class,
+)]
+class TechRiderCreate
+{
+    #[Assert\NotBlank(message: 'Veuillez spécifier un nom')]
+    #[Assert\Length(max: 255, maxMessage: 'Le nom ne peut pas dépasser {{ limit }} caractères')]
+    public string $name;
+}

--- a/src/ApiResource/BandSpace/TechRider/TechRiderResource.php
+++ b/src/ApiResource/BandSpace/TechRider/TechRiderResource.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\TechRider\TechRiderDeleteProcessor;
+use App\State\Processor\BandSpace\TechRider\TechRiderUnarchiveProcessor;
+use App\State\Processor\BandSpace\TechRider\TechRiderUpdateProcessor;
+use App\State\Provider\BandSpace\TechRider\TechRiderCollectionProvider;
+use App\State\Provider\BandSpace\TechRider\TechRiderItemProvider;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    shortName: 'TechRider',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            openapi: new Operation(tags: ['Band Space Tech Rider']),
+            paginationEnabled: false,
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_tech_riders_get_collection',
+            provider: TechRiderCollectionProvider::class,
+            parameters: [
+                // archived=true lists the archive instead of the live riders. Same shape as the files trash.
+                'archived' => new QueryParameter(key: 'archived'),
+            ],
+        ),
+        new Get(
+            uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders/{id}',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space Tech Rider']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_tech_riders_get_item',
+            provider: TechRiderItemProvider::class,
+        ),
+        new Patch(
+            uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders/{id}',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space Tech Rider']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_tech_riders_patch',
+            provider: TechRiderItemProvider::class,
+            processor: TechRiderUpdateProcessor::class,
+        ),
+        // read: false because TechRiderItemProvider would hydrate a resource this
+        // operation never reads, and the processor loads the entity itself anyway.
+        new Post(
+            uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders/{id}/unarchive',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space Tech Rider']),
+            security: "is_granted('ROLE_USER')",
+            input: false,
+            read: false,
+            name: 'api_band_space_tech_riders_unarchive',
+            processor: TechRiderUnarchiveProcessor::class,
+        ),
+        new Delete(
+            uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders/{id}',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space Tech Rider']),
+            security: "is_granted('ROLE_USER')",
+            read: false,
+            name: 'api_band_space_tech_riders_delete',
+            processor: TechRiderDeleteProcessor::class,
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+class TechRiderResource
+{
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    #[ApiProperty(identifier: true)]
+    public string $bandSpaceId;
+
+    #[Assert\NotBlank(message: 'Veuillez spécifier un nom')]
+    #[Assert\Length(max: 255, maxMessage: 'Le nom ne peut pas dépasser {{ limit }} caractères')]
+    public string $name;
+
+    public ?string $createdByUsername = null;
+    public ?\DateTimeInterface $archiveDatetime = null;
+    public \DateTimeInterface $creationDatetime;
+    public ?\DateTimeInterface $updateDatetime = null;
+}

--- a/src/ApiResource/BandSpace/TechRider/TechRiderResource.php
+++ b/src/ApiResource/BandSpace/TechRider/TechRiderResource.php
@@ -60,8 +60,9 @@ use Symfony\Component\Validator\Constraints as Assert;
             provider: TechRiderItemProvider::class,
             processor: TechRiderUpdateProcessor::class,
         ),
-        // read: false because TechRiderItemProvider would hydrate a resource this
-        // operation never reads, and the processor loads the entity itself anyway.
+        // read: false on this operation and on Delete below: TechRiderItemProvider would
+        // hydrate a resource neither one reads, and both processors load the entity
+        // themselves. Setlist still pays that cost on its Delete.
         new Post(
             uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders/{id}/unarchive',
             uriVariables: [

--- a/src/Entity/BandSpace/TechRider.php
+++ b/src/Entity/BandSpace/TechRider.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity\BandSpace;
+
+use App\Entity\User;
+use App\Repository\BandSpace\TechRiderRepository;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * A technical rider: the document a band sends to a venue before a show.
+ *
+ * Unlike every other Band Space document this one is read by someone outside the band,
+ * which is why it carries its author and why archiving is preferred to deletion.
+ */
+#[ORM\Entity(repositoryClass: TechRiderRepository::class)]
+#[ORM\Table(name: 'band_space_tech_rider')]
+#[ORM\Index(name: 'idx_tech_rider_band_archive', columns: ['band_space_id', 'archive_datetime'])]
+class TechRider
+{
+    #[ORM\Id]
+    #[ORM\Column(type: "uuid", unique: true)]
+    #[ORM\GeneratedValue(strategy: "CUSTOM")]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    public UuidInterface|string|null $id = null {
+        get {
+            return is_string($this->id) ? $this->id : $this->id?->toString();
+        }
+    }
+
+    #[ORM\ManyToOne(targetEntity: BandSpace::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    public BandSpace $bandSpace;
+
+    /**
+     * Nullable so deleting the author does not take the rider with them: the band still
+     * needs the document. Same shape as BandSpaceFile::$createdBy.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    public ?User $createdBy = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    public string $name;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    public ?DateTimeImmutable $archiveDatetime = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    public DateTimeInterface $creationDatetime;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    public ?DateTimeInterface $updateDatetime = null;
+
+    public function __construct()
+    {
+        $this->creationDatetime = new DateTime();
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->archiveDatetime instanceof DateTimeImmutable;
+    }
+}

--- a/src/Enum/BandSpace/BandSpaceModule.php
+++ b/src/Enum/BandSpace/BandSpaceModule.php
@@ -11,4 +11,5 @@ enum BandSpaceModule: string
     case Notes = 'notes';
     case Settings = 'settings';
     case Setlist = 'setlist';
+    case Rider = 'rider';
 }

--- a/src/Enum/BandSpace/BandSpaceRiderActivityType.php
+++ b/src/Enum/BandSpace/BandSpaceRiderActivityType.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace App\Enum\BandSpace;
+
+/**
+ * The band_space_activity.type column is 30 characters, so every value added here
+ * must stay within that. The natural names for this module run long.
+ */
+enum BandSpaceRiderActivityType: string
+{
+    case RiderCreated = 'rider_created';
+    case RiderRenamed = 'rider_renamed';
+    case RiderArchived = 'rider_archived';
+    case RiderUnarchived = 'rider_unarchived';
+}

--- a/src/Repository/BandSpace/TechRiderRepository.php
+++ b/src/Repository/BandSpace/TechRiderRepository.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\TechRider;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<TechRider>
+ */
+class TechRiderRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TechRider::class);
+    }
+
+    /**
+     * Live riders by default; $archivedOnly swaps to the archive view rather than
+     * widening the result, matching the files trash (?archived=true) rather than
+     * SetlistRepository::findByBandSpace, which includes both.
+     *
+     * @return TechRider[]
+     */
+    public function findByBandSpace(BandSpace $bandSpace, bool $archivedOnly = false): array
+    {
+        return $this->createQueryBuilder('r')
+            ->addSelect('author')
+            ->leftJoin('r.createdBy', 'author')
+            ->where('r.bandSpace = :bandSpace')
+            ->andWhere($archivedOnly ? 'r.archiveDatetime IS NOT NULL' : 'r.archiveDatetime IS NULL')
+            ->setParameter('bandSpace', $bandSpace)
+            ->orderBy('r.creationDatetime', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Direct id lookup does NOT filter archived riders: an archived rider still has to
+     * be readable so it can be restored or duplicated into next year's.
+     *
+     * The id is validated before it reaches the query because the column is a uuid and
+     * Doctrine throws ValueNotConvertible on a non-uuid value, which surfaces as a 500
+     * where the caller wants a 404.
+     */
+    public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?TechRider
+    {
+        if (!Uuid::isValid($id)) {
+            return null;
+        }
+
+        return $this->createQueryBuilder('r')
+            ->addSelect('author')
+            ->leftJoin('r.createdBy', 'author')
+            ->where('r.id = :id')
+            ->andWhere('r.bandSpace = :bandSpace')
+            ->setParameter('id', $id)
+            ->setParameter('bandSpace', $bandSpace)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/src/Repository/BandSpace/TechRiderRepository.php
+++ b/src/Repository/BandSpace/TechRiderRepository.php
@@ -6,7 +6,6 @@ use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\TechRider;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
-use Ramsey\Uuid\Uuid;
 
 /**
  * @extends ServiceEntityRepository<TechRider>
@@ -42,16 +41,15 @@ class TechRiderRepository extends ServiceEntityRepository
      * Direct id lookup does NOT filter archived riders: an archived rider still has to
      * be readable so it can be restored or duplicated into next year's.
      *
-     * The id is validated before it reaches the query because the column is a uuid and
-     * Doctrine throws ValueNotConvertible on a non-uuid value, which surfaces as a 500
-     * where the caller wants a 404.
+     * A non-uuid $id returns null rather than blowing up, because setParameter() with no
+     * explicit type binds the plain string and it simply matches no row. That safety does
+     * NOT survive a switch to find() or findOneBy(['id' => $id]), which bind through the
+     * column's uuid type and throw ValueNotConvertible, surfacing as a 500 where the
+     * caller wants a 404. Keep the query builder.
+     * Pinned by TechRiderGetItemTest::test_get_tech_rider_with_a_non_uuid_id_is_not_found.
      */
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?TechRider
     {
-        if (!Uuid::isValid($id)) {
-            return null;
-        }
-
         return $this->createQueryBuilder('r')
             ->addSelect('author')
             ->leftJoin('r.createdBy', 'author')

--- a/src/Service/Builder/BandSpace/TechRider/TechRiderBuilder.php
+++ b/src/Service/Builder/BandSpace/TechRider/TechRiderBuilder.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\Builder\BandSpace\TechRider;
+
+use App\ApiResource\BandSpace\TechRider\TechRiderResource;
+use App\Entity\BandSpace\TechRider;
+
+readonly class TechRiderBuilder
+{
+    /**
+     * @param TechRider[] $entities
+     * @return TechRiderResource[]
+     */
+    public function buildFromList(array $entities): array
+    {
+        return array_map(
+            fn (TechRider $entity): TechRiderResource => $this->buildItem($entity),
+            $entities,
+        );
+    }
+
+    public function buildItem(TechRider $entity): TechRiderResource
+    {
+        $dto = new TechRiderResource();
+        $dto->id = (string) $entity->id;
+        $dto->bandSpaceId = (string) $entity->bandSpace->id;
+        $dto->name = $entity->name;
+        $dto->createdByUsername = $entity->createdBy?->username;
+        $dto->archiveDatetime = $entity->archiveDatetime;
+        $dto->creationDatetime = $entity->creationDatetime;
+        $dto->updateDatetime = $entity->updateDatetime;
+
+        return $dto;
+    }
+}

--- a/src/Service/Builder/BandSpace/TechRider/TechRiderBuilder.php
+++ b/src/Service/Builder/BandSpace/TechRider/TechRiderBuilder.php
@@ -8,6 +8,12 @@ use App\Entity\BandSpace\TechRider;
 readonly class TechRiderBuilder
 {
     /**
+     * The list view reuses buildItem() because a rider is currently name plus dates.
+     * That stops being true once sections, patch rows and the stage plot land: the
+     * collection must not embed them, or listing a space ships every rider's full
+     * content to render a table of names. SetlistBuilder shows the trap, it embeds
+     * every item and runs a duration query per setlist even for the collection.
+     *
      * @param TechRider[] $entities
      * @return TechRiderResource[]
      */

--- a/src/State/Processor/BandSpace/TechRider/TechRiderCreateProcessor.php
+++ b/src/State/Processor/BandSpace/TechRider/TechRiderCreateProcessor.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\TechRider\TechRiderCreate;
+use App\ApiResource\BandSpace\TechRider\TechRiderResource;
+use App\Entity\BandSpace\TechRider;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceRiderActivityType;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\Builder\BandSpace\TechRider\TechRiderBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @implements ProcessorInterface<TechRiderCreate, TechRiderResource>
+ */
+readonly class TechRiderCreateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private TechRiderBuilder $techRiderBuilder,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param TechRiderCreate $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): TechRiderResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $techRider = new TechRider();
+        $techRider->bandSpace = $bandSpace;
+        $techRider->createdBy = $user;
+        $techRider->name = $data->name;
+
+        $this->entityManager->persist($techRider);
+
+        $this->activityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Rider,
+            type: BandSpaceRiderActivityType::RiderCreated,
+            resourceId: (string) $techRider->id,
+            actor: $user,
+            payload: ['name' => $techRider->name],
+        );
+
+        $this->entityManager->flush();
+
+        return $this->techRiderBuilder->buildItem($techRider);
+    }
+}

--- a/src/State/Processor/BandSpace/TechRider/TechRiderDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/TechRider/TechRiderDeleteProcessor.php
@@ -23,10 +23,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *
  * Soft delete: sets archiveDatetime. TechRiderUnarchiveProcessor is what undoes it.
  *
- * A second archive returns 409 rather than succeeding silently the way
- * SetlistDeleteProcessor does. Riders stay readable once archived, so the caller can
- * see the state it is asking for and a repeated call means a stale client, which is
- * worth surfacing. Same choice as BandSpaceFileRestoreProcessor.
+ * A second archive returns 409. The codebase has no single convention for this:
+ * SetlistDeleteProcessor succeeds silently, BandSpaceFileDeleteProcessor returns 404
+ * because its lookup excludes archived rows. Neither fits here. Archived riders stay
+ * readable (they are restored and duplicated from the archive), so 404 would be a lie,
+ * and the unarchive direction has no sensible silent behaviour, so it must return 409.
+ * Symmetry with that endpoint is what settles it: the two halves of the same toggle
+ * should answer the same way when the state is already what you asked for.
  */
 readonly class TechRiderDeleteProcessor implements ProcessorInterface
 {

--- a/src/State/Processor/BandSpace/TechRider/TechRiderDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/TechRider/TechRiderDeleteProcessor.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\BandSpace\TechRider;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceRiderActivityType;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<mixed, void>
+ *
+ * Soft delete: sets archiveDatetime. TechRiderUnarchiveProcessor is what undoes it.
+ *
+ * A second archive returns 409 rather than succeeding silently the way
+ * SetlistDeleteProcessor does. Riders stay readable once archived, so the caller can
+ * see the state it is asking for and a repeated call means a stale client, which is
+ * worth surfacing. Same choice as BandSpaceFileRestoreProcessor.
+ */
+readonly class TechRiderDeleteProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private TechRiderRepository $techRiderRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $techRider = $this->techRiderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$techRider instanceof TechRider) {
+            throw new NotFoundHttpException('Tech rider introuvable');
+        }
+
+        if ($techRider->isArchived()) {
+            throw new ConflictHttpException('Ce tech rider est déjà archivé');
+        }
+
+        $techRider->archiveDatetime = new DateTimeImmutable();
+
+        $this->activityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Rider,
+            type: BandSpaceRiderActivityType::RiderArchived,
+            resourceId: (string) $techRider->id,
+            actor: $user,
+            payload: ['name' => $techRider->name],
+        );
+
+        $this->entityManager->flush();
+    }
+}

--- a/src/State/Processor/BandSpace/TechRider/TechRiderUnarchiveProcessor.php
+++ b/src/State/Processor/BandSpace/TechRider/TechRiderUnarchiveProcessor.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\TechRider\TechRiderResource;
+use App\Entity\BandSpace\TechRider;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceRiderActivityType;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\Builder\BandSpace\TechRider\TechRiderBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<mixed, TechRiderResource>
+ *
+ * Takes a rider back out of the archive. Mirrors TechRiderDeleteProcessor, which is
+ * what put it there.
+ *
+ * Setlist declares a setlist_unarchived activity type but has no endpoint behind it,
+ * so its archive is one way. Riders are made per tour and next year's is built from
+ * last year's, so the return path exists from the start here.
+ */
+readonly class TechRiderUnarchiveProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private TechRiderRepository $techRiderRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private TechRiderBuilder $techRiderBuilder,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): TechRiderResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $techRider = $this->techRiderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$techRider instanceof TechRider) {
+            throw new NotFoundHttpException('Tech rider introuvable');
+        }
+
+        if (!$techRider->isArchived()) {
+            throw new ConflictHttpException('Ce tech rider n\'est pas archivé');
+        }
+
+        $techRider->archiveDatetime = null;
+
+        $this->activityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Rider,
+            type: BandSpaceRiderActivityType::RiderUnarchived,
+            resourceId: (string) $techRider->id,
+            actor: $user,
+            payload: ['name' => $techRider->name],
+        );
+
+        $this->entityManager->flush();
+
+        return $this->techRiderBuilder->buildItem($techRider);
+    }
+}

--- a/src/State/Processor/BandSpace/TechRider/TechRiderUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/TechRider/TechRiderUpdateProcessor.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\TechRider\TechRiderResource;
+use App\Entity\BandSpace\TechRider;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceRiderActivityType;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\Builder\BandSpace\TechRider\TechRiderBuilder;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<TechRiderResource, TechRiderResource>
+ */
+readonly class TechRiderUpdateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private TechRiderRepository $techRiderRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private TechRiderBuilder $techRiderBuilder,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param TechRiderResource $data
+     *
+     * Only `name` is mutable through PATCH (rename). The other fields on TechRiderResource
+     * are hydrated by the provider and ignored here, matching SetlistUpdateProcessor.
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): TechRiderResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $techRider = $this->techRiderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$techRider instanceof TechRider) {
+            throw new NotFoundHttpException('Tech rider introuvable');
+        }
+
+        $techRider->name = $data->name;
+        $techRider->updateDatetime = new DateTime();
+
+        $this->activityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Rider,
+            type: BandSpaceRiderActivityType::RiderRenamed,
+            resourceId: (string) $techRider->id,
+            actor: $user,
+            payload: ['name' => $techRider->name],
+        );
+
+        $this->entityManager->flush();
+
+        return $this->techRiderBuilder->buildItem($techRider);
+    }
+}

--- a/src/State/Provider/BandSpace/TechRider/TechRiderCollectionProvider.php
+++ b/src/State/Provider/BandSpace/TechRider/TechRiderCollectionProvider.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\TechRider\TechRiderResource;
+use App\Entity\User;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\TechRider\TechRiderBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @implements ProviderInterface<TechRiderResource>
+ */
+readonly class TechRiderCollectionProvider implements ProviderInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private TechRiderRepository $techRiderRepository,
+        private TechRiderBuilder $techRiderBuilder,
+        private Security $security,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * @return TechRiderResource[]
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+
+        $archivedOnly = $this->requestStack->getCurrentRequest()?->query->getBoolean('archived') ?? false;
+
+        return $this->techRiderBuilder->buildFromList(
+            $this->techRiderRepository->findByBandSpace($bandSpace, $archivedOnly),
+        );
+    }
+}

--- a/src/State/Provider/BandSpace/TechRider/TechRiderItemProvider.php
+++ b/src/State/Provider/BandSpace/TechRider/TechRiderItemProvider.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\TechRider\TechRiderResource;
+use App\Entity\BandSpace\TechRider;
+use App\Entity\User;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\TechRider\TechRiderBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProviderInterface<TechRiderResource>
+ */
+readonly class TechRiderItemProvider implements ProviderInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private TechRiderRepository $techRiderRepository,
+        private TechRiderBuilder $techRiderBuilder,
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?TechRiderResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+
+        // Archived riders stay readable: they are restored and duplicated from here.
+        $techRider = $this->techRiderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$techRider instanceof TechRider) {
+            throw new NotFoundHttpException('Tech rider introuvable');
+        }
+
+        return $this->techRiderBuilder->buildItem($techRider);
+    }
+}

--- a/tests/Api/BandSpace/BandSpacePendingDeletionWriteBlockTest.php
+++ b/tests/Api/BandSpace/BandSpacePendingDeletionWriteBlockTest.php
@@ -193,6 +193,7 @@ class BandSpacePendingDeletionWriteBlockTest extends ApiTestCase
         yield 'agenda' => ['agenda-entries'];
         yield 'setlists' => ['setlists'];
         yield 'finance categories' => ['finance/categories'];
+        yield 'tech riders' => ['tech_riders'];
     }
 
     /**

--- a/tests/Api/BandSpace/TechRider/TechRiderCreateTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderCreateTest.php
@@ -1,0 +1,187 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class TechRiderCreateTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_create_tech_rider(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders',
+            ['name' => 'Technical rider 2026'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $repository = self::getContainer()->get(TechRiderRepository::class);
+        $riders = $repository->findByBandSpace($bandSpace);
+        $this->assertCount(1, $riders);
+        $rider = $riders[0];
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+            '@type' => 'TechRider',
+            'id' => $rider->id,
+            'band_space_id' => $bandSpace->id,
+            'name' => 'Technical rider 2026',
+            'created_by_username' => $user->username,
+            'archive_datetime' => null,
+            'creation_datetime' => $rider->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => null,
+        ]);
+
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::Rider, $rider->id);
+        $this->assertCount(1, $activities);
+        $this->assertSame('rider_created', $activities[0]->type);
+        $this->assertSame(['name' => 'Technical rider 2026'], $activities[0]->payload);
+    }
+
+    public function test_create_tech_rider_name_required(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders',
+            ['name' => ''],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Veuillez spécifier un nom',
+                    'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                ],
+            ],
+            'detail' => 'name: Veuillez spécifier un nom',
+            'type' => '/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            'title' => 'An error occurred',
+            'description' => 'name: Veuillez spécifier un nom',
+        ]);
+    }
+
+    public function test_create_tech_rider_name_too_long(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders',
+            ['name' => str_repeat('a', 256)],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Le nom ne peut pas dépasser 255 caractères',
+                    'code' => 'd94b19cc-114f-4f44-9cc4-4138e80a87b9',
+                ],
+            ],
+            'detail' => 'name: Le nom ne peut pas dépasser 255 caractères',
+            'type' => '/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            'title' => 'An error occurred',
+            'description' => 'name: Le nom ne peut pas dépasser 255 caractères',
+        ]);
+    }
+
+    public function test_create_tech_rider_not_member(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders',
+            ['name' => 'Rejected'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    public function test_create_tech_rider_blocked_when_space_pending_deletion(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('+30 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders',
+            ['name' => 'Blocked'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/TechRider/TechRiderDeleteTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderDeleteTest.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class TechRiderDeleteTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    /**
+     * DELETE archives rather than removing the row: the rider must still be there
+     * afterwards, findable through the archive view.
+     */
+    public function test_delete_archives_the_rider_and_keeps_the_row(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $rider = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Technical rider 2025',
+            'creationDatetime' => new DateTime('2025-01-15T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $repository = self::getContainer()->get(TechRiderRepository::class);
+        $this->assertCount(0, $repository->findByBandSpace($bandSpace));
+
+        $archived = $repository->findByBandSpace($bandSpace, archivedOnly: true);
+        $this->assertCount(1, $archived);
+        $this->assertSame((string) $rider->id, (string) $archived[0]->id);
+        $this->assertTrue($archived[0]->isArchived());
+
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::Rider, $rider->id);
+        $this->assertCount(1, $activities);
+        $this->assertSame('rider_archived', $activities[0]->type);
+        $this->assertSame(['name' => 'Technical rider 2025'], $activities[0]->payload);
+    }
+
+    public function test_delete_an_already_archived_rider_conflicts(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $rider = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Already archived',
+            'archiveDatetime' => new DateTimeImmutable('2026-03-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Ce tech rider est déjà archivé',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Ce tech rider est déjà archivé',
+        ]);
+    }
+
+    public function test_delete_not_member(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $rider = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => 'Protected'])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/TechRider/TechRiderGetCollectionTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderGetCollectionTest.php
@@ -1,0 +1,192 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class TechRiderGetCollectionTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_collection_lists_live_riders_newest_first(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $older = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Technical rider 2025',
+            'createdBy' => $user,
+            'creationDatetime' => new DateTime('2025-01-15T10:00:00+00:00'),
+        ])->create();
+        $newer = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Technical rider 2026',
+            'createdBy' => $user,
+            'creationDatetime' => new DateTime('2026-01-15T10:00:00+00:00'),
+        ])->create();
+        TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Archived rider',
+            'creationDatetime' => new DateTime('2026-02-15T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-03-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/tech_riders');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders',
+            '@type' => 'Collection',
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $newer->id,
+                    '@type' => 'TechRider',
+                    'id' => $newer->id,
+                    'band_space_id' => $bandSpace->id,
+                    'name' => 'Technical rider 2026',
+                    'created_by_username' => $user->username,
+                    'archive_datetime' => null,
+                    'creation_datetime' => $newer->creationDatetime->format(DateTimeInterface::ATOM),
+                    'update_datetime' => null,
+                ],
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $older->id,
+                    '@type' => 'TechRider',
+                    'id' => $older->id,
+                    'band_space_id' => $bandSpace->id,
+                    'name' => 'Technical rider 2025',
+                    'created_by_username' => $user->username,
+                    'archive_datetime' => null,
+                    'creation_datetime' => $older->creationDatetime->format(DateTimeInterface::ATOM),
+                    'update_datetime' => null,
+                ],
+            ],
+            'totalItems' => 2,
+        ]);
+    }
+
+    public function test_collection_archived_true_lists_only_the_archive(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Live rider',
+            'creationDatetime' => new DateTime('2026-01-15T10:00:00+00:00'),
+        ])->create();
+        $archived = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Archived rider',
+            'creationDatetime' => new DateTime('2025-01-15T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-03-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/tech_riders?archived=true');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders',
+            '@type' => 'Collection',
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $archived->id,
+                    '@type' => 'TechRider',
+                    'id' => $archived->id,
+                    'band_space_id' => $bandSpace->id,
+                    'name' => 'Archived rider',
+                    'created_by_username' => null,
+                    'archive_datetime' => $archived->archiveDatetime?->format(DateTimeInterface::ATOM),
+                    'creation_datetime' => $archived->creationDatetime->format(DateTimeInterface::ATOM),
+                    'update_datetime' => null,
+                ],
+            ],
+            'totalItems' => 1,
+            // Present only because the request carries a query string.
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders?archived=true',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_collection_scoped_to_the_band_space(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $myBand = BandSpaceFactory::new()->create();
+        $otherBand = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $myBand, 'user' => $user])->create();
+
+        $mine = TechRiderFactory::new([
+            'bandSpace' => $myBand,
+            'name' => 'Mine',
+            'creationDatetime' => new DateTime('2026-01-15T10:00:00+00:00'),
+        ])->create();
+        TechRiderFactory::new(['bandSpace' => $otherBand, 'name' => 'Theirs'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $myBand->id . '/tech_riders');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $myBand->id . '/tech_riders',
+            '@type' => 'Collection',
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $myBand->id . '/tech_riders/' . $mine->id,
+                    '@type' => 'TechRider',
+                    'id' => $mine->id,
+                    'band_space_id' => $myBand->id,
+                    'name' => 'Mine',
+                    'created_by_username' => null,
+                    'archive_datetime' => null,
+                    'creation_datetime' => $mine->creationDatetime->format(DateTimeInterface::ATOM),
+                    'update_datetime' => null,
+                ],
+            ],
+            'totalItems' => 1,
+        ]);
+    }
+
+    public function test_collection_not_member(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/tech_riders');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/TechRider/TechRiderGetItemTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderGetItemTest.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class TechRiderGetItemTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_get_tech_rider(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $rider = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Technical rider 2026',
+            'createdBy' => $user,
+            'creationDatetime' => new DateTime('2026-01-15T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+            '@type' => 'TechRider',
+            'id' => $rider->id,
+            'band_space_id' => $bandSpace->id,
+            'name' => 'Technical rider 2026',
+            'created_by_username' => $user->username,
+            'archive_datetime' => null,
+            'creation_datetime' => $rider->creationDatetime->format(DateTimeInterface::ATOM),
+            'update_datetime' => null,
+        ]);
+    }
+
+    /**
+     * An archived rider stays readable so it can be restored or, later, duplicated
+     * into the next tour's rider.
+     */
+    public function test_get_archived_tech_rider_is_readable(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $rider = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Technical rider 2025',
+            'creationDatetime' => new DateTime('2025-01-15T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-01-05T09:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+            '@type' => 'TechRider',
+            'id' => $rider->id,
+            'band_space_id' => $bandSpace->id,
+            'name' => 'Technical rider 2025',
+            'created_by_username' => null,
+            'archive_datetime' => $rider->archiveDatetime?->format(DateTimeInterface::ATOM),
+            'creation_datetime' => $rider->creationDatetime->format(DateTimeInterface::ATOM),
+            'update_datetime' => null,
+        ]);
+    }
+
+    public function test_get_tech_rider_from_another_band_space_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $myBand = BandSpaceFactory::new()->create();
+        $otherBand = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $myBand, 'user' => $user])->create();
+
+        $theirs = TechRiderFactory::new(['bandSpace' => $otherBand, 'name' => 'Theirs'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $myBand->id . '/tech_riders/' . $theirs->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Tech rider introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Tech rider introuvable',
+        ]);
+    }
+
+    /**
+     * The id column is a uuid, so a non-uuid lookup makes Doctrine throw
+     * ValueNotConvertible. Without the guard in the repository that surfaces as a 500.
+     */
+    public function test_get_tech_rider_with_a_non_uuid_id_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/tech_riders/not-a-uuid');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Tech rider introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Tech rider introuvable',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/TechRider/TechRiderGetItemTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderGetItemTest.php
@@ -111,8 +111,10 @@ class TechRiderGetItemTest extends ApiTestCase
     }
 
     /**
-     * The id column is a uuid, so a non-uuid lookup makes Doctrine throw
-     * ValueNotConvertible. Without the guard in the repository that surfaces as a 500.
+     * The id column is a uuid, so a non-uuid lookup is only safe as long as the repository
+     * keeps binding it as a plain string through the query builder. Switching to find() or
+     * findOneBy() would bind through the uuid type and throw ValueNotConvertible, turning
+     * this 404 into a 500. This test is what catches that.
      */
     public function test_get_tech_rider_with_a_non_uuid_id_is_not_found(): void
     {

--- a/tests/Api/BandSpace/TechRider/TechRiderUnarchiveTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderUnarchiveTest.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class TechRiderUnarchiveTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_unarchive_restores_the_rider(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $rider = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Technical rider 2025',
+            'createdBy' => $user,
+            'creationDatetime' => new DateTime('2025-01-15T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-03-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id . '/unarchive',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+            '@type' => 'TechRider',
+            'id' => $rider->id,
+            'band_space_id' => $bandSpace->id,
+            'name' => 'Technical rider 2025',
+            'created_by_username' => $user->username,
+            'archive_datetime' => null,
+            'creation_datetime' => $rider->creationDatetime->format(DateTimeInterface::ATOM),
+            'update_datetime' => null,
+        ]);
+
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::Rider, $rider->id);
+        $this->assertCount(1, $activities);
+        $this->assertSame('rider_unarchived', $activities[0]->type);
+        $this->assertSame(['name' => 'Technical rider 2025'], $activities[0]->payload);
+    }
+
+    public function test_unarchive_a_live_rider_conflicts(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $rider = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => 'Still live'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id . '/unarchive',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Ce tech rider n'est pas archivé",
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => "Ce tech rider n'est pas archivé",
+        ]);
+    }
+
+    public function test_unarchive_not_member(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $rider = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Protected',
+            'archiveDatetime' => new DateTimeImmutable('2026-03-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id . '/unarchive',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/TechRider/TechRiderUpdateTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderUpdateTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use DateTimeInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class TechRiderUpdateTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_rename_tech_rider(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $rider = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Draft',
+            'createdBy' => $user,
+            'creationDatetime' => new DateTime('2026-01-15T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+            ['name' => 'Technical rider 2026'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+            '@type' => 'TechRider',
+            'id' => $rider->id,
+            'band_space_id' => $bandSpace->id,
+            'name' => 'Technical rider 2026',
+            'created_by_username' => $user->username,
+            'archive_datetime' => null,
+            'creation_datetime' => $rider->creationDatetime->format(DateTimeInterface::ATOM),
+            'update_datetime' => $rider->updateDatetime?->format(DateTimeInterface::ATOM),
+        ]);
+
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::Rider, $rider->id);
+        $this->assertCount(1, $activities);
+        $this->assertSame('rider_renamed', $activities[0]->type);
+        $this->assertSame(['name' => 'Technical rider 2026'], $activities[0]->payload);
+    }
+
+    public function test_rename_tech_rider_name_required(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $rider = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => 'Draft'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+            ['name' => ''],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Veuillez spécifier un nom',
+                    'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                ],
+            ],
+            'detail' => 'name: Veuillez spécifier un nom',
+            'type' => '/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            'title' => 'An error occurred',
+            'description' => 'name: Veuillez spécifier un nom',
+        ]);
+    }
+
+    public function test_rename_tech_rider_from_another_band_space_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $myBand = BandSpaceFactory::new()->create();
+        $otherBand = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $myBand, 'user' => $user])->create();
+
+        $theirs = TechRiderFactory::new(['bandSpace' => $otherBand, 'name' => 'Theirs'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $myBand->id . '/tech_riders/' . $theirs->id,
+            ['name' => 'Hijacked'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Tech rider introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Tech rider introuvable',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/TechRider/TechRiderUpdateTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderUpdateTest.php
@@ -98,6 +98,36 @@ class TechRiderUpdateTest extends ApiTestCase
         ]);
     }
 
+    public function test_rename_tech_rider_not_member(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $rider = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => 'Protected'])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+            ['name' => 'Hijacked'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
     public function test_rename_tech_rider_from_another_band_space_is_not_found(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();

--- a/tests/Factory/BandSpace/TechRiderFactory.php
+++ b/tests/Factory/BandSpace/TechRiderFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Factory\BandSpace;
+
+use App\Entity\BandSpace\TechRider;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+
+/**
+ * @extends PersistentObjectFactory<TechRider>
+ */
+final class TechRiderFactory extends PersistentObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [
+            'bandSpace' => BandSpaceFactory::new(),
+            'name' => self::faker()->sentence(3),
+            'creationDatetime' => self::faker()->dateTime(),
+        ];
+    }
+
+    public static function class(): string
+    {
+        return TechRider::class;
+    }
+}


### PR DESCRIPTION
Closes #766. First slice of the Tech Rider epic (#776): the `TechRider` entity, its CRUD API, archive and unarchive, activity feed wiring, the migration and tests. Backend only, no frontend yet (that is #771), and no PDF export (deliberately excluded from the epic pending #741).

## Endpoints

| Method | Route |
|---|---|
| POST | `/api/band_spaces/{bandSpaceId}/tech_riders` |
| GET | `/api/band_spaces/{bandSpaceId}/tech_riders` (`?archived=true` for the archive) |
| GET | `/api/band_spaces/{bandSpaceId}/tech_riders/{id}` |
| PATCH | `/api/band_spaces/{bandSpaceId}/tech_riders/{id}` (rename only) |
| POST | `/api/band_spaces/{bandSpaceId}/tech_riders/{id}/unarchive` |
| DELETE | `/api/band_spaces/{bandSpaceId}/tech_riders/{id}` (soft delete) |

The module mirrors Setlist for its structure and the files trash (M-755) for its archive semantics. Providers use `checkMember()`, processors use `checkMemberForWrite()`, so a space pending deletion returns 409.

## Two deliberate departures from the Setlist precedent

**Archiving an already archived rider returns 409, not a silent success.** There is no single convention here: Setlist succeeds silently, Files returns 404 because its lookup excludes archived rows. Neither fits. Archived riders stay readable, since they are restored and later duplicated from the archive, so 404 would be a lie. What settles it is symmetry with unarchive, which has no sensible silent behaviour. Both halves of the same toggle answer the same way.

**Unarchive exists from the start.** Setlist declares a `setlist_unarchived` activity type with no endpoint behind it, so its archive is one way. Riders are made per tour and next year's is built from last year's, so the return path is needed. That gap in Setlist is untouched here.

`read: false` on Delete and Unarchive also departs from Setlist, which points its Delete at a provider that fully hydrates a resource the processor then discards and refetches.

## Verification

- Full suite **1816 green** (1792 before, so exactly the 24 tests added here), PHPStan level 8 clean, Biome at its 44 info baseline, `npm run build` clean.
- **The migration was validated on the migration database, not the Foundry story one.** Applied it, then `doctrine:schema:validate` there reports drift only on four pre-existing tables and mentions `tech_rider` zero times, which is the actual proof it matches the mapping. Round tripped `migrate prev` (table confirmed absent via `information_schema`) then `migrate` again.
- All six routes verified registered under the names #766 specified.
- `BandSpaceWriteGuardCoverageTest` green with no new `ALLOWED_UNGUARDED` entry, and it does recursively scan the new processor directory.

## Review notes

Reviewed before the PR. Two gaps in test coverage were real and are fixed in the second commit: the rename operation had no non-member 403 test, which every sibling operation has, and `BandSpacePendingDeletionWriteBlockTest` had not been extended to prove rider reads stay open during the grace period.

The review also suggested a non-uuid `bandSpaceId` would return 500. Probed it: it returns 404, because `setParameter()` with no explicit type binds a plain string that matches no row. That result then invalidated a guard I had written myself, a `Uuid::isValid()` early return whose docblock claimed to prevent a 500. Removing the guard and re-running the test proved it never fired, so it is gone and the docblock now records the real mechanism, including that it would not survive a switch to `find()` or `findOneBy()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
