### PR TITLE
feat(M-775): duplicate a tech rider, deep copying every item type

### DIFF
--- a/assets/js/api/bandSpace/band-space-tech-riders.js
+++ b/assets/js/api/bandSpace/band-space-tech-riders.js
@@ -60,6 +60,21 @@ export default {
       .catch(handleApiError)
   },
 
+  /**
+   * Optional name: a rider is named for a year or a tour, so "Rider 2026 (copie)" is rarely what
+   * the band wanted. Omitting it takes that default.
+   */
+  duplicateTechRider(bandSpaceId, riderId, name = null) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_tech_riders_duplicate', { bandSpaceId, id: riderId }),
+        name === null ? {} : { name },
+        { headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' } }
+      )
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
   createItem(bandSpaceId, riderId, data) {
     return axios
       .post(

--- a/assets/js/components/BandSpace/Settings/activitySentences.js
+++ b/assets/js/components/BandSpace/Settings/activitySentences.js
@@ -152,6 +152,8 @@ const SENTENCES = {
   'rider.rider_renamed': (a) => `a renommé le tech rider en « ${a.payload?.name ?? '—'} »`,
   'rider.rider_archived': (a) => `a archivé le tech rider « ${a.payload?.name ?? '—'} »`,
   'rider.rider_unarchived': (a) => `a réintégré le tech rider « ${a.payload?.name ?? '—'} »`,
+  'rider.rider_duplicated': (a) =>
+    `a dupliqué le tech rider « ${a.payload?.source_name ?? '—'} » sous le nom « ${a.payload?.name ?? '—'} »`,
   'rider.rider_item_added': (a) =>
     `a ajouté l'élément « ${a.payload?.title ?? '—'} » au tech rider « ${a.payload?.rider_name ?? '—'} »`,
   'rider.rider_item_renamed': (a) =>

--- a/assets/js/components/BandSpace/TechRider/TechRiderFormDialog.vue
+++ b/assets/js/components/BandSpace/TechRider/TechRiderFormDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <Dialog
     v-model:visible="visible"
-    :header="isRename ? 'Renommer le tech rider' : 'Nouveau tech rider'"
+    :header="HEADERS[mode]"
     modal
     :style="{ width: '28rem' }"
     @hide="resetForm"
@@ -27,7 +27,7 @@
 
       <div class="flex justify-end gap-2 pt-2">
         <Button label="Annuler" severity="secondary" text type="button" @click="visible = false" />
-        <Button :label="isRename ? 'Renommer' : 'Créer'" type="submit" :loading="isSubmitting" />
+        <Button :label="SUBMIT_LABELS[mode]" type="submit" :loading="isSubmitting" />
       </div>
     </form>
   </Dialog>
@@ -43,6 +43,7 @@ import { useBandTechRidersStore } from '../../../store/bandSpace/bandSpaceTechRi
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
+  /** create, rename or duplicate. */
   mode: { type: String, default: 'create' },
   riderId: { type: String, default: null },
   initialName: { type: String, default: '' }
@@ -58,13 +59,33 @@ const name = ref('')
 const isSubmitting = ref(false)
 const violation = ref(null)
 
+const HEADERS = {
+  create: 'Nouveau tech rider',
+  rename: 'Renommer le tech rider',
+  duplicate: 'Dupliquer le tech rider'
+}
+
+const SUBMIT_LABELS = {
+  create: 'Créer',
+  rename: 'Renommer',
+  duplicate: 'Dupliquer'
+}
+
+const SUCCESS_SUMMARIES = {
+  create: 'Tech rider créé',
+  rename: 'Tech rider renommé',
+  duplicate: 'Tech rider dupliqué'
+}
+
 const isRename = computed(() => props.mode === 'rename')
+const isDuplicate = computed(() => props.mode === 'duplicate')
 
 watch(visible, (isOpen) => {
-  if (isOpen) {
-    name.value = isRename.value ? props.initialName : ''
-    violation.value = null
-  }
+  if (!isOpen) return
+  // Rename starts from the current name; duplicate starts from the caller's suggestion, which is
+  // the source name so the band edits a year rather than retyping the lot.
+  name.value = isRename.value || isDuplicate.value ? props.initialName : ''
+  violation.value = null
 })
 
 function resetForm() {
@@ -83,10 +104,12 @@ async function handleSubmit() {
   try {
     const saved = isRename.value
       ? await techRidersStore.renameTechRider(props.bandSpaceId, props.riderId, trimmed)
-      : await techRidersStore.createTechRider(props.bandSpaceId, trimmed)
+      : isDuplicate.value
+        ? await techRidersStore.duplicateTechRider(props.bandSpaceId, props.riderId, trimmed)
+        : await techRidersStore.createTechRider(props.bandSpaceId, trimmed)
     toast.add({
       severity: 'success',
-      summary: isRename.value ? 'Tech rider renommé' : 'Tech rider créé',
+      summary: SUCCESS_SUMMARIES[props.mode],
       life: 3000
     })
     emit('saved', saved)

--- a/assets/js/constants/techRider.js
+++ b/assets/js/constants/techRider.js
@@ -1,0 +1,11 @@
+/**
+ * Mirrors `App\Procedure\BandSpace\TechRiderDuplicateProcedure`, whose constants these are.
+ *
+ * Duplicated because the duplicate dialog proposes a name in its field rather than letting the
+ * server apply its default, so the client has to do the same arithmetic or offer a name the server
+ * will refuse. Pinned against the PHP by
+ * tests/Unit/Procedure/BandSpace/TechRiderDuplicateNameLimitsTest.php.
+ */
+export const MAX_NAME_LENGTH = 255
+
+export const COPY_SUFFIX = ' (copie)'

--- a/assets/js/store/bandSpace/bandSpaceTechRiders.js
+++ b/assets/js/store/bandSpace/bandSpaceTechRiders.js
@@ -130,6 +130,17 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
   }
 
   /**
+   * The copy is always live, even from an archived source, so it joins the live list regardless of
+   * which list the original was in.
+   */
+  async function duplicateTechRider(bandSpaceId, riderId, name = null) {
+    const created = await bandSpaceTechRidersApi.duplicateTechRider(bandSpaceId, riderId, name)
+    liveRiders.value = [created, ...liveRiders.value]
+
+    return created
+  }
+
+  /**
    * Items live on activeTechRider and every mutation returns the updated rider, so the
    * open document stays the single source the editor renders from.
    */
@@ -344,6 +355,7 @@ export const useBandTechRidersStore = defineStore('bandTechRiders', () => {
     renameTechRider,
     archiveTechRider,
     unarchiveTechRider,
+    duplicateTechRider,
     createItem,
     renameItem,
     saveItemContent,

--- a/assets/js/views/BandSpace/TechRider.vue
+++ b/assets/js/views/BandSpace/TechRider.vue
@@ -51,21 +51,32 @@
             @create="openCreateDialog"
           />
         </div>
-        <div v-if="rider && !isArchived" class="flex items-center gap-2">
+        <div v-if="rider" class="flex items-center gap-2">
+          <!-- Offered on an archived rider too: starting next year's from last year's archived one
+               is the main reason this action exists. -->
           <Button
-            label="Renommer"
-            icon="pi pi-pencil"
+            label="Dupliquer"
+            icon="pi pi-copy"
             severity="secondary"
             outlined
-            @click="openRenameDialog"
+            @click="openDuplicateDialog"
           />
-          <Button
-            label="Archiver"
-            icon="pi pi-inbox"
-            severity="secondary"
-            outlined
-            @click="confirmArchive"
-          />
+          <template v-if="!isArchived">
+            <Button
+              label="Renommer"
+              icon="pi pi-pencil"
+              severity="secondary"
+              outlined
+              @click="openRenameDialog"
+            />
+            <Button
+              label="Archiver"
+              icon="pi pi-inbox"
+              severity="secondary"
+              outlined
+              @click="confirmArchive"
+            />
+          </template>
         </div>
       </div>
 
@@ -103,8 +114,8 @@
       v-model:visible="formDialogOpen"
       :band-space-id="bandSpaceId"
       :mode="formDialogMode"
-      :rider-id="formDialogMode === 'rename' ? selectedRiderId : null"
-      :initial-name="formDialogMode === 'rename' ? (rider?.name ?? '') : ''"
+      :rider-id="formDialogMode === 'create' ? null : selectedRiderId"
+      :initial-name="dialogInitialName"
       @saved="handleSaved"
     />
   </div>
@@ -122,6 +133,7 @@ import RiderItemList from '../../components/BandSpace/TechRider/RiderItemList.vu
 import TechRiderFormDialog from '../../components/BandSpace/TechRider/TechRiderFormDialog.vue'
 import TechRiderSelector from '../../components/BandSpace/TechRider/TechRiderSelector.vue'
 import { LAST_TECH_RIDER_KEY } from '../../constants/bandSpace.js'
+import { COPY_SUFFIX, MAX_NAME_LENGTH } from '../../constants/techRider.js'
 import { useBandTechRidersStore } from '../../store/bandSpace/bandSpaceTechRiders.js'
 
 const route = useRoute()
@@ -140,6 +152,25 @@ const hasAnyRider = computed(
 const selectedRiderId = ref(null)
 const formDialogOpen = ref(false)
 const formDialogMode = ref('create')
+
+/**
+ * What the dialog's field starts with. The duplicate suffix is proposed here rather than left to
+ * the server default, so the band sees it and can replace it with the year they actually mean.
+ *
+ * Capped with the same arithmetic the server uses, because the dialog always submits the field as
+ * an explicit name and never falls through to that default. Without the cap, duplicating a rider
+ * whose name is already near the limit would pre-fill something over it and 422 on submit, which
+ * is the one-click path breaking for exactly the people with the most descriptive names. The
+ * source is trimmed rather than the result, so the suffix survives: it is what tells a reader
+ * which of two identically named riders is the new one.
+ */
+const dialogInitialName = computed(() => {
+  const current = rider.value?.name ?? ''
+  if (formDialogMode.value === 'rename') return current
+  if (formDialogMode.value !== 'duplicate' || current === '') return ''
+
+  return current.slice(0, MAX_NAME_LENGTH - COPY_SUFFIX.length) + COPY_SUFFIX
+})
 
 /** localStorage key is per space: each band remembers its own rider. */
 function rememberedKey() {
@@ -208,8 +239,17 @@ function openRenameDialog() {
   formDialogOpen.value = true
 }
 
+function openDuplicateDialog() {
+  formDialogMode.value = 'duplicate'
+  formDialogOpen.value = true
+}
+
+/**
+ * A create or a duplicate both produce a new rider worth opening; a rename does not move anywhere.
+ * The dirty guard inside selectRider still applies, so an unsaved plot is not lost by duplicating.
+ */
 function handleSaved(saved) {
-  if (formDialogMode.value === 'create') {
+  if (formDialogMode.value !== 'rename') {
     selectRider(saved.id)
   }
 }

--- a/src/ApiResource/BandSpace/TechRider/TechRiderDuplicate.php
+++ b/src/ApiResource/BandSpace/TechRider/TechRiderDuplicate.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\TechRider\TechRiderDuplicateProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Duplicating a rider is how the next one gets made.
+ *
+ * Riders are per tour or per year: next year's is this year's with a new drummer and one changed
+ * backline line. Without this, people either edit last year's in place and lose it, or retype a
+ * 24 row patch list.
+ *
+ * Unlike SetlistDuplicate this takes an optional name, because a rider's name is a year or a tour
+ * and "Tech rider 2026 (copie)" is never what the band wanted to call it.
+ */
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders/{id}/duplicate',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: TechRiderResource::class, identifiers: ['bandSpaceId']),
+        'id' => new Link(fromClass: TechRiderResource::class, identifiers: ['id']),
+    ],
+    openapi: new Operation(tags: ['Band Space Tech Rider']),
+    security: "is_granted('ROLE_USER')",
+    normalizationContext: ['groups' => [TechRiderResource::ITEM, TechRiderItemResource::READ], 'skip_null_values' => false],
+    output: TechRiderResource::class,
+    name: 'api_band_space_tech_riders_duplicate',
+    processor: TechRiderDuplicateProcessor::class,
+)]
+class TechRiderDuplicate
+{
+    /**
+     * Absent falls back to the source name plus a suffix. Blank is refused rather than falling back,
+     * because sending an empty name is a client asking for something impossible, not a client
+     * declining to choose.
+     *
+     * Normalised with trim, because NotBlank does not consider a run of spaces blank on its own.
+     */
+    #[Assert\NotBlank(allowNull: true, normalizer: 'trim', message: 'Veuillez spécifier un nom')]
+    #[Assert\Length(max: 255, maxMessage: 'Le nom ne peut pas dépasser {{ limit }} caractères')]
+    public ?string $name = null;
+}

--- a/src/Enum/BandSpace/BandSpaceRiderActivityType.php
+++ b/src/Enum/BandSpace/BandSpaceRiderActivityType.php
@@ -12,6 +12,7 @@ enum BandSpaceRiderActivityType: string
     case RiderRenamed = 'rider_renamed';
     case RiderArchived = 'rider_archived';
     case RiderUnarchived = 'rider_unarchived';
+    case RiderDuplicated = 'rider_duplicated';
 
     case RiderItemAdded = 'rider_item_added';
     case RiderItemRenamed = 'rider_item_renamed';

--- a/src/Procedure/BandSpace/TechRiderDuplicateProcedure.php
+++ b/src/Procedure/BandSpace/TechRiderDuplicateProcedure.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace App\Procedure\BandSpace;
+
+use App\Entity\BandSpace\TechRider;
+use App\Entity\BandSpace\TechRiderItem;
+use App\Entity\BandSpace\TechRiderPatchRow;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceRiderActivityType;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use Doctrine\ORM\EntityManagerInterface;
+
+readonly class TechRiderDuplicateProcedure
+{
+    public const string NAME_SUFFIX = ' (copie)';
+
+    /** Matches the column length on TechRider::$name. */
+    public const int MAX_NAME_LENGTH = 255;
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceActivityRecorder $activityRecorder,
+    ) {
+    }
+
+    /**
+     * Deep copies a rider, in one transaction.
+     *
+     * Deep is the whole point. A shallow copy that shared rows would not be a missing feature, it
+     * would be data corruption: editing next year's patch list would silently rewrite last year's,
+     * and the band would not find out until they looked at the archived document.
+     *
+     * A rider with seven items and 128 patch rows is 136 inserts, so the graph is built first and
+     * flushed once rather than per entity.
+     */
+    public function duplicate(TechRider $source, ?string $name, User $actor): TechRider
+    {
+        return $this->entityManager->wrapInTransaction(function () use ($source, $name, $actor): TechRider {
+            $copy = new TechRider();
+            $copy->bandSpace = $source->bandSpace;
+            $copy->name = $name ?? $this->defaultName($source->name);
+            // The person duplicating, not the original author: they are the one who made this rider.
+            $copy->createdBy = $actor;
+            // Always live, even from an archived source. Starting next year's rider from last
+            // year's archived one is the main reason this endpoint exists, so producing another
+            // archived rider would defeat it.
+            $copy->archiveDatetime = null;
+
+            $this->entityManager->persist($copy);
+
+            foreach ($source->items as $sourceItem) {
+                $this->entityManager->persist($this->copyItem($sourceItem, $copy));
+            }
+
+            $this->activityRecorder->record(
+                bandSpace: $source->bandSpace,
+                module: BandSpaceModule::Rider,
+                type: BandSpaceRiderActivityType::RiderDuplicated,
+                resourceId: (string) $copy->id,
+                actor: $actor,
+                payload: [
+                    'name' => $copy->name,
+                    'source_name' => $source->name,
+                    'source_id' => (string) $source->id,
+                ],
+            );
+
+            return $copy;
+        });
+    }
+
+    /**
+     * What a copy means differs per item type, and each answer here is deliberate:
+     *
+     * - `content` carries the body of a Text, Contacts or StagePlot item. PHP arrays are value
+     *   types, so this assignment is already a copy; there is no shared reference to worry about
+     *   once it is written back to its own JSON column.
+     * - `file` copies the **reference**, never the file. A rider's document item points at
+     *   something already in the band's files, so duplicating a rider must not duplicate a 40MB
+     *   PDF, must not touch the storage quota, and must leave one copy of the diagram to keep
+     *   current.
+     * - `patchRows` are real rows in their own table, so they are the one part that genuinely has
+     *   to be recreated.
+     *
+     * A Contacts item needs nothing beyond its content: it holds no member data at all and renders
+     * from the roster on every read, so the copy is correct the moment it exists.
+     */
+    private function copyItem(TechRiderItem $source, TechRider $rider): TechRiderItem
+    {
+        $copy = new TechRiderItem();
+        $copy->techRider = $rider;
+        $copy->type = $source->type;
+        $copy->title = $source->title;
+        $copy->isIncluded = $source->isIncluded;
+        $copy->content = $source->content;
+        $copy->file = $source->file;
+        $copy->position = $source->position;
+
+        $rider->items->add($copy);
+
+        foreach ($source->patchRows as $sourceRow) {
+            $rowCopy = new TechRiderPatchRow();
+            $rowCopy->item = $copy;
+            $rowCopy->direction = $sourceRow->direction;
+            $rowCopy->channel = $sourceRow->channel;
+            $rowCopy->name = $sourceRow->name;
+            $rowCopy->microphone = $sourceRow->microphone;
+            $rowCopy->routing = $sourceRow->routing;
+            $rowCopy->colour = $sourceRow->colour;
+            $rowCopy->position = $sourceRow->position;
+
+            $this->entityManager->persist($rowCopy);
+            $copy->patchRows->add($rowCopy);
+        }
+
+        return $copy;
+    }
+
+    /**
+     * The source name is trimmed rather than the whole result, so the suffix survives: "(copie)"
+     * is the part that tells a reader which of two identically named riders is the new one.
+     */
+    private function defaultName(string $sourceName): string
+    {
+        $available = self::MAX_NAME_LENGTH - mb_strlen(self::NAME_SUFFIX);
+
+        return mb_substr($sourceName, 0, $available) . self::NAME_SUFFIX;
+    }
+}

--- a/src/State/Processor/BandSpace/TechRider/TechRiderDuplicateProcessor.php
+++ b/src/State/Processor/BandSpace/TechRider/TechRiderDuplicateProcessor.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\TechRider\TechRiderDuplicate;
+use App\ApiResource\BandSpace\TechRider\TechRiderResource;
+use App\Entity\BandSpace\TechRider;
+use App\Entity\User;
+use App\Procedure\BandSpace\TechRiderDuplicateProcedure;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\TechRider\TechRiderBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<TechRiderDuplicate, TechRiderResource>
+ */
+readonly class TechRiderDuplicateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private TechRiderRepository $techRiderRepository,
+        private TechRiderDuplicateProcedure $duplicateProcedure,
+        private TechRiderBuilder $techRiderBuilder,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param TechRiderDuplicate $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): TechRiderResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        // Deliberately not guarded by TechRiderWriteGuard: an archived rider is a valid source, and
+        // duplicating it does not modify it. Starting next year's rider from last year's archived
+        // one is the reason this endpoint exists.
+        $source = $this->techRiderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$source instanceof TechRider) {
+            throw new NotFoundHttpException('Tech rider introuvable');
+        }
+
+        // Null means "not provided, use the default". Validation has already refused blank, so any
+        // string arriving here is a real name; trimmed only to store it tidily.
+        return $this->techRiderBuilder->buildItem(
+            $this->duplicateProcedure->duplicate($source, $data->name === null ? null : trim($data->name), $user),
+        );
+    }
+}

--- a/tests/Api/BandSpace/TechRider/TechRiderDuplicateTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderDuplicateTest.php
@@ -1,0 +1,614 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\TechRider;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\TechRiderItemType;
+use App\Enum\BandSpace\TechRiderPatchDirection;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\TechRiderItemRepository;
+use App\Repository\BandSpace\TechRiderPatchRowRepository;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\BandSpace\TechRiderItemFactory;
+use App\Tests\Factory\BandSpace\TechRiderPatchRowFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * Duplicating is how next year's rider gets made, so the property that matters is independence: a
+ * shallow copy sharing rows would not be a missing feature, it would be data corruption, and the
+ * band would not notice until they opened last year's archived document and found it rewritten.
+ *
+ * A naive equality test passes on a shallow clone, which is why the central test here edits the
+ * copy and reads the original back.
+ */
+#[ResetDatabase]
+class TechRiderDuplicateTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = [
+        'CONTENT_TYPE' => 'application/ld+json',
+        'HTTP_ACCEPT' => 'application/ld+json',
+    ];
+
+    private const array SAMPLE_DOC = [
+        'type' => 'doc',
+        'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Deux retours']]]],
+    ];
+
+    /**
+     * The test this file exists for. Every mutable part of the copy is changed, then the original is
+     * read back and asserted unchanged.
+     */
+    public function test_editing_the_copy_leaves_the_original_untouched(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $copyId = $this->getResponseAsArray()['id'];
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+
+        $copy = self::getContainer()->get(TechRiderRepository::class)->findOneByIdAndBandSpace($copyId, $bandSpace);
+        self::assertInstanceOf(TechRider::class, $copy);
+
+        // Rewrite everything mutable on the copy.
+        $copy->name = 'Renommé';
+        foreach ($copy->items as $item) {
+            $item->title = 'Titre modifié';
+            $item->isIncluded = false;
+            if ($item->content !== null) {
+                $item->content = ['type' => 'doc', 'content' => []];
+            }
+            $item->file = null;
+            foreach ($item->patchRows as $row) {
+                $row->name = 'MODIFIÉ';
+                $row->channel = 99;
+            }
+        }
+        $entityManager->flush();
+
+        $sourceId = (string) $source->id;
+        $bandSpaceId = (string) $bandSpace->id;
+        // Cleared so the reads below come from the database rather than from the identity map,
+        // where a shared reference would still look correct. Everything held before this point is
+        // detached afterwards, so the band space is re-loaded rather than reused.
+        $entityManager->clear();
+
+        $freshBandSpace = $entityManager->find(BandSpace::class, $bandSpaceId);
+        self::assertInstanceOf(BandSpace::class, $freshBandSpace);
+        $reloaded = self::getContainer()->get(TechRiderRepository::class)
+            ->findOneByIdAndBandSpace($sourceId, $freshBandSpace);
+        self::assertInstanceOf(TechRider::class, $reloaded);
+
+        $this->assertSame('Rider 2026', $reloaded->name);
+        $items = $reloaded->items->toArray();
+        usort($items, static fn ($a, $b): int => $a->position <=> $b->position);
+
+        $this->assertSame(
+            ['Sonorisation', 'Patch', 'Schéma', 'Membres', 'Plan'],
+            array_map(static fn ($item): string => $item->title, $items),
+        );
+        $this->assertTrue($items[0]->isIncluded);
+        $this->assertSame(self::SAMPLE_DOC, $items[0]->content);
+        $this->assertNotNull($items[2]->file, 'The document item kept its file reference.');
+
+        $patchRows = $items[1]->patchRows->toArray();
+        usort(
+            $patchRows,
+            static fn ($a, $b): int => [$a->direction->value, $a->position] <=> [$b->direction->value, $b->position],
+        );
+        $this->assertSame(
+            [['input', 1, 'KICK IN'], ['input', 2, 'SNARE'], ['output', 1, 'WEDGE']],
+            array_map(
+                static fn ($row): array => [$row->direction->value, $row->channel, $row->name],
+                $patchRows,
+            ),
+        );
+    }
+
+    /**
+     * The whole response once. Every other success test here reads a slice, so without this a
+     * regression in the envelope, a leaked serialization group or a snake_case drift on this
+     * endpoint specifically would go unnoticed.
+     */
+    public function test_the_full_response_is_the_new_rider(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            $this->duplicateUrl($bandSpace, $source),
+            ['name' => 'Rider 2027'],
+            self::HEADERS,
+        );
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $body = $this->getResponseAsArray();
+        $copyId = $body['id'];
+        $itemIds = array_column($body['items'], 'id');
+        $patchRows = $body['items'][1]['patch_list'];
+        $fileId = (string) $this->itemOfType($source, TechRiderItemType::Document)->file?->id;
+
+        $itemUrl = static fn (string $itemId): string =>
+            '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $copyId . '/items/' . $itemId;
+        $itemBase = static fn (int $index, string $type, string $title, int $position): array => [
+            '@id' => $itemUrl($itemIds[$index]),
+            '@type' => 'TechRiderItem',
+            'id' => $itemIds[$index],
+            'band_space_id' => (string) $bandSpace->id,
+            'rider_id' => $copyId,
+            'type' => $type,
+            'is_included' => true,
+            'title' => $title,
+            'content' => null,
+            'file' => null,
+            'patch_list' => null,
+            'contacts' => null,
+            'position' => $position,
+            'creation_datetime' => $body['items'][$index]['creation_datetime'],
+            'update_datetime' => null,
+        ];
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TechRider',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $copyId,
+            '@type' => 'TechRider',
+            'id' => $copyId,
+            'band_space_id' => (string) $bandSpace->id,
+            'name' => 'Rider 2027',
+            'created_by_username' => $user->username,
+            'archive_datetime' => null,
+            'creation_datetime' => $body['creation_datetime'],
+            'update_datetime' => null,
+            'items' => [
+                [...$itemBase(0, 'text', 'Sonorisation', 0), 'content' => self::SAMPLE_DOC],
+                [...$itemBase(1, 'patch_list', 'Patch', 1), 'patch_list' => $patchRows],
+                [
+                    ...$itemBase(2, 'document', 'Schéma', 2),
+                    'file' => [
+                        'id' => $fileId,
+                        'original_name' => 'schema.png',
+                        'mime_type' => 'image/png',
+                        'is_archived' => false,
+                        'download_url' => '/api/band_spaces/' . $bandSpace->id . '/files/' . $fileId . '/download',
+                    ],
+                ],
+                [
+                    ...$itemBase(3, 'contacts', 'Membres', 3),
+                    'content' => ['showEmails' => true, 'note' => self::SAMPLE_DOC],
+                    // Rendered live from the roster, so the copy is correct the moment it exists.
+                    'contacts' => [
+                        'show_emails' => true,
+                        'lines' => [$user->username],
+                        'emails' => [$user->email],
+                    ],
+                ],
+                [
+                    ...$itemBase(4, 'stage_plot', 'Plan', 4),
+                    'content' => $body['items'][4]['content'],
+                ],
+            ],
+            'item_count' => 5,
+        ]);
+
+        // The parts echoed from the response above, pinned here so the assertion is not circular.
+        $this->assertSame(
+            ['KICK IN', 'SNARE'],
+            array_column($patchRows['inputs'], 'name'),
+        );
+        $this->assertSame(['WEDGE'], array_column($patchRows['outputs'], 'name'));
+        $this->assertSame(1, $body['items'][4]['content']['version']);
+        $this->assertCount(1, $body['items'][4]['content']['elements']);
+    }
+
+    /** Every id in the copy differs, at every level. */
+    public function test_the_copy_shares_no_ids_with_the_original(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $copyId = $this->getResponseAsArray()['id'];
+        $this->assertNotSame((string) $source->id, $copyId);
+
+        $itemRepository = self::getContainer()->get(TechRiderItemRepository::class);
+        $rowRepository = self::getContainer()->get(TechRiderPatchRowRepository::class);
+        $copy = self::getContainer()->get(TechRiderRepository::class)->findOneByIdAndBandSpace($copyId, $bandSpace);
+
+        $sourceItemIds = array_map(
+            static fn ($item): string => (string) $item->id,
+            $itemRepository->findByRider($source),
+        );
+        $copyItemIds = array_map(
+            static fn ($item): string => (string) $item->id,
+            $itemRepository->findByRider($copy),
+        );
+
+        $this->assertCount(5, $copyItemIds);
+        $this->assertSame([], array_intersect($sourceItemIds, $copyItemIds));
+
+        $patchItem = array_values(array_filter(
+            $itemRepository->findByRider($copy),
+            static fn ($item): bool => $item->type === TechRiderItemType::PatchList,
+        ));
+        $copyRowIds = array_map(
+            static fn ($row): string => (string) $row->id,
+            $rowRepository->findByItem($patchItem[0]),
+        );
+        $this->assertCount(3, $copyRowIds);
+    }
+
+    /**
+     * A document item points at a file the band already has. Duplicating a rider must not duplicate
+     * a 40MB PDF, touch the quota, or leave two copies of a diagram to keep current.
+     */
+    public function test_a_document_item_shares_the_file_rather_than_copying_it(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $body = $this->getResponseAsArray();
+        $sourceFileId = (string) $this->itemOfType($source, TechRiderItemType::Document)->file?->id;
+        $copyDocument = array_values(array_filter(
+            $body['items'],
+            static fn (array $item): bool => $item['type'] === 'document',
+        ));
+
+        $this->assertSame($sourceFileId, $copyDocument[0]['file']['id']);
+    }
+
+    public function test_positions_are_preserved(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $body = $this->getResponseAsArray();
+        $this->assertSame([0, 1, 2, 3, 4], array_column($body['items'], 'position'));
+        $this->assertSame(
+            ['Sonorisation', 'Patch', 'Schéma', 'Membres', 'Plan'],
+            array_column($body['items'], 'title'),
+        );
+
+        $patch = array_values(array_filter(
+            $body['items'],
+            static fn (array $item): bool => $item['type'] === 'patch_list',
+        ));
+        $this->assertSame([0, 1], array_column($patch[0]['patch_list']['inputs'], 'position'));
+        $this->assertSame([0], array_column($patch[0]['patch_list']['outputs'], 'position'));
+    }
+
+    public function test_the_default_name_suffixes_the_source(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame('Rider 2026 (copie)', $this->getResponseAsArray()['name']);
+    }
+
+    /**
+     * The source name is trimmed rather than the whole result, so the suffix survives: it is the
+     * part that tells a reader which of two identically named riders is the new one.
+     */
+    public function test_a_maximum_length_name_does_not_overflow_the_column(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $source = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => str_repeat('é', 255)])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $name = $this->getResponseAsArray()['name'];
+        $this->assertSame(255, mb_strlen($name));
+        $this->assertStringEndsWith(' (copie)', $name);
+    }
+
+    public function test_an_explicit_name_is_used(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            $this->duplicateUrl($bandSpace, $source),
+            ['name' => 'Tech rider 2027'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame('Tech rider 2027', $this->getResponseAsArray()['name']);
+    }
+
+    public function test_a_blank_name_is_refused(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            $this->duplicateUrl($bandSpace, $source),
+            ['name' => '   '],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Veuillez spécifier un nom',
+                    'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                ],
+            ],
+            'detail' => 'name: Veuillez spécifier un nom',
+            'type' => '/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            'title' => 'An error occurred',
+            'description' => 'name: Veuillez spécifier un nom',
+        ]);
+    }
+
+    public function test_the_duplicating_user_becomes_the_author(): void
+    {
+        $author = UserFactory::new()->asBaseUser()->create(['username' => 'author_user']);
+        $duplicator = UserFactory::new()->create(['username' => 'duplicator', 'email' => 'dup@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $duplicator])->create();
+        $source = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Rider 2026',
+            'createdBy' => $author,
+        ])->create();
+
+        $this->client->loginUser($duplicator);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame('duplicator', $this->getResponseAsArray()['created_by_username']);
+    }
+
+    /**
+     * The main reason unarchive and duplicate both exist: last year's rider is archived and this
+     * year's starts from it, so the copy has to come back live.
+     */
+    public function test_duplicating_an_archived_rider_produces_a_live_one(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $source = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Rider 2026',
+            'archiveDatetime' => new DateTimeImmutable('-1 year'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertNull($this->getResponseAsArray()['archive_datetime']);
+    }
+
+    public function test_the_duplication_is_recorded_in_the_activity_feed(): void
+    {
+        [$user, $bandSpace, $source] = $this->seedPopulatedRider();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $copyId = $this->getResponseAsArray()['id'];
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($bandSpace, BandSpaceModule::Rider, $copyId);
+
+        $this->assertCount(1, $activities);
+        $this->assertSame('rider_duplicated', $activities[0]->type);
+        $this->assertSame([
+            'name' => 'Rider 2026 (copie)',
+            'source_name' => 'Rider 2026',
+            'source_id' => (string) $source->id,
+        ], $activities[0]->payload);
+    }
+
+    public function test_duplicating_as_a_non_member_is_forbidden(): void
+    {
+        [, $bandSpace, $source] = $this->seedPopulatedRider();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    public function test_duplicating_a_rider_of_another_space_is_not_found(): void
+    {
+        [$user, $bandSpace] = $this->seedPopulatedRider();
+        $elsewhere = TechRiderFactory::new(['bandSpace' => BandSpaceFactory::new()->create()])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $elsewhere), [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Tech rider introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Tech rider introuvable',
+        ]);
+    }
+
+    public function test_duplicating_is_blocked_when_the_space_is_pending_deletion(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('+30 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $source = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => 'Rider 2026'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', $this->duplicateUrl($bandSpace, $source), [], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+        ]);
+    }
+
+    private function itemOfType(TechRider $rider, TechRiderItemType $type): object
+    {
+        $items = array_values(array_filter(
+            self::getContainer()->get(TechRiderItemRepository::class)->findByRider($rider),
+            static fn ($item): bool => $item->type === $type,
+        ));
+        self::assertNotEmpty($items, sprintf('No %s item was seeded.', $type->value));
+
+        return $items[0];
+    }
+
+    /**
+     * One rider holding an item of every type, so a copy is exercised against the whole model
+     * rather than against the two types that happen to be easiest to seed.
+     *
+     * @return array{User, BandSpace, TechRider}
+     */
+    private function seedPopulatedRider(): array
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $source = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Rider 2026',
+            'createdBy' => $user,
+        ])->create();
+
+        TechRiderItemFactory::new([
+            'techRider' => $source,
+            'type' => TechRiderItemType::Text,
+            'title' => 'Sonorisation',
+            'content' => self::SAMPLE_DOC,
+            'position' => 0,
+        ])->create();
+
+        $patchItem = TechRiderItemFactory::new([
+            'techRider' => $source,
+            'type' => TechRiderItemType::PatchList,
+            'title' => 'Patch',
+            'position' => 1,
+        ])->create();
+        TechRiderPatchRowFactory::new(['item' => $patchItem, 'direction' => TechRiderPatchDirection::Input, 'channel' => 1, 'name' => 'KICK IN', 'position' => 0])->create();
+        TechRiderPatchRowFactory::new(['item' => $patchItem, 'direction' => TechRiderPatchDirection::Input, 'channel' => 2, 'name' => 'SNARE', 'position' => 1])->create();
+        TechRiderPatchRowFactory::new(['item' => $patchItem, 'direction' => TechRiderPatchDirection::Output, 'channel' => 1, 'name' => 'WEDGE', 'position' => 0])->create();
+
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'originalName' => 'schema.png'])->create();
+        $file->currentVersion = BandSpaceFileVersionFactory::new([
+            'bandSpaceFile' => $file,
+            'mimeType' => 'image/png',
+            'versionNumber' => 1,
+        ])->create();
+        TechRiderItemFactory::new([
+            'techRider' => $source,
+            'type' => TechRiderItemType::Document,
+            'title' => 'Schéma',
+            'file' => $file,
+            'position' => 2,
+        ])->create();
+
+        TechRiderItemFactory::new([
+            'techRider' => $source,
+            'type' => TechRiderItemType::Contacts,
+            'title' => 'Membres',
+            'content' => ['showEmails' => true, 'note' => self::SAMPLE_DOC],
+            'position' => 3,
+        ])->create();
+
+        TechRiderItemFactory::new([
+            'techRider' => $source,
+            'type' => TechRiderItemType::StagePlot,
+            'title' => 'Plan',
+            'content' => [
+                'version' => 1,
+                'stage' => ['aspect_ratio' => 1.4],
+                'elements' => [[
+                    'id' => 'el-1',
+                    'icon' => 'drum_kit',
+                    'x' => 0.5,
+                    'y' => 0.3,
+                    'scale' => 1,
+                    'rotation' => 0,
+                    'label' => 'Batterie',
+                    'colour' => null,
+                ]],
+                'legend' => [],
+            ],
+            'position' => 4,
+        ])->create();
+
+        self::getContainer()->get('doctrine')->getManager()->flush();
+
+        return [$user, $bandSpace, $source];
+    }
+
+    private function duplicateUrl(BandSpace $bandSpace, TechRider $rider): string
+    {
+        return '/api/band_spaces/' . $bandSpace->id . '/tech_riders/' . $rider->id . '/duplicate';
+    }
+}

--- a/tests/Unit/Procedure/BandSpace/TechRiderDuplicateNameLimitsTest.php
+++ b/tests/Unit/Procedure/BandSpace/TechRiderDuplicateNameLimitsTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Procedure\BandSpace;
+
+use App\Procedure\BandSpace\TechRiderDuplicateProcedure;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The duplicate dialog proposes a name in its field rather than submitting nothing and letting the
+ * server apply its default, so it has to do the same arithmetic. If the two drift, duplicating a
+ * rider whose name is near the limit pre-fills something the server then refuses, and the one click
+ * path breaks for exactly the people with the most descriptive names.
+ *
+ * Same approach as the colour palette and the stage plot limits: the duplication is deliberate, and
+ * this is the contract between the two copies.
+ */
+class TechRiderDuplicateNameLimitsTest extends TestCase
+{
+    private const string CONSTANTS_PATH = 'assets/js/constants/techRider.js';
+
+    public function test_the_client_name_limit_matches_the_procedure(): void
+    {
+        preg_match('/export const MAX_NAME_LENGTH = (\d+)/', $this->read(), $matches);
+        self::assertNotEmpty($matches, sprintf('No MAX_NAME_LENGTH export found in %s.', self::CONSTANTS_PATH));
+
+        $this->assertSame(TechRiderDuplicateProcedure::MAX_NAME_LENGTH, (int) $matches[1]);
+    }
+
+    public function test_the_client_copy_suffix_matches_the_procedure(): void
+    {
+        preg_match("/export const COPY_SUFFIX = '([^']+)'/", $this->read(), $matches);
+        self::assertNotEmpty($matches, sprintf('No COPY_SUFFIX export found in %s.', self::CONSTANTS_PATH));
+
+        $this->assertSame(TechRiderDuplicateProcedure::NAME_SUFFIX, $matches[1]);
+    }
+
+    private function read(): string
+    {
+        // tests/Unit/Procedure/BandSpace -> project root
+        $path = \dirname(__DIR__, 4) . '/' . self::CONSTANTS_PATH;
+        self::assertFileExists($path);
+
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+}

--- a/tests/Unit/Procedure/BandSpace/TechRiderItemCopyCoverageTest.php
+++ b/tests/Unit/Procedure/BandSpace/TechRiderItemCopyCoverageTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Procedure\BandSpace;
+
+use App\Entity\BandSpace\TechRiderItem;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionProperty;
+
+/**
+ * The failure this guards against is a future item type bringing storage that the duplication then
+ * silently drops. It is not hypothetical: a patch list keeps its rows in its own table, a document
+ * keeps a file reference, a stage plot keeps a JSON document, and every one of those had to be
+ * handled by hand in TechRiderDuplicateProcedure::copyItem.
+ *
+ * An exhaustive match on the item type would not catch it. Match exhaustiveness is over enum cases,
+ * and the danger is a new *property*, not a new case; today every branch would also perform the
+ * identical three operations, so the match would be duplication for no behavioural gain.
+ *
+ * So this enumerates the entity's own properties instead and fails on an unrecognised one, pointing
+ * at the place a decision is owed. Same shape as BandSpaceWriteGuardCoverageTest, which greps
+ * processors, and TechRiderStagePlotIconArtworkTest, which pairs enum cases with files on disk.
+ */
+class TechRiderItemCopyCoverageTest extends TestCase
+{
+    /**
+     * Every property of TechRiderItem, and what duplication does with it. Adding a property means
+     * adding a line here, which is the moment to decide what a copy of it means.
+     *
+     * @var array<string, string>
+     */
+    private const array COPY_DECISIONS = [
+        // Identity and ownership: the copy gets its own.
+        'id' => 'new, generated',
+        'techRider' => 'points at the new rider',
+        'creationDatetime' => 'now, set by the constructor',
+        'updateDatetime' => 'null, the copy has not been edited',
+
+        // Carried across verbatim.
+        'type' => 'copied',
+        'title' => 'copied',
+        'isIncluded' => 'copied',
+        'content' => 'copied by value, PHP arrays are value types',
+        'position' => 'copied, so the composed order survives',
+
+        // The two deliberate non-deep copies.
+        'file' => 'the reference is shared, never the file: duplicating a rider must not duplicate '
+            . 'a 40MB PDF, touch the quota, or leave two copies of a diagram to keep current',
+
+        // The one part that genuinely has to be recreated.
+        'patchRows' => 'recreated as new rows in their own table',
+    ];
+
+    public function test_every_property_of_an_item_has_a_duplication_decision(): void
+    {
+        $undecided = array_diff($this->propertyNames(), array_keys(self::COPY_DECISIONS));
+
+        self::assertSame([], array_values($undecided), sprintf(
+            "These properties of %s have no recorded duplication decision.\n"
+            . "Decide what a copy of each one means, handle it in %s::copyItem(), and add it to\n"
+            . "COPY_DECISIONS in %s.\n",
+            TechRiderItem::class,
+            'App\Procedure\BandSpace\TechRiderDuplicateProcedure',
+            self::class,
+        ));
+    }
+
+    /** The other direction, so a removed property does not leave a stale note claiming otherwise. */
+    public function test_the_decision_list_has_no_stale_entries(): void
+    {
+        $stale = array_diff(array_keys(self::COPY_DECISIONS), $this->propertyNames());
+
+        self::assertSame([], array_values($stale), 'These decisions name properties that no longer exist.');
+    }
+
+    /**
+     * Guards against the reflection silently returning nothing, which would make the test above pass
+     * vacuously.
+     */
+    public function test_the_reflection_actually_finds_the_properties(): void
+    {
+        self::assertGreaterThan(8, count($this->propertyNames()));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function propertyNames(): array
+    {
+        return array_values(array_map(
+            static fn (ReflectionProperty $property): string => $property->getName(),
+            array_filter(
+                (new ReflectionClass(TechRiderItem::class))->getProperties(),
+                // Static and virtual-only members are not state a copy has to carry.
+                static function (ReflectionProperty $property): bool {
+                    $type = $property->getType();
+
+                    return !$property->isStatic()
+                        && !($type instanceof ReflectionNamedType && $type->getName() === 'void');
+                },
+            ),
+        ));
+    }
+}


### PR DESCRIPTION
Closes #775, and with it the epic #776.

`POST /api/band_spaces/{bandSpaceId}/tech_riders/{id}/duplicate`, with an optional name. Riders are per year or per tour, so duplicating is how the next one gets made: without it people either edit last year's in place and lose it, or retype a 24 row patch list.

**Note on the issue text**: #775 was written before #772 reshaped the model, so it describes `sections`, a `showMemberEmails` field and a `stagePlot` field on the rider. None of those exist any more; all three live inside typed items. This works from the current model.

## What a copy means differs per item type

This is the substance of the change, and two of the five types deliberately do not deep copy.

**A document copies the reference, never the file.** It points at something already in the band's files, so duplicating a rider must not duplicate a 40MB PDF, must not touch the storage quota, and must leave exactly one copy of the diagram to keep current.

**A contacts item needs nothing beyond its stored choices.** It holds no member data at all and renders from the roster on every read, so the copy is correct the moment it exists.

**Patch rows are the one part that genuinely has to be recreated**, because they are real rows in their own table.

**Text and stage plot carry their `content`.** PHP arrays are value types, so that assignment is already a copy; there is no shared reference once it is written back to its own JSON column.

## Deliberately not behind the rider write guard

An archived rider is a valid source, and duplicating it does not modify it. Starting next year's rider from last year's archived one is the reason this endpoint exists, so the copy always comes back live. The Dupliquer button is offered on an archived rider for the same reason, while Renommer and Archiver stay hidden.

The space level guard still applies through `checkMemberForWrite`, so a space pending deletion is a 409.

## Independence is the property that matters

A shallow copy sharing rows would not be a missing feature, it would be data corruption: editing next year's patch list would silently rewrite last year's, and nobody would find out until they opened the archived document.

A naive equality test passes on a shallow clone, so the central test rewrites everything mutable on the copy, clears the identity map so the reads come from the database rather than from a place where a shared reference still looks right, and reads the original back. Mutation tested by re-parenting the source's rows to the copy, which is the plausible version of this bug, and it fails there.

Verified live as well: built a source with a real patch list, archived it, duplicated it, overwrote the copy's grid, and the source still held its own rows.

## Review

No blockers. Three findings, all fixed.

**The client name suggestion had no cap, and the server's truncation never ran from the UI.** The dialog always submits its field as an explicit name, so `defaultName()`'s "trim the source so the suffix survives" arithmetic was only ever reachable by direct API calls. A rider named 248 characters or more, which nothing prevents, would pre-fill a suggestion over the limit and be refused on submit: the one click path breaking for exactly the people with the most descriptive names. The same arithmetic now runs client side, with the two constants pinned to the PHP by a drift test.

**There was no forcing function for a sixth item type** bringing storage nobody remembers to copy, which is the failure I was most worried about. An exhaustive `match` is not the answer and review was right about why: match exhaustiveness is over enum cases, while the danger is a new *property*, and today every branch would perform the identical three operations anyway. Instead a reflection test enumerates `TechRiderItem`'s properties against a recorded decision for each and fails pointing at `copyItem()`. It caught an omission on its first run: `position` was copied correctly but absent from the record.

**No success path asserted the full response.** Every one read a slice, so a leaked serialization group or a snake_case drift on this endpoint would have gone unnoticed. One test now pins the whole envelope across all five item types.

Two nits also fixed: an attribute that lost its indentation, which Biome does not catch in a `.vue` template, and "vers" to "sous le nom" in the activity sentence, which is how a French speaker says it.

## Verification

Suite **1970** green (1954 before), PHPStan level 8 clean, Biome at its 44 info baseline, `npm run build` clean. No migration, no schema change.

Browser: duplicated through the dialog and landed on the copy; then on a throwaway rider addressed by id, built a source with a populated patch list, archived it, duplicated it, and confirmed the copy came back live with rows recreated under new ids and every field carried including colour.

## What the epic leaves behind

The module is complete and still gated. Releasing it is one line, `RIDER_SUPER_ADMIN_ONLY` in `assets/js/constants/bandSpace.js`.

Not rider work, but named so it is not lost:

- #741, the Gotenberg spike. Its own stated decision driver was whether PDF stays a one off or grows across the app, and the rider is the answer to that question. The module has been built to keep that door open: fractional coordinates so a renderer places elements from numbers rather than a bitmap, PNG icons rather than SVG, a closed colour palette with server side hex, and quarter turn rotations because dompdf has no CSS transforms.
- #798, patch list presets, for a later version.
- Page break control and a cover page block, both waiting on the export, because the renderer decides what is even expressible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
