### PR TITLE
Tech rider: export the composed rider as a PDF

### DIFF
--- a/assets/js/api/bandSpace/band-space-tech-riders.js
+++ b/assets/js/api/bandSpace/band-space-tech-riders.js
@@ -1,6 +1,7 @@
 /** global: Routing */
 
 import axios from 'axios'
+import { filenameFromContentDisposition } from '../../utils/downloadBlob.js'
 import { handleApiError } from '../utils/handleApiError.js'
 
 export default {
@@ -165,6 +166,28 @@ export default {
       .get(Routing.generate('api_band_space_tech_rider_stage_plot_icons_get_collection'))
       .then((resp) => resp.data.member ?? [])
       .catch(handleApiError)
+  },
+
+  /**
+   * Fetches the rider PDF as a blob rather than navigating to it, so the caller can show progress
+   * and report a failure instead of opening a tab onto a raw error page.
+   *
+   * Through axios, not fetch, so the global 401 interceptor still applies: a rider can take a couple
+   * of seconds to render when it has attachments to merge, and an expired token has to send the user
+   * to log in rather than look like a broken export.
+   */
+  downloadPdf(bandSpaceId, riderId) {
+    return axios
+      .get(
+        Routing.generate('api_band_space_tech_riders_pdf_export', { bandSpaceId, id: riderId }),
+        {
+          responseType: 'blob'
+        }
+      )
+      .then((resp) => ({
+        blob: resp.data,
+        filename: filenameFromContentDisposition(resp.headers['content-disposition'])
+      }))
   },
 
   reorderItems(bandSpaceId, riderId, positions) {

--- a/assets/js/views/BandSpace/TechRider.vue
+++ b/assets/js/views/BandSpace/TechRider.vue
@@ -52,8 +52,14 @@
           />
         </div>
         <div v-if="rider" class="flex items-center gap-2">
-          <!-- Offered on an archived rider too: starting next year's from last year's archived one
-               is the main reason this action exists. -->
+          <!-- Offered on an archived rider too, like Dupliquer: last year's rider is exactly the
+               thing you send when a venue asks what you used. -->
+          <Button
+            :label="isExporting ? 'Génération...' : 'Télécharger le PDF'"
+            :icon="isExporting ? 'pi pi-spin pi-spinner' : 'pi pi-download'"
+            :disabled="isExporting"
+            @click="handleExport"
+          />
           <Button
             label="Dupliquer"
             icon="pi pi-copy"
@@ -129,12 +135,14 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router'
+import bandSpaceTechRidersApi from '../../api/bandSpace/band-space-tech-riders.js'
 import RiderItemList from '../../components/BandSpace/TechRider/RiderItemList.vue'
 import TechRiderFormDialog from '../../components/BandSpace/TechRider/TechRiderFormDialog.vue'
 import TechRiderSelector from '../../components/BandSpace/TechRider/TechRiderSelector.vue'
 import { LAST_TECH_RIDER_KEY } from '../../constants/bandSpace.js'
 import { COPY_SUFFIX, MAX_NAME_LENGTH } from '../../constants/techRider.js'
 import { useBandTechRidersStore } from '../../store/bandSpace/bandSpaceTechRiders.js'
+import { downloadBlob } from '../../utils/downloadBlob.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -150,6 +158,7 @@ const hasAnyRider = computed(
 )
 
 const selectedRiderId = ref(null)
+const isExporting = ref(false)
 const formDialogOpen = ref(false)
 const formDialogMode = ref('create')
 
@@ -237,6 +246,36 @@ function openCreateDialog() {
 function openRenameDialog() {
   formDialogMode.value = 'rename'
   formDialogOpen.value = true
+}
+
+async function handleExport() {
+  if (isExporting.value || !rider.value) {
+    return
+  }
+
+  isExporting.value = true
+
+  try {
+    const { blob, filename } = await bandSpaceTechRidersApi.downloadPdf(
+      bandSpaceId.value,
+      rider.value.id
+    )
+    downloadBlob(blob, filename ?? 'tech-rider.pdf')
+  } catch (error) {
+    // A 401 already redirects to the login page through the global interceptor, so a toast on top of
+    // that is only noise. Everything else says so here, because API Platform blanks the message on a
+    // 5xx and the response carries no usable detail.
+    if (error?.response?.status !== 401) {
+      toast.add({
+        severity: 'error',
+        summary: 'Export impossible',
+        detail: 'Le PDF n’a pas pu être généré. Veuillez réessayer dans un instant.',
+        life: 6000
+      })
+    }
+  } finally {
+    isExporting.value = false
+  }
 }
 
 function openDuplicateDialog() {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,9 +91,11 @@ services:
     # Headless Chromium as an HTTP service, rendering the setlist PDF export (#741). The
     # integration tests need it running; the rest of the suite substitutes the client.
     gotenberg:
-        # Chromium only. The full image is about 1.7GB and adds LibreOffice plus the PDF engines,
-        # which are needed for Office conversion and for PDF/A. Bring it back as gotenberg:8 if
-        # invoicing ever arrives, since Factur-X is PDF/A-3.
+        # Chromium only. The full image is about 1.7GB and what it adds is **LibreOffice**, needed
+        # for Office conversion. It does not add the PDF engines: this variant already reports
+        # `modules: api chromium exiftool pdfcpu pdfengines pdftk prometheus qpdf webhook`, so
+        # /forms/pdfengines/merge works here, which is what the tech rider export relies on to fold a
+        # PDF attachment into the document. An earlier version of this comment said otherwise.
         #
         # Pinned to a patch tag, matching CI, so an upstream change is a deliberate act. The pin in
         # config/packages/sensiolabs_gotenberg.yaml is the oldest version we rely on and is a

--- a/src/ApiResource/BandSpace/TechRider/TechRiderPdfExport.php
+++ b/src/ApiResource/BandSpace/TechRider/TechRiderPdfExport.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Provider\BandSpace\TechRider\TechRiderPdfExportProvider;
+
+/**
+ * The document a rider exists to produce. A separate resource rather than an operation on
+ * TechRiderResource, matching SetlistPdfExport: it returns a file, not a representation of a rider,
+ * so `output: false` and the provider hands back a Response itself.
+ */
+#[ApiResource(
+    shortName: 'TechRiderPdfExport',
+    operations: [
+        new Get(
+            uriTemplate: '/band_spaces/{bandSpaceId}/tech_riders/{id}/pdf',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space Tech Rider']),
+            security: "is_granted('ROLE_USER')",
+            output: false,
+            name: 'api_band_space_tech_riders_pdf_export',
+            provider: TechRiderPdfExportProvider::class,
+        ),
+    ],
+)]
+class TechRiderPdfExport
+{
+    #[ApiProperty(identifier: true)]
+    public string $bandSpaceId;
+
+    #[ApiProperty(identifier: true)]
+    public string $id;
+}

--- a/src/Service/BandSpace/TechRider/TechRiderAttachmentReader.php
+++ b/src/Service/BandSpace/TechRider/TechRiderAttachmentReader.php
@@ -1,0 +1,192 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace\TechRider;
+
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\BandSpace\BandSpaceFileVersion;
+use App\Entity\BandSpace\TechRiderItem;
+use App\Service\BandSpace\File\BandSpaceFileMimeAllowlist;
+use Vich\UploaderBundle\Storage\StorageInterface;
+
+/**
+ * Spools a document item's file to a local temp file so the export can place it, and decides when it
+ * cannot be placed at all.
+ *
+ * Every refusal returns a reference instead of throwing. A rider that silently drops an attachment is
+ * worse than one that names it: the band can see what to send separately, and one bad file cannot
+ * stop the whole export.
+ *
+ * Bytes are copied stream to stream and never materialise in this process. That is not tidiness: a
+ * band space file may be 500 MiB, and although the size check below refuses anything that large, the
+ * copy is written so that a stale or wrong size cannot turn into a fatal.
+ */
+readonly class TechRiderAttachmentReader
+{
+    private const array IMAGE_EXTENSIONS = [
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+        'image/gif' => 'gif',
+        'image/webp' => 'webp',
+    ];
+
+    /** Read size for the encryption scan. The whole file is covered, this is just the chunk. */
+    private const int SCAN_CHUNK_BYTES = 65536;
+
+    public function __construct(
+        private StorageInterface $vichStorage,
+    ) {
+    }
+
+    /**
+     * @return array{kind: 'merge'|'image', path: string, name: string}|array{kind: 'reference', name: string, reason: string}
+     */
+    public function prepare(TechRiderItem $item, string $workspace, int $maxBytes): array
+    {
+        $file = $item->file;
+        if (!$file instanceof BandSpaceFile) {
+            return self::reference('Aucun fichier', 'Aucun fichier n\'est joint à cet élément.');
+        }
+
+        $name = $file->originalName;
+
+        if ($file->isArchived()) {
+            return self::reference($name, 'Ce fichier a été supprimé de l\'espace et n\'a pas pu être inclus.');
+        }
+
+        $version = $file->currentVersion;
+        if (!$version instanceof BandSpaceFileVersion) {
+            return self::reference($name, 'Aucune version disponible pour ce fichier.');
+        }
+
+        // Re-checked here on purpose: the type is validated when the file is attached, and a later
+        // version upload can replace it with something that has no visual form at all.
+        if (!BandSpaceFileMimeAllowlist::isRenderableAsPage($version->mimeType)) {
+            return self::reference($name, 'Ce type de fichier ne peut pas être inclus dans le document.');
+        }
+
+        if ($version->size !== null && $version->size > $maxBytes) {
+            return self::reference($name, sprintf(
+                'Fichier trop volumineux pour être inclus (%s Mo). À envoyer séparément.',
+                number_format($version->size / (1024 * 1024), 1, ',', ' '),
+            ));
+        }
+
+        $extension = self::IMAGE_EXTENSIONS[$version->mimeType] ?? 'pdf';
+        $path = sprintf('%s/attachment-%s.%s', $workspace, bin2hex(random_bytes(6)), $extension);
+
+        $failure = $this->spool($version, $path, $maxBytes);
+        if ($failure !== null) {
+            return self::reference($name, $failure);
+        }
+
+        if ($extension !== 'pdf') {
+            return ['kind' => 'image', 'path' => $path, 'name' => $name];
+        }
+
+        $refusal = $this->pdfRefusal($path);
+
+        return $refusal === null
+            ? ['kind' => 'merge', 'path' => $path, 'name' => $name]
+            : self::reference($name, $refusal);
+    }
+
+    /**
+     * Copies storage to disk. Returns null on success, or the reason to print instead.
+     *
+     * The reason matters rather than a bare boolean: an object that turns out to be larger than its
+     * version row claimed is a different thing from one that is not there, and telling a band their
+     * file is missing when it is merely oversized sends them looking for the wrong problem.
+     */
+    private function spool(BandSpaceFileVersion $version, string $path, int $maxBytes): ?string
+    {
+        $source = $this->vichStorage->resolveStream($version, 'uploadedFile');
+        if (!is_resource($source)) {
+            return 'Le fichier est introuvable dans le stockage.';
+        }
+
+        $target = @fopen($path, 'wb');
+        if ($target === false) {
+            fclose($source);
+
+            return 'Le fichier n\'a pas pu être préparé pour le document.';
+        }
+
+        try {
+            // One byte past the cap on purpose: copying exactly the cap cannot tell a file that fits
+            // from one that was truncated at the limit, so the overshoot is what detects the second.
+            $copied = stream_copy_to_stream($source, $target, $maxBytes + 1);
+
+            if ($copied === false) {
+                return 'Le fichier est introuvable dans le stockage.';
+            }
+
+            // Reached only when the version row disagrees with the object actually in storage.
+            return $copied > $maxBytes
+                ? 'Fichier trop volumineux pour être inclus. À envoyer séparément.'
+                : null;
+        } finally {
+            fclose($target);
+            fclose($source);
+        }
+    }
+
+    /**
+     * Why this PDF cannot be merged, or null when it can.
+     *
+     * Both checks are cheap and local, and both fail safe: the worst case of a false positive is that
+     * a perfectly good attachment is named rather than merged, where the alternative is a merge that
+     * fails and takes the whole export down with it.
+     */
+    private function pdfRefusal(string $path): ?string
+    {
+        $handle = @fopen($path, 'rb');
+        if ($handle === false) {
+            return 'Le fichier n\'a pas pu être lu.';
+        }
+
+        try {
+            if (fread($handle, 5) !== '%PDF-') {
+                return 'Ce fichier n\'est pas un PDF valide et n\'a pas pu être inclus.';
+            }
+
+            // A password protected PDF cannot be merged, so it is named instead.
+            //
+            // The whole file is scanned rather than the tail. The encryption dictionary is referenced
+            // from the trailer, which is usually at the end, but not dependably: a file with many
+            // objects pushes its trailer past any fixed window, and a document saved incrementally
+            // carries an earlier trailer further up. The scan is bounded anyway by the size cap
+            // above, so there is nothing to buy by guessing where to look.
+            //
+            // It can still miss, because a cross reference stream keeps the trailer compressed. The
+            // consequence of a miss is a failed merge, which is why this is a courtesy rather than
+            // the guarantee.
+            fseek($handle, 0);
+            $carry = '';
+            while (!feof($handle)) {
+                $chunk = fread($handle, self::SCAN_CHUNK_BYTES);
+                if (!is_string($chunk)) {
+                    break;
+                }
+
+                if (str_contains($carry . $chunk, '/Encrypt')) {
+                    return 'Ce PDF est protégé par un mot de passe et n\'a pas pu être inclus.';
+                }
+
+                // Enough overlap that the marker cannot hide across a chunk boundary.
+                $carry = substr($chunk, -8);
+            }
+
+            return null;
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @return array{kind: 'reference', name: string, reason: string}
+     */
+    private static function reference(string $name, string $reason): array
+    {
+        return ['kind' => 'reference', 'name' => $name, 'reason' => $reason];
+    }
+}

--- a/src/Service/BandSpace/TechRider/TechRiderPdfRenderer.php
+++ b/src/Service/BandSpace/TechRider/TechRiderPdfRenderer.php
@@ -1,0 +1,434 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace\TechRider;
+
+use App\Entity\BandSpace\TechRider;
+use App\Entity\BandSpace\TechRiderItem;
+use App\Entity\BandSpace\TechRiderPatchRow;
+use App\Enum\BandSpace\TechRiderItemType;
+use App\Enum\BandSpace\TechRiderPatchDirection;
+use App\Enum\BandSpace\TechRiderStagePlotIcon;
+use Sensiolabs\GotenbergBundle\Builder\BuilderFileInterface;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\HtmlPdfBuilder;
+use Sensiolabs\GotenbergBundle\Builder\Pdf\MergePdfBuilder;
+use Sensiolabs\GotenbergBundle\Enumeration\PaperSize;
+use Sensiolabs\GotenbergBundle\Enumeration\Unit;
+use Sensiolabs\GotenbergBundle\Exception\ExceptionInterface as GotenbergException;
+use Sensiolabs\GotenbergBundle\GotenbergPdfInterface;
+use Sensiolabs\GotenbergBundle\Processor\InMemoryProcessor;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientException;
+use Twig\Environment;
+
+/**
+ * Renders a whole tech rider to PDF. Callers depend only on render() returning the bytes.
+ *
+ * A rider is not one document but a sequence, because a document item points at a real PDF that
+ * cannot share a page with rider content. So the rider is walked into **segments**: contiguous runs
+ * of ordinary items become one HTML render each, and every mergeable attachment becomes a segment of
+ * its own. A rider with no PDF attachment is a single segment and costs exactly one request, the same
+ * as the setlist export.
+ *
+ * Bytes rather than a stream, for the reason SetlistPdfRenderer records: GotenbergFileResult::stream()
+ * builds its own Content-Disposition with no ASCII fallback, which is the #731 crash.
+ */
+readonly class TechRiderPdfRenderer
+{
+    private const string FONT_DIRECTORY = 'assets/fonts/pdf';
+    private const string FONT_FAMILY = 'Rider Inter';
+    private const string FONT_REGULAR_FILE = 'Inter-Regular.ttf';
+    private const string FONT_BOLD_FILE = 'Inter-Bold.ttf';
+
+    /** Where the stage plot icons live, under public/ and unhashed so the path is predictable. */
+    private const string ICON_DIRECTORY = 'public';
+
+    private const float MARGIN_TOP_MM = 16.0;
+    private const float MARGIN_BOTTOM_MM = 14.0;
+    private const float MARGIN_SIDE_MM = 14.0;
+
+    /** Matches BASE_ICON_PERCENT in assets/js/constants/stagePlot.js, so a plot prints to scale. */
+    private const float BASE_ICON_PERCENT = 6.0;
+
+    /** Matches DEFAULT_ASPECT_RATIO in the editor, for a plot saved before `stage` existed. */
+    private const float DEFAULT_ASPECT_RATIO = 1.4;
+
+    /**
+     * An attachment above this is named rather than included.
+     *
+     * A band space file may be up to 500 MiB, which must never reach this process: even streamed to
+     * disk it would be uploaded to Gotenberg and merged. A rider attachment is a stage plan or a
+     * photo, so this is generous, and the size is known from the version row without reading a byte.
+     */
+    private const int MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+
+    public function __construct(
+        private Environment $twig,
+        private GotenbergPdfInterface $gotenberg,
+        private TipTapHtmlRenderer $tipTapRenderer,
+        private TechRiderContactsRenderer $contactsRenderer,
+        private TechRiderAttachmentReader $attachmentReader,
+        #[Autowire('%kernel.project_dir%')]
+        private string $projectDir,
+    ) {
+    }
+
+    public function render(TechRider $rider): string
+    {
+        $filesystem = new Filesystem();
+        $workspace = sprintf('%s/tech-rider-%s', sys_get_temp_dir(), bin2hex(random_bytes(8)));
+        $filesystem->mkdir($workspace);
+
+        try {
+            return $this->renderSegments($rider, $workspace);
+        } finally {
+            // Whatever happened, the spooled attachments go. They can be hundreds of megabytes.
+            $filesystem->remove($workspace);
+        }
+    }
+
+    /**
+     * Walks the rider into segments, then renders and if necessary merges them.
+     */
+    private function renderSegments(TechRider $rider, string $workspace): string
+    {
+        /** @var list<array{html: string, assets: list<string>}|array{pdf: string}> $segments */
+        $segments = [];
+
+        /** @var list<array<string, mixed>> $pending */
+        $pending = [];
+        /** @var list<string> $pendingAssets */
+        $pendingAssets = [];
+        $isFirstHtmlSegment = true;
+
+        $flush = function () use ($rider, &$segments, &$pending, &$pendingAssets, &$isFirstHtmlSegment): void {
+            // A cover with nothing after it is still a document; an empty trailing run is not.
+            if ($pending === [] && !$isFirstHtmlSegment) {
+                return;
+            }
+
+            $segments[] = [
+                'html' => $this->renderHtml($rider, $pending, $isFirstHtmlSegment),
+                'assets' => array_values(array_unique($pendingAssets)),
+            ];
+            $isFirstHtmlSegment = false;
+            $pending = [];
+            $pendingAssets = [];
+        };
+
+        foreach ($this->includedItems($rider) as $item) {
+            if ($item->type === TechRiderItemType::Document) {
+                $attachment = $this->attachmentReader->prepare($item, $workspace, self::MAX_ATTACHMENT_BYTES);
+
+                if ($attachment['kind'] === 'merge') {
+                    $flush();
+                    $segments[] = ['pdf' => $attachment['path']];
+
+                    continue;
+                }
+
+                if ($attachment['kind'] === 'image') {
+                    $pendingAssets[] = $attachment['path'];
+                }
+
+                $pending[] = $this->documentViewModel($item, $attachment);
+
+                continue;
+            }
+
+            $pending[] = $this->viewModel($item, $pendingAssets);
+        }
+
+        $flush();
+
+        return $this->produce($segments, $workspace);
+    }
+
+    /**
+     * @param list<array{html: string, assets: list<string>}|array{pdf: string}> $segments
+     */
+    private function produce(array $segments, string $workspace): string
+    {
+        // The ordinary rider: one render, no temp file, no merge.
+        if (count($segments) === 1 && isset($segments[0]['html'])) {
+            return $this->generate($this->htmlBuilder($segments[0]['html'], $segments[0]['assets']));
+        }
+
+        $filesystem = new Filesystem();
+        $paths = [];
+        // Gotenberg merges in **alphabetical order of filename**, not in the order the files are
+        // sent, so the ordinal is what preserves the composed order of the rider. Named any other
+        // way, an attachment called "Plan de salle.pdf" sorts before the cover page.
+        //
+        // The width is derived rather than fixed, because alphabetical is not numeric: with two
+        // digits, "100.pdf" sorts ahead of "20.pdf" and a rider with enough attachments comes out
+        // shuffled. Nothing caps how many items a rider may hold.
+        $width = max(2, strlen((string) (count($segments) - 1)));
+
+        foreach ($segments as $index => $segment) {
+            $path = sprintf('%s/%0' . $width . 'd.pdf', $workspace, $index);
+
+            if (isset($segment['pdf'])) {
+                $filesystem->rename($segment['pdf'], $path);
+                $paths[] = $path;
+
+                continue;
+            }
+
+            // Merging takes paths, never bytes, and insists on a .pdf extension.
+            $filesystem->dumpFile($path, $this->generate($this->htmlBuilder($segment['html'], $segment['assets'])));
+            $paths[] = $path;
+        }
+
+        return $this->generate($this->gotenberg->merge()->files(...$paths)->processor(new InMemoryProcessor()));
+    }
+
+    /**
+     * Returns the marker interface rather than HtmlPdfBuilder because in dev every builder is wrapped
+     * in a TraceableBuilder that proxies through __call, so a concrete return type errors on the first
+     * call. The docblock is what keeps the chain statically checked.
+     *
+     * @param list<string> $assets
+     *
+     * @return HtmlPdfBuilder
+     */
+    private function htmlBuilder(string $html, array $assets): BuilderFileInterface
+    {
+        $fontDirectory = $this->projectDir . '/' . self::FONT_DIRECTORY;
+
+        return $this->gotenberg->html()
+            ->contentRaw($html)
+            ->assets(
+                $fontDirectory . '/' . self::FONT_REGULAR_FILE,
+                $fontDirectory . '/' . self::FONT_BOLD_FILE,
+                ...$assets,
+            )
+            ->paperStandardSize(PaperSize::A4)
+            ->margins(
+                self::MARGIN_TOP_MM,
+                self::MARGIN_BOTTOM_MM,
+                self::MARGIN_SIDE_MM,
+                self::MARGIN_SIDE_MM,
+                Unit::Millimeters,
+            )
+            ->printBackground()
+            ->processor(new InMemoryProcessor());
+    }
+
+    /**
+     * A failed render is a dependency failure, not a client mistake, so it is a 502 rather than the
+     * 500 an uncaught transport error would produce.
+     */
+    private function generate(BuilderFileInterface $builder): string
+    {
+        try {
+            /**
+             * InMemoryProcessor is ProcessorInterface<string>, but the builders are not generic over
+             * their processor, so PHPStan resolves process() to the default NullProcessor's null.
+             *
+             * @var string $pdf
+             */
+            $pdf = $builder->generate()->process();
+        } catch (GotenbergException|HttpClientException $e) {
+            throw new HttpException(
+                Response::HTTP_BAD_GATEWAY,
+                'Le service de génération PDF est momentanément indisponible. Veuillez réessayer.',
+                $e,
+            );
+        }
+
+        return $pdf;
+    }
+
+    /**
+     * The items that belong in the document, in the order they were composed.
+     *
+     * Both halves matter. isIncluded is filtered nowhere else on the server, so this is the first and
+     * only place it is honoured. And the sort is not optional: the repository's fetch join carries no
+     * ORDER BY, and an entity OrderBy does not apply to a fetch-joined collection.
+     *
+     * @return list<TechRiderItem>
+     */
+    private function includedItems(TechRider $rider): array
+    {
+        $items = array_values(array_filter(
+            $rider->items->toArray(),
+            static fn (TechRiderItem $item): bool => $item->isIncluded,
+        ));
+
+        usort($items, static fn (TechRiderItem $a, TechRiderItem $b): int => $a->position <=> $b->position);
+
+        return $items;
+    }
+
+    /**
+     * @param list<string> $assets collects the stage plot icons this item needs
+     *
+     * @return array<string, mixed>
+     */
+    private function viewModel(TechRiderItem $item, array &$assets): array
+    {
+        $base = ['type' => $item->type->value, 'title' => $item->title];
+
+        return match ($item->type) {
+            TechRiderItemType::Text => $base + ['html' => $this->tipTapRenderer->render($item->content)],
+            TechRiderItemType::PatchList => $base + $this->patchListViewModel($item),
+            TechRiderItemType::StagePlot => $base + $this->stagePlotViewModel($item, $assets),
+            TechRiderItemType::Contacts => $base + $this->contactsViewModel($item),
+            TechRiderItemType::Document => $base,
+        };
+    }
+
+    /**
+     * @param array{kind: string, path?: string, name: string, reason?: string} $attachment
+     *
+     * @return array<string, mixed>
+     */
+    private function documentViewModel(TechRiderItem $item, array $attachment): array
+    {
+        $base = ['type' => $item->type->value, 'title' => $item->title, 'name' => $attachment['name']];
+
+        if ($attachment['kind'] === 'image') {
+            return $base + ['image' => basename($attachment['path'] ?? '')];
+        }
+
+        return $base + ['reason' => $attachment['reason'] ?? ''];
+    }
+
+    /**
+     * Patch rows sort by direction **then** position: position restarts per direction, so on its own
+     * it is not a total order and the two tables would interleave.
+     *
+     * @return array<string, mixed>
+     */
+    private function patchListViewModel(TechRiderItem $item): array
+    {
+        $rows = $item->patchRows->toArray();
+        usort($rows, static fn (TechRiderPatchRow $a, TechRiderPatchRow $b): int => $a->position <=> $b->position);
+
+        $partition = static fn (TechRiderPatchDirection $direction): array => array_values(array_filter(
+            $rows,
+            static fn (TechRiderPatchRow $row): bool => $row->direction === $direction,
+        ));
+
+        return [
+            'inputs' => $partition(TechRiderPatchDirection::Input),
+            'outputs' => $partition(TechRiderPatchDirection::Output),
+        ];
+    }
+
+    /**
+     * @param list<string> $assets
+     *
+     * @return array<string, mixed>
+     */
+    private function stagePlotViewModel(TechRiderItem $item, array &$assets): array
+    {
+        $document = $item->content ?? [];
+        $aspectRatio = $document['stage']['aspect_ratio'] ?? null;
+
+        $elements = [];
+        foreach (is_array($document['elements'] ?? null) ? $document['elements'] : [] as $element) {
+            if (!is_array($element)) {
+                continue;
+            }
+
+            $icon = TechRiderStagePlotIcon::tryFrom(is_string($element['icon'] ?? null) ? $element['icon'] : '');
+            if ($icon === null) {
+                continue;
+            }
+
+            $assets[] = $this->iconPath($icon);
+            $scale = is_numeric($element['scale'] ?? null) ? (float) $element['scale'] : 1.0;
+
+            $elements[] = [
+                'image' => $icon->value . '.png',
+                'left' => round(((float) ($element['x'] ?? 0)) * 100, 4),
+                'top' => round(((float) ($element['y'] ?? 0)) * 100, 4),
+                'width' => round(self::BASE_ICON_PERCENT * $scale, 4),
+                'rotation' => is_int($element['rotation'] ?? null) ? $element['rotation'] : 0,
+                'label' => is_string($element['label'] ?? null) ? $element['label'] : null,
+                'colour' => $this->colourHex($element['colour'] ?? null),
+            ];
+        }
+
+        $legend = [];
+        foreach (is_array($document['legend'] ?? null) ? $document['legend'] : [] as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            $icon = TechRiderStagePlotIcon::tryFrom(is_string($entry['icon'] ?? null) ? $entry['icon'] : '');
+            if ($icon === null) {
+                continue;
+            }
+
+            $assets[] = $this->iconPath($icon);
+            $legend[] = [
+                'image' => $icon->value . '.png',
+                'label' => is_string($entry['label'] ?? null) && $entry['label'] !== ''
+                    ? $entry['label']
+                    : $icon->label(),
+            ];
+        }
+
+        return [
+            'aspect_ratio' => is_numeric($aspectRatio) ? (float) $aspectRatio : self::DEFAULT_ASPECT_RATIO,
+            'elements' => $elements,
+            'legend' => $legend,
+        ];
+    }
+
+    /**
+     * The lines come from TechRiderContactsRenderer rather than being formatted here, so the document
+     * a venue receives says exactly what the band proof read on screen.
+     *
+     * @return array<string, mixed>
+     */
+    private function contactsViewModel(TechRiderItem $item): array
+    {
+        $showEmails = ($item->content['showEmails'] ?? false) === true;
+        $rendered = $this->contactsRenderer->render($item->techRider->bandSpace, $showEmails);
+
+        return [
+            'lines' => $rendered['lines'],
+            'emails' => $rendered['emails'],
+            // The note is not part of the API's contacts block, so it is read straight from content.
+            'note_html' => $this->tipTapRenderer->render(
+                is_array($item->content['note'] ?? null) ? $item->content['note'] : null,
+            ),
+        ];
+    }
+
+    private function colourHex(mixed $colour): ?string
+    {
+        if (!is_string($colour)) {
+            return null;
+        }
+
+        return \App\Enum\BandSpace\TechRiderColour::tryFrom($colour)?->hex();
+    }
+
+    private function iconPath(TechRiderStagePlotIcon $icon): string
+    {
+        return $this->projectDir . '/' . self::ICON_DIRECTORY . $icon->imagePath();
+    }
+
+    /**
+     * @param list<array<string, mixed>> $items
+     */
+    private function renderHtml(TechRider $rider, array $items, bool $withCover): string
+    {
+        return $this->twig->render('pdf/tech_rider/rider.html.twig', [
+            'rider' => $rider,
+            'items' => $items,
+            'with_cover' => $withCover,
+            'generated_at' => (new \DateTimeImmutable())->format('d/m/Y'),
+            'font_family' => self::FONT_FAMILY,
+            'font_regular_file' => self::FONT_REGULAR_FILE,
+            'font_bold_file' => self::FONT_BOLD_FILE,
+        ]);
+    }
+}

--- a/src/Service/BandSpace/TechRider/TipTapHtmlRenderer.php
+++ b/src/Service/BandSpace/TechRider/TipTapHtmlRenderer.php
@@ -1,0 +1,291 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace\TechRider;
+
+use App\Enum\BandSpace\TechRiderColour;
+
+/**
+ * Turns a stored TipTap document into HTML for the PDF export.
+ *
+ * This is the security boundary as much as the renderer, because nothing else is one. A rider's text
+ * is stored exactly as the browser sent it: TechRiderItemContentValidator checks only that the value
+ * is an array within a depth and a byte budget, and no HtmlSanitizer is wired anywhere in the rider
+ * module. The colour allowlist that keeps pasted CSS out of a document lives in the editor, in
+ * JavaScript, which a crafted PATCH simply skips.
+ *
+ * So this works by allowlist rather than by sanitising: it walks the tree and emits only the node
+ * types, marks and attribute values it recognises, escaping every piece of text. Anything unknown is
+ * dropped rather than cleaned, which means an attribute nobody thought about cannot reach the output
+ * by default. That is the opposite bias to a denylist and the reason no sanitiser is needed.
+ *
+ * The vocabulary is whatever the editor can actually produce, read off the installed packages rather
+ * than guessed: StarterKit 3.29 with headings limited to h2 and h3, and note that it bundles link and
+ * underline, which the editor's own extension list does not mention. Plus TextAlign on headings and
+ * paragraphs, tables whose rows hold only cells, and the TextStyle colour mark the rider adds.
+ */
+readonly class TipTapHtmlRenderer
+{
+    /** Everything else is dropped, including images: a rider's text has never been able to hold one. */
+    private const array BLOCK_NODES = [
+        'paragraph',
+        'heading',
+        'bulletList',
+        'orderedList',
+        'listItem',
+        'blockquote',
+        'codeBlock',
+        'horizontalRule',
+        'hardBreak',
+        'table',
+        'tableRow',
+        'tableCell',
+    ];
+
+    /** The editor is configured for h2 and h3 only, so anything else falls back to the smaller one. */
+    private const array HEADING_LEVELS = [2, 3];
+
+    private const array TEXT_ALIGNMENTS = ['left', 'center', 'right', 'justify'];
+
+    /** More columns than this in a rider table is a broken document, not a wide one. */
+    private const int MAX_CELL_SPAN = 64;
+
+    /**
+     * A link in a document sent to a venue becomes a clickable annotation in the PDF, so the scheme
+     * is allowlisted. Without this a stored `javascript:` or `data:` href would ship to a stranger.
+     */
+    private const string HREF_PATTERN = '#^(?:https?://|mailto:)[^\s<>"\']+$#i';
+
+    /** @param array<array-key, mixed>|null $document */
+    public function render(?array $document): string
+    {
+        if ($document === null) {
+            return '';
+        }
+
+        // A TipTap document is always a `doc` with a content list; anything else is not one.
+        if (($document['type'] ?? null) !== 'doc') {
+            return '';
+        }
+
+        return $this->renderContent($document['content'] ?? null);
+    }
+
+    private function renderContent(mixed $content): string
+    {
+        if (!is_array($content)) {
+            return '';
+        }
+
+        $html = '';
+        foreach ($content as $node) {
+            if (is_array($node)) {
+                $html .= $this->renderNode($node);
+            }
+        }
+
+        return $html;
+    }
+
+    /** @param array<array-key, mixed> $node */
+    private function renderNode(array $node): string
+    {
+        $type = $node['type'] ?? null;
+        if (!is_string($type)) {
+            return '';
+        }
+
+        if ($type === 'text') {
+            return $this->renderText($node);
+        }
+
+        if (!in_array($type, self::BLOCK_NODES, true)) {
+            return '';
+        }
+
+        return match ($type) {
+            'horizontalRule' => '<hr>',
+            'hardBreak' => '<br>',
+            'heading' => $this->wrap($this->headingTag($node), $node, $this->alignmentStyle($node)),
+            'paragraph' => $this->wrap('p', $node, $this->alignmentStyle($node)),
+            'bulletList' => $this->wrap('ul', $node),
+            'orderedList' => $this->wrap('ol', $node),
+            'listItem' => $this->wrap('li', $node),
+            'blockquote' => $this->wrap('blockquote', $node),
+            'codeBlock' => '<pre><code>' . $this->renderTextOnly($node['content'] ?? null) . '</code></pre>',
+            'table' => $this->wrap('table', $node),
+            'tableRow' => $this->wrap('tr', $node),
+            'tableCell' => $this->wrap('td', $node, '', $this->spanAttributes($node)),
+        };
+    }
+
+    /** @param array<array-key, mixed> $node */
+    /**
+     * A code block holds text and nothing else, which is what the editor's own schema says. Recursing
+     * through the generic dispatch would let a heading or a link nest inside <pre><code>, which the
+     * editor could never produce, so the vocabulary this class claims to accept would not be the one
+     * it actually accepts. Marks are dropped too: formatting inside a code block is not a thing.
+     *
+     * @param array<array-key, mixed>|mixed $content
+     */
+    private function renderTextOnly(mixed $content): string
+    {
+        if (!is_array($content)) {
+            return '';
+        }
+
+        $text = '';
+        foreach ($content as $node) {
+            if (is_array($node) && ($node['type'] ?? null) === 'text' && is_string($node['text'] ?? null)) {
+                $text .= htmlspecialchars($node['text'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            }
+        }
+
+        return $text;
+    }
+
+    /** @param array<array-key, mixed> $node */
+    private function wrap(string $tag, array $node, string $style = '', string $attributes = ''): string
+    {
+        $styleAttribute = $style === '' ? '' : sprintf(' style="%s"', $style);
+
+        return sprintf(
+            '<%1$s%2$s%3$s>%4$s</%1$s>',
+            $tag,
+            $styleAttribute,
+            $attributes,
+            $this->renderContent($node['content'] ?? null),
+        );
+    }
+
+    /**
+     * Marks wrap the escaped text from the inside out, in the order the document lists them, so the
+     * result is stable for the same input rather than depending on iteration order.
+     *
+     * @param array<array-key, mixed> $node
+     */
+    private function renderText(array $node): string
+    {
+        $text = $node['text'] ?? null;
+        if (!is_string($text) || $text === '') {
+            return '';
+        }
+
+        $html = htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $marks = $node['marks'] ?? null;
+        if (!is_array($marks)) {
+            return $html;
+        }
+
+        foreach ($marks as $mark) {
+            if (!is_array($mark)) {
+                continue;
+            }
+
+            $tags = $this->markTags($mark);
+            if ($tags !== null) {
+                $html = $tags[0] . $html . $tags[1];
+            }
+        }
+
+        return $html;
+    }
+
+    /**
+     * @return array{0: string, 1: string}|null the opening and closing tags, or null to drop the mark
+     *
+     * @param array<array-key, mixed> $mark
+     */
+    private function markTags(array $mark): ?array
+    {
+        return match ($mark['type'] ?? null) {
+            'bold' => ['<strong>', '</strong>'],
+            'italic' => ['<em>', '</em>'],
+            'strike' => ['<s>', '</s>'],
+            'underline' => ['<u>', '</u>'],
+            'code' => ['<code>', '</code>'],
+            'link' => $this->linkTags($mark),
+            'textStyle' => $this->colourTags($mark),
+            default => null,
+        };
+    }
+
+    /**
+     * @return array{0: string, 1: string}|null
+     *
+     * @param array<array-key, mixed> $mark
+     */
+    private function linkTags(array $mark): ?array
+    {
+        $href = $mark['attrs']['href'] ?? null;
+        if (!is_string($href) || preg_match(self::HREF_PATTERN, trim($href)) !== 1) {
+            // The text survives, only the link is dropped: a venue reading the printed rider still
+            // gets the words, and an unusable scheme never becomes an annotation.
+            return null;
+        }
+
+        return [
+            sprintf('<a href="%s">', htmlspecialchars(trim($href), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')),
+            '</a>',
+        ];
+    }
+
+    /**
+     * The palette and nothing else. This is the first place the allowlist is enforced anywhere but the
+     * browser, so a colour smuggled in by a crafted request stops here.
+     *
+     * @return array{0: string, 1: string}|null
+     *
+     * @param array<array-key, mixed> $mark
+     */
+    private function colourTags(array $mark): ?array
+    {
+        $colour = $mark['attrs']['color'] ?? null;
+        if (!is_string($colour)) {
+            return null;
+        }
+
+        foreach (TechRiderColour::cases() as $case) {
+            if (strcasecmp($case->hex(), trim($colour)) === 0) {
+                return [sprintf('<span style="color:%s">', $case->hex()), '</span>'];
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<array-key, mixed> $node */
+    private function headingTag(array $node): string
+    {
+        $level = $node['attrs']['level'] ?? null;
+
+        return in_array($level, self::HEADING_LEVELS, true) ? 'h' . $level : 'h3';
+    }
+
+    /** @param array<array-key, mixed> $node */
+    private function alignmentStyle(array $node): string
+    {
+        $alignment = $node['attrs']['textAlign'] ?? null;
+
+        return is_string($alignment) && in_array($alignment, self::TEXT_ALIGNMENTS, true)
+            ? 'text-align:' . $alignment
+            : '';
+    }
+
+    /** Only positive integers, and only when they actually span, so the markup stays minimal. *
+     * @param array<array-key, mixed> $node
+     */
+    private function spanAttributes(array $node): string
+    {
+        $attributes = '';
+        foreach (['colspan', 'rowspan'] as $name) {
+            $span = $node['attrs'][$name] ?? null;
+            // Upper bound as well as lower, so the one numeric attribute this class emits is as
+            // bounded as every other value it lets through.
+            if (is_int($span) && $span > 1 && $span <= self::MAX_CELL_SPAN) {
+                $attributes .= sprintf(' %s="%d"', $name, $span);
+            }
+        }
+
+        return $attributes;
+    }
+}

--- a/src/State/Provider/BandSpace/TechRider/TechRiderPdfExportProvider.php
+++ b/src/State/Provider/BandSpace/TechRider/TechRiderPdfExportProvider.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace\TechRider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Entity\BandSpace\TechRider;
+use App\Entity\User;
+use App\Http\ContentDisposition;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\TechRider\TechRiderPdfRenderer;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProviderInterface<Response>
+ */
+readonly class TechRiderPdfExportProvider implements ProviderInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private TechRiderRepository $techRiderRepository,
+        private TechRiderPdfRenderer $pdfRenderer,
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): Response
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // checkMember rather than checkMemberForWrite: reads and downloads stay open while a space is
+        // pending deletion, which is when a band most needs to get its documents out.
+        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+
+        // Archived riders are intentionally still exportable, matching GET /tech_riders/{id} and the
+        // setlist policy: last year's rider is a thing you send when asked what you used.
+        $techRider = $this->techRiderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$techRider instanceof TechRider) {
+            throw new NotFoundHttpException('Tech rider introuvable');
+        }
+
+        $response = new Response($this->pdfRenderer->render($techRider));
+        $response->headers->set('Content-Type', 'application/pdf');
+        $response->headers->set('Content-Disposition', ContentDisposition::attachment($techRider->name . '.pdf'));
+
+        return $response;
+    }
+}

--- a/templates/pdf/tech_rider/_contacts.html.twig
+++ b/templates/pdf/tech_rider/_contacts.html.twig
@@ -1,0 +1,17 @@
+{% if item.lines is empty %}
+    <p class="attachment-reason">Aucun membre actif dans cet espace.</p>
+{% else %}
+    <ul class="contact-lines">
+        {% for line in item.lines %}
+            <li>{{ line }}</li>
+        {% endfor %}
+    </ul>
+
+    {% if item.emails is not empty %}
+        <p class="contact-emails">{{ item.emails|join(' · ') }}</p>
+    {% endif %}
+{% endif %}
+
+{% if item.note_html %}
+    <div class="prose">{{ item.note_html|raw }}</div>
+{% endif %}

--- a/templates/pdf/tech_rider/_document.html.twig
+++ b/templates/pdf/tech_rider/_document.html.twig
@@ -1,0 +1,16 @@
+{#
+    A document item is a file already in the band's space. An image is placed here directly; a PDF is
+    merged in as its own pages after this render, so it contributes nothing to the HTML.
+
+    Anything that could not be included says so by name rather than vanishing, because a rider that
+    silently drops an attachment is worse than one that admits it: the band can see what to send
+    separately.
+#}
+{% if item.image is defined %}
+    <img class="attachment-image" src="{{ item.image }}" alt="{{ item.name }}">
+{% elseif item.reason is defined %}
+    <div class="attachment">
+        <div class="attachment-name">{{ item.name }}</div>
+        <div class="attachment-reason">{{ item.reason }}</div>
+    </div>
+{% endif %}

--- a/templates/pdf/tech_rider/_patch_list.html.twig
+++ b/templates/pdf/tech_rider/_patch_list.html.twig
@@ -1,0 +1,67 @@
+{% if item.inputs is empty and item.outputs is empty %}
+    <p class="attachment-reason">Aucune ligne dans cette patch list.</p>
+{% endif %}
+
+{% if item.inputs is not empty %}
+    <p class="patch-caption">Entrées</p>
+    <table class="patch">
+        <thead>
+            <tr>
+                <th class="num">Ch.</th>
+                <th>Source</th>
+                <th>Micro ou boîtier</th>
+                <th>Routing</th>
+                <th>Couleur</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in item.inputs %}
+                <tr>
+                    <td class="num">{{ row.channel }}</td>
+                    <td>{{ row.name ?: '—' }}</td>
+                    <td>{{ row.microphone ?: '—' }}</td>
+                    <td>{{ row.routing ?: '—' }}</td>
+                    <td>
+                        {% if row.colour %}
+                            <span class="chip" style="background:{{ row.colour.hex }}"></span>{{ row.colour.label }}
+                        {% else %}
+                            —
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if item.outputs is not empty %}
+    <p class="patch-caption">Sorties</p>
+    <table class="patch">
+        <thead>
+            <tr>
+                <th class="num">Ch.</th>
+                <th>Destination</th>
+                <th>Type</th>
+                <th>Routing</th>
+                <th>Couleur</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in item.outputs %}
+                <tr>
+                    <td class="num">{{ row.channel }}</td>
+                    <td>{{ row.name ?: '—' }}</td>
+                    <td>{{ row.microphone ?: '—' }}</td>
+                    <td>{{ row.routing ?: '—' }}</td>
+                    <td>
+                        {% if row.colour %}
+                            <span class="chip" style="background:{{ row.colour.hex }}"></span>{{ row.colour.label }}
+                        {% else %}
+                            —
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}

--- a/templates/pdf/tech_rider/_stage_plot.html.twig
+++ b/templates/pdf/tech_rider/_stage_plot.html.twig
@@ -1,0 +1,35 @@
+{% if item.elements is empty %}
+    <p class="attachment-reason">Aucun élément placé sur ce plan de scène.</p>
+{% else %}
+    <div class="stage-block">
+        {#
+            The aspect ratio is what makes the stored fractions mean the same thing here as on screen:
+            every position is a fraction of this box, so the box has to have the shape the editor had.
+        #}
+        <div class="stage" style="aspect-ratio: {{ item.aspect_ratio }}">
+            {% for element in item.elements %}
+                <div
+                    class="stage-item"
+                    style="left:{{ element.left }}%;top:{{ element.top }}%;width:{{ element.width }}%"
+                >
+                    <img src="{{ element.image }}" alt="" style="transform:rotate({{ element.rotation }}deg)">
+                    {% if element.label %}
+                        <span class="stage-label"{% if element.colour %} style="color:{{ element.colour }}"{% endif %}>{{ element.label }}</span>
+                    {% endif %}
+                </div>
+            {% endfor %}
+            <p class="stage-front">Face public</p>
+        </div>
+
+        {% if item.legend is not empty %}
+            <ul class="legend">
+                {% for entry in item.legend %}
+                    <li>
+                        <img src="{{ entry.image }}" alt="">
+                        <span>{{ entry.label }}</span>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
+{% endif %}

--- a/templates/pdf/tech_rider/_text.html.twig
+++ b/templates/pdf/tech_rider/_text.html.twig
@@ -1,0 +1,5 @@
+{#
+    Printed raw because TipTapHtmlRenderer produced it, and that renderer escapes every piece of text
+    and emits only tags it recognises. Nothing else in the request is trusted to build this string.
+#}
+<div class="prose">{{ item.html|raw }}</div>

--- a/templates/pdf/tech_rider/rider.html.twig
+++ b/templates/pdf/tech_rider/rider.html.twig
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ rider.name }}</title>
+    <style>
+        {#
+            No @page rule and no scale variable, following what #741 settled for the setlist: paper
+            size and margins are set through the Gotenberg builder, because a CSS @page margin
+            silently overrides the builder's margin fields and the two would disagree.
+
+            The fonts travel with the document as uploaded assets, so they are referenced by bare
+            filename. Nothing is written to a font cache.
+        #}
+        @font-face {
+            font-family: '{{ font_family }}';
+            src: url('{{ font_regular_file }}') format('truetype');
+            font-weight: normal;
+        }
+        @font-face {
+            font-family: '{{ font_family }}';
+            src: url('{{ font_bold_file }}') format('truetype');
+            font-weight: bold;
+        }
+
+        :root {
+            --accent: #f5b400;
+            --ink: #1a1a1a;
+            --muted: #666;
+            --rule: #e5e5e5;
+            --wash: #fafafa;
+        }
+
+        * { box-sizing: border-box; }
+
+        html {
+            font-family: '{{ font_family }}', sans-serif;
+            font-size: 10pt;
+            line-height: 1.45;
+            color: var(--ink);
+            print-color-adjust: exact;
+            -webkit-print-color-adjust: exact;
+        }
+
+        body { margin: 0; }
+
+        {% if with_cover %}
+        {# Height in mm rather than vh: the page box is known here and vh in print is not worth betting on. #}
+        .cover {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            min-height: 250mm;
+            break-after: page;
+        }
+        .cover-band {
+            font-size: 11pt;
+            text-transform: uppercase;
+            letter-spacing: 0.35em;
+            color: var(--muted);
+        }
+        .cover-name {
+            margin-top: 3mm;
+            font-size: 34pt;
+            font-weight: bold;
+            line-height: 1.1;
+        }
+        .cover-rule {
+            height: 0;
+            border: 0;
+            border-top: 3px solid var(--accent);
+            margin: 6mm 0 0;
+            width: 40mm;
+        }
+        .cover-meta {
+            font-size: 9pt;
+            color: var(--muted);
+            border-top: 1px solid var(--rule);
+            padding-top: 4mm;
+        }
+        {% endif %}
+
+        .item { margin-bottom: 10mm; }
+        .item-title {
+            font-size: 14pt;
+            margin: 0 0 3mm;
+            padding-bottom: 1.5mm;
+            border-bottom: 2px solid var(--accent);
+            /* A title must never end a page. Without this the stage plot's own break-inside pushed
+               the drawing to the next page and left its heading stranded at the foot of the previous
+               one, which reads as a section with nothing in it. */
+            break-after: avoid;
+        }
+
+        {# Rich text coming out of TipTapHtmlRenderer. Only the tags it can emit are styled. #}
+        .prose { orphans: 3; widows: 3; }
+        .prose h2 { font-size: 12pt; margin: 5mm 0 2mm; }
+        .prose h3 { font-size: 11pt; margin: 4mm 0 2mm; }
+        .prose p { margin: 0 0 2.5mm; }
+        .prose ul, .prose ol { margin: 0 0 2.5mm; padding-left: 6mm; }
+        .prose li { margin-bottom: 1mm; }
+        .prose blockquote {
+            margin: 0 0 2.5mm;
+            padding-left: 4mm;
+            border-left: 2px solid var(--rule);
+            color: var(--muted);
+        }
+        .prose pre {
+            margin: 0 0 2.5mm;
+            padding: 3mm;
+            background: var(--wash);
+            border-radius: 1.5mm;
+            white-space: pre-wrap;
+            font-size: 9pt;
+        }
+        .prose hr { border: 0; border-top: 1px solid var(--rule); margin: 4mm 0; }
+        .prose table { width: 100%; border-collapse: collapse; margin: 0 0 2.5mm; }
+        .prose td { border: 1px solid var(--rule); padding: 1.5mm 2mm; vertical-align: top; }
+        .prose a { color: var(--ink); }
+
+        .patch { width: 100%; border-collapse: collapse; margin-bottom: 5mm; }
+        {# Brings the column heads back at the top of a second page, which a long list needs. #}
+        .patch thead { display: table-header-group; }
+        .patch tr { break-inside: avoid; }
+        .patch th {
+            text-align: left;
+            font-size: 7.5pt;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--muted);
+            padding: 1.5mm 2mm;
+            border-bottom: 1px solid var(--rule);
+        }
+        .patch td { padding: 1.4mm 2mm; border-bottom: 1px solid var(--rule); }
+        .patch tbody tr:nth-child(even) { background: var(--wash); }
+        .patch .num { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
+        .patch-caption {
+            font-size: 8pt;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+            margin: 0 0 1.5mm;
+        }
+        .chip {
+            display: inline-block;
+            width: 2.6mm;
+            height: 2.6mm;
+            margin-right: 1.5mm;
+            border-radius: 50%;
+            vertical-align: middle;
+        }
+
+        {# A plot is a drawing: splitting it across a page break would make it unreadable. #}
+        .stage-block { break-inside: avoid; }
+        .stage {
+            position: relative;
+            width: 100%;
+            border: 1px solid var(--rule);
+            border-radius: 3mm;
+            background: var(--wash);
+            overflow: hidden;
+        }
+        .stage-item { position: absolute; transform: translate(-50%, -50%); }
+        {# The rotation sits on the image so the label underneath stays level whatever the icon does. #}
+        .stage-item img { display: block; width: 100%; }
+        .stage-label {
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            margin-top: 0.8mm;
+            font-size: 6pt;
+            white-space: nowrap;
+            color: var(--muted);
+        }
+        .stage-front {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            margin: 0;
+            padding: 1.2mm 0;
+            text-align: center;
+            font-size: 7pt;
+            letter-spacing: 0.3em;
+            text-transform: uppercase;
+            color: #fff;
+            background: rgba(26, 26, 26, 0.75);
+        }
+        .legend {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 2mm 4mm;
+            margin: 4mm 0 0;
+            padding: 0;
+            list-style: none;
+        }
+        .legend li { display: flex; align-items: center; gap: 2mm; font-size: 8pt; }
+        .legend img { width: 5mm; }
+
+        .contact-lines { margin: 0 0 3mm; padding: 0; list-style: none; }
+        .contact-lines li { padding: 1.2mm 0; border-bottom: 1px solid var(--rule); }
+        .contact-emails { font-size: 9pt; color: var(--muted); }
+
+        .attachment {
+            padding: 4mm;
+            border: 1px dashed var(--rule);
+            border-radius: 2mm;
+            background: var(--wash);
+            font-size: 9pt;
+            break-inside: avoid;
+        }
+        .attachment-name { font-weight: bold; }
+        .attachment-reason { color: var(--muted); margin-top: 1mm; }
+        .attachment-image { width: 100%; display: block; break-inside: avoid; }
+    </style>
+</head>
+<body>
+{% if with_cover %}
+    <section class="cover">
+        <div>
+            <div class="cover-band">{{ rider.bandSpace.name }}</div>
+            <div class="cover-name">{{ rider.name }}</div>
+            <hr class="cover-rule">
+        </div>
+        <div class="cover-meta">Fiche technique éditée le {{ generated_at }}</div>
+    </section>
+{% endif %}
+
+{% for item in items %}
+    <section class="item">
+        <h1 class="item-title">{{ item.title }}</h1>
+        {% if item.type == 'text' %}
+            {% include 'pdf/tech_rider/_text.html.twig' %}
+        {% elseif item.type == 'patch_list' %}
+            {% include 'pdf/tech_rider/_patch_list.html.twig' %}
+        {% elseif item.type == 'stage_plot' %}
+            {% include 'pdf/tech_rider/_stage_plot.html.twig' %}
+        {% elseif item.type == 'contacts' %}
+            {% include 'pdf/tech_rider/_contacts.html.twig' %}
+        {% elseif item.type == 'document' %}
+            {% include 'pdf/tech_rider/_document.html.twig' %}
+        {% endif %}
+    </section>
+{% endfor %}
+</body>
+</html>

--- a/tests/Api/BandSpace/TechRider/TechRiderPdfExportTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderPdfExportTest.php
@@ -1,0 +1,465 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\TechRider;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\TechRider;
+use App\Enum\BandSpace\TechRiderColour;
+use App\Enum\BandSpace\TechRiderItemType;
+use App\Enum\BandSpace\TechRiderPatchDirection;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Service\BandSpace\TechRider\TechRiderPdfRenderer;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Double\RecordingGotenbergClient;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\BandSpace\TechRiderItemFactory;
+use App\Tests\Factory\BandSpace\TechRiderPatchRowFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Sensiolabs\GotenbergBundle\Exception\ClientException;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * The export, asserted on what it sends rather than on opaque PDF bytes.
+ *
+ * The segment pipeline is the part worth pinning here: a rider with no attachment must cost one
+ * request, and a PDF attachment must split the document into three calls ending in a merge. Whether
+ * the result is a readable document is a question only Chromium can answer, and that lives in
+ * TechRiderPdfRenderTest.
+ */
+#[ResetDatabase]
+class TechRiderPdfExportTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const string MERGE_ENDPOINT = '/forms/pdfengines/merge';
+    private const string HTML_ENDPOINT = '/forms/chromium/convert/html';
+
+    public function test_a_member_downloads_the_rider_as_a_pdf(): void
+    {
+        [$user, $bandSpace, $rider] = $this->seed();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', $this->url($bandSpace, $rider));
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->client->getResponse();
+        $this->assertSame('application/pdf', $response->headers->get('Content-Type'));
+        $this->assertSame(
+            "attachment; filename=Fiche-technique.pdf; filename*=utf-8''Fiche%20technique.pdf",
+            (string) $response->headers->get('Content-Disposition'),
+        );
+        $this->assertStringStartsWith('%PDF-', (string) $response->getContent());
+    }
+
+    /** #731 again, and worth its own case because a rider is named by a French band. */
+    public function test_an_accented_rider_name_keeps_the_header_ascii(): void
+    {
+        [$user, $bandSpace, $rider] = $this->seed(name: 'Fiche générale');
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', $this->url($bandSpace, $rider));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            "attachment; filename=Fiche-generale.pdf; filename*=utf-8''Fiche%20g%C3%A9n%C3%A9rale.pdf",
+            (string) $this->client->getResponse()->headers->get('Content-Disposition'),
+        );
+    }
+
+    /** Matching GET /tech_riders/{id} and the setlist policy: last year's rider is a thing you send. */
+    public function test_an_archived_rider_is_still_exportable(): void
+    {
+        [$user, $bandSpace, $rider] = $this->seed(archived: true);
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', $this->url($bandSpace, $rider));
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function test_a_rider_of_another_band_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $mine = BandSpaceFactory::new()->create();
+        $other = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $mine, 'user' => $user])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $other, 'user' => $user])->create();
+        $rider = TechRiderFactory::new(['bandSpace' => $other])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', $this->url($mine, $rider));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Tech rider introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Tech rider introuvable',
+        ]);
+    }
+
+    public function test_a_non_member_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $rider = TechRiderFactory::new(['bandSpace' => $bandSpace])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', $this->url($bandSpace, $rider));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * New failure mode: the rider used to be data, and is now a call to a service. A dependency being
+     * down is a 502, not the 500 an uncaught transport error would produce. The detail is deliberately
+     * generic, because API Platform blanks the message on any 5xx outside debug.
+     */
+    public function test_an_unreachable_renderer_is_a_502(): void
+    {
+        [$user, $bandSpace, $rider] = $this->seed();
+        self::getContainer()->get(RecordingGotenbergClient::class)->failWith(
+            new ClientException('Could not resolve host: gotenberg.musicall'),
+        );
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', $this->url($bandSpace, $rider));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_GATEWAY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/502',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Internal Server Error',
+            'status' => 502,
+            'type' => '/errors/502',
+            'description' => 'Internal Server Error',
+        ]);
+    }
+
+    // ------------------------------------------------------------------ the segment pipeline
+
+    /** The ordinary rider. One request, no merge, and the whole document in a single render. */
+    public function test_a_rider_without_a_pdf_attachment_costs_one_request(): void
+    {
+        [, $bandSpace, $rider] = $this->seed();
+        $this->addTextItem($rider, 'Accueil', 0);
+
+        $gotenberg = $this->render($bandSpace, $rider);
+
+        $this->assertCount(1, $gotenberg->calls());
+        $this->assertSame(self::HTML_ENDPOINT, $gotenberg->lastCall()['endpoint']);
+    }
+
+    /**
+     * A PDF attachment cannot share a page with rider content, so the document splits around it: the
+     * items before, the attachment, the items after, then one merge.
+     */
+    public function test_a_pdf_attachment_splits_the_document_and_merges(): void
+    {
+        [$user, $bandSpace, $rider] = $this->seed();
+        $this->addTextItem($rider, 'Avant', 0);
+        $this->addPdfAttachment($user, $bandSpace, $rider, position: 1);
+        $this->addTextItem($rider, 'Après', 2);
+
+        $gotenberg = $this->render($bandSpace, $rider);
+        $calls = $gotenberg->calls();
+
+        $this->assertCount(3, $calls, 'Two HTML segments and the merge');
+        $this->assertSame(self::HTML_ENDPOINT, $calls[0]['endpoint']);
+        $this->assertSame(self::HTML_ENDPOINT, $calls[1]['endpoint']);
+        $this->assertSame(self::MERGE_ENDPOINT, $calls[2]['endpoint']);
+
+        // The cover belongs to the first segment only, and the split really is around the attachment.
+        $this->assertStringContainsString('Avant', $calls[0]['documents']['index.html']);
+        $this->assertStringNotContainsString('Après', $calls[0]['documents']['index.html']);
+        $this->assertStringContainsString('Après', $calls[1]['documents']['index.html']);
+        $this->assertStringNotContainsString('Avant', $calls[1]['documents']['index.html']);
+
+        /**
+         * Gotenberg merges in alphabetical order of filename rather than in the order the files are
+         * sent, so the ordinal prefix is the only thing keeping the composed order. Without it an
+         * attachment called "Plan de salle.pdf" sorts ahead of the cover page, and the merge still
+         * succeeds with the right page count, which is why this is asserted rather than assumed.
+         */
+        $merged = array_keys($calls[2]['assets']);
+        $this->assertSame(['00.pdf', '01.pdf', '02.pdf'], $merged);
+    }
+
+    #[DataProvider('degradedAttachmentProvider')]
+    public function test_an_unusable_attachment_is_named_rather_than_dropped(string $case, string $expected): void
+    {
+        [$user, $bandSpace, $rider] = $this->seed();
+        $this->addPdfAttachment($user, $bandSpace, $rider, position: 0, degrade: $case);
+
+        $gotenberg = $this->render($bandSpace, $rider);
+
+        // No split and no merge: there is nothing to splice in.
+        $this->assertCount(1, $gotenberg->calls());
+        $this->assertStringContainsString($expected, $gotenberg->lastCall()['documents']['index.html']);
+    }
+
+    /**
+     * A rider that silently drops an attachment is worse than one that admits it, so every refusal
+     * prints the file's name and the reason instead of throwing.
+     *
+     * The expectations deliberately avoid apostrophes: this asserts on rendered markup, where Twig
+     * has already turned every one of them into `&#039;`.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function degradedAttachmentProvider(): iterable
+    {
+        yield 'the file was trashed' => ['archived', 'supprimé de'];
+        yield 'the version is gone' => ['no-version', 'Aucune version disponible'];
+        yield 'the type is no longer usable' => ['bad-mime', 'ne peut pas être inclus'];
+        yield 'it is larger than the cap' => ['huge', 'trop volumineux'];
+        yield 'the object is missing from storage' => ['missing-bytes', 'introuvable dans le stockage'];
+        yield 'it is not really a pdf' => ['not-a-pdf', 'pas un PDF valide'];
+        yield 'it is password protected' => ['encrypted', 'protégé par un mot de passe'];
+    }
+
+    /**
+     * Patch rows sort by direction **then** position. Position restarts per direction, so on its own
+     * it is not a total order: sorted by position alone the two tables interleave, and the seeding
+     * below is deliberately arranged so that bug would show.
+     */
+    public function test_patch_rows_are_grouped_by_direction_and_ordered_within_it(): void
+    {
+        [, $bandSpace, $rider] = $this->seed();
+        $item = TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::PatchList,
+            'title' => 'Patch list',
+            'position' => 0,
+        ])->create();
+
+        // Interleaved on purpose, and both directions restart at position 0.
+        foreach ([
+            [TechRiderPatchDirection::Output, 0, 'SORTIE UNE'],
+            [TechRiderPatchDirection::Input, 1, 'ENTREE DEUX'],
+            [TechRiderPatchDirection::Output, 1, 'SORTIE DEUX'],
+            [TechRiderPatchDirection::Input, 0, 'ENTREE UNE'],
+        ] as $index => [$direction, $position, $name]) {
+            TechRiderPatchRowFactory::new([
+                'item' => $item, 'direction' => $direction, 'channel' => $index + 1,
+                'name' => $name, 'position' => $position, 'colour' => TechRiderColour::Red,
+            ])->create();
+        }
+
+        $html = $this->render($bandSpace, $rider)->lastCall()['documents']['index.html'];
+
+        // Every input before every output, and each in its own position order.
+        $this->assertLessThan(strpos($html, 'ENTREE DEUX'), strpos($html, 'ENTREE UNE'));
+        $this->assertLessThan(strpos($html, 'SORTIE UNE'), strpos($html, 'ENTREE DEUX'));
+        $this->assertLessThan(strpos($html, 'SORTIE DEUX'), strpos($html, 'SORTIE UNE'));
+        // The palette reaches the page as a swatch rather than as a colour name alone.
+        $this->assertStringContainsString(TechRiderColour::Red->hex(), $html);
+    }
+
+    /**
+     * The rider goes to a venue, so an address that was not opted in must not be on it. The flag is
+     * stored per item and the roster is read live, which makes this the one place the two meet.
+     */
+    #[DataProvider('emailVisibilityProvider')]
+    public function test_member_emails_appear_only_when_the_item_asks_for_them(bool $showEmails): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create(['email' => 'regie@musicall.test']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace, 'user' => $user, 'stageName' => 'Jérémy',
+        ])->create();
+        $rider = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => 'Fiche technique'])->create();
+
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::Contacts,
+            'title' => 'Contacts',
+            'position' => 0,
+            'content' => ['showEmails' => $showEmails, 'note' => ['type' => 'doc', 'content' => [
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'NOTE DU GROUPE']]],
+            ]]],
+        ])->create();
+
+        $html = $this->render($bandSpace, $rider)->lastCall()['documents']['index.html'];
+
+        // The roster line and the note are there either way; only the address is gated.
+        $this->assertStringContainsString('Jérémy', $html);
+        $this->assertStringContainsString('NOTE DU GROUPE', $html);
+
+        if ($showEmails) {
+            $this->assertStringContainsString('regie@musicall.test', $html);
+        } else {
+            $this->assertStringNotContainsString('regie@musicall.test', $html);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function emailVisibilityProvider(): iterable
+    {
+        yield 'opted in' => [true];
+        yield 'not opted in' => [false];
+    }
+
+    /** Reachable before a file is picked, and again after the referenced file is deleted (SET NULL). */
+    public function test_a_document_item_with_no_file_says_so(): void
+    {
+        [, $bandSpace, $rider] = $this->seed();
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::Document,
+            'title' => 'Plan de salle',
+            'position' => 0,
+        ])->create();
+
+        $gotenberg = $this->render($bandSpace, $rider);
+
+        $this->assertCount(1, $gotenberg->calls());
+        $this->assertStringContainsString(
+            'Aucun fichier',
+            $gotenberg->lastCall()['documents']['index.html'],
+        );
+    }
+
+    /** The flag is honoured nowhere else on the server, so the export is the only thing enforcing it. */
+    public function test_an_excluded_item_is_left_out(): void
+    {
+        [, $bandSpace, $rider] = $this->seed();
+        $this->addTextItem($rider, 'Visible', 0);
+        $this->addTextItem($rider, 'Cachée', 1, included: false);
+
+        $gotenberg = $this->render($bandSpace, $rider);
+        $html = $gotenberg->lastCall()['documents']['index.html'];
+
+        $this->assertStringContainsString('Visible', $html);
+        $this->assertStringNotContainsString('Cachée', $html);
+    }
+
+    /** The fetch join carries no ORDER BY, so the renderer sorting is the only thing ordering these. */
+    public function test_items_are_composed_in_position_order(): void
+    {
+        [, $bandSpace, $rider] = $this->seed();
+        $this->addTextItem($rider, 'Troisième', 2);
+        $this->addTextItem($rider, 'Premier', 0);
+        $this->addTextItem($rider, 'Deuxième', 1);
+
+        $gotenberg = $this->render($bandSpace, $rider);
+        $html = $gotenberg->lastCall()['documents']['index.html'];
+
+        $this->assertLessThan(strpos($html, 'Deuxième'), strpos($html, 'Premier'));
+        $this->assertLessThan(strpos($html, 'Troisième'), strpos($html, 'Deuxième'));
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /**
+     * @return array{\App\Entity\User, BandSpace, TechRider}
+     */
+    private function seed(string $name = 'Fiche technique', bool $archived = false): array
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $rider = TechRiderFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => $name,
+            'archiveDatetime' => $archived ? new \DateTimeImmutable('-1 day') : null,
+        ])->create();
+
+        return [$user, $bandSpace, $rider];
+    }
+
+    private function addTextItem(object $rider, string $title, int $position, bool $included = true): void
+    {
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::Text,
+            'title' => $title,
+            'position' => $position,
+            'isIncluded' => $included,
+            'content' => ['type' => 'doc', 'content' => []],
+        ])->create();
+    }
+
+    private function addPdfAttachment(
+        object $user,
+        object $bandSpace,
+        object $rider,
+        int $position,
+        ?string $degrade = null,
+    ): void {
+        $bytes = match ($degrade) {
+            'not-a-pdf' => 'GIF89a this is not a pdf at all',
+            'encrypted' => "%PDF-1.7\n1 0 obj\n<<>>\nendobj\ntrailer\n<< /Encrypt 9 0 R >>\n%%EOF\n",
+            default => "%PDF-1.4\n1 0 obj\n<</Type /Page>>\nendobj\ntrailer\n<<>>\n%%EOF\n",
+        };
+
+        $storagePath = 'rider-' . bin2hex(random_bytes(4)) . '.pdf';
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'originalName' => 'Plan de salle.pdf',
+            'archiveDatetime' => $degrade === 'archived' ? new \DateTimeImmutable('-1 day') : null,
+        ])->create();
+
+        if ($degrade !== 'no-version') {
+            $version = BandSpaceFileVersionFactory::new([
+                'bandSpaceFile' => $file,
+                'versionNumber' => 1,
+                'createdBy' => $user,
+                'mimeType' => $degrade === 'bad-mime' ? 'audio/mpeg' : 'application/pdf',
+                'size' => $degrade === 'huge' ? 400 * 1024 * 1024 : strlen($bytes),
+                'storagePath' => $storagePath,
+            ])->create();
+            $file->currentVersion = $version;
+        }
+
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        if ($degrade !== 'missing-bytes' && $degrade !== 'no-version') {
+            self::getContainer()->get('oneup_flysystem.musicall_filesystem')
+                ->write('/band_space_files/' . $bandSpace->id . '/' . $storagePath, $bytes);
+        }
+
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::Document,
+            'title' => 'Plan de salle',
+            'position' => $position,
+            'file' => $file,
+        ])->create();
+    }
+
+    /** Renders through the service so a rider can be exercised without loginUser's one-request life. */
+    private function render(object $bandSpace, object $rider): RecordingGotenbergClient
+    {
+        $gotenberg = self::getContainer()->get(RecordingGotenbergClient::class);
+        $entity = self::getContainer()->get(TechRiderRepository::class)
+            ->findOneByIdAndBandSpace((string) $rider->id, $bandSpace);
+
+        self::assertInstanceOf(TechRider::class, $entity);
+        self::getContainer()->get(TechRiderPdfRenderer::class)->render($entity);
+
+        return $gotenberg;
+    }
+
+    private function url(object $bandSpace, object $rider): string
+    {
+        return sprintf('/api/band_spaces/%s/tech_riders/%s/pdf', $bandSpace->id, $rider->id);
+    }
+}

--- a/tests/Integration/TechRider/TechRiderPdfRenderTest.php
+++ b/tests/Integration/TechRider/TechRiderPdfRenderTest.php
@@ -1,0 +1,288 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Integration\TechRider;
+
+use App\Entity\BandSpace\TechRider;
+use App\Enum\BandSpace\TechRiderColour;
+use App\Enum\BandSpace\TechRiderItemType;
+use App\Repository\BandSpace\TechRiderRepository;
+use App\Service\BandSpace\TechRider\TechRiderPdfRenderer;
+use App\Tests\ApiTestCase;
+use App\Tests\Double\RecordingGotenbergClient;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use App\Tests\Factory\BandSpace\TechRiderFactory;
+use App\Tests\Factory\BandSpace\TechRiderItemFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpClient\HttpClient;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * The three things a fake Gotenberg can never answer.
+ *
+ * Everything else about the export is asserted on the request, which is faster and sharper. But
+ * whether the font really embedded, whether the merged document really carries the attachment's pages
+ * in the composed order, and whether a stage plot really draws are all properties of Chromium's
+ * output, and each of them is exactly the kind of thing that breaks quietly.
+ *
+ * These fail rather than skip under CI, because a test that skips on a missing service reports green
+ * on a completely broken renderer.
+ */
+#[ResetDatabase]
+class TechRiderPdfRenderTest extends ApiTestCase
+{
+    private TechRiderPdfRenderer $renderer;
+
+    private TechRiderRepository $riderRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requireGotenberg();
+        self::getContainer()->get(RecordingGotenbergClient::class)->passthrough();
+
+        $this->renderer = self::getContainer()->get(TechRiderPdfRenderer::class);
+        $this->riderRepository = self::getContainer()->get(TechRiderRepository::class);
+    }
+
+    /**
+     * Under dompdf the equivalent failure was a font that silently fell back to Helvetica. Here it is
+     * an asset that never arrives, and the document still renders, just in the wrong typeface.
+     */
+    public function test_the_bundled_font_is_really_embedded(): void
+    {
+        [$bandSpace, $rider] = $this->seed();
+        $this->addText($rider, 'Accueil', 0, 'Le plateau doit être dégagé une heure avant la balance.');
+
+        $pdf = $this->render($bandSpace, $rider);
+
+        $this->assertStringStartsWith('%PDF-', $pdf);
+        $this->assertMatchesRegularExpression(
+            '/\/BaseFont\s*\/[A-Z]{6}\+Inter/',
+            $pdf,
+            'Inter must be embedded, not replaced by a system fallback',
+        );
+    }
+
+    /**
+     * The merge, and specifically its **order**.
+     *
+     * Gotenberg merges in alphabetical order of filename rather than in the order the files are sent.
+     * The first version of this named its temp files after their content, so a "Plan de salle.pdf"
+     * sorted ahead of the cover and the venue received the attachment first. The page count was right
+     * and nothing failed, which is why the assertion below is about which page carries what.
+     */
+    public function test_an_attachment_is_merged_at_the_position_it_was_composed(): void
+    {
+        [$bandSpace, $rider, $user] = $this->seed();
+        $this->addText($rider, 'Avant', 0, 'Avant la pièce jointe.');
+        // Deliberately A5. Page geometry is what identifies the attachment's pages in the merged
+        // document, because Chromium subsets its fonts and writes glyph ids rather than text, so the
+        // words are not recoverable from the bytes without a PDF toolchain this container lacks.
+        $this->attachPdf($user, $bandSpace, $rider, position: 1);
+        $this->addText($rider, 'Après', 2, 'Après la pièce jointe.');
+
+        $sizes = $this->pageSizes($this->render($bandSpace, $rider));
+
+        $this->assertCount(4, $sizes, 'Cover, the first run, the attachment, then the last run');
+        $this->assertSame(
+            ['portrait-a4', 'portrait-a4', 'attachment-a5', 'portrait-a4'],
+            $sizes,
+            'The attachment must land where it was composed, not first: Gotenberg merges in '
+            . 'alphabetical order of filename, so only the ordinal naming keeps this right',
+        );
+    }
+
+    /** The drawing itself: fractional coordinates, the icon assets, and the audience edge. */
+    public function test_a_stage_plot_draws(): void
+    {
+        [$bandSpace, $rider] = $this->seed();
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::StagePlot,
+            'title' => 'Plan de scène',
+            'position' => 0,
+            'content' => [
+                'version' => 1,
+                'stage' => ['aspect_ratio' => 1.4],
+                'elements' => [
+                    ['id' => 'a', 'icon' => 'drum_kit', 'x' => 0.5, 'y' => 0.3, 'scale' => 1.8, 'rotation' => 0, 'label' => 'Batterie'],
+                    ['id' => 'b', 'icon' => 'guitar_amp', 'x' => 0.22, 'y' => 0.35, 'scale' => 1.2, 'rotation' => 90, 'label' => 'Ampli guitare', 'colour' => TechRiderColour::Green->value],
+                ],
+                'legend' => [['icon' => 'drum_kit', 'label' => 'Batterie']],
+            ],
+        ])->create();
+
+        $pdf = $this->render($bandSpace, $rider);
+
+        $this->assertStringStartsWith('%PDF-', $pdf);
+        $this->assertCount(2, $this->pageSizes($pdf), 'A cover and the plot');
+        // The icons are uploaded assets referenced by bare filename, so an embedded image is the
+        // proof they resolved. A broken reference renders a page that is silently empty.
+        $this->assertMatchesRegularExpression(
+            '#/Subtype\s*/Image#',
+            $pdf,
+            'The stage plot icons must be embedded in the document',
+        );
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /**
+     * @return array{object, object, object}
+     */
+    private function seed(): array
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new(['name' => 'Les Amplis'])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $rider = TechRiderFactory::new(['bandSpace' => $bandSpace, 'name' => 'Fiche technique'])->create();
+
+        return [$bandSpace, $rider, $user];
+    }
+
+    private function addText(object $rider, string $title, int $position, string $body): void
+    {
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::Text,
+            'title' => $title,
+            'position' => $position,
+            'content' => ['type' => 'doc', 'content' => [
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $body]]],
+            ]],
+        ])->create();
+    }
+
+    /** A real one-page A5 PDF, built by Chromium so the merge is fed something it actually produced. */
+    private function attachPdf(object $user, object $bandSpace, object $rider, int $position): void
+    {
+        $bytes = $this->renderStandalonePdf('Pièce jointe');
+        $storagePath = 'rider-' . bin2hex(random_bytes(4)) . '.pdf';
+
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'Plan de salle.pdf',
+        ])->create();
+        $version = BandSpaceFileVersionFactory::new([
+            'bandSpaceFile' => $file, 'versionNumber' => 1, 'createdBy' => $user,
+            'mimeType' => 'application/pdf', 'size' => strlen($bytes), 'storagePath' => $storagePath,
+        ])->create();
+        $file->currentVersion = $version;
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        self::getContainer()->get('oneup_flysystem.musicall_filesystem')
+            ->write('/band_space_files/' . $bandSpace->id . '/' . $storagePath, $bytes);
+
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::Document,
+            'title' => 'Plan de salle',
+            'position' => $position,
+            'file' => $file,
+        ])->create();
+    }
+
+    private function renderStandalonePdf(string $marker): string
+    {
+        $html = sprintf('<!DOCTYPE html><html><head><title>a</title></head><body><p>%s</p></body></html>', $marker);
+        $boundary = 'b' . bin2hex(random_bytes(8));
+        $body = sprintf(
+            "--%1\$s\r\nContent-Disposition: form-data; name=\"files\"; filename=\"index.html\"\r\n"
+            . "Content-Type: text/html\r\n\r\n%2\$s\r\n--%1\$s--\r\n",
+            $boundary,
+            $html,
+        );
+
+        $body = str_replace(
+            "--{$boundary}--",
+            sprintf(
+                "--%1\$s\r\nContent-Disposition: form-data; name=\"paperWidth\"\r\n\r\n5.83\r\n"
+                . "--%1\$s\r\nContent-Disposition: form-data; name=\"paperHeight\"\r\n\r\n8.27\r\n--%1\$s--",
+                $boundary,
+            ),
+            $body,
+        );
+
+        return HttpClient::create()->request('POST', $this->dsn() . '/forms/chromium/convert/html', [
+            'headers' => ['Content-Type' => 'multipart/form-data; boundary=' . $boundary],
+            'body' => $body,
+        ])->getContent();
+    }
+
+    private function render(object $bandSpace, object $rider): string
+    {
+        $entity = $this->riderRepository->findOneByIdAndBandSpace((string) $rider->id, $bandSpace);
+        self::assertInstanceOf(TechRider::class, $entity);
+
+        return $this->renderer->render($entity);
+    }
+
+    /**
+     * Each page's shape, in page order, named rather than measured so a failure reads as an ordering
+     * problem rather than a wall of numbers.
+     *
+     * The page dictionary is written uncompressed, so the media boxes are readable straight from the
+     * bytes, and their order in the file matches page order. Note the two producers space the array
+     * differently: Chromium writes `[0 0 ...]` and the merge engine `[ 0 0 ... ]`.
+     *
+     * @return list<string>
+     */
+    private function pageSizes(string $pdf): array
+    {
+        preg_match_all(
+            '#/MediaBox\s*\[\s*[\d.+-]+\s+[\d.+-]+\s+([\d.]+)\s+([\d.]+)\s*\]#',
+            $pdf,
+            $matches,
+            PREG_SET_ORDER,
+        );
+
+        return array_map(static function (array $match): string {
+            $width = (int) round((float) $match[1]);
+
+            return $width > 500 ? 'portrait-a4' : 'attachment-a5';
+        }, $matches);
+    }
+
+    private function requireGotenberg(): void
+    {
+        $reason = 'Gotenberg is required for this test. Set GOTENBERG_DSN and start the service.';
+
+        try {
+            $status = HttpClient::create()
+                ->request('GET', $this->dsn() . '/health', ['timeout' => 3.0])
+                ->getStatusCode();
+        } catch (\Throwable $e) {
+            $this->skipOrFail($reason . ' ' . $e->getMessage());
+
+            return;
+        }
+
+        if ($status !== 200) {
+            $this->skipOrFail(sprintf('%s Health returned HTTP %d.', $reason, $status));
+        }
+    }
+
+    private function dsn(): string
+    {
+        $dsn = $_SERVER['GOTENBERG_DSN'] ?? $_ENV['GOTENBERG_DSN'] ?? '';
+
+        return rtrim(is_string($dsn) ? $dsn : '', '/');
+    }
+
+    /**
+     * Skipping is a convenience for a developer without the container running. In CI it would hide a
+     * broken renderer behind a green run, so there it is a failure.
+     */
+    private function skipOrFail(string $reason): void
+    {
+        if (($_SERVER['CI'] ?? $_ENV['CI'] ?? false) !== false) {
+            self::fail($reason);
+        }
+
+        self::markTestSkipped($reason);
+    }
+}

--- a/tests/Unit/Service/BandSpace/TechRider/TipTapHtmlRendererTest.php
+++ b/tests/Unit/Service/BandSpace/TechRider/TipTapHtmlRendererTest.php
@@ -1,0 +1,335 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\BandSpace\TechRider;
+
+use App\Enum\BandSpace\TechRiderColour;
+use App\Service\BandSpace\TechRider\TipTapHtmlRenderer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The rider's text is stored exactly as the browser sent it, so this renderer is the only thing
+ * standing between that JSON and a document sent to a venue. Most of what follows is therefore about
+ * what does *not* come out.
+ */
+class TipTapHtmlRendererTest extends TestCase
+{
+    private TipTapHtmlRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->renderer = new TipTapHtmlRenderer();
+    }
+
+    private static function doc(array ...$content): array
+    {
+        return ['type' => 'doc', 'content' => $content];
+    }
+
+    private static function text(string $text, array ...$marks): array
+    {
+        return $marks === []
+            ? ['type' => 'text', 'text' => $text]
+            : ['type' => 'text', 'text' => $text, 'marks' => $marks];
+    }
+
+    // ---------------------------------------------------------------- the vocabulary
+
+    public function test_a_paragraph_of_plain_text(): void
+    {
+        $html = $this->renderer->render(self::doc(['type' => 'paragraph', 'content' => [self::text('Deux wedges')]]));
+
+        $this->assertSame('<p>Deux wedges</p>', $html);
+    }
+
+    #[DataProvider('supportedMarkProvider')]
+    public function test_each_supported_mark_wraps_the_text(array $mark, string $expected): void
+    {
+        $html = $this->renderer->render(self::doc(['type' => 'paragraph', 'content' => [self::text('x', $mark)]]));
+
+        $this->assertSame('<p>' . $expected . '</p>', $html);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, string}>
+     */
+    public static function supportedMarkProvider(): iterable
+    {
+        yield 'bold' => [['type' => 'bold'], '<strong>x</strong>'];
+        yield 'italic' => [['type' => 'italic'], '<em>x</em>'];
+        yield 'strike' => [['type' => 'strike'], '<s>x</s>'];
+        // Underline ships inside StarterKit even though the editor's extension list never names it.
+        yield 'underline' => [['type' => 'underline'], '<u>x</u>'];
+        yield 'code' => [['type' => 'code'], '<code>x</code>'];
+    }
+
+    #[DataProvider('supportedNodeProvider')]
+    public function test_each_supported_node_renders(array $node, string $expected): void
+    {
+        $this->assertSame($expected, $this->renderer->render(self::doc($node)));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, string}>
+     */
+    public static function supportedNodeProvider(): iterable
+    {
+        yield 'h2' => [['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [self::text('Son')]], '<h2>Son</h2>'];
+        yield 'h3' => [['type' => 'heading', 'attrs' => ['level' => 3], 'content' => [self::text('Son')]], '<h3>Son</h3>'];
+        yield 'horizontal rule' => [['type' => 'horizontalRule'], '<hr>'];
+        yield 'hard break' => [['type' => 'hardBreak'], '<br>'];
+        yield 'blockquote' => [
+            ['type' => 'blockquote', 'content' => [['type' => 'paragraph', 'content' => [self::text('a')]]]],
+            '<blockquote><p>a</p></blockquote>',
+        ];
+        yield 'code block' => [
+            ['type' => 'codeBlock', 'content' => [self::text('48 kHz')]],
+            '<pre><code>48 kHz</code></pre>',
+        ];
+        yield 'bullet list' => [
+            ['type' => 'bulletList', 'content' => [['type' => 'listItem', 'content' => [['type' => 'paragraph', 'content' => [self::text('a')]]]]]],
+            '<ul><li><p>a</p></li></ul>',
+        ];
+        yield 'ordered list' => [
+            ['type' => 'orderedList', 'content' => [['type' => 'listItem', 'content' => [['type' => 'paragraph', 'content' => [self::text('a')]]]]]],
+            '<ol><li><p>a</p></li></ol>',
+        ];
+        yield 'table' => [
+            ['type' => 'table', 'content' => [['type' => 'tableRow', 'content' => [['type' => 'tableCell', 'content' => [self::text('a')]]]]]],
+            '<table><tr><td>a</td></tr></table>',
+        ];
+    }
+
+    /** The editor only offers h2 and h3, so anything else becomes the smaller of the two. */
+    public function test_an_unexpected_heading_level_falls_back_rather_than_emitting_it(): void
+    {
+        $html = $this->renderer->render(self::doc(['type' => 'heading', 'attrs' => ['level' => 1], 'content' => [self::text('Titre')]]));
+
+        $this->assertSame('<h3>Titre</h3>', $html);
+    }
+
+    public function test_a_cell_span_is_emitted_only_when_it_actually_spans(): void
+    {
+        $cell = static fn (array $attrs): array => ['type' => 'table', 'content' => [
+            ['type' => 'tableRow', 'content' => [['type' => 'tableCell', 'attrs' => $attrs, 'content' => [self::text('a')]]]],
+        ]];
+
+        $this->assertStringContainsString('<td colspan="2">', $this->renderer->render(self::doc($cell(['colspan' => 2]))));
+        $this->assertStringContainsString('<td>', $this->renderer->render(self::doc($cell(['colspan' => 1]))));
+        // A string span is not a span. Emitting it unchecked would put arbitrary text in an attribute.
+        $this->assertStringContainsString('<td>', $this->renderer->render(self::doc($cell(['colspan' => '2" onload="x']))));
+    }
+
+    #[DataProvider('alignmentProvider')]
+    public function test_text_alignment(mixed $alignment, string $expected): void
+    {
+        $html = $this->renderer->render(self::doc([
+            'type' => 'paragraph',
+            'attrs' => ['textAlign' => $alignment],
+            'content' => [self::text('a')],
+        ]));
+
+        $this->assertSame($expected, $html);
+    }
+
+    /**
+     * @return iterable<string, array{mixed, string}>
+     */
+    public static function alignmentProvider(): iterable
+    {
+        yield 'centre' => ['center', '<p style="text-align:center">a</p>'];
+        yield 'justify' => ['justify', '<p style="text-align:justify">a</p>'];
+        yield 'an unknown keyword is dropped' => ['diagonal', '<p>a</p>'];
+        yield 'a smuggled declaration is dropped' => ['left;position:fixed;top:0', '<p>a</p>'];
+        yield 'a non string is dropped' => [42, '<p>a</p>'];
+    }
+
+    // ---------------------------------------------------------------- what must not come out
+
+    public function test_text_is_escaped(): void
+    {
+        $html = $this->renderer->render(self::doc([
+            'type' => 'paragraph',
+            'content' => [self::text('<script>alert(1)</script> & "quoted"')],
+        ]));
+
+        $this->assertSame(
+            '<p>&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;quoted&quot;</p>',
+            $html,
+        );
+    }
+
+    /**
+     * The allowlist bias: an unknown node contributes nothing, rather than being cleaned up and kept.
+     * An image is the realistic case, since the package is installed and another editor uses it.
+     */
+    public function test_an_unknown_node_is_dropped_whole(): void
+    {
+        $html = $this->renderer->render(self::doc(
+            ['type' => 'image', 'attrs' => ['src' => 'https://elsewhere.test/tracker.png']],
+            ['type' => 'paragraph', 'content' => [self::text('après')]],
+        ));
+
+        $this->assertSame('<p>après</p>', $html);
+    }
+
+    public function test_an_unknown_mark_is_dropped_but_its_text_survives(): void
+    {
+        $html = $this->renderer->render(self::doc([
+            'type' => 'paragraph',
+            'content' => [self::text('important', ['type' => 'highlight', 'attrs' => ['color' => 'red']])],
+        ]));
+
+        $this->assertSame('<p>important</p>', $html);
+    }
+
+    #[DataProvider('paletteProvider')]
+    public function test_a_palette_colour_is_kept(TechRiderColour $colour): void
+    {
+        $html = $this->renderer->render(self::doc([
+            'type' => 'paragraph',
+            'content' => [self::text('a', ['type' => 'textStyle', 'attrs' => ['color' => $colour->hex()]])],
+        ]));
+
+        $this->assertSame(sprintf('<p><span style="color:%s">a</span></p>', $colour->hex()), $html);
+    }
+
+    /**
+     * @return iterable<string, array{TechRiderColour}>
+     */
+    public static function paletteProvider(): iterable
+    {
+        foreach (TechRiderColour::cases() as $colour) {
+            yield $colour->value => [$colour];
+        }
+    }
+
+    /**
+     * The hole this closes. The palette is enforced in the editor, in JavaScript, so a crafted PATCH
+     * can already store any colour string it likes; this is the first place that stops.
+     */
+    #[DataProvider('rejectedColourProvider')]
+    public function test_a_colour_outside_the_palette_is_dropped(mixed $colour): void
+    {
+        $html = $this->renderer->render(self::doc([
+            'type' => 'paragraph',
+            'content' => [self::text('a', ['type' => 'textStyle', 'attrs' => ['color' => $colour]])],
+        ]));
+
+        $this->assertSame('<p>a</p>', $html);
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function rejectedColourProvider(): iterable
+    {
+        yield 'an arbitrary hex' => ['#123456'];
+        yield 'a named colour' => ['rebeccapurple'];
+        yield 'a smuggled declaration' => ['#dc2626;position:fixed;left:0'];
+        yield 'a url' => ['url(https://elsewhere.test/x)'];
+        yield 'a closed quote' => ['#dc2626"><script>alert(1)</script>'];
+        yield 'a non string' => [['#dc2626']];
+    }
+
+    #[DataProvider('linkProvider')]
+    public function test_only_a_usable_scheme_becomes_a_link(string $href, ?string $expectedHref): void
+    {
+        $html = $this->renderer->render(self::doc([
+            'type' => 'paragraph',
+            'content' => [self::text('ici', ['type' => 'link', 'attrs' => ['href' => $href]])],
+        ]));
+
+        $expected = $expectedHref === null
+            ? '<p>ici</p>'
+            : sprintf('<p><a href="%s">ici</a></p>', $expectedHref);
+
+        $this->assertSame($expected, $html);
+    }
+
+    /**
+     * A link becomes a clickable annotation in the PDF a venue receives, which is why the scheme is
+     * allowlisted rather than merely escaped.
+     *
+     * @return iterable<string, array{string, string|null}>
+     */
+    public static function linkProvider(): iterable
+    {
+        yield 'https' => ['https://musicall.test/rider', 'https://musicall.test/rider'];
+        yield 'http' => ['http://musicall.test', 'http://musicall.test'];
+        yield 'mailto' => ['mailto:regie@musicall.test', 'mailto:regie@musicall.test'];
+        yield 'surrounding whitespace is trimmed' => ['  https://musicall.test  ', 'https://musicall.test'];
+        yield 'javascript is refused' => ['javascript:alert(1)', null];
+        yield 'javascript behind whitespace is refused' => ['   javascript:alert(1)', null];
+        yield 'a data uri is refused' => ['data:text/html;base64,PHNjcmlwdD4=', null];
+        yield 'a file uri is refused' => ['file:///etc/passwd', null];
+        yield 'a relative path is refused' => ['/band/secrets', null];
+        yield 'an attribute break is refused' => ['https://musicall.test" onmouseover="x', null];
+        yield 'a scheme relative url is refused' => ['//elsewhere.test/x', null];
+        yield 'an embedded newline is refused' => ["https://musicall.test\njavascript:alert(1)", null];
+        yield 'an embedded carriage return is refused' => ["https://musicall.test\r\nx", null];
+    }
+
+    // ---------------------------------------------------------------- shapes that are not documents
+
+    #[DataProvider('nonDocumentProvider')]
+    public function test_anything_that_is_not_a_document_renders_nothing(?array $document): void
+    {
+        $this->assertSame('', $this->renderer->render($document));
+    }
+
+    /**
+     * @return iterable<string, array{array<array-key, mixed>|null}>
+     */
+    public static function nonDocumentProvider(): iterable
+    {
+        yield 'null' => [null];
+        yield 'empty' => [[]];
+        yield 'the wrong root type' => [['type' => 'paragraph', 'content' => []]];
+        yield 'a document with no content' => [['type' => 'doc']];
+        yield 'a document whose content is not a list' => [['type' => 'doc', 'content' => 'text']];
+        yield 'a node with no type' => [['type' => 'doc', 'content' => [['content' => []]]]];
+        yield 'a text node with no text' => [['type' => 'doc', 'content' => [['type' => 'text']]]];
+    }
+
+    /**
+     * A code block holds text, which is what the editor's schema says. Recursing through the generic
+     * dispatch would let a heading or a working link live inside <pre><code>, which the editor could
+     * never produce, so the vocabulary claimed would not be the vocabulary accepted.
+     */
+    public function test_a_code_block_holds_text_and_nothing_else(): void
+    {
+        $html = $this->renderer->render(self::doc(['type' => 'codeBlock', 'content' => [
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [self::text('Titre')]],
+            self::text('48 kHz <ok>', ['type' => 'link', 'attrs' => ['href' => 'https://elsewhere.test']]),
+        ]]));
+
+        $this->assertSame('<pre><code>48 kHz &lt;ok&gt;</code></pre>', $html);
+    }
+
+    /** Bounded above as well as below, like every other value this class lets through. */
+    public function test_an_absurd_cell_span_is_dropped(): void
+    {
+        $html = $this->renderer->render(self::doc(['type' => 'table', 'content' => [
+            ['type' => 'tableRow', 'content' => [
+                ['type' => 'tableCell', 'attrs' => ['colspan' => 999999], 'content' => [self::text('a')]],
+            ]],
+        ]]));
+
+        $this->assertSame('<table><tr><td>a</td></tr></table>', $html);
+    }
+
+    /** Nesting is bounded by the validator at 40 levels, so the renderer only has to not fall over. */
+    public function test_a_deeply_nested_document_renders(): void
+    {
+        $node = ['type' => 'paragraph', 'content' => [self::text('fond')]];
+        for ($depth = 0; $depth < 30; ++$depth) {
+            $node = ['type' => 'blockquote', 'content' => [$node]];
+        }
+
+        $html = $this->renderer->render(self::doc($node));
+
+        $this->assertSame(30, substr_count($html, '<blockquote>'));
+        $this->assertStringContainsString('<p>fond</p>', $html);
+    }
+}


### PR DESCRIPTION
Closes #803.

A rider exists to be emailed to a venue three weeks before the show. Until now the module could compose one but not produce a document, which is why the release gate (`RIDER_SUPER_ADMIN_ONLY`) was right to stay shut.

## How it renders

A rider renders as an ordered list of segments, each either HTML or an attachment PDF. Contiguous runs of non-PDF items accumulate into one HTML segment, and each mergeable PDF attachment becomes a segment of its own. A rider with no PDF attachment is one segment and costs exactly one Gotenberg request, the same as the setlist export. More than one segment goes through `/forms/pdfengines/merge`.

A PDF attachment cannot share a page with rider content anyway, so segmenting is not a compromise, it is what the document already implies.

## Two things worth knowing before reviewing

**The compose comment about the PDF engines was wrong and is corrected here.** It claimed the full Gotenberg image adds LibreOffice plus the PDF engines. It adds LibreOffice only. The pinned `8.34.0-chromium` already reports `pdfengines pdfcpu pdftk qpdf`, verified by merging two real PDFs through the running service. So merging needed no image change in compose or CI.

**Gotenberg merges alphabetically by filename, not in send order.** The first version named its temp files after their content, so a `Plan de salle.pdf` sorted ahead of the cover and the venue received the attachment first. The page count was right and nothing failed, which is exactly why it is dangerous. Segments are now written under zero-padded ordinals, with the width computed from the segment count so it does not break at 100.

## The TipTap renderer is a security boundary, not just a renderer

Text items are stored as TipTap JSON and nothing sanitised them: `TechRiderItemContentValidator` checks only depth and size. The colour allowlist that keeps pasted CSS out lived **only in the browser**, so a crafted PATCH could already store arbitrary CSS colour.

`TipTapHtmlRenderer` is an allowlist by construction. It walks the document and emits only the node types and marks it knows, escaping all text, so an unknown node is dropped rather than sanitised. Colour marks are restricted to `TechRiderColour::hex()` and the output echoes the enum's own hex, never the input. This is the first server-side enforcement of that palette.

## Attachments degrade, they never throw

A rider that silently drops an attachment is worse than one that names it: the band can see what to send separately, and one bad file cannot stop the whole export. Every refusal prints a reference block instead of a page: archived file, no current version, a mime that is no longer renderable (re-checked here, because a later version upload can change it), oversize, unreadable, not a PDF, or password protected.

The size cap is enforced twice on purpose. The version row is checked first, then the copy is bounded at one byte past the cap, because a version row can disagree with the object actually in storage and copying exactly the cap cannot tell a file that fits from one truncated at the limit. Bytes are copied stream to stream and never materialise in PHP.

## Tests

40 tests across three levels, and the levels are not arbitrary:

- **Unit** (`TipTapHtmlRendererTest`, 34 cases) for the security boundary, since it is pure: every supported node and mark, unknown nodes and marks dropped, colours outside the palette dropped, text escaped, hostile hrefs refused, deep nesting.
- **API** (`TechRiderPdfExportTest`, 21 cases) hermetic through a recording Gotenberg double: call counts, which route was hit, the composed order, the `isIncluded` filter, each degradation path, the patch-row grouping, and the `showEmails` gate both ways.
- **Integration** (`TechRiderPdfRenderTest`, 3 cases) against real Chromium, for the three things a fake can never answer: that Inter really embedded rather than falling back, that the merged document carries the attachment's pages **in the composed position**, and that a stage plot really draws its icons. These fail rather than skip under CI, because a test that skips on a missing service reports green on a completely broken renderer.

Each new assertion was mutation-tested. Notably the merge-order test is asserted on which page carries what rather than on page count, because page count passed while the order was wrong.

## Deliberately not in this PR

Page break control (needs a migration, and the design is the part most likely to be wrong without real use), a band logo on the cover (`BandSpace` has no logo field at all, so that needs its own issue first), PDF/A (measured in #741 at +50% size and 3x the time, and an archival rider buys nothing), and emailing the rider.
