### PR TITLE
feat(M-773): patch list grid editor with explicit save and unsaved-changes guards

### DIFF
--- a/assets/js/api/bandSpace/band-space-tech-riders.js
+++ b/assets/js/api/bandSpace/band-space-tech-riders.js
@@ -102,6 +102,27 @@ export default {
       .catch(handleApiError)
   },
 
+  /**
+   * PUT, because the whole grid is replaced. Positions are not sent: array order is the order
+   * the server stores, so the payload cannot disagree with the list the user is looking at.
+   *
+   * Returns the updated item, which carries the saved rows with their new ids.
+   */
+  savePatchList(bandSpaceId, riderId, itemId, { inputs, outputs }) {
+    return axios
+      .put(
+        Routing.generate('api_band_space_tech_rider_patch_list_put', {
+          bandSpaceId,
+          riderId,
+          itemId
+        }),
+        { inputs, outputs },
+        { headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' } }
+      )
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
   reorderItems(bandSpaceId, riderId, positions) {
     return axios
       .post(

--- a/assets/js/components/BandSpace/TechRider/RiderItemList.vue
+++ b/assets/js/components/BandSpace/TechRider/RiderItemList.vue
@@ -130,6 +130,14 @@
           :read-only="readOnly"
           @choose="handleChooseFile"
         />
+        <RiderPatchListEditor
+          v-else-if="item.type === 'patch_list'"
+          :band-space-id="bandSpaceId"
+          :rider-id="riderId"
+          :item-id="item.id"
+          :patch-list="item.patch_list"
+          :read-only="readOnly"
+        />
         <p v-else class="text-surface-600 dark:text-surface-300 py-4 text-center">
           Ce type d'élément arrivera prochainement.
         </p>
@@ -194,6 +202,7 @@ import { useToast } from 'primevue/usetoast'
 import { reactive, ref } from 'vue'
 import { useBandTechRidersStore } from '../../../store/bandSpace/bandSpaceTechRiders.js'
 import RiderDocumentItemEditor from './RiderDocumentItemEditor.vue'
+import RiderPatchListEditor from './RiderPatchListEditor.vue'
 import RiderTextItemEditor from './RiderTextItemEditor.vue'
 
 const props = defineProps({
@@ -215,7 +224,8 @@ const collapsed = reactive({})
 const addDialogOpen = ref(false)
 const ITEM_TYPES = [
   { value: 'text', label: 'Texte libre' },
-  { value: 'document', label: 'Document (image ou PDF)' }
+  { value: 'document', label: 'Document (image ou PDF)' },
+  { value: 'patch_list', label: 'Patch list' }
 ]
 
 const newTitle = ref('')

--- a/assets/js/components/BandSpace/TechRider/RiderPatchGrid.vue
+++ b/assets/js/components/BandSpace/TechRider/RiderPatchGrid.vue
@@ -1,0 +1,508 @@
+<template>
+  <section class="flex flex-col gap-2 min-w-0" :aria-label="label">
+    <div class="flex flex-wrap items-center gap-2">
+      <h4 class="font-semibold">{{ label }}</h4>
+      <span
+        class="text-xs px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800 text-surface-700 dark:text-surface-200"
+        :class="isFull ? 'text-red-700 dark:text-red-300' : ''"
+      >
+        {{ rows.length }} / {{ maxRows }}
+      </span>
+      <span class="flex-1" />
+
+      <template v-if="!readOnly">
+        <Button
+          label="Renuméroter"
+          icon="pi pi-sort-numeric-down"
+          severity="secondary"
+          text
+          size="small"
+          :disabled="rows.length === 0"
+          v-tooltip.top="'Renumérote les canaux de 1 à N dans l\'ordre affiché'"
+          :aria-label="`Renuméroter les canaux (${label.toLowerCase()})`"
+          @click="renumber"
+        />
+        <Button
+          label="Colorer une plage"
+          icon="pi pi-palette"
+          severity="secondary"
+          text
+          size="small"
+          :disabled="rows.length === 0"
+          :aria-label="`Colorer une plage de lignes (${label.toLowerCase()})`"
+          @click="openRangeDialog"
+        />
+        <Button
+          label="Ajouter"
+          icon="pi pi-plus"
+          severity="secondary"
+          outlined
+          size="small"
+          :disabled="isFull"
+          :aria-label="`Ajouter une ligne (${label.toLowerCase()})`"
+          @click="addRow"
+        />
+      </template>
+    </div>
+
+    <Message v-if="isFull" severity="warn" :closable="false" size="small">
+      La limite de {{ maxRows }} lignes est atteinte.
+    </Message>
+
+    <Message v-for="(message, index) in listErrors" :key="index" severity="error" :closable="false" size="small">
+      {{ message }}
+    </Message>
+
+    <p v-if="rows.length === 0" class="text-sm text-surface-600 dark:text-surface-300 py-3">
+      Aucune ligne. Ajoutez la première entrée de votre patch.
+    </p>
+
+    <template v-else>
+      <!-- Headers name the columns once instead of every field repeating its label. Each input
+           still carries an aria-label with its row, because a header is not associated with a
+           cell the way a real <th> would be, and 24 unlabelled inputs are unusable by ear. -->
+      <div
+        class="hidden sm:grid gap-2 px-2 text-xs font-medium text-surface-600 dark:text-surface-300"
+        :style="{ gridTemplateColumns: GRID_COLUMNS }"
+        aria-hidden="true"
+      >
+        <span>Canal</span>
+        <span>Nom</span>
+        <span>Micro</span>
+        <span>Routage</span>
+        <span>Couleur</span>
+        <span />
+      </div>
+
+      <ul class="flex flex-col gap-2">
+        <li
+          v-for="(row, index) in rows"
+          :key="row.key"
+          class="rounded-lg border p-2 sm:grid sm:items-center flex flex-col gap-2"
+          :style="{ gridTemplateColumns: GRID_COLUMNS }"
+          :class="[
+            dropTargetKey === row.key ? 'ring-2 ring-primary-400' : '',
+            rowHasError(index)
+              ? 'border-red-400 dark:border-red-500 bg-red-50 dark:bg-red-950/30'
+              : 'border-surface-200 dark:border-surface-700'
+          ]"
+          :draggable="!readOnly"
+          @dragstart="handleDragStart(row.key)"
+          @dragend="handleDragEnd"
+          @dragover.prevent="handleDragOver(row.key)"
+          @dragleave="handleDragLeave(row.key)"
+          @drop.prevent="handleDrop(row.key)"
+        >
+          <!-- The `sm:hidden` captions are the stacked layout's labels. Below sm the column
+               headers are gone, so without them a sighted user sees five unlabelled boxes;
+               above sm the header already says it and repeating it would be noise. -->
+          <div class="flex items-center gap-1">
+            <i
+              v-if="!readOnly"
+              class="pi pi-bars text-surface-400 cursor-grab shrink-0 text-xs"
+              aria-hidden="true"
+            />
+            <span class="sm:hidden text-xs text-surface-600 dark:text-surface-300 w-16 shrink-0">
+              Canal
+            </span>
+            <InputNumber
+              v-model="row.channel"
+              :min="1"
+              :max="999"
+              :use-grouping="false"
+              :disabled="readOnly"
+              :input-class="[
+                'w-full',
+                isDuplicate(row) ? 'border-red-400 dark:border-red-500' : ''
+              ]"
+              class="w-full"
+              :aria-label="`Canal, ligne ${index + 1}`"
+              :input-props="{ inputmode: 'numeric' }"
+            />
+          </div>
+
+          <div class="flex items-center gap-1 min-w-0">
+            <span class="sm:hidden text-xs text-surface-600 dark:text-surface-300 w-16 shrink-0">
+              Nom
+            </span>
+            <InputText
+              v-model="row.name"
+              :disabled="readOnly"
+              :maxlength="FIELD_LIMITS.name"
+              class="w-full"
+              placeholder="KICK IN"
+              :aria-label="`Nom, ligne ${index + 1}`"
+            />
+          </div>
+          <div class="flex items-center gap-1 min-w-0">
+            <span class="sm:hidden text-xs text-surface-600 dark:text-surface-300 w-16 shrink-0">
+              Micro
+            </span>
+            <InputText
+              v-model="row.microphone"
+              :disabled="readOnly"
+              :maxlength="FIELD_LIMITS.microphone"
+              class="w-full"
+              placeholder="Beta 91 ou équivalent"
+              :aria-label="`Micro, ligne ${index + 1}`"
+            />
+          </div>
+          <div class="flex items-center gap-1 min-w-0">
+            <span class="sm:hidden text-xs text-surface-600 dark:text-surface-300 w-16 shrink-0">
+              Routage
+            </span>
+            <InputText
+              v-model="row.routing"
+              :disabled="readOnly"
+              :maxlength="FIELD_LIMITS.routing"
+              class="w-full"
+              placeholder="Vers split micro A1"
+              :aria-label="`Routage, ligne ${index + 1}`"
+            />
+          </div>
+
+          <div class="flex items-center gap-1 min-w-0">
+            <span class="sm:hidden text-xs text-surface-600 dark:text-surface-300 w-16 shrink-0">
+              Couleur
+            </span>
+            <Select
+              v-model="row.colour"
+              :options="COLOUR_OPTIONS"
+              option-label="label"
+              option-value="value"
+              :disabled="readOnly"
+              class="w-full"
+              :aria-label="`Couleur, ligne ${index + 1}`"
+            >
+              <!-- The name travels with the swatch in both the closed state and the list, so
+                   the grouping is never conveyed by colour alone. -->
+              <template #value="{ value }">
+                <span class="flex items-center gap-2">
+                  <span
+                    class="w-3 h-3 rounded-sm border border-surface-300 dark:border-surface-600 shrink-0"
+                    :style="{ backgroundColor: hexFor(value) ?? 'transparent' }"
+                    aria-hidden="true"
+                  />
+                  <span class="truncate">{{ labelFor(value) }}</span>
+                </span>
+              </template>
+              <template #option="{ option }">
+                <span class="flex items-center gap-2">
+                  <span
+                    class="w-3 h-3 rounded-sm border border-surface-300 dark:border-surface-600 shrink-0"
+                    :style="{ backgroundColor: option.hex ?? 'transparent' }"
+                    aria-hidden="true"
+                  />
+                  <span>{{ option.label }}</span>
+                </span>
+              </template>
+            </Select>
+          </div>
+
+          <div v-if="!readOnly" class="flex items-center justify-end gap-0.5">
+            <!-- Drag is not an accessible reorder, so the same move is available as buttons. -->
+            <Button
+              icon="pi pi-arrow-up"
+              severity="secondary"
+              text
+              rounded
+              size="small"
+              :disabled="index === 0"
+              :aria-label="`Monter la ligne ${index + 1}`"
+              v-tooltip.top="'Monter'"
+              @click="move(index, index - 1)"
+            />
+            <Button
+              icon="pi pi-arrow-down"
+              severity="secondary"
+              text
+              rounded
+              size="small"
+              :disabled="index === rows.length - 1"
+              :aria-label="`Descendre la ligne ${index + 1}`"
+              v-tooltip.top="'Descendre'"
+              @click="move(index, index + 1)"
+            />
+            <Button
+              icon="pi pi-trash"
+              severity="danger"
+              text
+              rounded
+              size="small"
+              :aria-label="`Supprimer la ligne ${index + 1}${row.name ? ` (${row.name})` : ''}`"
+              v-tooltip.top="'Supprimer'"
+              @click="removeRow(index)"
+            />
+          </div>
+
+          <p
+            v-if="rowHasError(index)"
+            class="text-xs text-red-700 dark:text-red-300 sm:col-span-6"
+            role="alert"
+          >
+            {{ rowErrorText(index) }}
+          </p>
+        </li>
+      </ul>
+    </template>
+
+    <Dialog
+      v-model:visible="rangeDialogOpen"
+      modal
+      :header="`Colorer une plage (${label.toLowerCase()})`"
+      :style="{ width: '30rem' }"
+    >
+      <form class="flex flex-col gap-4" @submit.prevent="applyRange">
+        <p class="text-sm text-surface-600 dark:text-surface-300">
+          Les couleurs marquent des groupes de lignes qui partent au même endroit.
+        </p>
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <label :for="`${uid}-from`" class="block text-sm font-medium mb-1">Première ligne</label>
+            <Select
+              :id="`${uid}-from`"
+              v-model="rangeFrom"
+              :options="rowChoices"
+              option-label="label"
+              option-value="value"
+              class="w-full"
+            />
+          </div>
+          <div>
+            <label :for="`${uid}-to`" class="block text-sm font-medium mb-1">Dernière ligne</label>
+            <Select
+              :id="`${uid}-to`"
+              v-model="rangeTo"
+              :options="rowChoices"
+              option-label="label"
+              option-value="value"
+              class="w-full"
+            />
+          </div>
+        </div>
+        <div>
+          <label :for="`${uid}-colour`" class="block text-sm font-medium mb-1">Couleur</label>
+          <Select
+            :id="`${uid}-colour`"
+            v-model="rangeColour"
+            :options="COLOUR_OPTIONS"
+            option-label="label"
+            option-value="value"
+            class="w-full"
+          >
+            <template #option="{ option }">
+              <span class="flex items-center gap-2">
+                <span
+                  class="w-3 h-3 rounded-sm border border-surface-300 dark:border-surface-600 shrink-0"
+                  :style="{ backgroundColor: option.hex ?? 'transparent' }"
+                  aria-hidden="true"
+                />
+                <span>{{ option.label }}</span>
+              </span>
+            </template>
+          </Select>
+        </div>
+        <div class="flex justify-end gap-2">
+          <Button label="Annuler" severity="secondary" text type="button" @click="rangeDialogOpen = false" />
+          <Button label="Appliquer" type="submit" />
+        </div>
+      </form>
+    </Dialog>
+  </section>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import InputNumber from 'primevue/inputnumber'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import Select from 'primevue/select'
+import { computed, ref, useId } from 'vue'
+import { TECH_RIDER_COLOURS } from '../../../constants/techRiderColours.js'
+
+const props = defineProps({
+  label: { type: String, required: true },
+  /**
+   * Mutated in place. The parent owns the grid so it can diff both directions against one
+   * snapshot and save them in a single request; handing every row edit back up as an event
+   * would be the same state with a courier in front of it.
+   */
+  rows: { type: Array, required: true },
+  maxRows: { type: Number, required: true },
+  /** `{ list: string[], rows: { [index]: string[] } }`, as returned by the server for 422s. */
+  errors: { type: Object, default: () => ({ list: [], rows: {} }) },
+  readOnly: { type: Boolean, default: false }
+})
+
+const uid = useId()
+
+// channel | name | micro | routage | couleur | actions
+const GRID_COLUMNS = '6rem minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.3fr) 9rem auto'
+
+/**
+ * Mirrors the column lengths in App\Validator\BandSpace\TechRider\TechRiderPatchRows. Enforced
+ * here as well as there so a paste that is too long stops at the field instead of coming back as
+ * a rejected save of the whole grid. Pinned against the PHP constants by
+ * tests/Unit/Validator/BandSpace/TechRider/TechRiderPatchLimitsTest.php.
+ */
+const FIELD_LIMITS = { name: 120, microphone: 120, routing: 180 }
+
+const COLOUR_OPTIONS = [
+  { value: null, label: 'Aucune', hex: null },
+  ...TECH_RIDER_COLOURS.map((colour) => ({
+    value: colour.value,
+    label: colour.label,
+    hex: colour.hex
+  }))
+]
+
+let keyCounter = 0
+
+const rangeDialogOpen = ref(false)
+const rangeFrom = ref(0)
+const rangeTo = ref(0)
+const rangeColour = ref(null)
+
+const draggedKey = ref(null)
+const dropTargetKey = ref(null)
+
+const isFull = computed(() => props.rows.length >= props.maxRows)
+const listErrors = computed(() => props.errors.list ?? [])
+
+/**
+ * Flagged as you type rather than only on a rejected save. A duplicate channel is the mistake
+ * this grid invites, and finding out at save time means finding out after the trip.
+ */
+const duplicateChannels = computed(() => {
+  const seen = new Set()
+  const duplicates = new Set()
+  for (const row of props.rows) {
+    if (row.channel === null || row.channel === undefined) continue
+    if (seen.has(row.channel)) duplicates.add(row.channel)
+    seen.add(row.channel)
+  }
+  return duplicates
+})
+
+/** Named by position and by what is in them, so picking a range needs no counting. */
+const rowChoices = computed(() =>
+  props.rows.map((row, index) => {
+    const details = [row.channel ? `canal ${row.channel}` : null, row.name || null].filter(Boolean)
+    return {
+      value: index,
+      label:
+        details.length > 0 ? `Ligne ${index + 1} (${details.join(', ')})` : `Ligne ${index + 1}`
+    }
+  })
+)
+
+function isDuplicate(row) {
+  return duplicateChannels.value.has(row.channel)
+}
+
+function hexFor(value) {
+  return COLOUR_OPTIONS.find((option) => option.value === value)?.hex ?? null
+}
+
+function labelFor(value) {
+  return COLOUR_OPTIONS.find((option) => option.value === value)?.label ?? 'Aucune'
+}
+
+function rowHasError(index) {
+  return (props.errors.rows?.[index]?.length ?? 0) > 0
+}
+
+function rowErrorText(index) {
+  return (props.errors.rows?.[index] ?? []).join('. ')
+}
+
+/** One past the highest in use, so adding rows in order never lands on a duplicate. */
+function nextChannel() {
+  const used = props.rows.map((row) => row.channel ?? 0)
+  return used.length === 0 ? 1 : Math.max(...used) + 1
+}
+
+function addRow() {
+  if (isFull.value) return
+  props.rows.push({
+    // A client-side key, not the server id: a full replace regenerates every id, and a row that
+    // has never been saved has none at all, so v-for cannot be keyed on it.
+    key: `row-${uid}-${keyCounter++}`,
+    channel: nextChannel(),
+    name: '',
+    microphone: '',
+    routing: '',
+    colour: null
+  })
+}
+
+function removeRow(index) {
+  props.rows.splice(index, 1)
+}
+
+function move(fromIndex, toIndex) {
+  if (toIndex < 0 || toIndex >= props.rows.length) return
+  const [moved] = props.rows.splice(fromIndex, 1)
+  props.rows.splice(toIndex, 0, moved)
+}
+
+/** Rewrites channels to 1..N in the order shown. Local only, written on the next save. */
+function renumber() {
+  props.rows.forEach((row, index) => {
+    row.channel = index + 1
+  })
+}
+
+function openRangeDialog() {
+  rangeFrom.value = 0
+  rangeTo.value = props.rows.length - 1
+  rangeColour.value = null
+  rangeDialogOpen.value = true
+}
+
+/**
+ * Sorted, so picking the last row first still colours the range the user drew rather than
+ * silently doing nothing.
+ */
+function applyRange() {
+  const [start, end] = [rangeFrom.value, rangeTo.value].sort((a, b) => a - b)
+  for (let index = start; index <= end; index++) {
+    if (props.rows[index]) props.rows[index].colour = rangeColour.value
+  }
+  rangeDialogOpen.value = false
+}
+
+function handleDragStart(key) {
+  if (props.readOnly) return
+  draggedKey.value = key
+}
+
+function handleDragOver(key) {
+  if (!draggedKey.value || draggedKey.value === key) return
+  dropTargetKey.value = key
+}
+
+function handleDragLeave(key) {
+  if (dropTargetKey.value === key) dropTargetKey.value = null
+}
+
+// dragend always fires on the source, so a drop outside the list cannot leave a row stuck.
+function handleDragEnd() {
+  draggedKey.value = null
+  dropTargetKey.value = null
+}
+
+function handleDrop(targetKey) {
+  const sourceKey = draggedKey.value
+  dropTargetKey.value = null
+  draggedKey.value = null
+  if (!sourceKey || sourceKey === targetKey) return
+
+  const fromIndex = props.rows.findIndex((row) => row.key === sourceKey)
+  const toIndex = props.rows.findIndex((row) => row.key === targetKey)
+  if (fromIndex === -1 || toIndex === -1) return
+
+  move(fromIndex, toIndex)
+}
+</script>

--- a/assets/js/components/BandSpace/TechRider/RiderPatchListEditor.vue
+++ b/assets/js/components/BandSpace/TechRider/RiderPatchListEditor.vue
@@ -1,0 +1,257 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <Message v-if="globalError" severity="error" :closable="false">{{ globalError }}</Message>
+
+    <!-- Stacked, not side by side. Two grids sharing the width leaves 65px for a name and 85px
+         for a routing note that may run to 180 characters, which is not a column, it is an
+         ellipsis. Outputs are only ever a handful of rows, so the vertical cost is small. -->
+    <div class="flex flex-col gap-8">
+      <RiderPatchGrid
+        label="Entrées"
+        :rows="inputs"
+        :max-rows="MAX_ROWS_PER_DIRECTION"
+        :errors="errors.inputs"
+        :read-only="readOnly"
+      />
+      <RiderPatchGrid
+        label="Retours"
+        :rows="outputs"
+        :max-rows="MAX_ROWS_PER_DIRECTION"
+        :errors="errors.outputs"
+        :read-only="readOnly"
+      />
+    </div>
+
+    <!-- Explicit save, never autosave: a half typed row is a normal state in a grid, and the
+         endpoint replaces the whole list, so saving mid-edit would write nonsense. -->
+    <div
+      v-if="!readOnly && isDirty"
+      class="sticky bottom-0 flex flex-wrap items-center gap-3 p-3 rounded-lg border border-primary-200 dark:border-primary-800 bg-primary-50 dark:bg-primary-950"
+    >
+      <i class="pi pi-exclamation-circle text-primary" aria-hidden="true" />
+      <span class="text-sm">Modifications non enregistrées.</span>
+      <span class="flex-1" />
+      <Button
+        label="Annuler les modifications"
+        severity="secondary"
+        text
+        size="small"
+        :disabled="isSaving"
+        @click="reset"
+      />
+      <Button label="Sauvegarder" icon="pi pi-check" size="small" :loading="isSaving" @click="save" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { useToast } from 'primevue/usetoast'
+import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
+import { useBandTechRidersStore } from '../../../store/bandSpace/bandSpaceTechRiders.js'
+import RiderPatchGrid from './RiderPatchGrid.vue'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true },
+  riderId: { type: String, required: true },
+  itemId: { type: String, required: true },
+  /** `{ inputs: [...], outputs: [...] }` as the API returns it, or null on a fresh item. */
+  patchList: { type: Object, default: null },
+  readOnly: { type: Boolean, default: false }
+})
+
+/** Mirrors TechRiderPatchRows::MAX_ROWS_PER_DIRECTION. */
+const MAX_ROWS_PER_DIRECTION = 64
+
+const techRidersStore = useBandTechRidersStore()
+const toast = useToast()
+
+const inputs = reactive([])
+const outputs = reactive([])
+const errors = reactive({
+  inputs: { list: [], rows: {} },
+  outputs: { list: [], rows: {} }
+})
+const globalError = ref(null)
+const isSaving = ref(false)
+
+/**
+ * The last state the server confirmed, as a string. Comparing serialised payloads rather than
+ * tracking every field means no edit can be missed because somebody forgot to flag it, and a
+ * change that cancels itself out correctly reads as clean again.
+ */
+const savedSnapshot = ref('')
+let keyCounter = 0
+
+const isDirty = computed(() => serialise() !== savedSnapshot.value)
+
+function toLocalRows(apiRows) {
+  return (apiRows ?? []).map((row) => ({
+    // Server ids are regenerated on every save, so they cannot key a list that survives one.
+    key: `row-${props.itemId}-${keyCounter++}`,
+    channel: row.channel,
+    name: row.name ?? '',
+    microphone: row.microphone ?? '',
+    routing: row.routing ?? '',
+    colour: row.colour ?? null
+  }))
+}
+
+/**
+ * Empty strings collapse to null, matching what the server stores, so a field the user typed
+ * into and then cleared does not read as a change forever after.
+ */
+function toPayloadRows(rows) {
+  return rows.map((row) => ({
+    channel: row.channel,
+    name: row.name?.trim() ? row.name.trim() : null,
+    microphone: row.microphone?.trim() ? row.microphone.trim() : null,
+    routing: row.routing?.trim() ? row.routing.trim() : null,
+    colour: row.colour ?? null
+  }))
+}
+
+function serialise() {
+  return JSON.stringify({ inputs: toPayloadRows(inputs), outputs: toPayloadRows(outputs) })
+}
+
+function seed() {
+  inputs.splice(0, inputs.length, ...toLocalRows(props.patchList?.inputs))
+  outputs.splice(0, outputs.length, ...toLocalRows(props.patchList?.outputs))
+  clearErrors()
+  savedSnapshot.value = serialise()
+}
+
+function reset() {
+  seed()
+}
+
+function clearErrors() {
+  errors.inputs = { list: [], rows: {} }
+  errors.outputs = { list: [], rows: {} }
+  globalError.value = null
+}
+
+const FIELD_LABELS = {
+  channel: 'Canal',
+  name: 'Nom',
+  microphone: 'Micro',
+  routing: 'Routage',
+  colour: 'Couleur'
+}
+
+/**
+ * Maps the server's property paths back onto rows. A duplicate channel arrives as `inputs`, a
+ * bad field as `inputs[3].routing`; both have to land somewhere the user can see, or a refused
+ * save looks like the data was lost when in fact the server kept the previous list.
+ */
+function applyViolations(violations) {
+  clearErrors()
+
+  for (const violation of violations) {
+    const match = /^(inputs|outputs)(?:\[(\d+)])?(?:\.(\w+))?$/.exec(violation.propertyPath ?? '')
+    if (!match) {
+      globalError.value = [globalError.value, violation.message].filter(Boolean).join('. ')
+      continue
+    }
+
+    const [, direction, index, field] = match
+    if (index === undefined) {
+      errors[direction].list.push(violation.message)
+      continue
+    }
+
+    const rowIndex = Number(index)
+    const existing = errors[direction].rows[rowIndex] ?? []
+    errors[direction].rows[rowIndex] = [
+      ...existing,
+      field ? `${FIELD_LABELS[field] ?? field} : ${violation.message}` : violation.message
+    ]
+  }
+}
+
+/**
+ * A blank channel is caught here rather than sent. The server would reject it, but with a
+ * message about the row's shape, which does not tell somebody who tabbed past a field what to
+ * go and fix.
+ */
+function findBlankChannel() {
+  for (const [direction, rows] of [
+    ['inputs', inputs],
+    ['outputs', outputs]
+  ]) {
+    const index = rows.findIndex((row) => row.channel === null || row.channel === undefined)
+    if (index !== -1) return { direction, index }
+  }
+
+  return null
+}
+
+async function save() {
+  clearErrors()
+
+  const blank = findBlankChannel()
+  if (blank) {
+    errors[blank.direction].rows[blank.index] = ['Canal : ce champ est requis']
+    return
+  }
+
+  // Both captured before the request goes out, and the snapshot is the one applied afterwards.
+  // Nothing stops the user typing while the PUT is in flight, and re-serialising after the await
+  // would fold those keystrokes into the saved baseline as though the server had confirmed them.
+  // The grid would then read as clean, every guard would stand down, and the edit would be lost
+  // on the next navigation without a prompt.
+  const payload = { inputs: toPayloadRows(inputs), outputs: toPayloadRows(outputs) }
+  const sentSnapshot = JSON.stringify(payload)
+
+  isSaving.value = true
+  try {
+    await techRidersStore.savePatchList(props.bandSpaceId, props.riderId, props.itemId, payload)
+    savedSnapshot.value = sentSnapshot
+    toast.add({ severity: 'success', summary: 'Patch list enregistrée', life: 2500 })
+  } catch (e) {
+    if (e.isValidationError) {
+      applyViolations(e.violations ?? [])
+    } else {
+      globalError.value = e.message
+    }
+  } finally {
+    isSaving.value = false
+  }
+}
+
+// Seeded before the watchers exist, not after. An empty savedSnapshot compares unequal to an
+// empty grid, so a watcher created first would report a brand new editor as dirty and the page
+// would ask about unsaved changes the moment it loaded.
+seed()
+
+// The guard that protects these edits lives two levels up, on the route and on the rider
+// switcher, because both destroy this component without asking.
+watch(isDirty, (dirty) => techRidersStore.setItemDirty(props.itemId, dirty))
+
+// Server violations are addressed by array index, so adding, deleting or moving a row leaves
+// them pointing at whichever row now sits at that index: the red border would move to an
+// innocent row and the guilty one would look fine. Editing a field cannot do that, so field
+// edits deliberately keep the messages, which is what lets somebody fix one and still see the
+// rest.
+watch(
+  () => [inputs.map((row) => row.key).join(), outputs.map((row) => row.key).join()].join('|'),
+  clearErrors
+)
+
+// Reseeds when the item is swapped, and when a save elsewhere replaces the rider. Guarded on
+// dirtiness so an in-flight edit is never overwritten by a refresh.
+watch(
+  () => props.patchList,
+  () => {
+    if (!isDirty.value) seed()
+  }
+)
+
+watch(() => props.itemId, seed)
+
+// An unmounted editor holds no edits, so leaving the flag set would make the guard warn about
+// changes that no longer exist anywhere.
+onBeforeUnmount(() => techRidersStore.setItemDirty(props.itemId, false))
+</script>

--- a/assets/js/store/bandSpace/bandSpaceTechRiders.js
+++ b/assets/js/store/bandSpace/bandSpaceTechRiders.js
@@ -9,6 +9,7 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
   const liveRiders = ref([])
   const archivedRiders = ref([])
   const activeTechRider = ref(null)
+  const dirtyItemIds = ref([])
   const isLoading = ref(false)
   const isLoadingActive = ref(false)
   const loadError = ref(null)
@@ -161,6 +162,11 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     )
   }
 
+  async function savePatchList(bandSpaceId, riderId, itemId, grid) {
+    replaceItem(await bandSpaceTechRidersApi.savePatchList(bandSpaceId, riderId, itemId, grid))
+    setItemDirty(itemId, false)
+  }
+
   async function setItemIncluded(bandSpaceId, riderId, itemId, isIncluded) {
     replaceItem(
       await bandSpaceTechRidersApi.updateItem(bandSpaceId, riderId, itemId, {
@@ -217,6 +223,35 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     }
   }
 
+  /**
+   * Items that hold edits the server has not seen.
+   *
+   * Kept here rather than inside the editor because the thing that has to react to it is two
+   * levels up: leaving the route, and switching rider, both destroy the editor without asking.
+   * Losing a 24 row patch list to a mistaken click is the worst outcome this module has.
+   */
+  function setItemDirty(itemId, isDirty) {
+    const without = dirtyItemIds.value.filter((id) => id !== itemId)
+    dirtyItemIds.value = isDirty ? [...without, itemId] : without
+  }
+
+  /**
+   * Asks once, and only when there is something to lose. Returns true when it is safe to carry
+   * on, so callers read as `if (!confirmDiscardingEdits()) return`.
+   */
+  function confirmDiscardingEdits() {
+    if (dirtyItemIds.value.length === 0) return true
+
+    const confirmed = window.confirm(
+      'Des modifications ne sont pas enregistrées et seront perdues. Continuer ?'
+    )
+    if (confirmed) {
+      dirtyItemIds.value = []
+    }
+
+    return confirmed
+  }
+
   /** Looks in both lists, so a remembered id resolves whether or not it has been archived. */
   function findRider(riderId) {
     return (
@@ -228,6 +263,9 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
 
   function clearActive() {
     activeTechRider.value = null
+    // The editors holding these edits are about to be destroyed, so keeping the ids would leave
+    // the guard warning about changes that no longer exist anywhere.
+    dirtyItemIds.value = []
     activeRequestId++
   }
 
@@ -244,6 +282,7 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     liveRiders: readonly(liveRiders),
     archivedRiders: readonly(archivedRiders),
     activeTechRider: readonly(activeTechRider),
+    dirtyItemIds: readonly(dirtyItemIds),
     isLoading: readonly(isLoading),
     isLoadingActive: readonly(isLoadingActive),
     loadError: readonly(loadError),
@@ -256,8 +295,11 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     createItem,
     renameItem,
     saveItemContent,
+    savePatchList,
     setItemFile,
     setItemIncluded,
+    setItemDirty,
+    confirmDiscardingEdits,
     deleteItem,
     reorderItems,
     findRider,

--- a/assets/js/views/BandSpace/TechRider.vue
+++ b/assets/js/views/BandSpace/TechRider.vue
@@ -116,8 +116,8 @@ import Message from 'primevue/message'
 import ProgressSpinner from 'primevue/progressspinner'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
-import { computed, onMounted, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router'
 import RiderItemList from '../../components/BandSpace/TechRider/RiderItemList.vue'
 import TechRiderFormDialog from '../../components/BandSpace/TechRider/TechRiderFormDialog.vue'
 import TechRiderSelector from '../../components/BandSpace/TechRider/TechRiderSelector.vue'
@@ -166,8 +166,14 @@ function resolveInitialRider() {
   return techRidersStore.liveRiders[0]?.id ?? techRidersStore.archivedRiders[0]?.id ?? null
 }
 
+/**
+ * Switching rider destroys the open editors, so unsaved grid edits are asked about here as well
+ * as on route leave. Losing 24 typed rows to a click in the switcher is the worst outcome this
+ * module has, and the switcher is the easiest way to do it by accident.
+ */
 function selectRider(riderId) {
   if (!riderId || riderId === selectedRiderId.value) return
+  if (!techRidersStore.confirmDiscardingEdits()) return
   selectedRiderId.value = riderId
   localStorage.setItem(rememberedKey(), riderId)
   syncQuery()
@@ -251,5 +257,28 @@ watch(bandSpaceId, () => {
   load()
 })
 
-onMounted(load)
+onBeforeRouteLeave(() => techRidersStore.confirmDiscardingEdits())
+
+// Switching band space changes only the id param, which keeps this route mounted and so never
+// fires onBeforeRouteLeave. The bandSpaceId watcher below then clears the open rider and every
+// editor with it, so the question has to be asked here, before the param change is committed.
+// Guarding the watcher instead would be too late: the URL would already say the new space.
+onBeforeRouteUpdate(() => techRidersStore.confirmDiscardingEdits())
+
+/**
+ * Covers closing the tab and reloading, which the router never sees. The browser shows its own
+ * wording here; returnValue is what makes it show anything at all.
+ */
+function warnOnUnload(event) {
+  if (techRidersStore.dirtyItemIds.length === 0) return
+  event.preventDefault()
+  event.returnValue = ''
+}
+
+onMounted(() => {
+  window.addEventListener('beforeunload', warnOnUnload)
+  load()
+})
+
+onBeforeUnmount(() => window.removeEventListener('beforeunload', warnOnUnload))
 </script>

--- a/tests/Unit/Validator/BandSpace/TechRider/TechRiderPatchLimitsTest.php
+++ b/tests/Unit/Validator/BandSpace/TechRider/TechRiderPatchLimitsTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Validator\BandSpace\TechRider;
+
+use App\Validator\BandSpace\TechRider\TechRiderPatchRows;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The patch list editor repeats the server's limits: the row cap so it can grey out "Ajouter" and
+ * show a count, and the field lengths so a long paste stops at the field rather than coming back
+ * as a rejected save of the whole grid.
+ *
+ * That is a deliberate duplication, for the same reason as the colour palette in
+ * TechRiderColourPaletteTest: the numbers are PHP constants, so changing them is a deploy and the
+ * bundle rebuilds in the same deploy, which makes an endpoint pure overhead. What the duplication
+ * does risk is drift, and drift is what this pins. Raise a limit on one side only and this fails.
+ */
+class TechRiderPatchLimitsTest extends TestCase
+{
+    private const string EDITOR_PATH = 'assets/js/components/BandSpace/TechRider/RiderPatchListEditor.vue';
+    private const string GRID_PATH = 'assets/js/components/BandSpace/TechRider/RiderPatchGrid.vue';
+
+    public function test_the_editor_row_cap_matches_the_constraint(): void
+    {
+        $this->assertSame(
+            TechRiderPatchRows::MAX_ROWS_PER_DIRECTION,
+            $this->parseInt(self::EDITOR_PATH, '/const MAX_ROWS_PER_DIRECTION = (\d+)/'),
+            sprintf('The row cap has drifted. Update %s and %s together.', self::EDITOR_PATH, TechRiderPatchRows::class),
+        );
+    }
+
+    public function test_the_grid_field_lengths_match_the_constraint(): void
+    {
+        $source = $this->read(self::GRID_PATH);
+
+        preg_match('/const FIELD_LIMITS = \{([^}]+)}/', $source, $block);
+        self::assertNotEmpty($block, sprintf('No FIELD_LIMITS declaration found in %s.', self::GRID_PATH));
+
+        $found = [];
+        preg_match_all('/(\w+):\s*(\d+)/', $block[1], $pairs, PREG_SET_ORDER);
+        foreach ($pairs as $pair) {
+            $found[$pair[1]] = (int) $pair[2];
+        }
+
+        $this->assertSame(
+            [
+                'name' => TechRiderPatchRows::MAX_NAME_LENGTH,
+                'microphone' => TechRiderPatchRows::MAX_MICROPHONE_LENGTH,
+                'routing' => TechRiderPatchRows::MAX_ROUTING_LENGTH,
+            ],
+            $found,
+            sprintf('The field lengths have drifted. Update %s and %s together.', self::GRID_PATH, TechRiderPatchRows::class),
+        );
+    }
+
+    private function parseInt(string $relativePath, string $pattern): int
+    {
+        preg_match($pattern, $this->read($relativePath), $matches);
+        // Guards against the regex silently matching nothing, which would compare the constant
+        // against zero and report a drift that is really a renamed variable.
+        self::assertNotEmpty($matches, sprintf('Pattern %s matched nothing in %s.', $pattern, $relativePath));
+
+        return (int) $matches[1];
+    }
+
+    private function read(string $relativePath): string
+    {
+        // tests/Unit/Validator/BandSpace/TechRider -> project root
+        $path = \dirname(__DIR__, 5) . '/' . $relativePath;
+        self::assertFileExists($path);
+
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+}


### PR DESCRIPTION
Closes #773. The editor for a `patch_list` item: two grids, inputs and outputs, saved as one document through the endpoint added in #768.

It renders inside the rider item list rather than in a tab, so a rider can hold more than one and the band decides where each sits in the exported document.

## Saving

Explicit, never autosaved. A half typed row is a normal intermediate state in a grid, and the endpoint replaces the whole list, so an autosave mid edit would write nonsense.

A dirty bar appears once anything changes, with Sauvegarder and Annuler les modifications. Leaving the route, switching rider in the header selector, and closing the tab all ask first, because all three destroy the editor without warning and losing 24 typed rows is the worst thing this screen can do.

On a 422 the local rows stay exactly where they are and the message is attached to the offending row. That is the part worth stating plainly: the server validates the whole payload before deleting anything, so a refused save leaves the stored list untouched, and the screen has to show that rather than looking like the data went missing.

## The bug review caught, which browser testing had not

**A save landing while the user kept typing marked the new keystrokes as saved.** The payload was built before the request went out, correctly, but the "this is now clean" snapshot was taken *after* it came back, by re-reading the current rows. Anything typed during the round trip was folded into the baseline as though the server had confirmed it. The grid then read as clean, every guard in this PR stood down, and the edit was gone at the next navigation with no prompt.

Reproduced before fixing: typed row 1, hit save, typed row 2 while the request was in flight. Screen showed the row 2 edit, dirty bar gone, database had the old value. The snapshot is now captured before the await and applied unchanged afterwards, so an edit made during the round trip keeps the grid dirty until a save actually carries it. Same sequence after the fix leaves the warning up, and the second save writes both rows.

## Two more from review

**Violations are addressed by array index, so reordering after a 422 moved the red border onto an innocent row.** Errors are now cleared when the row set changes, and deliberately kept when only a field changes, which is what lets somebody fix one problem and still see the others.

**Switching band space changes only the id param**, so the route stays mounted and `onBeforeRouteLeave` never fires, while the watcher underneath clears the open rider and every editor with it. Added `onBeforeRouteUpdate`. No shipped UI reaches that path today, since every band switcher navigates to the dashboard, but it sits directly on the mechanism this PR is built around.

## Divergences from the issue

**Stacked grids, not two columns side by side.** Built it as asked, then measured at 1600px: the name field came out 65px and routing 85px, for fields that hold 120 and 180 characters. "KICK IN" rendered as "KICK". Stacked they are 259px and 336px. Outputs are only ever a handful of rows, so the vertical cost is small.

**A colour range dialog rather than shift click range selection.** Two selects reading `Ligne 3 (canal 5, SNARE)` plus a colour. No selection state to model, no counting rows, and it works from the keyboard, which shift click does not. Colouring rows 1 to 8 is one action either way.

## Duplication, and what pins it

The editor repeats the server's row cap and the three field lengths, so it can grey out Ajouter, show a count, and stop a long paste at the field instead of at a rejected save. `TechRiderPatchLimitsTest` parses the two Vue files and compares them to `TechRiderPatchRows`, the same approach the colour palette already uses. Mutation tested both ways: change either number on one side only and it fails.

## Verification

No JS test runner exists in this project, so this was verified by hand in the browser on the dev app.

Entered the reference rider's 24 input rows and 4 outputs, coloured rows 1 to 8 in one action through the range dialog, saved, and confirmed 28 rows in the database with positions following array order and blank microphones stored as NULL. Forced a duplicate channel: the server refused it, the message named the channel, all 24 local rows stayed, and the stored list was still intact with channel 5 present. Cancel restored the saved rows. Route leave prompted, dismissing kept the edit and stayed put, accepting left. Reorder by button then renumber produced 1 to 24 in display order. An archived rider renders read only: fields disabled, no toolbar, no save bar, colour select refuses to open. Light and dark, and 400px wide with no horizontal scroll and every field captioned. No console errors.

Suite **1881** green (1879 before, plus the two drift tests), Biome at its 44 info baseline, `npm run build` clean.

## Note for deploying

Adding a serialized property to an API resource needs the application cache pool cleared, not only `var/cache`. `patch_list` came back absent from the rider GET until `cache:pool:clear` ran, which is worth knowing when #768 and this go out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
