### PR TITLE
M-790: document item type, a band space file as a rider page

### DIFF
--- a/assets/js/components/BandSpace/TechRider/RiderDocumentItemEditor.vue
+++ b/assets/js/components/BandSpace/TechRider/RiderDocumentItemEditor.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <Message v-if="file?.is_archived" severity="warn" :closable="false" class="mb-3">
+      Le fichier « {{ file.original_name }} » est dans la corbeille. Restaurez-le depuis les
+      fichiers pour que cette page réapparaisse dans le document.
+    </Message>
+
+    <div v-if="!file || file.is_archived" class="text-center py-6">
+      <i class="pi pi-file text-3xl text-surface-400 dark:text-surface-500" aria-hidden="true" />
+      <p class="mt-2 text-surface-600 dark:text-surface-300">
+        {{
+          file
+            ? 'La page réapparaîtra si le fichier est restauré, ou choisissez-en un autre.'
+            : 'Aucun fichier choisi. Une page peut être une image ou un PDF déjà présent dans vos fichiers.'
+        }}
+      </p>
+      <Button
+        v-if="!readOnly"
+        :label="file ? 'Choisir un autre fichier' : 'Choisir un fichier'"
+        icon="pi pi-folder-open"
+        severity="secondary"
+        outlined
+        class="mt-3"
+        @click="pickerOpen = true"
+      />
+    </div>
+
+    <div v-else class="flex flex-col gap-3">
+      <div
+        class="rounded-lg border border-surface-200 dark:border-surface-700 overflow-hidden bg-surface-50 dark:bg-surface-800"
+      >
+        <img
+          v-if="isImage"
+          :src="file.download_url"
+          :alt="`Aperçu de ${file.original_name}`"
+          class="max-h-96 w-full object-contain"
+        />
+        <!-- No inline PDF render: a preview iframe per item would load every PDF of the rider
+             at once. The name and a link are enough to confirm the right page is attached. -->
+        <div v-else class="flex items-center gap-3 p-4">
+          <i class="pi pi-file-pdf text-2xl text-red-600 dark:text-red-400" aria-hidden="true" />
+          <div class="min-w-0">
+            <p class="font-medium truncate">{{ file.original_name }}</p>
+            <a
+              :href="file.download_url"
+              target="_blank"
+              rel="noopener"
+              class="text-sm text-primary hover:underline"
+            >
+              Ouvrir le PDF
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="!readOnly" class="flex items-center gap-2">
+        <Button
+          label="Changer de fichier"
+          icon="pi pi-folder-open"
+          severity="secondary"
+          text
+          size="small"
+          @click="pickerOpen = true"
+        />
+        <Button
+          label="Retirer"
+          icon="pi pi-times"
+          severity="secondary"
+          text
+          size="small"
+          @click="emit('choose', { itemId, fileId: null })"
+        />
+      </div>
+    </div>
+
+    <RiderFilePickerDialog
+      v-model:visible="pickerOpen"
+      :band-space-id="bandSpaceId"
+      @choose="(fileId) => emit('choose', { itemId, fileId })"
+    />
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { computed, ref } from 'vue'
+import RiderFilePickerDialog from './RiderFilePickerDialog.vue'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true },
+  itemId: { type: String, required: true },
+  file: { type: Object, default: null },
+  readOnly: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['choose'])
+
+const pickerOpen = ref(false)
+
+const isImage = computed(() => (props.file?.mime_type ?? '').startsWith('image/'))
+</script>

--- a/assets/js/components/BandSpace/TechRider/RiderFilePickerDialog.vue
+++ b/assets/js/components/BandSpace/TechRider/RiderFilePickerDialog.vue
@@ -1,0 +1,126 @@
+<template>
+  <Dialog
+    v-model:visible="visible"
+    modal
+    header="Choisir un fichier"
+    :style="{ width: '40rem' }"
+    @show="reset"
+  >
+    <div class="flex flex-col gap-3">
+      <p class="text-sm text-surface-600 dark:text-surface-300">
+        Seuls les images et les PDF de vos fichiers peuvent servir de page. Importez le fichier
+        depuis le module Fichiers s'il n'apparaît pas ici.
+      </p>
+
+      <InputText v-model="query" placeholder="Rechercher un fichier..." class="w-full" @input="debouncedLoad" />
+
+      <div v-if="isLoading" class="py-8 flex justify-center">
+        <ProgressSpinner style="width: 2rem; height: 2rem" />
+      </div>
+
+      <Message v-else-if="loadError" severity="error" :closable="false">{{ loadError }}</Message>
+
+      <p v-else-if="files.length === 0" class="py-6 text-center text-surface-600 dark:text-surface-300">
+        Aucune image ni PDF dans les fichiers de cet espace.
+      </p>
+
+      <ul v-else class="flex flex-col gap-1 max-h-80 overflow-y-auto">
+        <li v-for="file in files" :key="file.id">
+          <button
+            type="button"
+            class="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left hover:bg-surface-100 dark:hover:bg-surface-800 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-primary-500"
+            @click="choose(file.id)"
+          >
+            <i :class="['pi', iconFor(file), 'text-surface-500 shrink-0']" aria-hidden="true" />
+            <span class="flex-1 min-w-0 truncate">{{ file.original_name }}</span>
+            <span class="text-xs text-surface-500 shrink-0">{{ file.mime_type }}</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </Dialog>
+</template>
+
+<script setup>
+import Dialog from 'primevue/dialog'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import ProgressSpinner from 'primevue/progressspinner'
+import { onBeforeUnmount, ref } from 'vue'
+import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true }
+})
+
+const emit = defineEmits(['choose'])
+const visible = defineModel('visible', { type: Boolean, default: false })
+
+const files = ref([])
+const query = ref('')
+const isLoading = ref(false)
+const loadError = ref(null)
+
+let searchTimeout = null
+let requestId = 0
+
+/**
+ * The server has no "renderable as a page" filter, and adding one for a picker would put a
+ * rider concern in the files API. Fetching the two families it does filter on and merging is
+ * two small requests against an endpoint that is already paginated.
+ */
+async function load() {
+  const currentRequest = ++requestId
+  isLoading.value = true
+  loadError.value = null
+
+  try {
+    const [images, pdfs] = await Promise.all([
+      bandSpaceFilesApi.getFiles(props.bandSpaceId, {
+        mime: 'image',
+        query: query.value || undefined
+      }),
+      bandSpaceFilesApi.getFiles(props.bandSpaceId, {
+        mime: 'application/pdf',
+        query: query.value || undefined
+      })
+    ])
+    if (currentRequest !== requestId) return
+    files.value = [...(images.member ?? []), ...(pdfs.member ?? [])].sort((a, b) =>
+      a.original_name.localeCompare(b.original_name)
+    )
+  } catch (e) {
+    if (currentRequest !== requestId) return
+    loadError.value = e.message
+    files.value = []
+  } finally {
+    if (currentRequest === requestId) {
+      isLoading.value = false
+    }
+  }
+}
+
+/** Reopening for a different item should not inherit the last search. */
+function reset() {
+  query.value = ''
+  load()
+}
+
+function debouncedLoad() {
+  if (searchTimeout) clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(load, 300)
+}
+
+onBeforeUnmount(() => {
+  if (searchTimeout) clearTimeout(searchTimeout)
+})
+
+function iconFor(file) {
+  return (file.mime_type ?? '').startsWith('image/') ? 'pi-image' : 'pi-file-pdf'
+}
+
+function choose(fileId) {
+  emit('choose', fileId)
+  visible.value = false
+}
+</script>

--- a/assets/js/components/BandSpace/TechRider/RiderItemList.vue
+++ b/assets/js/components/BandSpace/TechRider/RiderItemList.vue
@@ -122,6 +122,14 @@
           :read-only="readOnly"
           @save="handleSave"
         />
+        <RiderDocumentItemEditor
+          v-else-if="item.type === 'document'"
+          :band-space-id="bandSpaceId"
+          :item-id="item.id"
+          :file="item.file"
+          :read-only="readOnly"
+          @choose="handleChooseFile"
+        />
         <p v-else class="text-surface-600 dark:text-surface-300 py-4 text-center">
           Ce type d'élément arrivera prochainement.
         </p>
@@ -139,6 +147,17 @@
             Titre <span class="text-red-600 dark:text-red-400">*</span>
           </label>
           <InputText id="newItemTitle" v-model="newTitle" autofocus class="w-full" placeholder="ex. Loges" />
+        </div>
+        <div>
+          <label for="newItemType" class="block text-sm font-medium mb-1">Type</label>
+          <Select
+            id="newItemType"
+            v-model="newType"
+            :options="ITEM_TYPES"
+            option-label="label"
+            option-value="value"
+            class="w-full"
+          />
         </div>
         <div class="flex justify-end gap-2">
           <Button label="Annuler" severity="secondary" text type="button" @click="addDialogOpen = false" />
@@ -168,11 +187,13 @@
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
 import ToggleSwitch from 'primevue/toggleswitch'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { reactive, ref } from 'vue'
 import { useBandTechRidersStore } from '../../../store/bandSpace/bandSpaceTechRiders.js'
+import RiderDocumentItemEditor from './RiderDocumentItemEditor.vue'
 import RiderTextItemEditor from './RiderTextItemEditor.vue'
 
 const props = defineProps({
@@ -192,7 +213,13 @@ const saveError = reactive({})
 const collapsed = reactive({})
 
 const addDialogOpen = ref(false)
+const ITEM_TYPES = [
+  { value: 'text', label: 'Texte libre' },
+  { value: 'document', label: 'Document (image ou PDF)' }
+]
+
 const newTitle = ref('')
+const newType = ref('text')
 const isAdding = ref(false)
 
 const renameDialogOpen = ref(false)
@@ -213,6 +240,14 @@ const TYPE_ICONS = {
 
 function typeIcon(type) {
   return TYPE_ICONS[type] ?? 'pi-align-left'
+}
+
+async function handleChooseFile({ itemId, fileId }) {
+  try {
+    await techRidersStore.setItemFile(props.bandSpaceId, props.riderId, itemId, fileId)
+  } catch (e) {
+    toast.add({ severity: 'error', summary: 'Erreur', detail: e.message, life: 5000 })
+  }
 }
 
 async function setIncluded(item, isIncluded) {
@@ -262,10 +297,14 @@ async function handleAdd() {
 
   isAdding.value = true
   try {
-    await techRidersStore.createItem(props.bandSpaceId, props.riderId, { title })
+    await techRidersStore.createItem(props.bandSpaceId, props.riderId, {
+      title,
+      type: newType.value
+    })
     toast.add({ severity: 'success', summary: 'Élément ajouté', life: 2500 })
     addDialogOpen.value = false
     newTitle.value = ''
+    newType.value = 'text'
   } catch (e) {
     toast.add({ severity: 'error', summary: 'Erreur', detail: e.message, life: 5000 })
   } finally {

--- a/assets/js/store/bandSpace/bandSpaceTechRiders.js
+++ b/assets/js/store/bandSpace/bandSpaceTechRiders.js
@@ -155,6 +155,12 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     replaceItem(await bandSpaceTechRidersApi.updateItem(bandSpaceId, riderId, itemId, { content }))
   }
 
+  async function setItemFile(bandSpaceId, riderId, itemId, fileId) {
+    replaceItem(
+      await bandSpaceTechRidersApi.updateItem(bandSpaceId, riderId, itemId, { file_id: fileId })
+    )
+  }
+
   async function setItemIncluded(bandSpaceId, riderId, itemId, isIncluded) {
     replaceItem(
       await bandSpaceTechRidersApi.updateItem(bandSpaceId, riderId, itemId, {
@@ -250,6 +256,7 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     createItem,
     renameItem,
     saveItemContent,
+    setItemFile,
     setItemIncluded,
     deleteItem,
     reorderItems,

--- a/migrations/2026/08/Version20260802160330.php
+++ b/migrations/2026/08/Version20260802160330.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Purely additive, so the generated SQL is kept as is.
+ *
+ * ON DELETE SET NULL, not cascade: deleting the file must not silently delete a page of the
+ * rider. The item survives with no file and says so.
+ */
+final class Version20260802160330 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the file reference that backs a Document rider item';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space_tech_rider_item ADD file_id CHAR(36) DEFAULT NULL');
+        $this->addSql('ALTER TABLE band_space_tech_rider_item ADD CONSTRAINT FK_E5B0A2893CB796C FOREIGN KEY (file_id) REFERENCES band_space_file (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_E5B0A2893CB796C ON band_space_tech_rider_item (file_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space_tech_rider_item DROP FOREIGN KEY FK_E5B0A2893CB796C');
+        $this->addSql('DROP INDEX IDX_E5B0A2893CB796C ON band_space_tech_rider_item');
+        $this->addSql('ALTER TABLE band_space_tech_rider_item DROP file_id');
+    }
+}

--- a/src/ApiResource/BandSpace/TechRider/TechRiderItemResource.php
+++ b/src/ApiResource/BandSpace/TechRider/TechRiderItemResource.php
@@ -103,6 +103,22 @@ class TechRiderItemResource
     #[Groups([self::READ])]
     public ?array $content = null;
 
+    /**
+     * The referenced file, for a Document item. Enough to render the page without a second
+     * call, including whether the file has been trashed, which the item has to say out loud
+     * rather than showing a blank page.
+     *
+     * @var array<string, mixed>|null
+     */
+    #[Groups([self::READ])]
+    public ?array $file = null;
+
+    /**
+     * Write side of the above. Deliberately outside the read group: the response carries the
+     * resolved `file` block instead, and echoing both would be two ways to say one thing.
+     */
+    public ?string $fileId = null;
+
     #[Assert\PositiveOrZero(message: 'La position doit être positive ou zéro')]
     #[Groups([self::READ])]
     public int $position = 0;

--- a/src/Entity/BandSpace/BandSpaceFile.php
+++ b/src/Entity/BandSpace/BandSpaceFile.php
@@ -64,6 +64,11 @@ class BandSpaceFile
     #[ORM\JoinTable(name: 'band_space_file_to_tag')]
     public Collection $tags;
 
+    public function isArchived(): bool
+    {
+        return $this->archiveDatetime instanceof DateTimeImmutable;
+    }
+
     public function __construct()
     {
         $this->creationDatetime = new DateTime();

--- a/src/Entity/BandSpace/TechRiderItem.php
+++ b/src/Entity/BandSpace/TechRiderItem.php
@@ -51,6 +51,17 @@ class TechRiderItem
     public bool $isIncluded = true;
 
     /**
+     * The page itself, for a Document item: a file the band already has in its files area
+     * rather than a second upload silo, so folders, versions, tags and quota keep working.
+     *
+     * SET NULL rather than cascade: deleting the file must not silently delete a page of the
+     * rider. The item survives, empty, and says so.
+     */
+    #[ORM\ManyToOne(targetEntity: BandSpaceFile::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    public ?BandSpaceFile $file = null;
+
+    /**
      * Payload for the types that store a document: a TipTap doc for Text, the plot for
      * StagePlot. Null until written in, which is how seeded items start. Types backed by
      * their own tables leave it null.

--- a/src/Enum/BandSpace/TechRiderItemType.php
+++ b/src/Enum/BandSpace/TechRiderItemType.php
@@ -10,13 +10,14 @@ namespace App\Enum\BandSpace;
  * to follow it. It also lets a rider carry two stage plots (a club setup and a festival one)
  * or two patch lists (electric and acoustic), which fixed pages could not express.
  *
- * Only implemented types appear here. Contacts, StagePlot, PatchList and Document each
- * arrive with their own issue; adding a case before its renderer exists would put a type in
- * the picker that produces a blank block.
+ * Only implemented types appear here. Contacts, StagePlot and PatchList each arrive with
+ * their own issue; adding a case before its renderer exists would put a type in the picker
+ * that produces a blank block.
  */
 enum TechRiderItemType: string
 {
     case Text = 'text';
+    case Document = 'document';
 
     /** @return list<string> for Assert\Choice, which cannot take an enum directly here. */
     public static function values(): array
@@ -28,6 +29,7 @@ enum TechRiderItemType: string
     {
         return match ($this) {
             self::Text => 'Texte libre',
+            self::Document => 'Document',
         };
     }
 }

--- a/src/Repository/BandSpace/TechRiderRepository.php
+++ b/src/Repository/BandSpace/TechRiderRepository.php
@@ -50,13 +50,16 @@ class TechRiderRepository extends ServiceEntityRepository
      */
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?TechRider
     {
-        // Items are fetch-joined because every caller of this method builds the full
-        // rider, so leaving them lazy just moves the query. buildItem sorts them in PHP,
-        // so the join needs no ORDER BY of its own.
+        // Items are fetch-joined because every caller of this method builds the full rider,
+        // so leaving them lazy just moves the query. Their file and its current version come
+        // too, otherwise a document item costs two more queries each, which is the fan-out
+        // this join exists to avoid. buildItem sorts in PHP, so no ORDER BY is needed here.
         return $this->createQueryBuilder('r')
-            ->addSelect('author', 'items')
+            ->addSelect('author', 'items', 'file', 'fileVersion')
             ->leftJoin('r.createdBy', 'author')
             ->leftJoin('r.items', 'items')
+            ->leftJoin('items.file', 'file')
+            ->leftJoin('file.currentVersion', 'fileVersion')
             ->where('r.id = :id')
             ->andWhere('r.bandSpace = :bandSpace')
             ->setParameter('id', $id)

--- a/src/Service/BandSpace/File/BandSpaceFileMimeAllowlist.php
+++ b/src/Service/BandSpace/File/BandSpaceFileMimeAllowlist.php
@@ -59,4 +59,13 @@ final class BandSpaceFileMimeAllowlist
     {
         return in_array($mimeType, ['image/jpeg', 'image/png', 'image/gif', 'image/webp'], true);
     }
+
+    /**
+     * Whether the file can stand as a page of a generated document. Images render directly
+     * and PDF pages can be embedded; anything else has no visual form to place on a page.
+     */
+    public static function isRenderableAsPage(string $mimeType): bool
+    {
+        return self::isImage($mimeType) || $mimeType === 'application/pdf';
+    }
 }

--- a/src/Service/Builder/BandSpace/TechRider/TechRiderItemBuilder.php
+++ b/src/Service/Builder/BandSpace/TechRider/TechRiderItemBuilder.php
@@ -4,9 +4,15 @@ namespace App\Service\Builder\BandSpace\TechRider;
 
 use App\ApiResource\BandSpace\TechRider\TechRiderItemResource;
 use App\Entity\BandSpace\TechRiderItem;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 readonly class TechRiderItemBuilder
 {
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
     /**
      * @param TechRiderItem[] $entities
      * @return TechRiderItemResource[]
@@ -29,10 +35,37 @@ readonly class TechRiderItemBuilder
         $dto->isIncluded = $entity->isIncluded;
         $dto->title = $entity->title;
         $dto->content = $entity->content;
+        $dto->fileId = $entity->file === null ? null : (string) $entity->file->id;
+        $dto->file = $this->buildFile($entity);
         $dto->position = $entity->position;
         $dto->creationDatetime = $entity->creationDatetime;
         $dto->updateDatetime = $entity->updateDatetime;
 
         return $dto;
+    }
+
+    /**
+     * `is_archived` is part of the payload because a rider referencing a trashed file must
+     * warn rather than render nothing, and the client cannot tell from the id alone.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function buildFile(TechRiderItem $entity): ?array
+    {
+        $file = $entity->file;
+        if ($file === null) {
+            return null;
+        }
+
+        return [
+            'id' => (string) $file->id,
+            'original_name' => $file->originalName,
+            'mime_type' => $file->currentVersion?->mimeType,
+            'is_archived' => $file->isArchived(),
+            'download_url' => $this->urlGenerator->generate('api_band_space_files_download', [
+                'bandSpaceId' => (string) $entity->techRider->bandSpace->id,
+                'id' => (string) $file->id,
+            ]),
+        ];
     }
 }

--- a/src/State/Processor/BandSpace/TechRider/TechRiderItemUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/TechRider/TechRiderItemUpdateProcessor.php
@@ -6,17 +6,21 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\BandSpace\TechRider\TechRiderItemResource;
 use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
 use App\Entity\BandSpace\TechRider;
 use App\Entity\BandSpace\TechRiderItem;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceRiderActivityType;
+use App\Enum\BandSpace\TechRiderItemType;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\TechRiderRepository;
 use App\Repository\BandSpace\TechRiderItemRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Security\BandSpace\TechRiderWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileMimeAllowlist;
 use App\Service\Builder\BandSpace\TechRider\TechRiderItemBuilder;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
@@ -24,6 +28,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
  * @implements ProcessorInterface<TechRiderItemResource, TechRiderItemResource>
@@ -44,6 +49,7 @@ readonly class TechRiderItemUpdateProcessor implements ProcessorInterface
         private TechRiderRepository $techRiderRepository,
         private TechRiderItemRepository $itemRepository,
         private BandSpaceActivityRepository $activityRepository,
+        private BandSpaceFileRepository $fileRepository,
         private BandSpaceActivityRecorder $activityRecorder,
         private TechRiderItemBuilder $itemBuilder,
         private Security $security,
@@ -92,6 +98,24 @@ readonly class TechRiderItemUpdateProcessor implements ProcessorInterface
             $contentChanged = true;
         }
 
+        $fileChanged = false;
+        if (array_key_exists('file_id', $payload)) {
+            // Refused rather than ignored on other types. A text item holding a file reference
+            // is a state nothing can render, and anything later walking items by `file !== null`
+            // instead of by type would quietly act on it.
+            if ($item->type !== TechRiderItemType::Document) {
+                throw new UnprocessableEntityHttpException(
+                    'Seul un élément de type document peut référencer un fichier',
+                );
+            }
+
+            $file = $this->resolveFile($data->fileId, $bandSpace);
+            if ($item->file?->id !== $file?->id) {
+                $item->file = $file;
+                $fileChanged = true;
+            }
+        }
+
         // Composing the document, not editing it: no activity, because toggling an item in
         // and out while deciding what to send is not a change anyone needs a feed entry for.
         $inclusionChanged = false;
@@ -100,7 +124,7 @@ readonly class TechRiderItemUpdateProcessor implements ProcessorInterface
             $inclusionChanged = true;
         }
 
-        if (!$titleChanged && !$contentChanged && !$inclusionChanged) {
+        if (!$titleChanged && !$contentChanged && !$inclusionChanged && !$fileChanged) {
             return $this->itemBuilder->buildItem($item);
         }
 
@@ -133,6 +157,33 @@ readonly class TechRiderItemUpdateProcessor implements ProcessorInterface
         $this->entityManager->flush();
 
         return $this->itemBuilder->buildItem($item);
+    }
+
+    /**
+     * Null clears the page. Anything else must be a file of this band space that can actually
+     * be rendered as one: the cross-space check is what stops an id from another band being
+     * used to read its files through a rider, and the mime check stops a page that would
+     * render as nothing.
+     */
+    private function resolveFile(?string $fileId, BandSpace $bandSpace): ?BandSpaceFile
+    {
+        if ($fileId === null || $fileId === '') {
+            return null;
+        }
+
+        $file = $this->fileRepository->findOneByIdAndBandSpace($fileId, $bandSpace);
+        if (!$file instanceof BandSpaceFile) {
+            throw new UnprocessableEntityHttpException('Fichier introuvable dans cet espace');
+        }
+
+        $mimeType = $file->currentVersion?->mimeType;
+        if ($mimeType === null || !BandSpaceFileMimeAllowlist::isRenderableAsPage($mimeType)) {
+            throw new UnprocessableEntityHttpException(
+                'Ce type de fichier ne peut pas servir de page (images et PDF uniquement)',
+            );
+        }
+
+        return $file;
     }
 
     private function shouldRecordContentUpdate(BandSpace $bandSpace, TechRiderItem $item, User $user): bool

--- a/tests/Api/BandSpace/TechRider/TechRiderCreateTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderCreateTest.php
@@ -63,6 +63,7 @@ class TechRiderCreateTest extends ApiTestCase
                 'position' => $item->position,
                 'creation_datetime' => $item->creationDatetime->format(\DateTimeInterface::ATOM),
                 'update_datetime' => null,
+                'file' => null,
             ],
             $items,
         );

--- a/tests/Api/BandSpace/TechRider/TechRiderDocumentItemTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderDocumentItemTest.php
@@ -1,0 +1,325 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\BandSpace\TechRider;
+use App\Enum\BandSpace\TechRiderItemType;
+use App\Repository\BandSpace\TechRiderItemRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\BandSpace\TechRiderItemFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * A document item is a page of the rider that the band authored elsewhere: the reference
+ * rider's wiring diagram is exactly this. It points at a file in the band's own files area
+ * rather than uploading a second copy, so folders, versions, tags and quota keep working and
+ * there is only one copy to keep current.
+ */
+#[ResetDatabase]
+class TechRiderDocumentItemTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array PATCH_HEADERS = [
+        'CONTENT_TYPE' => 'application/merge-patch+json',
+        'HTTP_ACCEPT' => 'application/ld+json',
+    ];
+
+    public function test_attaching_a_file_makes_it_the_page(): void
+    {
+        [$user, $bandSpace, $rider, $item] = $this->seed();
+        $file = $this->renderableFile($bandSpace, 'schema-rack.png', 'image/png');
+
+        $this->patch($user, $bandSpace, $rider, $item, ['file_id' => (string) $file->id]);
+
+        $this->assertResponseIsSuccessful();
+
+        // Full body, so a regression anywhere else in the item shape shows up here too. Note
+        // there is no `file_id`: the write-side field never comes back, the resolved block is
+        // the one answer.
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRiderItem',
+            '@id' => $this->itemUrl($bandSpace, $rider, $item),
+            '@type' => 'TechRiderItem',
+            'id' => (string) $item->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'rider_id' => (string) $rider->id,
+            'type' => 'document',
+            'is_included' => true,
+            'title' => 'Schéma de câblage',
+            'content' => null,
+            'file' => [
+                'id' => (string) $file->id,
+                'original_name' => 'schema-rack.png',
+                'mime_type' => 'image/png',
+                'is_archived' => false,
+                'download_url' => '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/download',
+            ],
+            'position' => 0,
+            'creation_datetime' => $item->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $item->updateDatetime?->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_a_pdf_is_accepted(): void
+    {
+        [$user, $bandSpace, $rider, $item] = $this->seed();
+        $file = $this->renderableFile($bandSpace, 'patch.pdf', 'application/pdf');
+
+        $this->patch($user, $bandSpace, $rider, $item, ['file_id' => (string) $file->id]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRiderItem',
+            '@id' => $this->itemUrl($bandSpace, $rider, $item),
+            '@type' => 'TechRiderItem',
+            'id' => (string) $item->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'rider_id' => (string) $rider->id,
+            'type' => 'document',
+            'is_included' => true,
+            'title' => 'Schéma de câblage',
+            'content' => null,
+            'file' => [
+                'id' => (string) $file->id,
+                'original_name' => 'patch.pdf',
+                'mime_type' => 'application/pdf',
+                'is_archived' => false,
+                'download_url' => '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/download',
+            ],
+            'position' => 0,
+            'creation_datetime' => $item->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $item->updateDatetime?->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_clearing_the_file_empties_the_page(): void
+    {
+        [$user, $bandSpace, $rider, $item] = $this->seed();
+        $file = $this->renderableFile($bandSpace, 'schema.png', 'image/png');
+        $item->file = $file;
+        self::getContainer()->get('doctrine')->getManager()->flush();
+
+        $this->patch($user, $bandSpace, $rider, $item, ['file_id' => null]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRiderItem',
+            '@id' => $this->itemUrl($bandSpace, $rider, $item),
+            '@type' => 'TechRiderItem',
+            'id' => (string) $item->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'rider_id' => (string) $rider->id,
+            'type' => 'document',
+            'is_included' => true,
+            'title' => 'Schéma de câblage',
+            'content' => null,
+            'file' => null,
+            'position' => 0,
+            'creation_datetime' => $item->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $item->updateDatetime?->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * The cross space check is what stops an id from another band being used to surface its
+     * files through a rider.
+     */
+    public function test_a_file_from_another_band_space_is_rejected(): void
+    {
+        [$user, $bandSpace, $rider, $item] = $this->seed();
+        $otherSpace = BandSpaceFactory::new()->create();
+        $theirFile = $this->renderableFile($otherSpace, 'leur-schema.png', 'image/png');
+
+        $this->patch($user, $bandSpace, $rider, $item, ['file_id' => (string) $theirFile->id]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Fichier introuvable dans cet espace',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Fichier introuvable dans cet espace',
+        ]);
+
+        $stored = self::getContainer()->get(TechRiderItemRepository::class)
+            ->findOneByIdAndRider((string) $item->id, $rider);
+        $this->assertNull($stored?->file);
+    }
+
+    /**
+     * A page has to have a visual form. A zip or a text file would render as nothing, so it
+     * is refused at the point of choosing rather than discovered at export time.
+     */
+    public function test_a_file_that_cannot_be_rendered_as_a_page_is_rejected(): void
+    {
+        [$user, $bandSpace, $rider, $item] = $this->seed();
+        $file = $this->renderableFile($bandSpace, 'stems.zip', 'application/zip');
+
+        $this->patch($user, $bandSpace, $rider, $item, ['file_id' => (string) $file->id]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Ce type de fichier ne peut pas servir de page (images et PDF uniquement)',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Ce type de fichier ne peut pas servir de page (images et PDF uniquement)',
+        ]);
+    }
+
+    /**
+     * A file in the trash must be reported, not rendered as a blank page. Restoring the file
+     * restores the page, which is why the reference is kept rather than cleared.
+     */
+    public function test_a_trashed_file_is_reported_as_archived(): void
+    {
+        [$user, $bandSpace, $rider, $item] = $this->seed();
+        $file = $this->renderableFile($bandSpace, 'schema.png', 'image/png');
+        $item->file = $file;
+        $file->archiveDatetime = new DateTimeImmutable('2026-03-01T10:00:00+00:00');
+        self::getContainer()->get('doctrine')->getManager()->flush();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id,
+        );
+
+        $this->assertResponseIsSuccessful();
+        $riderBody = $this->getResponseAsArray();
+        $documentItem = $riderBody['items'][0];
+
+        $this->assertTrue($documentItem['file']['is_archived']);
+        $this->assertSame('schema.png', $documentItem['file']['original_name']);
+    }
+
+    /**
+     * SET NULL, not cascade: destroying the file must not destroy the page it was on. The
+     * item survives, empty, and the interface asks for a new file.
+     */
+    public function test_deleting_the_file_leaves_the_item_standing(): void
+    {
+        [, $bandSpace, $rider, $item] = $this->seed();
+        $file = $this->renderableFile($bandSpace, 'schema.png', 'image/png');
+
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+        $item->file = $file;
+        $entityManager->flush();
+
+        $entityManager->remove($file);
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $reloaded = self::getContainer()->get(TechRiderItemRepository::class)
+            ->findOneByIdAndRider((string) $item->id, $rider);
+
+        $this->assertInstanceOf(\App\Entity\BandSpace\TechRiderItem::class, $reloaded);
+        $this->assertNull($reloaded->file);
+        $this->assertSame('Schéma de câblage', $reloaded->title);
+    }
+
+    /**
+     * @return array{0: \App\Entity\User, 1: BandSpace, 2: TechRider, 3: \App\Entity\BandSpace\TechRiderItem}
+     */
+    /**
+     * A file reference is meaningless on any other type, so it is refused rather than stored:
+     * an item holding both prose and a file is a state nothing can render, and later code
+     * walking items by `file !== null` instead of by type would act on it.
+     */
+    public function test_a_text_item_cannot_be_given_a_file(): void
+    {
+        [$user, $bandSpace, $rider] = $this->seed();
+        $textItem = TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'title' => 'Sonorisation',
+            'type' => TechRiderItemType::Text,
+            'position' => 1,
+        ])->create();
+        $file = $this->renderableFile($bandSpace, 'schema.png', 'image/png');
+
+        $this->patch($user, $bandSpace, $rider, $textItem, ['file_id' => (string) $file->id]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Seul un élément de type document peut référencer un fichier',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Seul un élément de type document peut référencer un fichier',
+        ]);
+
+        $stored = self::getContainer()->get(TechRiderItemRepository::class)
+            ->findOneByIdAndRider((string) $textItem->id, $rider);
+        $this->assertNull($stored?->file);
+    }
+
+    private function itemUrl(mixed $bandSpace, mixed $rider, mixed $item): string
+    {
+        return '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id . '/items/' . $item->id;
+    }
+
+    private function seed(): array
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $rider = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => 'Rider'])->create();
+        $item = TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'title' => 'Schéma de câblage',
+            'type' => TechRiderItemType::Document,
+        ])->create();
+
+        return [$user, $bandSpace, $rider, $item];
+    }
+
+    private function renderableFile(BandSpace $bandSpace, string $name, string $mimeType): BandSpaceFile
+    {
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'originalName' => $name])->create();
+        $version = BandSpaceFileVersionFactory::new([
+            'bandSpaceFile' => $file,
+            'mimeType' => $mimeType,
+            'versionNumber' => 1,
+        ])->create();
+
+        $file->currentVersion = $version;
+        self::getContainer()->get('doctrine')->getManager()->flush();
+
+        return $file;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function patch(mixed $user, mixed $bandSpace, mixed $rider, mixed $item, array $payload): void
+    {
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id . '/items/' . $item->id,
+            $payload,
+            self::PATCH_HEADERS,
+        );
+    }
+}

--- a/tests/Api/BandSpace/TechRider/TechRiderItemTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderItemTest.php
@@ -82,6 +82,7 @@ class TechRiderItemTest extends ApiTestCase
             'position' => 1,
             'creation_datetime' => $created->creationDatetime->format(DateTimeInterface::ATOM),
             'update_datetime' => null,
+            'file' => null,
         ]);
 
         $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
@@ -261,6 +262,7 @@ class TechRiderItemTest extends ApiTestCase
             'position' => 0,
             'creation_datetime' => $item->creationDatetime->format(DateTimeInterface::ATOM),
             'update_datetime' => $item->updateDatetime?->format(DateTimeInterface::ATOM),
+            'file' => null,
         ]);
     }
 
@@ -300,6 +302,7 @@ class TechRiderItemTest extends ApiTestCase
             'position' => 0,
             'creation_datetime' => $item->creationDatetime->format(DateTimeInterface::ATOM),
             'update_datetime' => $item->updateDatetime?->format(DateTimeInterface::ATOM),
+            'file' => null,
         ]);
     }
 


### PR DESCRIPTION
Closes #790. Adds the `document` item type: a page of the rider that the band authored elsewhere. The reference rider's page IV, an I/O rack wiring diagram, is exactly this.

It references an existing `BandSpaceFile` rather than uploading a second copy, so folders, versions, tags and quota keep working and there is only one copy of the diagram to keep current. Under the old tab layout this would have been an "attachment" sitting outside the exported document, which is backwards: it is a page.

## Decisions

**`ON DELETE SET NULL`, not cascade.** Deleting the file must not silently delete a page of the rider. The item survives, empty, and says so. Proved by a test that removes the file through the entity manager, clears the identity map and reloads.

**Only images and PDFs may be a page**, via a new `BandSpaceFileMimeAllowlist::isRenderableAsPage()`. A zip has no visual form to place, so it is refused when chosen rather than discovered at export time.

**The file must belong to the same band space.** That check is what stops a rider being used to surface another band's files, and the 422 does not distinguish "does not exist" from "exists elsewhere".

**A trashed file is reported, never rendered blank.** `is_archived` rides in the payload and the item shows a warning plus a way to choose another file. Restoring the file restores the page, which is why the reference is kept rather than cleared.

**`file_id` is write only.** Reads get a resolved `file` block instead, so there is one way to say one thing.

## Divergence from the issue

#790 said the picker should reuse the existing file browser. **It does not, and I think that was the right call.** `AttachFileDialog` ships an upload tab that is explicitly out of scope here, and its existing-files tab filters `source: 'manual'`, which is the wrong scope for a rider page: a diagram already attached to a task should still be choosable. The new picker is its own small dialog.

That leaves about ten duplicated lines, a search debounce and a two-entry icon map. I chose not to extract a shared abstraction for that: two dialogs with different data sources and different row shapes would be harder to follow behind one wrapper than apart. Flagging it rather than hiding it.

The picker makes two requests (`mime=image`, `mime=application/pdf`) because the files API filter is a prefix LIKE with no notion of "renderable". Teaching the files API a rider concept seemed worse than two small requests against an endpoint that is already paginated.

## Verification

Suite **1856** green (1855 before), PHPStan level 8 clean, Biome at its 44 info baseline, build clean. Migration applied and round tripped on the migration database with zero drift; it is purely additive, so the generated SQL was kept.

Browser: created a document item through the new type selector, picked a seeded PDF through the picker, saw the card render, reloaded and it persisted.

## Review

Two real bugs, both fixed.

**An archived file rendered a broken preview underneath its own warning.** I had written the warning as a sibling of the empty/preview pair rather than as a third branch, so a trashed image showed the warning *and* an `<img>` pointing at a download the server correctly 404s for archived files. Now archived and empty share a branch, with wording that says the page returns if the file is restored.

**`file_id` was accepted on any item type.** A text item could be given a file, leaving an item with both prose and a file reference, which nothing can render. It is now a 422, with a test. The reviewer's argument for fixing rather than tolerating it is the right one: #775 duplicating a rider by walking `file !== null` instead of by type would quietly act on that state.

Also fixed: `findOneByIdAndBandSpace` fetch joins items but not their file, so every document item cost two extra lazy queries, in the one method whose comment exists to explain avoiding that fan-out; four of the new tests asserted a sub-field instead of the full body, against the project convention, and would have passed with the rest of the item shape broken; and the picker kept its previous search when reopened for a different item.

`BandSpaceFile` gained an `isArchived()` helper, matching the `User::isDeleted()` convention rather than inlining the `instanceof`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
