### PR TITLE
Stage plot: alignment guides while dragging an element

### DIFF
--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
@@ -92,6 +92,23 @@
         </template>
       </div>
 
+      <!-- Alignment guides, drawn after the elements so they sit over the icons. They only inform:
+           the grid is what keeps a plot tidy, and a line that also pulled the element would fight it.
+           aria-hidden and pointer-events-none for the same reason as the drag grips, a purely visual
+           aid during a pointer gesture. -->
+      <div
+        v-if="alignmentGuides.x !== null"
+        class="absolute top-0 bottom-0 w-px bg-primary-500/70 pointer-events-none"
+        :style="{ left: `${alignmentGuides.x * 100}%` }"
+        aria-hidden="true"
+      />
+      <div
+        v-if="alignmentGuides.y !== null"
+        class="absolute left-0 right-0 h-px bg-primary-500/70 pointer-events-none"
+        :style="{ top: `${alignmentGuides.y * 100}%` }"
+        aria-hidden="true"
+      />
+
       <!-- The audience side. Everything on a rider is described relative to it, so an unlabelled
            box is ambiguous. -->
       <div
@@ -118,6 +135,7 @@ import {
   COARSE_NUDGE_STEP,
   describePosition,
   FINE_NUDGE_STEP,
+  findAlignmentGuides,
   MAX_SCALE,
   MIN_SCALE,
   NUDGE_STEP,
@@ -156,6 +174,12 @@ const elementRefs = new Map()
 let drag = null
 let scaleDrag = null
 let rotateDrag = null
+
+/** Frozen because the same reference is assigned on every drag end; nothing may mutate it. */
+const NO_GUIDES = Object.freeze({ x: null, y: null })
+
+/** Only ever set while a move drag is running; scaling and rotating do not move an element. */
+const alignmentGuides = ref(NO_GUIDES)
 
 const gridImage = computed(() => {
   // Drawn with a gradient rather than an SVG asset: it is two lines, and this way it inherits the
@@ -244,6 +268,8 @@ function handlePointerMove(event) {
   const position = stageFractions(event)
   drag.element.x = applySnap(position.x + drag.offsetX, event)
   drag.element.y = applySnap(position.y + drag.offsetY, event)
+
+  alignmentGuides.value = findAlignmentGuides(drag.element, props.elements)
 }
 
 function handlePointerUp(event) {
@@ -251,6 +277,7 @@ function handlePointerUp(event) {
 
   const id = drag.element.id
   drag = null
+  alignmentGuides.value = NO_GUIDES
 
   stageRef.value.releasePointerCapture(event.pointerId)
   stageRef.value.removeEventListener('pointermove', handlePointerMove)

--- a/assets/js/constants/stagePlot.js
+++ b/assets/js/constants/stagePlot.js
@@ -57,6 +57,22 @@ export const NUDGE_STEP = SNAP_STEP
 export const FINE_NUDGE_STEP = 0.005
 export const COARSE_NUDGE_STEP = 0.1
 
+/**
+ * How near two centres have to be before a guide is drawn between them.
+ *
+ * Half a grid step, so it can never fight the grid: two positions that are both on the grid are
+ * either identical or a whole step apart, which is further than this, so a guide between two snapped
+ * elements always means exactly aligned.
+ *
+ * That is as far as the guarantee goes, and it is worth being precise about. It does not extend to
+ * the whole document, because an element can legitimately sit off the grid: Alt frees a drag from it,
+ * and FINE_NUDGE_STEP is 0.005, which is not a multiple of SNAP_STEP. So a snapped element dragged
+ * next to a neighbour nudged one fine step off 0.5 is 0.005 away, inside this tolerance and not
+ * aligned. The guide then slightly overstates the precision, which is tolerable only because guides
+ * inform and never move anything.
+ */
+export const ALIGNMENT_TOLERANCE = SNAP_STEP / 2
+
 const HORIZONTAL_BANDS = [
   { limit: 1 / 3, label: 'à gauche' },
   { limit: 2 / 3, label: 'au centre' },
@@ -93,6 +109,51 @@ export function toFraction(value) {
 
 export function snapFraction(value) {
   return toFraction(Math.round(value / SNAP_STEP) * SNAP_STEP)
+}
+
+/**
+ * The centres the dragged element lines up with, as `{ x, y }`, either being null for no alignment.
+ *
+ * Returns the *other* element's coordinate rather than the dragged one's, because the line has to be
+ * drawn where the reference sits: it says "the batterie is on this line", which is information. A
+ * line drawn at the dragged element's own coordinate would follow the pointer and say nothing.
+ *
+ * Centres only. The document stores no width or height, so an element's rendered box is its icon's
+ * intrinsic ratio times its scale, and asking for edges would mean measuring every element from the
+ * DOM on every pointer move. Centres are also what a stage plot means by aligned: two wedges at the
+ * same depth, a mic in front of an amp.
+ *
+ * Nothing is moved here. Guides inform; the grid is what keeps a plot tidy.
+ */
+export function findAlignmentGuides(dragged, others, tolerance = ALIGNMENT_TOLERANCE) {
+  let x = null
+  let y = null
+  let nearestX = Number.POSITIVE_INFINITY
+  let nearestY = Number.POSITIVE_INFINITY
+
+  for (const other of others) {
+    // An element always aligns with itself, which is never worth drawing. By identity rather than by
+    // id: the caller is dragging one of the entries in this very list, so identity is exact, while
+    // comparing ids silently drops a real alignment between two elements that share an id or, worse,
+    // between two that both lack one, since undefined equals undefined.
+    if (other === dragged) {
+      continue
+    }
+
+    const dx = Math.abs(other.x - dragged.x)
+    if (dx <= tolerance && dx < nearestX) {
+      nearestX = dx
+      x = other.x
+    }
+
+    const dy = Math.abs(other.y - dragged.y)
+    if (dy <= tolerance && dy < nearestY) {
+      nearestY = dy
+      y = other.y
+    }
+  }
+
+  return { x, y }
 }
 
 /**

--- a/assets/js/constants/stagePlot.test.js
+++ b/assets/js/constants/stagePlot.test.js
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import {
+  ALIGNMENT_TOLERANCE,
+  findAlignmentGuides,
   MAX_ROTATION,
   MIN_ROTATION,
   nextQuarterTurn,
@@ -8,7 +10,8 @@ import {
   pointerBearing,
   ROTATION_SNAP_STEP,
   rotationFromPointer,
-  rotationGrabOffset
+  rotationGrabOffset,
+  SNAP_STEP
 } from './stagePlot.js'
 
 /**
@@ -102,6 +105,104 @@ describe('rotationFromPointer', () => {
         assert.ok(angle >= MIN_ROTATION && angle <= MAX_ROTATION, `${angle} is out of range`)
       }
     }
+  })
+})
+
+describe('findAlignmentGuides', () => {
+  const at = (id, x, y) => ({ id, x, y })
+
+  it('finds an alignment on one axis without inventing one on the other', () => {
+    const dragged = at('dragged', 0.5, 0.5)
+    const others = [at('a', 0.5, 0.2)]
+
+    assert.deepEqual(findAlignmentGuides(dragged, others), { x: 0.5, y: null })
+  })
+
+  it('finds both axes when two different elements each line up', () => {
+    const dragged = at('dragged', 0.5, 0.5)
+    const others = [at('a', 0.5, 0.2), at('b', 0.9, 0.5)]
+
+    assert.deepEqual(findAlignmentGuides(dragged, others), { x: 0.5, y: 0.5 })
+  })
+
+  // The line is drawn at the reference element's coordinate, not the dragged one's, so it reads as
+  // "that element is on this line" rather than following the pointer.
+  it('reports the reference coordinate, not the dragged one', () => {
+    const dragged = at('dragged', 0.504, 0.5)
+    const others = [at('a', 0.5, 0.1)]
+
+    assert.deepEqual(findAlignmentGuides(dragged, others).x, 0.5)
+  })
+
+  // Both orderings, because either one alone passes against an implementation that simply lets the
+  // last match win: with the near candidate listed last, "nearest" and "last" agree.
+  it('prefers the nearest candidate whichever order they come in', () => {
+    const dragged = at('dragged', 0.5, 0.5)
+    const near = at('near', 0.502, 0.1)
+    const far = at('far', 0.51, 0.1)
+
+    assert.equal(findAlignmentGuides(dragged, [near, far]).x, 0.502)
+    assert.equal(findAlignmentGuides(dragged, [far, near]).x, 0.502)
+  })
+
+  it('never aligns an element against itself', () => {
+    const dragged = at('dragged', 0.5, 0.5)
+
+    assert.deepEqual(findAlignmentGuides(dragged, [dragged]), { x: null, y: null })
+  })
+
+  it('ignores a centre just outside the tolerance', () => {
+    const dragged = at('dragged', 0.5, 0.5)
+    const justOutside = ALIGNMENT_TOLERANCE + 0.0001
+
+    assert.deepEqual(
+      findAlignmentGuides(dragged, [at('a', 0.5 + justOutside, 0.5 + justOutside)]),
+      { x: null, y: null }
+    )
+  })
+
+  /**
+   * The boundary itself, which is the only value that distinguishes <= from <. Without it an
+   * off-by-one on the comparison ships silently, exactly as it did for MAX_ROTATION in #802.
+   *
+   * Measured from zero deliberately. The obvious construction, a neighbour at 0.5 plus or minus the
+   * tolerance, cannot test this: the two directions land either side of the boundary in floating
+   * point, 0.0124999... one way and 0.0125000... the other. Subtracting from zero is exact.
+   */
+  it('includes a centre exactly at the tolerance', () => {
+    const dragged = at('dragged', 0, 0)
+    const onTheBoundary = at('a', ALIGNMENT_TOLERANCE, ALIGNMENT_TOLERANCE)
+
+    assert.deepEqual(findAlignmentGuides(dragged, [onTheBoundary]), {
+      x: ALIGNMENT_TOLERANCE,
+      y: ALIGNMENT_TOLERANCE
+    })
+  })
+
+  // Two elements that both lack an id must still see each other. Filtering self by id rather than by
+  // identity would drop this, because undefined equals undefined.
+  it('aligns two distinct elements that share an id', () => {
+    const dragged = { x: 0.5, y: 0.5 }
+    const other = { x: 0.5, y: 0.1 }
+
+    assert.equal(findAlignmentGuides(dragged, [dragged, other]).x, 0.5)
+  })
+
+  it('copes with an empty stage', () => {
+    assert.deepEqual(findAlignmentGuides(at('dragged', 0.5, 0.5), []), { x: null, y: null })
+  })
+
+  /**
+   * The tolerance is half a grid step, which means it can never fire on a near miss while snapping is
+   * on: two snapped centres are either identical or a full step apart. So a guide during an ordinary
+   * drag always means exactly aligned, and only Alt placement can produce the approximate kind.
+   */
+  it('cannot report a near miss between two snapped positions', () => {
+    const dragged = at('dragged', 0.5, 0.5)
+    const oneStepAway = at('a', 0.5 + SNAP_STEP, 0.5 + SNAP_STEP)
+
+    assert.deepEqual(findAlignmentGuides(dragged, [oneStepAway]), { x: null, y: null })
+    assert.ok(ALIGNMENT_TOLERANCE < SNAP_STEP, 'the tolerance must stay inside one grid step')
   })
 })
 


### PR DESCRIPTION
Closes #805.

While you drag an element on a stage plot, a thin line now appears wherever its centre lines up with another element's, on either axis. Frontend only, no backend change, nothing stored.

## Guides inform, they do not snap

That is the decision the issue asked for and it is worth restating, because it inverts how most editors behave. There is already a position grid (`SNAP_STEP` of 0.025, with Alt to place freely), so **snapping was largely solved already**; what was missing was being told. A line that also pulled the element would fight the grid rather than add to it.

## Centres, because that is what the document knows

An element is stored as `{id, icon, x, y, scale, rotation, label, colour}` and positioned by its centre. There is no width or height anywhere: the rendered box is the icon's intrinsic ratio times its scale, and rotation is applied to the image.

So centre alignment costs nothing, computed straight from the stored document with no DOM reads, while edge alignment would mean a `getBoundingClientRect()` per element per pointer move and would get murky once an icon is turned 47 degrees. Centres are also what a stage plot means by aligned: two wedges at the same depth, a mic in front of an amp.

The guide reports the **other** element's coordinate, not the dragged one's, so the line is drawn where the reference sits and reads as "that element is on this line". A line at the dragged coordinate would follow the pointer and say nothing.

## Where the lines go

Top-left of the stage box is already taken by the rotation grip, and the right edge by the rotate button and the scale grip, but guides are not handles: they are two absolutely positioned lines, `pointer-events-none` and `aria-hidden`, drawn after the elements so they paint over the icons. `aria-hidden` for the same reason as the drag grips, which the codebase already establishes: a purely visual aid during a pointer gesture has no keyboard meaning.

Which is also the honest limit of this feature. **It does nothing for keyboard users.** Arrow keys nudge elements too, and a line means nothing to a screen reader. If alignment matters on the keyboard path, the answer is a different feature, an align command or numeric position fields, not guides.

## What the tolerance does and does not guarantee

`ALIGNMENT_TOLERANCE` is half a grid step, so it can never fight the grid: two positions that are both on the grid are either identical or a whole step apart, which is further than the tolerance. **A guide between two snapped elements therefore always means exactly aligned.** Verified by enumerating every grid point.

That is as far as it goes, and the code now says so explicitly, because my first version of that comment claimed more. An element can legitimately sit off the grid: Alt frees a drag, and `FINE_NUDGE_STEP` is 0.005, which is not a multiple of 0.025. So a snapped element dragged beside a neighbour nudged one fine step off 0.5 sits 0.005 away, inside the tolerance and not aligned, and the guide slightly overstates the precision. Tolerable only because guides never move anything.

## Verified in the browser

Logged in, opened a rider with a 21 element plot, and dragged the drum stool into the guitar amp column. Both guides appeared, and both were genuine rather than self-matches: the stool ended up sharing x with three elements and y with two. Guides clear on pointerup, after a render tick.

The MCP drag tool sends HTML5 drag events, which this handler does not listen for, so the gesture was driven with synthetic `PointerEvent`s at `pointerId: 1`, which is what `setPointerCapture` needs.

Contrast was measured rather than eyeballed, and that was the right call because **eyeballing it was wrong**. On the downscaled screenshot the guides looked as if they might be lost against the grid mesh, and sampled pixels then read plain background, which pointed at a bug. Both readings were off by one pixel. At the correct coordinate the guide reads (77, 108, 136) against a (24, 24, 27) background: unambiguous, and more visible than the grid.

No dev data was touched. The editor requires an explicit save, so the drag never persisted, and a reload discarded it. The stool is still at its original coordinates in the database.

## Tests

`findAlignmentGuides` is a pure exported function so `npm test` covers it, which is the runner added in #802. Nineteen tests in the file now.

Mutation tested, and that is where the real work was, because **three tests initially passed for the wrong reason**:

- "prefers the nearest candidate" listed its fixture as `[far, near]`, and the mutation it targets makes the *last* match win, which is `near` either way. It now asserts both orderings.
- The tolerance boundary cannot be tested as `0.5 plus or minus the tolerance`: in floating point the two directions land either side of it, 0.0124999 one way and 0.0125000 the other. Measured from zero it is exact.
- A test meant to prove two id-less elements still see each other failed against a belt and braces self filter, because `undefined === undefined`. That is the whole argument for comparing self by identity rather than by id, and the id check is gone.

Six mutations now each fail a test: both boundary directions, id instead of identity, the self filter removed entirely, nearest no longer winning, and reporting the dragged coordinate.

## Review

No blockers. The valuable finding was the tolerance claim above, which the reviewer refuted with a constructed counterexample I then reproduced. The missing boundary test and the identity versus id argument came from the same review.

One finding was filed rather than fixed: **#806**, where a `seed()` landing mid-drag detaches the element being dragged, because `seed()` replaces the element objects while all three drags capture one by reference. Pre-existing, narrow, self-healing, and it affects move, scale and rotate equally. The guides only inherit it, so it does not belong here.

Two nits left with reasons: the tie break on an exact floating point tie is order dependent but deterministic, and a guide near the audience edge is dimmed by the "Face public" band, consistent with how the elements themselves already render in that strip.

## Verification

`npm test` 19 of 19, `npm run lint` exits 0 at its 44 info baseline, `npm run build` clean. No PHP file is touched, and PHPStan is clean.

## Out of scope

- Edge and bounding box alignment, for the reasons above.
- Guides against the stage box itself, for instance centring an element on the stage. A reasonable follow up, but a different rule with a different tolerance.
- Distributing several elements evenly, which needs multi select, which does not exist.

