### PR TITLE
Stage plot: allow any rotation angle, not only quarter turns

### DIFF
--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -138,5 +138,10 @@ jobs:
             - name: Lint (Biome)
               run: npm run lint
 
+            # Node's own test runner, so there is no framework to install. It covers the pure helpers
+            # that carry logic worth pinning; anything needing a DOM is still untested.
+            - name: Test (node --test)
+              run: npm test
+
             - name: Build (Vite)
               run: npm run build

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
@@ -66,7 +66,7 @@
             type="button"
             class="absolute -top-2 -right-2 w-4 h-4 flex items-center justify-center rounded-full bg-primary text-primary-contrast shadow focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary-500"
             :aria-label="`Faire pivoter ${describeElement(element)}, actuellement ${element.rotation ?? 0} degrés`"
-            v-tooltip.top="'Pivoter d\'un quart de tour'"
+            v-tooltip.top="'Aligner sur le prochain quart de tour'"
             @pointerdown.stop
             @click.stop="rotateElement(element)"
           >
@@ -106,8 +106,8 @@
       déplacer, Maj + flèches pour aller plus vite, Alt + flèches pour un réglage fin, Alt pendant
       un déplacement à la souris pour ignorer la grille, Suppr pour retirer. Sur l'élément
       sélectionné, la poignée en bas à droite règle la taille, celle en haut à gauche l'orientation
-      (par pas de 15°, ou Alt pour un angle libre) et le bouton en haut à droite le fait pivoter
-      d'un quart de tour.
+      (par pas de 15°, ou Alt pour un angle libre) et le bouton en haut à droite l'aligne sur le
+      prochain quart de tour.
     </p>
   </div>
 </template>

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
@@ -80,6 +80,15 @@
             aria-hidden="true"
             @pointerdown.stop="handleScalePointerDown($event, element)"
           />
+
+          <!-- Free rotation, at top-left because the right edge is already taken: at the smallest
+               scale the wrapper is only 20px, and the rotate button and the scale grip between them
+               cover the whole of it. aria-hidden for the same reason as the scale grip. -->
+          <span
+            class="absolute -top-1.5 -left-1.5 w-3 h-3 rounded-full bg-primary border border-surface-0 dark:border-surface-950 cursor-grab"
+            aria-hidden="true"
+            @pointerdown.stop="handleRotatePointerDown($event, element)"
+          />
         </template>
       </div>
 
@@ -96,8 +105,9 @@
       Glissez une icône depuis la liste, ou sélectionnez-la et appuyez sur Entrée. Flèches pour
       déplacer, Maj + flèches pour aller plus vite, Alt + flèches pour un réglage fin, Alt pendant
       un déplacement à la souris pour ignorer la grille, Suppr pour retirer. Sur l'élément
-      sélectionné, la poignée en bas à droite règle la taille et le bouton en haut à droite le fait
-      pivoter.
+      sélectionné, la poignée en bas à droite règle la taille, celle en haut à gauche l'orientation
+      (par pas de 15°, ou Alt pour un angle libre) et le bouton en haut à droite le fait pivoter
+      d'un quart de tour.
     </p>
   </div>
 </template>
@@ -111,7 +121,9 @@ import {
   MAX_SCALE,
   MIN_SCALE,
   NUDGE_STEP,
-  ROTATIONS,
+  nextQuarterTurn,
+  rotationFromPointer,
+  rotationGrabOffset,
   SCALE_STEP,
   SNAP_STEP,
   snapFraction,
@@ -143,6 +155,7 @@ const elementRefs = new Map()
 
 let drag = null
 let scaleDrag = null
+let rotateDrag = null
 
 const gridImage = computed(() => {
   // Drawn with a gradient rather than an SVG asset: it is two lines, and this way it inherits the
@@ -206,7 +219,7 @@ function handleElementPointerDown(event, element) {
   if (props.readOnly || event.button !== 0) return
   // One drag at a time. A second pointer starting on another element would overwrite this state,
   // freezing the first element and leaving its stage listeners attached but inert.
-  if (drag || scaleDrag) return
+  if (drag || scaleDrag || rotateDrag) return
 
   emit('select', element.id)
   const start = stageFractions(event)
@@ -249,10 +262,69 @@ function handlePointerUp(event) {
   elementRefs.get(id)?.focus()
 }
 
-/** Quarter turns cycle, because those are the only values the model accepts. */
+/**
+ * The shortcut button: on to the next quarter turn, from wherever the element currently sits.
+ *
+ * It used to index into ROTATIONS, which returned -1 for anything off the list and so reset the
+ * angle to 0. Harmless while nothing could produce an off-list angle; wrong now that the grip can.
+ */
 function rotateElement(element) {
-  const current = element.rotation ?? 0
-  element.rotation = ROTATIONS[(ROTATIONS.indexOf(current) + 1) % ROTATIONS.length]
+  element.rotation = nextQuarterTurn(element.rotation ?? 0)
+}
+
+/**
+ * Rotation by drag: the element follows the pointer's bearing around its own centre.
+ *
+ * The offset between that bearing and the current angle is taken once, so grabbing the grip does not
+ * swing the icon round to meet the pointer. Snapping to 15 degrees keeps a plot tidy, and Alt frees
+ * it to whole degrees, which is the same bargain Alt already makes with the position grid.
+ */
+function handleRotatePointerDown(event, element) {
+  if (props.readOnly || drag || scaleDrag || rotateDrag) return
+
+  const box = stageRef.value.getBoundingClientRect()
+  const centre = {
+    x: box.left + box.width * element.x,
+    y: box.top + box.height * element.y
+  }
+  const point = { x: event.clientX, y: event.clientY }
+
+  rotateDrag = {
+    element,
+    centre,
+    grabOffset: rotationGrabOffset(centre, point, element.rotation ?? 0),
+    pointerId: event.pointerId
+  }
+
+  stageRef.value.setPointerCapture(event.pointerId)
+  stageRef.value.addEventListener('pointermove', handleRotatePointerMove)
+  stageRef.value.addEventListener('pointerup', handleRotatePointerUp)
+  stageRef.value.addEventListener('pointercancel', handleRotatePointerUp)
+}
+
+function handleRotatePointerMove(event) {
+  if (!rotateDrag || event.pointerId !== rotateDrag.pointerId) return
+
+  rotateDrag.element.rotation = rotationFromPointer(
+    rotateDrag.centre,
+    { x: event.clientX, y: event.clientY },
+    rotateDrag.grabOffset,
+    !event.altKey
+  )
+}
+
+function handleRotatePointerUp(event) {
+  if (!rotateDrag || event.pointerId !== rotateDrag.pointerId) return
+
+  const id = rotateDrag.element.id
+  rotateDrag = null
+
+  stageRef.value.releasePointerCapture(event.pointerId)
+  stageRef.value.removeEventListener('pointermove', handleRotatePointerMove)
+  stageRef.value.removeEventListener('pointerup', handleRotatePointerUp)
+  stageRef.value.removeEventListener('pointercancel', handleRotatePointerUp)
+
+  elementRefs.get(id)?.focus()
 }
 
 /**
@@ -261,7 +333,7 @@ function rotateElement(element) {
  * pointer over a long drag.
  */
 function handleScalePointerDown(event, element) {
-  if (props.readOnly || drag || scaleDrag) return
+  if (props.readOnly || drag || scaleDrag || rotateDrag) return
 
   const box = stageRef.value.getBoundingClientRect()
   const centre = {

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotElementInspector.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotElementInspector.vue
@@ -80,10 +80,27 @@
       </div>
 
       <div>
-        <span class="block text-xs font-medium mb-1">Rotation</span>
-        <!-- Quarter turns only, because that is what the model accepts and what every export
-             engine can render. Buttons rather than a free input for the same reason. -->
-        <div class="flex gap-1" role="group" aria-label="Rotation">
+        <label :for="`${uid}-rotation`" class="block text-xs font-medium mb-1">
+          Rotation ({{ element.rotation ?? 0 }}°)
+        </label>
+        <!-- Whole degrees, so the slider can represent every angle the server accepts. A coarser
+             step would quietly rewrite an angle placed freely on the canvas the moment anyone
+             touched this control. -->
+        <Slider
+          :id="`${uid}-rotation`"
+          :model-value="element.rotation ?? 0"
+          :min="MIN_ROTATION"
+          :max="MAX_ROTATION"
+          :step="FINE_ROTATION_STEP"
+          :disabled="readOnly"
+          class="w-full"
+          :aria-label="`Rotation de ${iconLabel}`"
+          @update:model-value="(value) => update({ rotation: value })"
+        />
+        <!-- The quarter turns kept as shortcuts beside the slider. They are one click where the
+             slider is an aim, and they are the keyboard path: arrows on a 360 stop slider would
+             need ninety presses to turn a corner. -->
+        <div class="flex gap-1 mt-1" role="group" aria-label="Quarts de tour">
           <Button
             v-for="rotation in ROTATIONS"
             :key="rotation"
@@ -131,8 +148,11 @@ import Slider from 'primevue/slider'
 import { computed, useId } from 'vue'
 import {
   describePosition,
+  FINE_ROTATION_STEP,
   MAX_LABEL_LENGTH,
+  MAX_ROTATION,
   MAX_SCALE,
+  MIN_ROTATION,
   MIN_SCALE,
   ROTATIONS,
   SCALE_STEP

--- a/assets/js/constants/stagePlot.js
+++ b/assets/js/constants/stagePlot.js
@@ -22,8 +22,22 @@ export const MAX_ASPECT_RATIO = 3.0
 
 export const DEFAULT_ASPECT_RATIO = 1.4
 
-/** Quarter turns only, matching what the model accepts. */
+/**
+ * Any whole degree from 0 to 359 is stored, so these four are shortcuts rather than the domain.
+ * They stay because a quarter turn is the common case, one click beats aiming a slider at it, and
+ * they are the only sane keyboard path: arrows on a 360 stop slider would need ninety presses.
+ */
+export const MIN_ROTATION = 0
+export const MAX_ROTATION = 359
 export const ROTATIONS = Object.freeze([0, 90, 180, 270])
+
+/**
+ * What the on-canvas rotation grip snaps to, with Alt giving whole degrees, mirroring how Alt frees
+ * a move drag from the position grid. Fifteen divides 90, so snapped dragging can always land on a
+ * quarter turn, which is what TechRiderStagePlotLimitsTest pins.
+ */
+export const ROTATION_SNAP_STEP = 15
+export const FINE_ROTATION_STEP = 1
 
 /**
  * The snap grid, as a fraction of the stage. A plot where nothing lines up looks careless on a
@@ -79,4 +93,53 @@ export function toFraction(value) {
 
 export function snapFraction(value) {
   return toFraction(Math.round(value / SNAP_STEP) * SNAP_STEP)
+}
+
+/**
+ * Folds any angle into the 0 to 359 whole degrees the server stores, so a drag that crosses twelve
+ * o'clock or turns backwards cannot produce 360 or a negative.
+ */
+export function normaliseRotation(degrees) {
+  return ((Math.round(degrees) % 360) + 360) % 360
+}
+
+/**
+ * The pointer's bearing from a centre, in degrees.
+ *
+ * Screen y grows downwards, which is the same direction CSS `rotate()` turns, so this maps onto a
+ * rotation with no sign flip.
+ */
+export function pointerBearing(centre, point) {
+  return (Math.atan2(point.y - centre.y, point.x - centre.x) * 180) / Math.PI
+}
+
+/**
+ * How far the element's rotation runs ahead of the pointer at the moment it is grabbed.
+ *
+ * Recorded once on pointerdown and added back on every move, so grabbing the grip anywhere leaves
+ * the icon where it was instead of snapping it round to meet the pointer.
+ */
+export function rotationGrabOffset(centre, point, currentRotation) {
+  return (currentRotation ?? 0) - pointerBearing(centre, point)
+}
+
+/** Where a rotation drag lands. Snapping is the default; Alt asks for whole degrees. */
+export function rotationFromPointer(centre, point, grabOffset, snap = true) {
+  const step = snap ? ROTATION_SNAP_STEP : FINE_ROTATION_STEP
+  const bearing = pointerBearing(centre, point) + grabOffset
+
+  // Snap first, then fold: rounding 355 to the nearest fifteen gives 360, which is not a value the
+  // server accepts.
+  return normaliseRotation(Math.round(bearing / step) * step)
+}
+
+/**
+ * The next quarter turn clockwise from any angle, for the shortcut button.
+ *
+ * It used to look the current value up in ROTATIONS, which returned -1 for anything off the list and
+ * so reset it to 0. Harmless while nothing could produce an off-list angle, and wrong the moment a
+ * drag can.
+ */
+export function nextQuarterTurn(current) {
+  return normaliseRotation((Math.floor(normaliseRotation(current) / 90) + 1) * 90)
 }

--- a/assets/js/constants/stagePlot.test.js
+++ b/assets/js/constants/stagePlot.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  MAX_ROTATION,
+  MIN_ROTATION,
+  nextQuarterTurn,
+  normaliseRotation,
+  pointerBearing,
+  ROTATION_SNAP_STEP,
+  rotationFromPointer,
+  rotationGrabOffset
+} from './stagePlot.js'
+
+/**
+ * The rotation maths, which is why those functions are exported rather than living inside
+ * StagePlotCanvas.vue: a drag gesture needs a browser, but the arithmetic behind it does not.
+ *
+ * Run with `npm test`. Node's own runner, so this costs no dependency. The pointer wiring itself
+ * still has no coverage, because that would need jsdom and a component harness.
+ */
+
+const CENTRE = { x: 100, y: 100 }
+
+/** A point on a circle around CENTRE at the given bearing, for sweeping the whole turn. */
+function pointAt(degrees, radius = 90) {
+  const radians = (degrees * Math.PI) / 180
+
+  return {
+    x: CENTRE.x + radius * Math.cos(radians),
+    y: CENTRE.y + radius * Math.sin(radians)
+  }
+}
+
+describe('pointerBearing', () => {
+  // Screen y grows downwards, which is the same direction CSS rotate() turns, so a bearing maps onto
+  // a rotation with no sign flip. These four pin that: get the sign wrong and every icon mirrors.
+  it('reads clockwise from the positive x axis, matching CSS rotate', () => {
+    assert.equal(normaliseRotation(pointerBearing(CENTRE, { x: 200, y: 100 })), 0)
+    assert.equal(normaliseRotation(pointerBearing(CENTRE, { x: 100, y: 200 })), 90)
+    assert.equal(normaliseRotation(pointerBearing(CENTRE, { x: 0, y: 100 })), 180)
+    assert.equal(normaliseRotation(pointerBearing(CENTRE, { x: 100, y: 0 })), 270)
+  })
+
+  // The grip sits outside the box so this should not happen, but atan2(0, 0) is 0 rather than NaN and
+  // a rotation of NaN would be written straight into the document.
+  it('does not produce NaN when the pointer is on the centre', () => {
+    assert.equal(Number.isNaN(pointerBearing(CENTRE, CENTRE)), false)
+  })
+})
+
+describe('normaliseRotation', () => {
+  it('folds any angle into the range the server accepts', () => {
+    assert.equal(normaliseRotation(360), 0)
+    assert.equal(normaliseRotation(-1), 359)
+    assert.equal(normaliseRotation(-90), 270)
+    assert.equal(normaliseRotation(725), 5)
+  })
+})
+
+describe('rotationFromPointer', () => {
+  // Grabbing the grip must not swing the icon round to meet the pointer, which is what the recorded
+  // offset is for. Only snapped angles are used here: an unsnapped one legitimately moves to its
+  // nearest stop on the first move.
+  it('leaves the angle alone at the moment of the grab', () => {
+    for (const rotation of [0, 15, 45, 90, 180, 270, 345]) {
+      const point = pointAt(37)
+      const offset = rotationGrabOffset(CENTRE, point, rotation)
+
+      assert.equal(rotationFromPointer(CENTRE, point, offset, true), rotation)
+    }
+  })
+
+  it('snaps to whole steps and reaches every stop over a full turn', () => {
+    const snapped = new Set()
+    for (let bearing = 0; bearing < 360; bearing += 1) {
+      snapped.add(rotationFromPointer(CENTRE, pointAt(bearing), 0, true))
+    }
+
+    assert.equal(snapped.size, 360 / ROTATION_SNAP_STEP)
+    assert.ok([...snapped].every((angle) => angle % ROTATION_SNAP_STEP === 0))
+    // The quarter turns have to be reachable by dragging, not only by the shortcut buttons.
+    assert.ok([0, 90, 180, 270].every((angle) => snapped.has(angle)))
+  })
+
+  it('gives finer control when snapping is off', () => {
+    const free = new Set()
+    for (let bearing = 0; bearing < 360; bearing += 1) {
+      free.add(rotationFromPointer(CENTRE, pointAt(bearing), 0, false))
+    }
+
+    assert.ok(free.size > 360 / ROTATION_SNAP_STEP)
+  })
+
+  // Snapping happens before folding, so a bearing near 355 rounds to 360 and then has to come back to
+  // 0. Folding first would not help: 359 still rounds up to 360 afterwards.
+  it('never yields a value outside the accepted range, snapped or free', () => {
+    for (let bearing = -720; bearing <= 720; bearing += 1) {
+      for (const snap of [true, false]) {
+        const angle = rotationFromPointer(CENTRE, pointAt(bearing), 0, snap)
+
+        assert.ok(Number.isInteger(angle), `${angle} is not a whole degree`)
+        assert.ok(angle >= MIN_ROTATION && angle <= MAX_ROTATION, `${angle} is out of range`)
+      }
+    }
+  })
+})
+
+describe('nextQuarterTurn', () => {
+  it('advances to the next quarter turn and wraps', () => {
+    assert.equal(nextQuarterTurn(0), 90)
+    assert.equal(nextQuarterTurn(90), 180)
+    assert.equal(nextQuarterTurn(270), 0)
+    assert.equal(nextQuarterTurn(359), 0)
+  })
+
+  // The bug this replaced: the old cycle looked the current value up in ROTATIONS, got -1 for an
+  // angle a drag had produced, and silently reset it to 0.
+  it('aligns an off-grid angle instead of discarding it', () => {
+    assert.equal(nextQuarterTurn(47), 90)
+    assert.equal(nextQuarterTurn(91), 180)
+    assert.equal(nextQuarterTurn(1), 90)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "node --test \"assets/js/**/*.test.js\"",
     "lint": "npx biome check",
     "lint-fix": "npx biome check --write"
   },

--- a/src/Validator/BandSpace/TechRider/TechRiderStagePlot.php
+++ b/src/Validator/BandSpace/TechRider/TechRiderStagePlot.php
@@ -41,15 +41,15 @@ class TechRiderStagePlot extends Constraint
     public const float MAX_ASPECT_RATIO = 3.0;
 
     /**
-     * Quarter turns only. The reference rider has sideways labels so rotation is a real need, and
-     * four values keep the editor's rotate control a single button rather than an angle picker.
+     * Any whole degree. A stage is not built on a grid: wedges angle in towards a performer and a
+     * riser sits across a corner, so quarter turns produced a diagram that read as approximate.
      *
-     * The original reason was narrower: the export engine was undecided (#741) and arbitrary angles
-     * were not renderable everywhere. That has been settled in favour of Chromium, which does
-     * support CSS transforms, so widening this is now possible. It stays closed because nothing has
-     * asked for it, not because it cannot be done.
+     * Whole degrees rather than fractions, and 0 to 359 rather than any integer, for the same
+     * reason: one representation per angle. 360 and 0 are the same rotation, so allowing both would
+     * mean two documents that draw identically no longer compare identically.
      */
-    public const array ALLOWED_ROTATIONS = [0, 90, 180, 270];
+    public const int MIN_ROTATION = 0;
+    public const int MAX_ROTATION = 359;
 
     public string $invalidDocumentMessage = 'Le plan de scène doit être un objet';
     public string $unknownKeyMessage = 'Champ inconnu dans le plan de scène';
@@ -62,7 +62,7 @@ class TechRiderStagePlot extends Constraint
     public string $duplicateIdMessage = 'Chaque élément doit avoir un identifiant unique';
     public string $coordinateOutOfRangeMessage = 'La position doit être comprise entre 0 et 1';
     public string $scaleOutOfRangeMessage = 'La taille doit être comprise entre {{ min }} et {{ max }}';
-    public string $invalidRotationMessage = 'La rotation doit valoir 0, 90, 180 ou 270';
+    public string $invalidRotationMessage = 'La rotation doit être un entier de 0 à 359 degrés';
     public string $tooLongLabelMessage = 'Le libellé ne peut pas dépasser {{ limit }} caractères';
     public string $unknownIconMessage = 'Icône inconnue';
     public string $unknownColourMessage = 'Couleur inconnue';

--- a/src/Validator/BandSpace/TechRider/TechRiderStagePlotValidator.php
+++ b/src/Validator/BandSpace/TechRider/TechRiderStagePlotValidator.php
@@ -167,8 +167,14 @@ class TechRiderStagePlotValidator extends ConstraintValidator
             }
         }
 
+        // Deliberately not through toFloat(), unlike every other numeric rule here: an integer keeps
+        // one representation per angle, so 90 and 90.0 cannot both be stored for the same rotation
+        // and two plots that draw identically compare identically. Nothing normalises this
+        // afterwards either, because the document is written back verbatim.
         if (array_key_exists('rotation', $element)
-            && !in_array($element['rotation'], TechRiderStagePlot::ALLOWED_ROTATIONS, true)
+            && (!is_int($element['rotation'])
+                || $element['rotation'] < TechRiderStagePlot::MIN_ROTATION
+                || $element['rotation'] > TechRiderStagePlot::MAX_ROTATION)
         ) {
             $this->violation($constraint->invalidRotationMessage, "$path.rotation", $constraint)->addViolation();
         }

--- a/tests/Api/BandSpace/TechRider/TechRiderStagePlotTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderStagePlotTest.php
@@ -171,18 +171,41 @@ class TechRiderStagePlotTest extends ApiTestCase
         $this->assertViolation('plot.elements[0].scale', 'La taille doit être comprise entre 0.25 et 4');
     }
 
-    /** Quarter turns only, because arbitrary angles are not renderable on every export engine. */
-    public function test_a_rotation_that_is_not_a_quarter_turn_is_refused(): void
+    /**
+     * The inverse of what this used to assert. Rotation was capped at quarter turns while the export
+     * engine was undecided, because arbitrary angles were not renderable everywhere; #741 settled on
+     * Chromium, which turns by any angle, so 45 is now a perfectly ordinary value.
+     */
+    public function test_an_arbitrary_angle_is_accepted(): void
     {
         [$user, $bandSpace, $rider, $item] = $this->seed();
 
         $this->put($user, $bandSpace, $rider, $item, [
             'plot' => ['version' => 1, 'elements' => [
-                ['id' => 'el-1', 'icon' => 'drum_kit', 'x' => 0.5, 'y' => 0.5, 'rotation' => 45],
+                ['id' => 'el-1', 'icon' => 'drum_kit', 'x' => 0.5, 'y' => 0.5, 'rotation' => 47],
             ]],
         ]);
 
-        $this->assertViolation('plot.elements[0].rotation', 'La rotation doit valoir 0, 90, 180 ou 270');
+        $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * Stored verbatim, not rounded to anything. An editor that snaps to 15 degrees is a convenience;
+     * the document has to keep whatever angle it was given, or a plot drawn with Alt held comes back
+     * subtly different from the one that was saved.
+     */
+    public function test_an_arbitrary_angle_survives_the_round_trip_unrounded(): void
+    {
+        [$user, $bandSpace, $rider, $item] = $this->seed();
+        $plot = ['version' => 1, 'elements' => [
+            ['id' => 'el-1', 'icon' => 'drum_kit', 'x' => 0.5, 'y' => 0.5, 'rotation' => 47],
+        ]];
+
+        $this->put($user, $bandSpace, $rider, $item, ['plot' => $plot]);
+        $this->assertResponseIsSuccessful();
+
+        $stored = self::getContainer()->get(TechRiderItemRepository::class)->find((string) $item->id);
+        $this->assertSame($plot, $stored?->content);
     }
 
     public function test_a_quarter_turn_is_accepted(): void
@@ -196,6 +219,38 @@ class TechRiderStagePlotTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * What is actually out of bounds now. 360 and a negative are refused so an angle has exactly one
+     * representation, and a float is refused so 90 and 90.0 cannot both mean the same rotation.
+     *
+     * One case per test rather than one payload with three bad elements, because assertViolation
+     * asserts the whole response body and therefore exactly one violation.
+     */
+    #[DataProvider('invalidRotationProvider')]
+    public function test_an_out_of_range_rotation_is_refused(int|float|string $rotation): void
+    {
+        [$user, $bandSpace, $rider, $item] = $this->seed();
+
+        $this->put($user, $bandSpace, $rider, $item, [
+            'plot' => ['version' => 1, 'elements' => [
+                ['id' => 'el-1', 'icon' => 'drum_kit', 'x' => 0.5, 'y' => 0.5, 'rotation' => $rotation],
+            ]],
+        ]);
+
+        $this->assertViolation('plot.elements[0].rotation', 'La rotation doit être un entier de 0 à 359 degrés');
+    }
+
+    /**
+     * @return iterable<string, array{int|float|string}>
+     */
+    public static function invalidRotationProvider(): iterable
+    {
+        yield 'a full turn, which is the same angle as zero' => [360];
+        yield 'a negative angle' => [-1];
+        yield 'a whole angle written as a float' => [90.0];
+        yield 'a numeric string' => ['90'];
     }
 
     public function test_an_unknown_icon_is_refused(): void
@@ -381,7 +436,7 @@ class TechRiderStagePlotTest extends ApiTestCase
                     'version' => 999,
                     'unknown_top_level_key' => 'x',
                     'elements' => [
-                        ['id' => 'x', 'icon' => 'pas_une_icone', 'x' => 50.0, 'y' => -30.0, 'rotation' => 45],
+                        ['id' => 'x', 'icon' => 'pas_une_icone', 'x' => 50.0, 'y' => -30.0, 'rotation' => 360],
                     ],
                 ],
             ],

--- a/tests/Api/BandSpace/TechRider/TechRiderStagePlotTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderStagePlotTest.php
@@ -208,17 +208,33 @@ class TechRiderStagePlotTest extends ApiTestCase
         $this->assertSame($plot, $stored?->content);
     }
 
-    public function test_a_quarter_turn_is_accepted(): void
+    /**
+     * Both ends of the range, and 359 is the one that matters: it is the only value that catches the
+     * upper bound being written as >= rather than >. Every other accepted angle sits comfortably
+     * inside, so without this the off-by-one passes.
+     */
+    #[DataProvider('acceptedRotationProvider')]
+    public function test_an_accepted_rotation_is_stored(int $rotation): void
     {
         [$user, $bandSpace, $rider, $item] = $this->seed();
 
         $this->put($user, $bandSpace, $rider, $item, [
             'plot' => ['version' => 1, 'elements' => [
-                ['id' => 'el-1', 'icon' => 'drum_kit', 'x' => 0.5, 'y' => 0.5, 'rotation' => 270],
+                ['id' => 'el-1', 'icon' => 'drum_kit', 'x' => 0.5, 'y' => 0.5, 'rotation' => $rotation],
             ]],
         ]);
 
         $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function acceptedRotationProvider(): iterable
+    {
+        yield 'the lower bound' => [TechRiderStagePlot::MIN_ROTATION];
+        yield 'the upper bound' => [TechRiderStagePlot::MAX_ROTATION];
+        yield 'a quarter turn' => [270];
     }
 
     /**
@@ -249,6 +265,10 @@ class TechRiderStagePlotTest extends ApiTestCase
     {
         yield 'a full turn, which is the same angle as zero' => [360];
         yield 'a negative angle' => [-1];
+        // This one only reaches the server as a float because jsonRequest() encodes with
+        // JSON_PRESERVE_ZERO_FRACTION; a plain json_encode(90.0) emits 90 and decodes back to an int.
+        // So it guards against a hand-written or non-JavaScript client, not against our own frontend,
+        // which cannot produce a trailing .0 through JSON.stringify at all.
         yield 'a whole angle written as a float' => [90.0];
         yield 'a numeric string' => ['90'];
     }

--- a/tests/Unit/Validator/BandSpace/TechRider/TechRiderStagePlotLimitsTest.php
+++ b/tests/Unit/Validator/BandSpace/TechRider/TechRiderStagePlotLimitsTest.php
@@ -56,17 +56,54 @@ class TechRiderStagePlotLimitsTest extends TestCase
     }
 
     /**
-     * The editor offers rotations as a button group, so an extra entry there would be a button that
-     * saves and then fails validation.
+     * The editor's rotation range has to be the server's, or the slider offers an angle that saves
+     * and then fails validation.
      */
-    public function test_the_editor_rotations_match_the_constraint(): void
+    public function test_the_editor_rotation_range_matches_the_constraint(): void
+    {
+        $source = $this->read();
+
+        preg_match('/export const MIN_ROTATION = (-?\d+)/', $source, $min);
+        preg_match('/export const MAX_ROTATION = (-?\d+)/', $source, $max);
+        self::assertNotEmpty($min, sprintf('No MIN_ROTATION export found in %s.', self::CONSTANTS_PATH));
+        self::assertNotEmpty($max, sprintf('No MAX_ROTATION export found in %s.', self::CONSTANTS_PATH));
+
+        $this->assertSame(TechRiderStagePlot::MIN_ROTATION, (int) $min[1]);
+        $this->assertSame(TechRiderStagePlot::MAX_ROTATION, (int) $max[1]);
+    }
+
+    /**
+     * The four quarter turns are shortcut buttons rather than the whole domain now, so they no longer
+     * have to equal the constraint. They do still have to be inside it: a shortcut that saves and
+     * then fails validation is the same bug as before, just wearing a different hat.
+     */
+    public function test_every_rotation_shortcut_is_within_the_accepted_range(): void
     {
         preg_match('/export const ROTATIONS = Object\.freeze\(\[([^\]]+)]\)/', $this->read(), $matches);
         self::assertNotEmpty($matches, sprintf('No ROTATIONS export found in %s.', self::CONSTANTS_PATH));
 
         $rotations = array_map('intval', array_map('trim', explode(',', $matches[1])));
+        self::assertNotEmpty($rotations);
 
-        $this->assertSame(TechRiderStagePlot::ALLOWED_ROTATIONS, $rotations);
+        foreach ($rotations as $rotation) {
+            $this->assertGreaterThanOrEqual(TechRiderStagePlot::MIN_ROTATION, $rotation);
+            $this->assertLessThanOrEqual(TechRiderStagePlot::MAX_ROTATION, $rotation);
+        }
+    }
+
+    /**
+     * The on-canvas grip snaps to this step, so it has to divide a quarter turn exactly. At a step of
+     * 20 a snapped drag could never land on 90, and the plot the editor makes easiest to build would
+     * be one nobody wants.
+     */
+    public function test_the_rotation_snap_step_divides_a_quarter_turn(): void
+    {
+        preg_match('/export const ROTATION_SNAP_STEP = (\d+)/', $this->read(), $matches);
+        self::assertNotEmpty($matches, sprintf('No ROTATION_SNAP_STEP export found in %s.', self::CONSTANTS_PATH));
+
+        $step = (int) $matches[1];
+        self::assertGreaterThan(0, $step);
+        $this->assertSame(0, 90 % $step, sprintf('A snap step of %d cannot reach a quarter turn.', $step));
     }
 
     /** The default has to be inside the range the server accepts, or a new plot cannot be saved. */


### PR DESCRIPTION
Closes #802.

Stage plot elements turned only in quarter turns. They now turn to any whole degree, by dragging a grip on the canvas or by a slider in the inspector.

The cap was never a design preference. It was chosen while the export engine was undecided, because arbitrary angles were not renderable on every candidate: dompdf has no CSS transform support at all. #741 settled on Chromium, which turns by any angle, so the reason had gone. A stage is not built on a grid: wedges angle in towards a performer and a riser sits across a corner, so quarter turns produced a diagram that read as approximate.

## Two things this did not need

**Rendering.** `StagePlotCanvas.vue` already emitted `transform: rotate(${rotation}deg)`, and it sits on the image rather than the wrapper so the label and the selection ring stay level whatever the icon does. Any angle already drew correctly, in the editor and in an export.

**A migration.** The change widens an allowlist into a range that contains every value already stored, so nothing has to be rewritten.

So the model change is a handful of lines and the work was the interaction.

## The model

`ALLOWED_ROTATIONS` became `MIN_ROTATION` and `MAX_ROTATION`, and the `in_array` became an integer range check. Three parts of that are deliberate:

**Integers only.** This is the one numeric rule in the validator that does not go through its `toFloat()` helper, so `90.0` and `"90"` are refused. One representation per angle means two plots that draw identically compare identically.

**360 and negatives refused**, for the same reason: 360 and 0 are the same rotation.

**Nothing normalised server side.** The processor writes the document verbatim, an existing test asserts it round-trips byte for byte, and a new test pins that an unsnapped 47 comes back as exactly 47. An editor that snaps is a convenience; a document that quietly rounds is a bug.

## The interaction

**The inspector keeps its four quarter-turn buttons and gains a 0 to 359 slider.** The buttons are one click where the slider is an aim, and they are the only sane keyboard path, since arrows on a 360 stop slider would need ninety presses to turn a corner. The slider is step 1 rather than something coarser so it can represent every angle the server accepts: a coarser step would quietly rewrite an angle placed freely on the canvas the moment anyone touched the control.

**The canvas grip snaps to 15 degrees, and Alt frees it to whole degrees.** That is the bargain Alt already makes in the same file, where position snaps to a grid and Alt ignores it.

**It sits at top-left**, because the right hand side is full. At the smallest scale the wrapper is 20px, and the rotate button and the scale grip between them cover the whole of that edge. Like the scale grip it is an `aria-hidden` span: a pointer-only gesture has no keyboard meaning, and the slider is the equivalent that does.

## A latent bug fixed on the way

`rotateElement()` looked the current angle up in `ROTATIONS`. `indexOf` returns -1 for anything off the list and `ROTATIONS[0]` is 0, so the shortcut button silently discarded the angle. Harmless while nothing could produce an off-list value, and wrong the moment the grip can. It now advances to the next quarter turn from wherever the element sits.

That also means the button no longer always turns 90 degrees, so its tooltip and the help text were corrected: from 47 it is a 43 degree turn.

## Verification

The angle maths is exported as pure functions specifically so it can be checked without a browser, and **that is now a permanent test rather than a script I threw away**: `assets/js/constants/stagePlot.test.js`, an `npm test` script, and a CI step. Node ships the runner, so this adds no dependency. It pins the `atan2` sign convention against screen coordinates, that snapping only produces multiples of 15 and reaches all 24 stops including every quarter turn, that Alt is finer, that the grab offset leaves the icon still, and that nothing escapes 0 to 359 over a three turn sweep.

Mutation tested, so it is known to have teeth. Folding before snapping fails two tests, flipping the `atan2` sign fails one, and restoring the old `indexOf` cycle fails one, which means it would have caught the bug this fixes.

PHP suite **1985 tests, 5299 assertions**, against a master baseline of 1976 and 5261. PHPStan level 8 clean, lint at its 44 info baseline, build clean.

Note that this adds the project's first JavaScript test and a CI step, which is slightly beyond the issue. It is here because the functions were extracted to be testable, so leaving them untested would have made that rationale untrue.

## Review

No blockers. The valuable finding was one the tests could not have told me.

**The upper bound was not pinned.** Mutating the check from `>` to `>=` left all 36 tests green, because every accepted value in them was 0, 47 or 270. The lower bound was caught, by an unrelated fixture that happens to use rotation 0, which is what made the asymmetry visible. A data provider now covers both bounds explicitly.

**One test passes for a reason I had wrong.** I assumed PHP's `serialize_precision` was what kept `90.0` a float. It is not: `json_encode(90.0)` emits `90`, which decodes back to an int. It survives only because Symfony's `jsonRequest()` encodes with `JSON_PRESERVE_ZERO_FRACTION`. So the case is real coverage against a hand written or non JavaScript client, but not against our own frontend, which cannot produce a trailing `.0` at all. Now commented, so the next reader does not repeat my conclusion.

One nit declined with a reason: the rotation drag does not need the scale drag's `startDistance < 1` guard, because unlike the scale drag it never divides by that distance, and `Math.atan2(0, 0)` is 0 rather than NaN.

## Known gap

The gesture itself was not exercised in a browser. The dev database has no `tech_rider_*` tables, so the editor cannot be opened without bringing that schema up to date first. This is the second change in a row where missing dev data blocked a hands on check, which is what #787 is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
