### PR TITLE
feat(M-774): stage plot editor with on-canvas handles and a full keyboard path

### DIFF
--- a/assets/js/api/bandSpace/band-space-tech-riders.js
+++ b/assets/js/api/bandSpace/band-space-tech-riders.js
@@ -123,6 +123,35 @@ export default {
       .catch(handleApiError)
   },
 
+  /**
+   * PUT, because the plot is replaced wholesale. Coordinates inside it are fractions of the stage
+   * box, never pixels, so the same numbers place the same items on any surface.
+   *
+   * Returns the updated item, whose `content` is the saved plot.
+   */
+  saveStagePlot(bandSpaceId, riderId, itemId, plot) {
+    return axios
+      .put(
+        Routing.generate('api_band_space_tech_rider_stage_plot_put', {
+          bandSpaceId,
+          riderId,
+          itemId
+        }),
+        { plot },
+        { headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' } }
+      )
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
+  /** Static application data, so it is fetched once and kept for the session. */
+  getStagePlotIcons() {
+    return axios
+      .get(Routing.generate('api_band_space_tech_rider_stage_plot_icons_get_collection'))
+      .then((resp) => resp.data.member ?? [])
+      .catch(handleApiError)
+  },
+
   reorderItems(bandSpaceId, riderId, positions) {
     return axios
       .post(

--- a/assets/js/components/BandSpace/TechRider/RiderItemList.vue
+++ b/assets/js/components/BandSpace/TechRider/RiderItemList.vue
@@ -140,6 +140,14 @@
           :read-only="readOnly"
           @save="handleSave"
         />
+        <RiderStagePlotEditor
+          v-else-if="item.type === 'stage_plot'"
+          :band-space-id="bandSpaceId"
+          :rider-id="riderId"
+          :item-id="item.id"
+          :content="item.content"
+          :read-only="readOnly"
+        />
         <RiderPatchListEditor
           v-else-if="item.type === 'patch_list'"
           :band-space-id="bandSpaceId"
@@ -214,6 +222,7 @@ import { useBandTechRidersStore } from '../../../store/bandSpace/bandSpaceTechRi
 import RiderContactsItemEditor from './RiderContactsItemEditor.vue'
 import RiderDocumentItemEditor from './RiderDocumentItemEditor.vue'
 import RiderPatchListEditor from './RiderPatchListEditor.vue'
+import RiderStagePlotEditor from './RiderStagePlotEditor.vue'
 import RiderTextItemEditor from './RiderTextItemEditor.vue'
 
 const props = defineProps({
@@ -237,7 +246,8 @@ const ITEM_TYPES = [
   { value: 'text', label: 'Texte libre' },
   { value: 'document', label: 'Document (image ou PDF)' },
   { value: 'patch_list', label: 'Patch list' },
-  { value: 'contacts', label: 'Membres et contacts' }
+  { value: 'contacts', label: 'Membres et contacts' },
+  { value: 'stage_plot', label: 'Plan de scène' }
 ]
 
 const newTitle = ref('')

--- a/assets/js/components/BandSpace/TechRider/RiderStagePlotEditor.vue
+++ b/assets/js/components/BandSpace/TechRider/RiderStagePlotEditor.vue
@@ -1,0 +1,412 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <Message v-if="globalError" severity="error" :closable="false">{{ globalError }}</Message>
+    <!-- Retryable, because without the catalogue there is nothing to place: a transient failure
+         would otherwise leave the editor useless until the whole page is reloaded. -->
+    <Message v-if="loadError" severity="error" :closable="false">
+      <div class="flex flex-wrap items-center justify-between gap-3 w-full">
+        <span>{{ loadError }}</span>
+        <Button
+          label="Réessayer"
+          icon="pi pi-refresh"
+          size="small"
+          :loading="isLoadingIcons"
+          @click="loadIcons"
+        />
+      </div>
+    </Message>
+
+    <div v-if="isLoadingIcons" class="py-8 flex justify-center">
+      <ProgressSpinner style="width: 2rem; height: 2rem" />
+    </div>
+
+    <div v-else class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_16rem] gap-4">
+      <div class="flex flex-col gap-3 min-w-0">
+        <div class="flex flex-wrap items-center gap-3">
+          <span class="text-xs text-surface-600 dark:text-surface-300">
+            {{ elements.length }} / {{ MAX_ELEMENTS }} éléments
+          </span>
+          <span class="flex-1" />
+          <label :for="`${uid}-ratio`" class="text-xs">Format de scène</label>
+          <Select
+            :id="`${uid}-ratio`"
+            :model-value="aspectRatio"
+            :options="ASPECT_RATIO_OPTIONS"
+            option-label="label"
+            option-value="value"
+            :disabled="readOnly"
+            size="small"
+            class="w-40"
+            @update:model-value="setAspectRatio"
+          />
+        </div>
+
+        <StagePlotCanvas
+          ref="canvasRef"
+          :elements="elements"
+          :aspect-ratio="aspectRatio"
+          :icons="icons"
+          :selected-id="selectedId"
+          :read-only="readOnly"
+          @select="(id) => (selectedId = id)"
+          @place="placeAt"
+          @edit-label="focusLabelFor"
+          @delete="removeElement"
+        />
+
+        <!-- The plot in words. A drawing conveys nothing to a screen reader, so the same
+             information exists as text rather than being locked inside the picture. -->
+        <details class="text-xs">
+          <summary class="cursor-pointer text-surface-600 dark:text-surface-300">
+            Description textuelle du plan ({{ elements.length }})
+          </summary>
+          <ul v-if="elements.length > 0" class="mt-2 flex flex-col gap-0.5">
+            <li v-for="element in elements" :key="element.id">{{ describeElement(element) }}</li>
+          </ul>
+          <p v-else class="mt-2 text-surface-600 dark:text-surface-300">La scène est vide.</p>
+        </details>
+      </div>
+
+      <div class="flex flex-col gap-4 min-w-0">
+        <StagePlotIconPicker :icons="icons" :read-only="readOnly" @place="placeInMiddle" />
+        <StagePlotElementInspector
+          :element="selectedElement"
+          :icons="icons"
+          :read-only="readOnly"
+          @update="updateElement"
+          @duplicate="duplicateElement"
+          @delete="removeElement"
+        />
+        <StagePlotLegendEditor
+          :legend="legend"
+          :icons="icons"
+          :read-only="readOnly"
+          @add="addLegendEntry"
+          @update="updateLegendEntry"
+          @remove="removeLegendEntry"
+        />
+      </div>
+    </div>
+
+    <!-- Explicit save. A drag crosses dozens of pixels, and autosaving would be a request per
+         one of them; the sections tab autosaves because typing has natural pauses. -->
+    <div
+      v-if="!readOnly && isDirty"
+      class="sticky bottom-0 flex flex-wrap items-center gap-3 p-3 rounded-lg border border-primary-200 dark:border-primary-800 bg-primary-50 dark:bg-primary-950"
+    >
+      <i class="pi pi-exclamation-circle text-primary" aria-hidden="true" />
+      <span class="text-sm">Modifications non enregistrées.</span>
+      <span class="flex-1" />
+      <Button
+        label="Annuler les modifications"
+        severity="secondary"
+        text
+        size="small"
+        :disabled="isSaving"
+        @click="seed"
+      />
+      <Button label="Sauvegarder" icon="pi pi-check" size="small" :loading="isSaving" @click="save" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import ProgressSpinner from 'primevue/progressspinner'
+import Select from 'primevue/select'
+import { useToast } from 'primevue/usetoast'
+import { computed, onBeforeUnmount, reactive, ref, useId, watch } from 'vue'
+import {
+  DEFAULT_ASPECT_RATIO,
+  describePosition,
+  MAX_ELEMENTS,
+  STAGE_PLOT_SCHEMA_VERSION,
+  snapFraction
+} from '../../../constants/stagePlot.js'
+import { useBandTechRidersStore } from '../../../store/bandSpace/bandSpaceTechRiders.js'
+import StagePlotCanvas from './StagePlot/StagePlotCanvas.vue'
+import StagePlotElementInspector from './StagePlot/StagePlotElementInspector.vue'
+import StagePlotIconPicker from './StagePlot/StagePlotIconPicker.vue'
+import StagePlotLegendEditor from './StagePlot/StagePlotLegendEditor.vue'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true },
+  riderId: { type: String, required: true },
+  itemId: { type: String, required: true },
+  /** The stored plot document, which is the item's `content`, or null on a fresh item. */
+  content: { type: Object, default: null },
+  readOnly: { type: Boolean, default: false }
+})
+
+const ASPECT_RATIO_OPTIONS = [
+  { value: 1.0, label: 'Carrée (1:1)' },
+  { value: 1.4, label: 'Standard (1.4:1)' },
+  { value: 1.78, label: 'Large (16:9)' },
+  { value: 2.4, label: 'Très large (2.4:1)' }
+]
+
+const techRidersStore = useBandTechRidersStore()
+const toast = useToast()
+
+const uid = useId()
+const canvasRef = ref(null)
+
+const elements = reactive([])
+const legend = reactive([])
+const aspectRatio = ref(DEFAULT_ASPECT_RATIO)
+const selectedId = ref(null)
+
+const isSaving = ref(false)
+const isLoadingIcons = ref(true)
+const globalError = ref(null)
+const loadError = ref(null)
+
+/**
+ * The last state the server confirmed, serialised. Comparing whole documents means no edit can be
+ * missed because somebody forgot to flag it, and a change that cancels itself out reads as clean.
+ */
+const savedSnapshot = ref('')
+let elementCounter = 0
+
+const icons = computed(() => techRidersStore.stagePlotIcons)
+const isDirty = computed(() => serialise() !== savedSnapshot.value)
+const selectedElement = computed(
+  () => elements.find((element) => element.id === selectedId.value) ?? null
+)
+
+/**
+ * The document as it will be stored. Keys are snake_case and coordinates are fractions, matching
+ * what the validator accepts; `undefined` never appears because JSON would drop it silently.
+ */
+function toPlot() {
+  return {
+    version: STAGE_PLOT_SCHEMA_VERSION,
+    stage: { aspect_ratio: aspectRatio.value },
+    elements: elements.map((element) => ({
+      id: element.id,
+      icon: element.icon,
+      x: element.x,
+      y: element.y,
+      scale: element.scale ?? 1,
+      rotation: element.rotation ?? 0,
+      label: element.label?.trim() ? element.label.trim() : null,
+      colour: element.colour ?? null
+    })),
+    legend: legend.map((entry) => ({
+      icon: entry.icon,
+      label: entry.label?.trim() ? entry.label.trim() : null
+    }))
+  }
+}
+
+function serialise() {
+  return JSON.stringify(toPlot())
+}
+
+function seed() {
+  const plot = props.content ?? {}
+  elements.splice(
+    0,
+    elements.length,
+    ...(plot.elements ?? []).map((element) => ({
+      id: element.id,
+      icon: element.icon,
+      x: element.x,
+      y: element.y,
+      scale: element.scale ?? 1,
+      rotation: element.rotation ?? 0,
+      label: element.label ?? '',
+      colour: element.colour ?? null
+    }))
+  )
+  legend.splice(0, legend.length, ...(plot.legend ?? []).map((entry) => ({ ...entry })))
+  aspectRatio.value = plot.stage?.aspect_ratio ?? DEFAULT_ASPECT_RATIO
+
+  // The selection survives a reseed when its element does. Clearing it unconditionally desynced
+  // selection from focus: the canvas only selects on a focus *event*, so an element that keeps
+  // focus across a cancel never re-emits, and the user ends up focused on an element whose
+  // inspector is empty and whose handles have vanished. Swapping items resolves to null on its
+  // own here, because none of the new ids match.
+  selectedId.value = elements.some((element) => element.id === selectedId.value)
+    ? selectedId.value
+    : null
+  globalError.value = null
+  savedSnapshot.value = serialise()
+}
+
+function describeElement(element) {
+  const name =
+    element.label || icons.value.find((icon) => icon.slug === element.icon)?.label || element.icon
+
+  return `${name}, ${describePosition(element.x, element.y)}`
+}
+
+/**
+ * Ids are generated client side and stored, unlike the patch list's, because the plot correlates
+ * an element with the selection and with the legend. Prefixed with the item so two editors open at
+ * once cannot mint the same one.
+ */
+function nextElementId() {
+  return `${props.itemId.slice(0, 8)}-${Date.now().toString(36)}-${elementCounter++}`
+}
+
+function addElement(slug, x, y) {
+  if (elements.length >= MAX_ELEMENTS) {
+    globalError.value = `Un plan de scène ne peut pas dépasser ${MAX_ELEMENTS} éléments.`
+
+    return null
+  }
+
+  const element = {
+    id: nextElementId(),
+    icon: slug,
+    x,
+    y,
+    scale: 1,
+    rotation: 0,
+    // Defaulted to the icon's French name so an unlabelled plot still reads, rather than a
+    // placeholder that says nothing on a printed page.
+    label: icons.value.find((icon) => icon.slug === slug)?.label ?? '',
+    colour: null
+  }
+  elements.push(element)
+  selectedId.value = element.id
+  globalError.value = null
+
+  return element
+}
+
+function placeAt({ slug, x, y }) {
+  const element = addElement(slug, x, y)
+  if (element) focusElement(element.id)
+}
+
+/**
+ * The keyboard placement path: the middle of the stage, then move it with the arrows. Landing in a
+ * fixed spot is deliberate, because a pointerless user has no cursor position to place at.
+ */
+function placeInMiddle(slug) {
+  const element = addElement(slug, snapFraction(0.5), snapFraction(0.5))
+  if (element) focusElement(element.id)
+}
+
+function focusElement(id) {
+  // Focus moves to the new element so the arrows act on it immediately, with no click needed.
+  requestAnimationFrame(() => canvasRef.value?.focusElement(id))
+}
+
+function updateElement({ id, ...patch }) {
+  const element = elements.find((candidate) => candidate.id === id)
+  if (element) Object.assign(element, patch)
+}
+
+function duplicateElement(id) {
+  const source = elements.find((element) => element.id === id)
+  if (!source) return
+
+  // Offset, so the copy is visible instead of sitting exactly on top of the original.
+  const copy = addElement(source.icon, snapFraction(source.x + 0.05), snapFraction(source.y + 0.05))
+  if (!copy) return
+
+  Object.assign(copy, {
+    scale: source.scale,
+    rotation: source.rotation,
+    label: source.label,
+    colour: source.colour
+  })
+  focusElement(copy.id)
+}
+
+function removeElement(id) {
+  const index = elements.findIndex((element) => element.id === id)
+  if (index === -1) return
+
+  elements.splice(index, 1)
+  if (selectedId.value === id) selectedId.value = null
+}
+
+/** A double click or Enter on the canvas sends the user to the label field rather than editing inline. */
+function focusLabelFor(id) {
+  selectedId.value = id
+  requestAnimationFrame(() => {
+    document.getElementById(`${uid}-label`)?.focus()
+  })
+}
+
+function setAspectRatio(value) {
+  aspectRatio.value = value
+}
+
+function addLegendEntry(entry) {
+  legend.push(entry)
+}
+
+function updateLegendEntry({ index, label }) {
+  if (legend[index]) legend[index].label = label
+}
+
+function removeLegendEntry(index) {
+  legend.splice(index, 1)
+}
+
+async function save() {
+  globalError.value = null
+
+  // Captured before the request, and applied unchanged afterwards. Re-serialising after the await
+  // would fold anything dragged during the round trip into the saved baseline as though the server
+  // had confirmed it, and every unsaved-changes guard would then stand down.
+  const plot = toPlot()
+  const sentSnapshot = JSON.stringify(plot)
+
+  isSaving.value = true
+  try {
+    await techRidersStore.saveStagePlot(props.bandSpaceId, props.riderId, props.itemId, plot)
+    savedSnapshot.value = sentSnapshot
+    toast.add({ severity: 'success', summary: 'Plan de scène enregistré', life: 2500 })
+  } catch (e) {
+    // The server's own message, so a rule the editor does not mirror still reaches the user.
+    globalError.value = e.isValidationError
+      ? (e.violations ?? []).map((violation) => violation.message).join('. ')
+      : e.message
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function loadIcons() {
+  isLoadingIcons.value = true
+  loadError.value = null
+  try {
+    await techRidersStore.loadStagePlotIcons()
+  } catch (e) {
+    loadError.value = `Les icônes n'ont pas pu être chargées : ${e.message}`
+  } finally {
+    isLoadingIcons.value = false
+  }
+}
+
+// Seeded before the watchers exist: an empty snapshot compares unequal to an empty document, so a
+// watcher created first would report a brand new editor as dirty and the page would ask about
+// unsaved changes the moment it loaded.
+seed()
+
+watch(isDirty, (dirty) => techRidersStore.setItemDirty(props.itemId, dirty))
+
+// Reseeds when a save elsewhere replaces the rider, guarded on dirtiness so an in-flight edit is
+// never overwritten by a refresh.
+watch(
+  () => props.content,
+  () => {
+    if (!isDirty.value) seed()
+  }
+)
+
+watch(() => props.itemId, seed)
+
+// An unmounted editor holds no edits, so leaving the flag set would make the guard warn about
+// changes that no longer exist anywhere.
+onBeforeUnmount(() => techRidersStore.setItemDirty(props.itemId, false))
+
+loadIcons()
+</script>

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
@@ -1,0 +1,376 @@
+<template>
+  <div class="flex flex-col gap-1 min-w-0">
+    <!-- The stage box. Aspect ratio drives the height so the shape is the same at any width, which
+         is what makes the stored fractions mean the same thing on a phone and on an A4 page. -->
+    <div
+      ref="stageRef"
+      class="relative w-full rounded-lg border-2 border-surface-300 dark:border-surface-600 bg-surface-50 dark:bg-surface-900 overflow-hidden select-none"
+      :style="{ aspectRatio: String(aspectRatio), backgroundImage: gridImage, backgroundSize: gridSize }"
+      role="application"
+      :aria-label="`Plan de scène, ${elements.length} éléments. Utilisez Tab pour parcourir les éléments et les flèches pour les déplacer.`"
+      @pointerdown="handleStagePointerDown"
+      @dragover.prevent
+      @drop.prevent="handleDrop"
+    >
+      <!-- The wrapper is sized in stage percentages, and the icon fills it. Sizing the icon itself
+           in percent does not work: its containing block is this wrapper, not the stage, so the
+           percentage resolved against a shrink-to-fit width and left the box as wide as the label
+           with a collapsed icon inside it. -->
+      <div
+        v-for="element in elements"
+        :key="element.id"
+        :ref="(el) => registerElement(element.id, el)"
+        class="absolute -translate-x-1/2 -translate-y-1/2 rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+        :class="[
+          element.id === selectedId ? 'ring-2 ring-primary-500' : '',
+          readOnly ? '' : 'cursor-move'
+        ]"
+        :style="{
+          left: `${element.x * 100}%`,
+          top: `${element.y * 100}%`,
+          width: `${BASE_ICON_PERCENT * (element.scale ?? 1)}%`,
+          minWidth: '20px'
+        }"
+        :tabindex="readOnly ? -1 : 0"
+        role="button"
+        :aria-label="describeElement(element)"
+        :aria-pressed="element.id === selectedId"
+        @pointerdown.stop="handleElementPointerDown($event, element)"
+        @keydown="handleElementKeydown($event, element)"
+        @focus="emit('select', element.id)"
+        @dblclick.stop="emit('edit-label', element.id)"
+      >
+        <img
+          :src="iconImage(element.icon)"
+          :alt="''"
+          class="pointer-events-none w-full block"
+          :style="{ transform: `rotate(${element.rotation ?? 0}deg)` }"
+        />
+
+        <!-- Real text, not painted into a bitmap: selectable, sharp at any size, and the thing
+             that carries the meaning when colour cannot. Taken out of the flow so a long label
+             cannot widen the box, which is what the selection ring wraps. -->
+        <span
+          v-if="element.label"
+          class="absolute top-full left-1/2 -translate-x-1/2 mt-0.5 text-[10px] leading-tight px-1 rounded bg-surface-0/80 dark:bg-surface-950/80 whitespace-nowrap pointer-events-none"
+          :style="element.colour ? { color: colourHex(element.colour) } : undefined"
+        >
+          {{ element.label }}
+        </span>
+
+        <!-- Handles on the selected element only, so the stage is not covered in furniture. Both
+             duplicate a control in the inspector rather than replacing it: this is the direct
+             manipulation shortcut, the panel is the accessible and precise path. -->
+        <template v-if="!readOnly && element.id === selectedId">
+          <button
+            type="button"
+            class="absolute -top-2 -right-2 w-4 h-4 flex items-center justify-center rounded-full bg-primary text-primary-contrast shadow focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary-500"
+            :aria-label="`Faire pivoter ${describeElement(element)}, actuellement ${element.rotation ?? 0} degrés`"
+            v-tooltip.top="'Pivoter d\'un quart de tour'"
+            @pointerdown.stop
+            @click.stop="rotateElement(element)"
+          >
+            <i class="pi pi-refresh text-[8px]" aria-hidden="true" />
+          </button>
+
+          <!-- A drag grip, so aria-hidden: a pointer-only gesture has no keyboard meaning, and the
+               inspector's slider is the equivalent that does. -->
+          <span
+            class="absolute -bottom-1.5 -right-1.5 w-3 h-3 rounded-sm bg-primary border border-surface-0 dark:border-surface-950 cursor-nwse-resize"
+            aria-hidden="true"
+            @pointerdown.stop="handleScalePointerDown($event, element)"
+          />
+        </template>
+      </div>
+
+      <!-- The audience side. Everything on a rider is described relative to it, so an unlabelled
+           box is ambiguous. -->
+      <div
+        class="absolute inset-x-0 bottom-0 h-5 flex items-center justify-center bg-surface-200/80 dark:bg-surface-800/80 text-[10px] uppercase tracking-wider text-surface-700 dark:text-surface-200"
+      >
+        Face public
+      </div>
+    </div>
+
+    <p class="text-xs text-surface-600 dark:text-surface-300">
+      Glissez une icône depuis la liste, ou sélectionnez-la et appuyez sur Entrée. Flèches pour
+      déplacer, Maj + flèches pour aller plus vite, Alt + flèches pour un réglage fin, Alt pendant
+      un déplacement à la souris pour ignorer la grille, Suppr pour retirer. Sur l'élément
+      sélectionné, la poignée en bas à droite règle la taille et le bouton en haut à droite le fait
+      pivoter.
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import {
+  COARSE_NUDGE_STEP,
+  describePosition,
+  FINE_NUDGE_STEP,
+  MAX_SCALE,
+  MIN_SCALE,
+  NUDGE_STEP,
+  ROTATIONS,
+  SCALE_STEP,
+  SNAP_STEP,
+  snapFraction,
+  toFraction
+} from '../../../../constants/stagePlot.js'
+import { TECH_RIDER_COLOURS } from '../../../../constants/techRiderColours.js'
+
+const props = defineProps({
+  /** Mutated in place: the parent owns the plot so it can diff the whole document at once. */
+  elements: { type: Array, required: true },
+  aspectRatio: { type: Number, required: true },
+  /** The catalogue, for resolving an icon slug to its image and French label. */
+  icons: { type: Array, default: () => [] },
+  selectedId: { type: String, default: null },
+  readOnly: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['select', 'place', 'edit-label', 'delete'])
+
+/**
+ * An icon's width as a percentage of the stage at scale 1. A percentage rather than pixels so an
+ * icon keeps its size relative to the stage at any viewport width, the same reason positions are
+ * fractions.
+ */
+const BASE_ICON_PERCENT = 6
+
+const stageRef = ref(null)
+const elementRefs = new Map()
+
+let drag = null
+let scaleDrag = null
+
+const gridImage = computed(() => {
+  // Drawn with a gradient rather than an SVG asset: it is two lines, and this way it inherits the
+  // theme's border colour instead of shipping a light and a dark image.
+  const line = 'color-mix(in srgb, currentColor 12%, transparent)'
+  return `linear-gradient(to right, ${line} 1px, transparent 1px), linear-gradient(to bottom, ${line} 1px, transparent 1px)`
+})
+
+const gridSize = computed(() => `${SNAP_STEP * 4 * 100}% ${SNAP_STEP * 4 * 100}%`)
+
+function registerElement(id, el) {
+  if (el) {
+    elementRefs.set(id, el)
+  } else {
+    elementRefs.delete(id)
+  }
+}
+
+function iconFor(slug) {
+  return props.icons.find((icon) => icon.slug === slug) ?? null
+}
+
+function iconImage(slug) {
+  return iconFor(slug)?.image_url ?? ''
+}
+
+function colourHex(value) {
+  return TECH_RIDER_COLOURS.find((colour) => colour.value === value)?.hex
+}
+
+/**
+ * What a screen reader hears. The position is words rather than numbers because "0.42, 0.55" says
+ * nothing, and this is the only description of the drawing a non-sighted user gets.
+ */
+function describeElement(element) {
+  const name = element.label || iconFor(element.icon)?.label || element.icon
+  return `${name}, ${describePosition(element.x, element.y)}`
+}
+
+/** Where a pointer sits inside the stage, as fractions. */
+function stageFractions(event) {
+  const box = stageRef.value.getBoundingClientRect()
+  return {
+    x: toFraction((event.clientX - box.left) / box.width),
+    y: toFraction((event.clientY - box.top) / box.height)
+  }
+}
+
+// Alt places freely; without it everything lands on the grid, because a plot where nothing lines
+// up looks careless on a printed page.
+function applySnap(value, event) {
+  return event.altKey ? toFraction(value) : snapFraction(value)
+}
+
+function handleStagePointerDown() {
+  if (props.readOnly) return
+  emit('select', null)
+}
+
+function handleElementPointerDown(event, element) {
+  if (props.readOnly || event.button !== 0) return
+  // One drag at a time. A second pointer starting on another element would overwrite this state,
+  // freezing the first element and leaving its stage listeners attached but inert.
+  if (drag || scaleDrag) return
+
+  emit('select', element.id)
+  const start = stageFractions(event)
+  drag = {
+    element,
+    offsetX: element.x - start.x,
+    offsetY: element.y - start.y,
+    pointerId: event.pointerId
+  }
+
+  // Captured on the stage, so a fast drag that outruns the pointer keeps moving the element
+  // instead of dropping it the moment the cursor leaves the icon.
+  stageRef.value.setPointerCapture(event.pointerId)
+  stageRef.value.addEventListener('pointermove', handlePointerMove)
+  stageRef.value.addEventListener('pointerup', handlePointerUp)
+  stageRef.value.addEventListener('pointercancel', handlePointerUp)
+}
+
+function handlePointerMove(event) {
+  if (!drag || event.pointerId !== drag.pointerId) return
+
+  const position = stageFractions(event)
+  drag.element.x = applySnap(position.x + drag.offsetX, event)
+  drag.element.y = applySnap(position.y + drag.offsetY, event)
+}
+
+function handlePointerUp(event) {
+  if (!drag || event.pointerId !== drag.pointerId) return
+
+  const id = drag.element.id
+  drag = null
+
+  stageRef.value.releasePointerCapture(event.pointerId)
+  stageRef.value.removeEventListener('pointermove', handlePointerMove)
+  stageRef.value.removeEventListener('pointerup', handlePointerUp)
+  stageRef.value.removeEventListener('pointercancel', handlePointerUp)
+
+  // No change event to emit: the parent's dirty state is computed from the same reactive elements
+  // this mutates, so it already knows. Focus follows the drag so the arrows act on what moved.
+  elementRefs.get(id)?.focus()
+}
+
+/** Quarter turns cycle, because those are the only values the model accepts. */
+function rotateElement(element) {
+  const current = element.rotation ?? 0
+  element.rotation = ROTATIONS[(ROTATIONS.indexOf(current) + 1) % ROTATIONS.length]
+}
+
+/**
+ * Scaling by drag, measured as the distance from the element's centre against where the grip
+ * started. Absolute ratio rather than incremental deltas, so the size never drifts away from the
+ * pointer over a long drag.
+ */
+function handleScalePointerDown(event, element) {
+  if (props.readOnly || drag || scaleDrag) return
+
+  const box = stageRef.value.getBoundingClientRect()
+  const centre = {
+    x: box.left + box.width * element.x,
+    y: box.top + box.height * element.y
+  }
+  const startDistance = Math.hypot(event.clientX - centre.x, event.clientY - centre.y)
+  if (startDistance < 1) return
+
+  scaleDrag = {
+    element,
+    centre,
+    startDistance,
+    startScale: element.scale ?? 1,
+    pointerId: event.pointerId
+  }
+
+  stageRef.value.setPointerCapture(event.pointerId)
+  stageRef.value.addEventListener('pointermove', handleScalePointerMove)
+  stageRef.value.addEventListener('pointerup', handleScalePointerUp)
+  stageRef.value.addEventListener('pointercancel', handleScalePointerUp)
+}
+
+function handleScalePointerMove(event) {
+  if (!scaleDrag || event.pointerId !== scaleDrag.pointerId) return
+
+  const distance = Math.hypot(
+    event.clientX - scaleDrag.centre.x,
+    event.clientY - scaleDrag.centre.y
+  )
+  const next = (scaleDrag.startScale * distance) / scaleDrag.startDistance
+
+  // Clamped and stepped to what the inspector's slider offers, so dragging cannot produce a value
+  // the panel is then unable to show or the server would refuse.
+  scaleDrag.element.scale = Math.min(
+    MAX_SCALE,
+    Math.max(MIN_SCALE, Math.round(next / SCALE_STEP) * SCALE_STEP)
+  )
+}
+
+function handleScalePointerUp(event) {
+  if (!scaleDrag || event.pointerId !== scaleDrag.pointerId) return
+
+  const id = scaleDrag.element.id
+  scaleDrag = null
+
+  stageRef.value.releasePointerCapture(event.pointerId)
+  stageRef.value.removeEventListener('pointermove', handleScalePointerMove)
+  stageRef.value.removeEventListener('pointerup', handleScalePointerUp)
+  stageRef.value.removeEventListener('pointercancel', handleScalePointerUp)
+
+  elementRefs.get(id)?.focus()
+}
+
+/** Drop target for the picker's drag placement. */
+function handleDrop(event) {
+  if (props.readOnly) return
+
+  const slug = event.dataTransfer?.getData('text/plain')
+  if (!slug) return
+
+  const position = stageFractions(event)
+  emit('place', { slug, x: applySnap(position.x, event), y: applySnap(position.y, event) })
+}
+
+/**
+ * The keyboard half of every pointer gesture. A canvas that only responds to dragging is unusable
+ * without a mouse, which #688 treated as a defect elsewhere in the app.
+ */
+function handleElementKeydown(event, element) {
+  if (props.readOnly) return
+
+  if (event.key === 'Delete' || event.key === 'Backspace') {
+    event.preventDefault()
+    emit('delete', element.id)
+
+    return
+  }
+
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    emit('edit-label', element.id)
+
+    return
+  }
+
+  // Alt for fine, Shift for coarse, plain for one grid step: the same three modes the pointer has.
+  const step = event.altKey ? FINE_NUDGE_STEP : event.shiftKey ? COARSE_NUDGE_STEP : NUDGE_STEP
+  const moves = {
+    ArrowLeft: [-step, 0],
+    ArrowRight: [step, 0],
+    ArrowUp: [0, -step],
+    ArrowDown: [0, step]
+  }
+  const move = moves[event.key]
+  if (!move) return
+
+  event.preventDefault()
+  // Re-snapped on the grid steps, so repeated presses cannot accumulate a fractional offset that
+  // leaves the element permanently a hair off the line.
+  const place = event.altKey ? toFraction : snapFraction
+  element.x = place(element.x + move[0])
+  element.y = place(element.y + move[1])
+}
+
+defineExpose({
+  /** Lets the parent put focus on an element it just created, so arrows work immediately. */
+  focusElement(id) {
+    elementRefs.get(id)?.focus()
+  }
+})
+</script>

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotElementInspector.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotElementInspector.vue
@@ -1,0 +1,177 @@
+<template>
+  <section class="flex flex-col gap-2 min-w-0" aria-label="Élément sélectionné">
+    <h4 class="font-semibold text-sm">Élément</h4>
+
+    <p v-if="!element" class="text-xs text-surface-600 dark:text-surface-300 py-2">
+      Sélectionnez un élément sur la scène pour le modifier.
+    </p>
+
+    <template v-else>
+      <p class="text-xs text-surface-600 dark:text-surface-300">
+        {{ iconLabel }} &middot; {{ describePosition(element.x, element.y) }}
+      </p>
+
+      <div>
+        <label :for="`${uid}-label`" class="block text-xs font-medium mb-1">Libellé</label>
+        <InputText
+          :id="`${uid}-label`"
+          :model-value="element.label ?? ''"
+          :disabled="readOnly"
+          :maxlength="MAX_LABEL_LENGTH"
+          class="w-full"
+          size="small"
+          @update:model-value="(value) => update({ label: value })"
+        />
+      </div>
+
+      <div>
+        <label :for="`${uid}-colour`" class="block text-xs font-medium mb-1">Couleur</label>
+        <Select
+          :id="`${uid}-colour`"
+          :model-value="element.colour ?? null"
+          :options="colourOptions"
+          option-label="label"
+          option-value="value"
+          :disabled="readOnly"
+          class="w-full"
+          size="small"
+          @update:model-value="(value) => update({ colour: value })"
+        >
+          <!-- The swatch never travels alone: the name is what carries the meaning if the colour
+               cannot be seen, and the element's label is what carries it on the stage itself. -->
+          <template #value="{ value }">
+            <span class="flex items-center gap-2">
+              <span
+                class="w-3 h-3 rounded-sm border border-surface-300 dark:border-surface-600 shrink-0"
+                :style="{ backgroundColor: hexFor(value) ?? 'transparent' }"
+                aria-hidden="true"
+              />
+              <span class="truncate">{{ labelFor(value) }}</span>
+            </span>
+          </template>
+          <template #option="{ option }">
+            <span class="flex items-center gap-2">
+              <span
+                class="w-3 h-3 rounded-sm border border-surface-300 dark:border-surface-600 shrink-0"
+                :style="{ backgroundColor: option.hex ?? 'transparent' }"
+                aria-hidden="true"
+              />
+              <span>{{ option.label }}</span>
+            </span>
+          </template>
+        </Select>
+      </div>
+
+      <div>
+        <label :for="`${uid}-scale`" class="block text-xs font-medium mb-1">
+          Taille ({{ (element.scale ?? 1).toFixed(2) }})
+        </label>
+        <Slider
+          :id="`${uid}-scale`"
+          :model-value="element.scale ?? 1"
+          :min="MIN_SCALE"
+          :max="MAX_SCALE"
+          :step="SCALE_STEP"
+          :disabled="readOnly"
+          class="w-full"
+          :aria-label="`Taille de ${iconLabel}`"
+          @update:model-value="(value) => update({ scale: value })"
+        />
+      </div>
+
+      <div>
+        <span class="block text-xs font-medium mb-1">Rotation</span>
+        <!-- Quarter turns only, because that is what the model accepts and what every export
+             engine can render. Buttons rather than a free input for the same reason. -->
+        <div class="flex gap-1" role="group" aria-label="Rotation">
+          <Button
+            v-for="rotation in ROTATIONS"
+            :key="rotation"
+            :label="`${rotation}°`"
+            size="small"
+            :severity="(element.rotation ?? 0) === rotation ? 'primary' : 'secondary'"
+            :outlined="(element.rotation ?? 0) !== rotation"
+            text
+            :disabled="readOnly"
+            :aria-pressed="(element.rotation ?? 0) === rotation"
+            @click="update({ rotation })"
+          />
+        </div>
+      </div>
+
+      <div v-if="!readOnly" class="flex gap-1 pt-1">
+        <Button
+          label="Dupliquer"
+          icon="pi pi-copy"
+          severity="secondary"
+          outlined
+          size="small"
+          :aria-label="`Dupliquer ${iconLabel}`"
+          @click="emit('duplicate', element.id)"
+        />
+        <Button
+          label="Retirer"
+          icon="pi pi-trash"
+          severity="danger"
+          outlined
+          size="small"
+          :aria-label="`Retirer ${iconLabel}`"
+          @click="emit('delete', element.id)"
+        />
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
+import Slider from 'primevue/slider'
+import { computed, useId } from 'vue'
+import {
+  describePosition,
+  MAX_LABEL_LENGTH,
+  MAX_SCALE,
+  MIN_SCALE,
+  ROTATIONS,
+  SCALE_STEP
+} from '../../../../constants/stagePlot.js'
+import { TECH_RIDER_COLOURS } from '../../../../constants/techRiderColours.js'
+
+const props = defineProps({
+  element: { type: Object, default: null },
+  icons: { type: Array, default: () => [] },
+  readOnly: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['update', 'duplicate', 'delete'])
+
+const uid = useId()
+
+const colourOptions = [
+  { value: null, label: 'Aucune', hex: null },
+  ...TECH_RIDER_COLOURS.map((colour) => ({
+    value: colour.value,
+    label: colour.label,
+    hex: colour.hex
+  }))
+]
+
+const iconLabel = computed(() => {
+  const slug = props.element?.icon
+  return props.icons.find((icon) => icon.slug === slug)?.label ?? slug ?? ''
+})
+
+function hexFor(value) {
+  return colourOptions.find((option) => option.value === value)?.hex ?? null
+}
+
+function labelFor(value) {
+  return colourOptions.find((option) => option.value === value)?.label ?? 'Aucune'
+}
+
+function update(patch) {
+  emit('update', { id: props.element.id, ...patch })
+}
+</script>

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotIconPicker.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotIconPicker.vue
@@ -1,0 +1,99 @@
+<template>
+  <section class="flex flex-col gap-2 min-w-0" aria-label="Icônes disponibles">
+    <h4 class="font-semibold text-sm">Icônes</h4>
+
+    <InputText
+      v-model="query"
+      class="w-full"
+      size="small"
+      placeholder="Rechercher..."
+      aria-label="Rechercher une icône"
+    />
+
+    <div class="flex flex-wrap gap-1">
+      <Button
+        v-for="category in categories"
+        :key="category.value ?? 'all'"
+        :label="category.label"
+        size="small"
+        :severity="activeCategory === category.value ? 'primary' : 'secondary'"
+        :outlined="activeCategory !== category.value"
+        text
+        :aria-pressed="activeCategory === category.value"
+        @click="activeCategory = category.value"
+      />
+    </div>
+
+    <p v-if="visibleIcons.length === 0" class="text-xs text-surface-600 dark:text-surface-300 py-2">
+      Aucune icône ne correspond.
+    </p>
+
+    <ul v-else class="grid grid-cols-3 gap-1 max-h-72 overflow-y-auto pr-1">
+      <li v-for="icon in visibleIcons" :key="icon.slug">
+        <!-- Both paths on one control: drag it, or focus it and press Enter. The keyboard path is
+             not a fallback, it is the only way to place an icon without a pointer. -->
+        <button
+          type="button"
+          class="w-full flex flex-col items-center gap-1 p-1 rounded border border-surface-200 dark:border-surface-700 hover:bg-surface-100 dark:hover:bg-surface-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          :draggable="!readOnly"
+          :disabled="readOnly"
+          :aria-label="`Placer ${icon.label} au centre de la scène`"
+          v-tooltip.top="icon.label"
+          @dragstart="handleDragStart($event, icon)"
+          @click="emit('place', icon.slug)"
+        >
+          <img :src="icon.image_url" :alt="''" class="w-8 h-8 object-contain" />
+          <span class="text-[10px] leading-tight text-center line-clamp-2">{{ icon.label }}</span>
+        </button>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  icons: { type: Array, default: () => [] },
+  readOnly: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['place'])
+
+const query = ref('')
+const activeCategory = ref(null)
+
+/**
+ * Derived from the catalogue rather than hardcoded, so an icon in a new category appears without a
+ * second edit here. Null is the "all" tab.
+ */
+const categories = computed(() => {
+  const seen = new Map()
+  for (const icon of props.icons) {
+    if (!seen.has(icon.category)) seen.set(icon.category, icon.category_label)
+  }
+
+  return [{ value: null, label: 'Tout' }, ...[...seen].map(([value, label]) => ({ value, label }))]
+})
+
+const visibleIcons = computed(() => {
+  const needle = query.value.trim().toLowerCase()
+
+  return props.icons.filter((icon) => {
+    if (activeCategory.value !== null && icon.category !== activeCategory.value) return false
+    if (needle === '') return true
+
+    // Matched on the slug too, so someone who knows the stored value finds it as easily as
+    // someone reading the French label.
+    return icon.label.toLowerCase().includes(needle) || icon.slug.includes(needle)
+  })
+})
+
+function handleDragStart(event, icon) {
+  if (props.readOnly) return
+  event.dataTransfer.setData('text/plain', icon.slug)
+  event.dataTransfer.effectAllowed = 'copy'
+}
+</script>

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotLegendEditor.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotLegendEditor.vue
@@ -1,0 +1,111 @@
+<template>
+  <section class="flex flex-col gap-2 min-w-0" aria-label="Légende">
+    <div class="flex items-center gap-2">
+      <h4 class="font-semibold text-sm">Légende</h4>
+      <span class="text-xs text-surface-600 dark:text-surface-300">
+        {{ legend.length }} / {{ MAX_LEGEND_ENTRIES }}
+      </span>
+    </div>
+
+    <!-- What makes a plot readable by somebody who was not in the room, which is the whole point of
+         sending it to a venue. -->
+    <p v-if="legend.length === 0" class="text-xs text-surface-600 dark:text-surface-300">
+      Associez une icône à un mot pour que la salle comprenne le plan sans explication.
+    </p>
+
+    <ul v-else class="flex flex-col gap-1">
+      <li v-for="(entry, index) in legend" :key="`${entry.icon}-${index}`" class="flex items-center gap-1">
+        <img :src="iconImage(entry.icon)" :alt="''" class="w-6 h-6 object-contain shrink-0" />
+        <InputText
+          :model-value="entry.label ?? ''"
+          :disabled="readOnly"
+          :maxlength="MAX_LABEL_LENGTH"
+          class="w-full"
+          size="small"
+          :aria-label="`Libellé de légende pour ${iconLabel(entry.icon)}`"
+          @update:model-value="(value) => emit('update', { index, label: value })"
+        />
+        <Button
+          v-if="!readOnly"
+          icon="pi pi-trash"
+          severity="danger"
+          text
+          rounded
+          size="small"
+          :aria-label="`Retirer ${iconLabel(entry.icon)} de la légende`"
+          v-tooltip.top="'Retirer'"
+          @click="emit('remove', index)"
+        />
+      </li>
+    </ul>
+
+    <div v-if="!readOnly && legend.length < MAX_LEGEND_ENTRIES" class="flex gap-1">
+      <Select
+        v-model="pendingIcon"
+        :options="icons"
+        option-label="label"
+        option-value="slug"
+        filter
+        class="w-full"
+        size="small"
+        placeholder="Ajouter une icône"
+        aria-label="Icône à ajouter à la légende"
+        empty-filter-message="Aucune icône trouvée"
+      >
+        <template #option="{ option }">
+          <span class="flex items-center gap-2">
+            <img :src="option.image_url" :alt="''" class="w-5 h-5 object-contain" />
+            <span>{{ option.label }}</span>
+          </span>
+        </template>
+      </Select>
+      <Button
+        label="Ajouter"
+        icon="pi pi-plus"
+        severity="secondary"
+        outlined
+        size="small"
+        :disabled="!pendingIcon"
+        @click="addPending"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import Select from 'primevue/select'
+import { ref } from 'vue'
+import { MAX_LABEL_LENGTH, MAX_LEGEND_ENTRIES } from '../../../../constants/stagePlot.js'
+
+const props = defineProps({
+  legend: { type: Array, required: true },
+  icons: { type: Array, default: () => [] },
+  readOnly: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['add', 'update', 'remove'])
+
+const pendingIcon = ref(null)
+
+function iconFor(slug) {
+  return props.icons.find((icon) => icon.slug === slug) ?? null
+}
+
+function iconImage(slug) {
+  return iconFor(slug)?.image_url ?? ''
+}
+
+function iconLabel(slug) {
+  return iconFor(slug)?.label ?? slug
+}
+
+function addPending() {
+  if (!pendingIcon.value) return
+  // Seeded with the icon's own French name, so a legend entry reads correctly before anybody
+  // types anything.
+  emit('add', { icon: pendingIcon.value, label: iconLabel(pendingIcon.value) })
+  pendingIcon.value = null
+}
+</script>

--- a/assets/js/constants/stagePlot.js
+++ b/assets/js/constants/stagePlot.js
@@ -1,0 +1,82 @@
+/**
+ * Shared vocabulary and limits for the stage plot editor.
+ *
+ * The numbers mirror `App\Validator\BandSpace\TechRider\TechRiderStagePlot`, so the editor can
+ * refuse an out-of-range value at the control rather than at a rejected save. They are pinned
+ * against the PHP constants by tests/Unit/Validator/BandSpace/TechRider/TechRiderStagePlotLimitsTest.php.
+ */
+export const STAGE_PLOT_SCHEMA_VERSION = 1
+
+export const MAX_ELEMENTS = 120
+export const MAX_LEGEND_ENTRIES = 20
+export const MAX_LABEL_LENGTH = 60
+
+export const MIN_SCALE = 0.25
+export const MAX_SCALE = 4.0
+
+/** The step the slider offers, which the on-canvas grip snaps to so the two agree. */
+export const SCALE_STEP = 0.25
+
+export const MIN_ASPECT_RATIO = 0.5
+export const MAX_ASPECT_RATIO = 3.0
+
+export const DEFAULT_ASPECT_RATIO = 1.4
+
+/** Quarter turns only, matching what the model accepts. */
+export const ROTATIONS = Object.freeze([0, 90, 180, 270])
+
+/**
+ * The snap grid, as a fraction of the stage. A plot where nothing lines up looks careless on a
+ * printed page, so snapping is the default and holding Alt places freely.
+ */
+export const SNAP_STEP = 0.025
+
+/**
+ * How far one arrow key press moves a selected element.
+ *
+ * Deliberately one grid step, not something smaller: a snapping editor whose keyboard path drifts
+ * off the grid produces exactly the misaligned page snapping exists to prevent. Holding Alt gives
+ * the fine step, mirroring how Alt frees a pointer drag from the grid, so the keyboard has the
+ * same three modes the pointer does.
+ */
+export const NUDGE_STEP = SNAP_STEP
+export const FINE_NUDGE_STEP = 0.005
+export const COARSE_NUDGE_STEP = 0.1
+
+const HORIZONTAL_BANDS = [
+  { limit: 1 / 3, label: 'à gauche' },
+  { limit: 2 / 3, label: 'au centre' },
+  { limit: Number.POSITIVE_INFINITY, label: 'à droite' }
+]
+
+// y grows downstage-to-upstage on screen: 0 is the back wall, 1 is the audience edge, which is
+// why "avant" is the high end rather than the low one.
+const VERTICAL_BANDS = [
+  { limit: 1 / 3, label: 'au fond' },
+  { limit: 2 / 3, label: 'au milieu' },
+  { limit: Number.POSITIVE_INFINITY, label: "à l'avant" }
+]
+
+function bandLabel(bands, value) {
+  return bands.find((band) => value < band.limit).label
+}
+
+/**
+ * Describes a position in words, for example "au fond au centre".
+ *
+ * One function, used by both an element's `aria-label` and the plot's text summary, so a screen
+ * reader is never told two different things about the same element. Coordinates are meaningless
+ * read aloud, and this is the only description a non-sighted user gets of a drawing.
+ */
+export function describePosition(x, y) {
+  return `${bandLabel(VERTICAL_BANDS, y)} ${bandLabel(HORIZONTAL_BANDS, x)}`
+}
+
+/** Rounded to the stored precision so a drag does not write fifteen decimal places. */
+export function toFraction(value) {
+  return Math.round(Math.min(1, Math.max(0, value)) * 1000) / 1000
+}
+
+export function snapFraction(value) {
+  return toFraction(Math.round(value / SNAP_STEP) * SNAP_STEP)
+}

--- a/assets/js/store/bandSpace/bandSpaceTechRiders.js
+++ b/assets/js/store/bandSpace/bandSpaceTechRiders.js
@@ -25,6 +25,9 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
   // Per item, not one counter: two items save independently and must not cancel each other.
   const contentRequestIds = new Map()
 
+  const stagePlotIcons = ref([])
+  let stagePlotIconsRequest = null
+
   async function fetchRiders(bandSpaceId) {
     if (bandSpaceId !== loadedBandSpaceId.value) {
       liveRiders.value = []
@@ -187,6 +190,33 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     setItemDirty(itemId, false)
   }
 
+  async function saveStagePlot(bandSpaceId, riderId, itemId, plot) {
+    replaceItem(await bandSpaceTechRidersApi.saveStagePlot(bandSpaceId, riderId, itemId, plot))
+    setItemDirty(itemId, false)
+  }
+
+  /**
+   * The icon catalogue is static application data, so it is fetched once per session and shared
+   * by every plot editor on the page. Concurrent callers await the same promise rather than each
+   * firing a request.
+   */
+  async function loadStagePlotIcons() {
+    if (stagePlotIcons.value.length > 0) return stagePlotIcons.value
+    stagePlotIconsRequest ??= bandSpaceTechRidersApi
+      .getStagePlotIcons()
+      .then((icons) => {
+        stagePlotIcons.value = icons
+        return icons
+      })
+      .catch((error) => {
+        // Cleared so a failed load can be retried rather than caching the rejection forever.
+        stagePlotIconsRequest = null
+        throw error
+      })
+
+    return stagePlotIconsRequest
+  }
+
   async function setItemIncluded(bandSpaceId, riderId, itemId, isIncluded) {
     replaceItem(
       await bandSpaceTechRidersApi.updateItem(bandSpaceId, riderId, itemId, {
@@ -304,6 +334,7 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     archivedRiders: readonly(archivedRiders),
     activeTechRider: readonly(activeTechRider),
     dirtyItemIds: readonly(dirtyItemIds),
+    stagePlotIcons: readonly(stagePlotIcons),
     isLoading: readonly(isLoading),
     isLoadingActive: readonly(isLoadingActive),
     loadError: readonly(loadError),
@@ -317,6 +348,8 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     renameItem,
     saveItemContent,
     savePatchList,
+    saveStagePlot,
+    loadStagePlotIcons,
     setItemFile,
     setItemIncluded,
     setItemDirty,

--- a/src/Enum/BandSpace/TechRiderItemType.php
+++ b/src/Enum/BandSpace/TechRiderItemType.php
@@ -10,9 +10,9 @@ namespace App\Enum\BandSpace;
  * to follow it. It also lets a rider carry two stage plots (a club setup and a festival one)
  * or two patch lists (electric and acoustic), which fixed pages could not express.
  *
- * Every type in the model now exists. A case is only added once something can render it, so the
- * picker never offers a type that produces a blank block: StagePlot is persisted here but is not
- * offered in the frontend picker until its editor lands (#774).
+ * Every type in the model exists and every one has an editor, so the picker offers all of them.
+ * A case is only added once something can render it: a type in the picker with no renderer would
+ * produce a block that displays nothing.
  */
 enum TechRiderItemType: string
 {

--- a/tests/Unit/Validator/BandSpace/TechRider/TechRiderStagePlotLimitsTest.php
+++ b/tests/Unit/Validator/BandSpace/TechRider/TechRiderStagePlotLimitsTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Validator\BandSpace\TechRider;
+
+use App\Validator\BandSpace\TechRider\TechRiderStagePlot;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The stage plot editor repeats the server's limits so a control can refuse a value where the user
+ * is looking rather than after a round trip: the element cap greys out placement, the scale range
+ * bounds a slider, the rotations fill a button group.
+ *
+ * Duplicated on purpose, for the same reason as the colour palette and the patch list limits: the
+ * numbers are PHP constants, so changing them is a deploy and the bundle rebuilds in the same
+ * deploy, which makes an endpoint pure overhead. Drift is the risk, and drift is what this pins.
+ */
+class TechRiderStagePlotLimitsTest extends TestCase
+{
+    private const string CONSTANTS_PATH = 'assets/js/constants/stagePlot.js';
+
+    /**
+     * @return array<string, int|float>
+     */
+    public static function expectedNumbers(): array
+    {
+        return [
+            'STAGE_PLOT_SCHEMA_VERSION' => TechRiderStagePlot::SCHEMA_VERSION,
+            'MAX_ELEMENTS' => TechRiderStagePlot::MAX_ELEMENTS,
+            'MAX_LEGEND_ENTRIES' => TechRiderStagePlot::MAX_LEGEND_ENTRIES,
+            'MAX_LABEL_LENGTH' => TechRiderStagePlot::MAX_LABEL_LENGTH,
+            'MIN_SCALE' => TechRiderStagePlot::MIN_SCALE,
+            'MAX_SCALE' => TechRiderStagePlot::MAX_SCALE,
+            'MIN_ASPECT_RATIO' => TechRiderStagePlot::MIN_ASPECT_RATIO,
+            'MAX_ASPECT_RATIO' => TechRiderStagePlot::MAX_ASPECT_RATIO,
+        ];
+    }
+
+    public function test_the_editor_limits_match_the_constraint(): void
+    {
+        $source = $this->read();
+
+        $found = [];
+        foreach (array_keys(self::expectedNumbers()) as $name) {
+            preg_match('/export const ' . $name . ' = ([0-9.]+)/', $source, $matches);
+            // Guards against a renamed export silently comparing against zero and reporting a
+            // drift that is really a rename.
+            self::assertNotEmpty($matches, sprintf('%s is not exported from %s.', $name, self::CONSTANTS_PATH));
+            $found[$name] = $matches[1] + 0;
+        }
+
+        $this->assertEquals(
+            self::expectedNumbers(),
+            $found,
+            sprintf('The stage plot limits have drifted. Update %s and %s together.', self::CONSTANTS_PATH, TechRiderStagePlot::class),
+        );
+    }
+
+    /**
+     * The editor offers rotations as a button group, so an extra entry there would be a button that
+     * saves and then fails validation.
+     */
+    public function test_the_editor_rotations_match_the_constraint(): void
+    {
+        preg_match('/export const ROTATIONS = Object\.freeze\(\[([^\]]+)]\)/', $this->read(), $matches);
+        self::assertNotEmpty($matches, sprintf('No ROTATIONS export found in %s.', self::CONSTANTS_PATH));
+
+        $rotations = array_map('intval', array_map('trim', explode(',', $matches[1])));
+
+        $this->assertSame(TechRiderStagePlot::ALLOWED_ROTATIONS, $rotations);
+    }
+
+    /** The default has to be inside the range the server accepts, or a new plot cannot be saved. */
+    public function test_the_default_aspect_ratio_is_within_range(): void
+    {
+        preg_match('/export const DEFAULT_ASPECT_RATIO = ([0-9.]+)/', $this->read(), $matches);
+        self::assertNotEmpty($matches);
+
+        $default = $matches[1] + 0;
+        $this->assertGreaterThanOrEqual(TechRiderStagePlot::MIN_ASPECT_RATIO, $default);
+        $this->assertLessThanOrEqual(TechRiderStagePlot::MAX_ASPECT_RATIO, $default);
+    }
+
+    /**
+     * Every ratio the editor offers has to be inside the range the server accepts, or a user picks
+     * one from a dropdown and the save is refused. Narrowing the range on the PHP side without
+     * pruning the list is the drift this catches.
+     */
+    public function test_every_offered_aspect_ratio_is_within_range(): void
+    {
+        preg_match_all(
+            '/\{ value: ([0-9.]+), label: /',
+            $this->readEditor(),
+            $matches,
+        );
+        self::assertNotEmpty($matches[1], 'No ASPECT_RATIO_OPTIONS entries were parsed.');
+
+        foreach ($matches[1] as $value) {
+            $ratio = $value + 0;
+            self::assertGreaterThanOrEqual(TechRiderStagePlot::MIN_ASPECT_RATIO, $ratio, (string) $value);
+            self::assertLessThanOrEqual(TechRiderStagePlot::MAX_ASPECT_RATIO, $ratio, (string) $value);
+        }
+    }
+
+    private function readEditor(): string
+    {
+        // tests/Unit/Validator/BandSpace/TechRider -> project root
+        $path = \dirname(__DIR__, 5) . '/assets/js/components/BandSpace/TechRider/RiderStagePlotEditor.vue';
+        self::assertFileExists($path);
+
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+
+    private function read(): string
+    {
+        // tests/Unit/Validator/BandSpace/TechRider -> project root
+        $path = \dirname(__DIR__, 5) . '/' . self::CONSTANTS_PATH;
+        self::assertFileExists($path);
+
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+}


### PR DESCRIPTION
Closes #774. The editor for a stage plot item: place icons on a stage, label them, build a legend.

## No canvas library, on purpose

Absolutely positioned DOM inside a relatively positioned stage box, moved with pointer events. No Konva, no Fabric.

The reason is the export. The stored document holds fractional coordinates, so any surface at any size places the same items from the same numbers. A canvas library pushes toward exporting a bitmap, which would make the exported document depend on a browser having generated an image and give us a second source of truth for what the plot says. Labels also stay real text: selectable, sharp at any size, and the thing that carries meaning when colour cannot.

Nothing anywhere stores a pixel. Verified by resizing the stage from 980px to 652px and re-measuring: elements still sit at exactly 0.5/0.25, 0.2/0.35, the aspect ratio holds, and **the resize does not mark the plot dirty**, which it would if pixels were involved.

## The editor

A stage box with an adjustable ratio, a subtle grid, and the audience side marked, because everything on a rider is described relative to it and an unlabelled box is ambiguous.

An icon picker fed by the catalogue endpoint from #769, with category tabs derived from the catalogue rather than hardcoded, and a search that matches the French label or the slug.

An inspector for the selected element: label, colour from the shared palette, size, quarter turn rotation, duplicate, delete. Plus **on-canvas handles** for rotation and size, added at review, each duplicating an inspector control rather than replacing it: the handle is the direct manipulation shortcut, the panel is the precise and accessible path.

A legend, because it is what makes a plot readable by somebody who was not in the room, which is the whole point of sending it to a venue. Entries are seeded with the icon's own French name so they read before anybody types.

Snapping to a coarse grid by default, with Alt to place freely.

## Accessibility

A drag-only canvas is unusable without a mouse, and #688 treated that pattern as a defect elsewhere in the app, so the keyboard path is not a fallback here.

Placing works without a pointer: focus an icon in the picker, press Enter, it lands centre stage. Elements are focusable and their `aria-label` describes position in words, because "0.42, 0.55" read aloud says nothing. Arrows move one grid step, Alt plus arrow gives a fine step, Shift plus arrow goes coarse, Delete removes, Enter edits the label. A collapsible summary lists every element as "Batterie, au fond au centre", so the drawing's information exists as text rather than being locked inside a picture.

The rotate handle is a real focusable button whose label tracks the current angle. The size grip is `aria-hidden`: a drag has no keyboard meaning, and the inspector's slider is the equivalent that does.

## Two bugs found and fixed during this work

**Icons were collapsing while their boxes stretched.** `width: N%` on the image resolved against the auto-width wrapper rather than the stage, and a percentage width inside a shrink-to-fit parent is circular, so the icon fell back to its minimum while the wrapper grew to fit the label. The selection ring wrapped that whole wide box. The wrapper now carries the percentage, the image fills it, and the label sits out of flow so a long name cannot widen what the ring wraps. Measured after: 59px, exactly 6 percent of a 980px stage, ring tight.

**Selection could desync from focus.** Selection is emitted from the canvas's focus handler, so clearing it in `seed()` left an element focused with an empty inspector and no handles until the user clicked away and back. Cancelling an edit now keeps the selection when its element survives; swapping items still clears it, because none of the new ids match.

## Review

No blockers. One important item and three smaller ones, all fixed.

**The icon catalogue had no retry.** A single failed fetch left the editor with nothing to place and no way back except reloading the page. Added a retry, and verified it by patching XHR to fail that request once: the error appears, one click recovers all 21 icons.

**A second pointer could freeze an element.** Two fingers starting a drag on two different elements overwrote the single drag state, leaving the first stuck and its stage listeners attached but inert. One drag at a time now.

**The aspect ratio dropdown was not pinned to the server's range**, only the default was, so narrowing the range on the PHP side would have turned a menu entry into a guaranteed 422. Now covered by the drift test.

**Arrow keys drifted off the snap grid.** Called cosmetic in review, and I disagree: snapping exists because a plot where nothing lines up looks careless on a printed page, and the keyboard path was producing exactly that. Plain arrows now move one grid step and re-snap, with Alt for the fine step, mirroring how Alt frees a pointer drag. The keyboard has the same three modes the pointer does.

## Verification

No JS test runner exists in this project, so this was verified by hand in a browser.

Rebuilt the reference rider's page V: 21 elements placed through the keyboard path, positioned, one renamed through the inspector, the four entry legend added, saved, reloaded **identical** and clean on load. Rotate handle cycles 0, 90, 180, 270 with the inspector staying in step. Size grip 59px to 117px, and dragging far past the limit clamps at scale 4 with the slider reading 4.00. An archived rider is read only: no tab stop, no handles, picker disabled, no legend add, no save bar. Light and dark. No console errors.

Suite **1954** green (1950 before), PHPStan level 8 clean, Biome at its 44 info baseline, `npm run build` clean. The JS limits are pinned to the PHP constraint by `TechRiderStagePlotLimitsTest`, mutation tested in both directions.

One gap worth naming: the browser tooling's drag helper sends HTML5 drag events, which this canvas uses only for picker drops, so the pointer move drag was exercised with synthetic pointer events against the real handler rather than genuine browser generated moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
