### PR TITLE
Tech rider stage plot: first batch of drawn icons

### DIFF
--- a/assets/icons/stage_plot/bass_amp.svg
+++ b/assets/icons/stage_plot/bass_amp.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" style="stroke-width:var(--sp-stroke, 2)">
+  <rect x="4" y="18" width="56" height="28" rx="1"/>
+  <circle cx="9.1" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="12.87" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="16.72" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="20.63" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <rect x="52.5" y="33.2" width="1.8" height="3.2" rx="0.4" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="56" cy="34.5" r="1.3" fill="currentColor" stroke="none"/>
+  <rect x="6.5" y="40.5" width="51.5" height="2.7" rx="0.4" fill="currentColor" stroke="none"/>
+</svg>

--- a/assets/icons/stage_plot/drum_kit.svg
+++ b/assets/icons/stage_plot/drum_kit.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" style="stroke-width:var(--sp-stroke, 2)">
+  <polygon points="25.6,11.7 38.9,11.7 32.3,23.4"/>
+  <rect x="21.2" y="37" width="21.2" height="14.4"/>
+  <rect x="31.8" y="31.6" width="2.5" height="5.9" rx="0.5"/>
+  <circle cx="9.8" cy="41.7" r="7.8"/>
+  <circle cx="9.8" cy="41.7" r="5.1" style="stroke-width:calc(var(--sp-stroke, 2) * 0.65)"/>
+  <circle cx="52.4" cy="44.5" r="7.8"/>
+  <circle cx="52.4" cy="44.5" r="5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.65)"/>
+  <rect x="49.8" y="20.1" width="5.4" height="2.8" rx="0.5" transform="rotate(-42 52.5 21.5)"/>
+  <circle cx="56.2" cy="28.3" r="5.7"/>
+  <circle cx="56.2" cy="28.3" r="3.7" style="stroke-width:calc(var(--sp-stroke, 2) * 0.65)"/>
+  <g fill="currentColor" stroke="none">
+    <circle cx="20.8" cy="26" r="7.6"/>
+    <circle cx="42" cy="27" r="7"/>
+    <circle cx="26.3" cy="39.2" r="6.2"/>
+    <circle cx="39.1" cy="39.9" r="5.4"/>
+  </g>
+</svg>

--- a/assets/icons/stage_plot/guitar_amp.svg
+++ b/assets/icons/stage_plot/guitar_amp.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" style="stroke-width:var(--sp-stroke, 2)">
+  <rect x="4" y="18" width="56" height="28" rx="1"/>
+  <circle cx="9.1" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="12.87" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="16.72" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="20.63" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="24.58" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="28.62" cy="34.8" r="1.5" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <rect x="52.5" y="33.2" width="1.8" height="3.2" rx="0.4" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <circle cx="56" cy="34.5" r="1.3" fill="currentColor" stroke="none"/>
+  <rect x="6.5" y="40.5" width="51.5" height="2.7" rx="0.4" fill="currentColor" stroke="none"/>
+</svg>

--- a/assets/icons/stage_plot/par_can.svg
+++ b/assets/icons/stage_plot/par_can.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" style="stroke-width:var(--sp-stroke, 2)">
+  <circle cx="32" cy="42" r="17"/>
+  <circle cx="32" cy="42" r="6.5"/>
+  <line x1="18" y1="31" x2="5" y2="5" stroke-dasharray="3 3" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <line x1="46" y1="31" x2="59" y2="5" stroke-dasharray="3 3" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+</svg>

--- a/assets/icons/stage_plot/power_socket.svg
+++ b/assets/icons/stage_plot/power_socket.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" style="stroke-width:var(--sp-stroke, 2)">
+  <circle cx="32" cy="32" r="24"/>
+  <circle cx="22" cy="25" r="2.8" fill="currentColor" stroke="none" style="r:calc(var(--sp-stroke, 2) * 2)"/>
+  <circle cx="42" cy="25" r="2.8" fill="currentColor" stroke="none" style="r:calc(var(--sp-stroke, 2) * 2)"/>
+  <polygon points="34,34 27,45 31,45 30,53 38,41 33,41" fill="currentColor" stroke="none"/>
+</svg>

--- a/assets/icons/stage_plot/vocal_mic.svg
+++ b/assets/icons/stage_plot/vocal_mic.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" style="stroke-width:var(--sp-stroke, 2)">
+  <line x1="32" y1="38" x2="32" y2="60"/>
+  <line x1="32" y1="38" x2="13" y2="27"/>
+  <line x1="32" y1="38" x2="51" y2="27"/>
+  <circle cx="32" cy="38" r="5"/>
+  <line x1="32" y1="33" x2="32" y2="16"/>
+  <circle cx="32" cy="10" r="6"/>
+</svg>

--- a/assets/icons/stage_plot/wedge_monitor.svg
+++ b/assets/icons/stage_plot/wedge_monitor.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" style="stroke-width:var(--sp-stroke, 2)">
+  <polygon points="15,10 49,10 59,54 5,54"/>
+  <line x1="19" y1="18" x2="45" y2="18" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+  <line x1="18" y1="25" x2="46" y2="25" style="stroke-width:calc(var(--sp-stroke, 2) * 0.6)"/>
+</svg>

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
@@ -40,11 +40,15 @@
         @focus="emit('select', element.id)"
         @dblclick.stop="emit('edit-label', element.id)"
       >
-        <img
-          :src="iconImage(element.icon)"
-          :alt="''"
-          class="pointer-events-none w-full block"
-          :style="{ transform: `rotate(${element.rotation ?? 0}deg)` }"
+        <StagePlotIcon
+          :slug="element.icon"
+          :image-url="iconImage(element.icon)"
+          :colour="symbolColour(element)"
+          class="pointer-events-none mx-auto"
+          :style="{
+            transform: `rotate(${element.rotation ?? 0}deg)`,
+            width: `${SYMBOL_SIZE_PERCENT}%`
+          }"
         />
 
         <!-- Real text, not painted into a bitmap: selectable, sharp at any size, and the thing
@@ -132,6 +136,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import {
+  BASE_ICON_PERCENT,
   COARSE_NUDGE_STEP,
   describePosition,
   FINE_NUDGE_STEP,
@@ -144,10 +149,12 @@ import {
   rotationGrabOffset,
   SCALE_STEP,
   SNAP_STEP,
+  SYMBOL_SIZE_PERCENT,
   snapFraction,
   toFraction
 } from '../../../../constants/stagePlot.js'
 import { TECH_RIDER_COLOURS } from '../../../../constants/techRiderColours.js'
+import StagePlotIcon from './StagePlotIcon.vue'
 
 const props = defineProps({
   /** Mutated in place: the parent owns the plot so it can diff the whole document at once. */
@@ -160,13 +167,6 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['select', 'place', 'edit-label', 'delete'])
-
-/**
- * An icon's width as a percentage of the stage at scale 1. A percentage rather than pixels so an
- * icon keeps its size relative to the stage at any viewport width, the same reason positions are
- * fractions.
- */
-const BASE_ICON_PERCENT = 6
 
 const stageRef = ref(null)
 const elementRefs = new Map()
@@ -204,6 +204,11 @@ function iconFor(slug) {
 
 function iconImage(slug) {
   return iconFor(slug)?.image_url ?? ''
+}
+
+/** The element's own colour wins; otherwise the symbol takes its category's. */
+function symbolColour(element) {
+  return colourHex(element.colour) ?? iconFor(element.icon)?.category_colour ?? null
 }
 
 function colourHex(value) {

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotIcon.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotIcon.vue
@@ -1,0 +1,52 @@
+<template>
+  <span class="stage-plot-icon" :style="style" aria-hidden="true">
+    <span v-if="symbol" v-html="symbol" />
+    <img v-else :src="imageUrl" :alt="''" />
+  </span>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { SYMBOL_STROKE_WIDTH } from '../../../../constants/stagePlot.js'
+
+/**
+ * Inlined at build time rather than fetched. An SVG behind an <img> is an isolated document that
+ * the page's colour cannot reach, so a referenced symbol would render black on every surface.
+ *
+ * Icons still on their placeholder PNG have no entry here and fall through to imageUrl.
+ */
+const SYMBOL_DIRECTORY = '../../../../../icons/stage_plot'
+const symbols = import.meta.glob('../../../../../icons/stage_plot/*.svg', {
+  query: '?raw',
+  import: 'default',
+  eager: true
+})
+
+const props = defineProps({
+  slug: { type: String, required: true },
+  imageUrl: { type: String, default: '' },
+  // Resolved by the caller, since only the canvas has an element to take a colour from.
+  colour: { type: String, default: null }
+})
+
+const symbol = computed(() => symbols[`${SYMBOL_DIRECTORY}/${props.slug}.svg`] ?? null)
+
+const style = computed(() => ({
+  color: props.colour ?? undefined,
+  '--sp-stroke': SYMBOL_STROKE_WIDTH
+}))
+</script>
+
+<style scoped>
+/* Width comes from whatever class the caller puts on this component, and the symbol fills it. */
+.stage-plot-icon {
+  display: block;
+}
+
+.stage-plot-icon > *,
+.stage-plot-icon :deep(svg) {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+</style>

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotIconPicker.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotIconPicker.vue
@@ -42,7 +42,12 @@
           @dragstart="handleDragStart($event, icon)"
           @click="emit('place', icon.slug)"
         >
-          <img :src="icon.image_url" :alt="''" class="w-8 h-8 object-contain" />
+          <StagePlotIcon
+            :slug="icon.slug"
+            :image-url="icon.image_url"
+            :colour="icon.category_colour"
+            class="w-8 h-8"
+          />
           <span class="text-[10px] leading-tight text-center line-clamp-2">{{ icon.label }}</span>
         </button>
       </li>
@@ -54,6 +59,7 @@
 import Button from 'primevue/button'
 import InputText from 'primevue/inputtext'
 import { computed, ref } from 'vue'
+import StagePlotIcon from './StagePlotIcon.vue'
 
 const props = defineProps({
   icons: { type: Array, default: () => [] },

--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotLegendEditor.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotLegendEditor.vue
@@ -15,7 +15,12 @@
 
     <ul v-else class="flex flex-col gap-1">
       <li v-for="(entry, index) in legend" :key="`${entry.icon}-${index}`" class="flex items-center gap-1">
-        <img :src="iconImage(entry.icon)" :alt="''" class="w-6 h-6 object-contain shrink-0" />
+        <StagePlotIcon
+          :slug="entry.icon"
+          :image-url="iconImage(entry.icon)"
+          :colour="iconFor(entry.icon)?.category_colour"
+          class="w-6 h-6 shrink-0"
+        />
         <InputText
           :model-value="entry.label ?? ''"
           :disabled="readOnly"
@@ -54,7 +59,12 @@
       >
         <template #option="{ option }">
           <span class="flex items-center gap-2">
-            <img :src="option.image_url" :alt="''" class="w-5 h-5 object-contain" />
+            <StagePlotIcon
+              :slug="option.slug"
+              :image-url="option.image_url"
+              :colour="option.category_colour"
+              class="w-5 h-5"
+            />
             <span>{{ option.label }}</span>
           </span>
         </template>
@@ -78,6 +88,7 @@ import InputText from 'primevue/inputtext'
 import Select from 'primevue/select'
 import { ref } from 'vue'
 import { MAX_LABEL_LENGTH, MAX_LEGEND_ENTRIES } from '../../../../constants/stagePlot.js'
+import StagePlotIcon from './StagePlotIcon.vue'
 
 const props = defineProps({
   legend: { type: Array, required: true },

--- a/assets/js/constants/stagePlot.js
+++ b/assets/js/constants/stagePlot.js
@@ -23,6 +23,20 @@ export const MAX_ASPECT_RATIO = 3.0
 export const DEFAULT_ASPECT_RATIO = 1.4
 
 /**
+ * How the icons are drawn. Mirrored in TechRiderPdfRenderer so a plot prints as it looks.
+ *
+ * The two SYMBOL_ values are the calibration knobs: tune them here after a test print, and every
+ * surface and the PDF follow. SYMBOL_STROKE_WIDTH is in viewBox units on a 0 0 64 64 canvas, so it
+ * is resolution independent, and the thinner strokes and filled details inside each file are
+ * multiples of it rather than fixed.
+ *
+ * For scale, an element is 10.9mm wide on A4 at scale 1, so stroke 1.4 is 0.24mm of ink.
+ */
+export const BASE_ICON_PERCENT = 6
+export const SYMBOL_STROKE_WIDTH = 1.4
+export const SYMBOL_SIZE_PERCENT = 100
+
+/**
  * Any whole degree from 0 to 359 is stored, so these four are shortcuts rather than the domain.
  * They stay because a quarter turn is the common case, one click beats aiming a slider at it, and
  * they are the only sane keyboard path: arrows on a 360 stop slider would need ninety presses.

--- a/public/images/band_space/stage_plot/README.md
+++ b/public/images/band_space/stage_plot/README.md
@@ -10,14 +10,26 @@ any future server side renderer could each end up naming a different file. An un
 one name, and a renderer reading from disk can predict it.
 
 PNG with transparency rather than SVG. The original reason was that the export engine was undecided
-(#741); it is now Chromium, which renders SVG properly, so SVG has become viable. PNG stays because
-these are small raster badges either way and swapping formats would mean redrawing all 21.
+(#741); it is now Chromium, which renders SVG properly, so SVG has become viable.
+
+**Real artwork is drawn as SVG and lives in `assets/icons/stage_plot/` instead** (#836). The two
+formats coexist on purpose: an icon with a drawn symbol uses it everywhere, and one still on its
+placeholder keeps the PNG below. `TechRiderStagePlotIcon::symbolPath()` is what decides, and it
+returns null for an icon with no symbol yet.
+
+Symbols are inlined rather than served, so they take the element's colour through `currentColor`.
+An SVG behind an `<img>` is an isolated document that the page's colour cannot reach, which would
+render every symbol black. That is also why they do not need the stable unhashed path the PNGs do:
+no URL is involved.
 
 ## Current artwork: placeholders
 
-**Every file here is a generated placeholder**, not final art: a rounded square in the category
-colour with the label's initials. They exist so the editor (#774) is buildable and so the
+**Every file in this directory is a generated placeholder**, not final art: a rounded square in the
+category colour with the label's initials. They exist so the editor (#774) is buildable and so the
 catalogue endpoint returns something that renders.
+
+Seven of the twenty-one now have real artwork in `assets/icons/stage_plot/` and no longer render
+from here, though their placeholder file stays so the catalogue's `image_url` keeps resolving.
 
 | Category | Placeholder colour |
 |---|---|
@@ -35,12 +47,29 @@ that leaves the band, so the licence of what is printed has to be known.
 
 | File | Source | Licence |
 |---|---|---|
-| _all_ | generated placeholder, this repository | n/a |
+| _all PNG placeholders_ | generated placeholder, this repository | n/a |
+| `assets/icons/stage_plot/*.svg` | drawn for this project | this repository |
 
 ## Adding an icon
 
 1. Add a case to `TechRiderStagePlotIcon` with its `category()` and French `label()`.
 2. Drop `{slug}.png` in this directory.
 
-`TechRiderStagePlotIconArtworkTest` fails if a case has no file, so the two halves cannot drift
-apart unnoticed.
+## Drawing a real symbol for one
+
+1. Draw it on a `0 0 64 64` viewBox, top down, `fill="none"`, `stroke="currentColor"`.
+2. Set no colour and no `stroke-width` attribute. Take the stroke from
+   `style="stroke-width:var(--sp-stroke, 2)"`, and express any thinner or thicker stroke, and any
+   filled detail, as a `calc()` multiple of it so the whole set scales together.
+3. Save it as `assets/icons/stage_plot/{slug}.svg`.
+4. Add the case to the `symbolPath()` match.
+
+`TechRiderStagePlotIconArtworkTest` fails if either half of either format is missing, and checks
+that a symbol hardcodes no colour and follows the stroke constant, so these cannot drift apart
+unnoticed.
+
+## Calibration
+
+`SYMBOL_STROKE_WIDTH` and `SYMBOL_SIZE_PERCENT` in `assets/js/constants/stagePlot.js`, mirrored in
+`TechRiderPdfRenderer`, are the two knobs. They exist to be tuned after printing a rider on A4: an
+element is 10.9mm wide at scale 1, so stroke 1.4 is 0.24mm of ink.

--- a/src/ApiResource/BandSpace/TechRider/TechRiderStagePlotIconResource.php
+++ b/src/ApiResource/BandSpace/TechRider/TechRiderStagePlotIconResource.php
@@ -56,6 +56,9 @@ class TechRiderStagePlotIconResource
 
     public string $categoryLabel;
 
+    /** Served rather than mapped in the browser so the four values live in one place. */
+    public string $categoryColour;
+
     /** Unhashed and under public/, so this URL is stable across builds. */
     public string $imageUrl;
 }

--- a/src/Enum/BandSpace/TechRiderStagePlotIcon.php
+++ b/src/Enum/BandSpace/TechRiderStagePlotIcon.php
@@ -40,6 +40,13 @@ enum TechRiderStagePlotIcon: string
     /** Directory only, so the path is built in one place and the tests can check it. */
     public const string IMAGE_DIRECTORY = 'images/band_space/stage_plot';
 
+    /**
+     * Under assets/ rather than public/ because a symbol is inlined, never fetched by URL: an SVG
+     * behind an <img> is an isolated document that the page's colour cannot reach, so currentColor
+     * would render black.
+     */
+    public const string SYMBOL_DIRECTORY = 'assets/icons/stage_plot';
+
     /** @return list<string> for Assert\Choice, which cannot take an enum directly here. */
     public static function values(): array
     {
@@ -54,6 +61,25 @@ enum TechRiderStagePlotIcon: string
     public function imagePath(): string
     {
         return sprintf('/%s/%s.png', self::IMAGE_DIRECTORY, $this->value);
+    }
+
+    /**
+     * Null is the normal state, not an error: symbols are drawn in batches so the stroke weight can
+     * be calibrated on a real print first. A null means fall back to the placeholder PNG.
+     */
+    public function symbolPath(): ?string
+    {
+        return match ($this) {
+            self::DrumKit,
+            self::WedgeMonitor,
+            self::GuitarAmp,
+            self::BassAmp,
+            self::VocalMic,
+            self::ParCan,
+            self::PowerSocket => sprintf('%s/%s.svg', self::SYMBOL_DIRECTORY, $this->value),
+
+            default => null,
+        };
     }
 
     public function category(): TechRiderStagePlotIconCategory

--- a/src/Enum/BandSpace/TechRiderStagePlotIconCategory.php
+++ b/src/Enum/BandSpace/TechRiderStagePlotIconCategory.php
@@ -24,4 +24,18 @@ enum TechRiderStagePlotIconCategory: string
             self::Other => 'Divers',
         };
     }
+
+    /**
+     * What a drawn symbol takes when its element has no colour of its own. Same four values the
+     * placeholder PNGs are painted with, which until now existed only as pixels and a README table.
+     */
+    public function hex(): string
+    {
+        return match ($this) {
+            self::Audio => '#2563eb',
+            self::Instrument => '#059669',
+            self::Lighting => '#d97706',
+            self::Other => '#64748b',
+        };
+    }
 }

--- a/src/Service/BandSpace/TechRider/TechRiderPdfRenderer.php
+++ b/src/Service/BandSpace/TechRider/TechRiderPdfRenderer.php
@@ -49,8 +49,16 @@ readonly class TechRiderPdfRenderer
     private const float MARGIN_BOTTOM_MM = 14.0;
     private const float MARGIN_SIDE_MM = 14.0;
 
-    /** Matches BASE_ICON_PERCENT in assets/js/constants/stagePlot.js, so a plot prints to scale. */
-    private const float BASE_ICON_PERCENT = 6.0;
+    /**
+     * These three mirror assets/js/constants/stagePlot.js so a plot prints as it looks, and are
+     * public so TechRiderStagePlotLimitsTest can pin the two files together.
+     *
+     * The SYMBOL_ pair is the calibration: tune them after a test print. Stroke is in viewBox units
+     * on a 0 0 64 64 canvas, so an element 10.9mm wide at scale 1 puts stroke 1.4 at 0.24mm of ink.
+     */
+    public const float BASE_ICON_PERCENT = 6.0;
+    public const float SYMBOL_STROKE_WIDTH = 1.4;
+    public const float SYMBOL_SIZE_PERCENT = 100.0;
 
     /** Matches DEFAULT_ASPECT_RATIO in the editor, for a plot saved before `stage` existed. */
     private const float DEFAULT_ASPECT_RATIO = 1.4;
@@ -340,17 +348,25 @@ readonly class TechRiderPdfRenderer
                 continue;
             }
 
-            $assets[] = $this->iconPath($icon);
             $scale = is_numeric($element['scale'] ?? null) ? (float) $element['scale'] : 1.0;
+            $colour = $this->colourHex($element['colour'] ?? null);
+            $symbol = $this->symbolMarkup($icon);
+
+            // Only a PNG needs uploading. A symbol is already in the HTML by the time this runs.
+            if ($symbol === null) {
+                $assets[] = $this->iconPath($icon);
+            }
 
             $elements[] = [
+                'symbol' => $symbol,
                 'image' => $icon->value . '.png',
                 'left' => round(((float) ($element['x'] ?? 0)) * 100, 4),
                 'top' => round(((float) ($element['y'] ?? 0)) * 100, 4),
                 'width' => round(self::BASE_ICON_PERCENT * $scale, 4),
                 'rotation' => is_int($element['rotation'] ?? null) ? $element['rotation'] : 0,
                 'label' => is_string($element['label'] ?? null) ? $element['label'] : null,
-                'colour' => $this->colourHex($element['colour'] ?? null),
+                'colour' => $colour,
+                'symbol_colour' => $colour ?? $icon->category()->hex(),
             ];
         }
 
@@ -365,9 +381,16 @@ readonly class TechRiderPdfRenderer
                 continue;
             }
 
-            $assets[] = $this->iconPath($icon);
+            $symbol = $this->symbolMarkup($icon);
+            if ($symbol === null) {
+                $assets[] = $this->iconPath($icon);
+            }
+
             $legend[] = [
+                'symbol' => $symbol,
                 'image' => $icon->value . '.png',
+                // The legend has no element behind it, so the category colour is the only one it has.
+                'symbol_colour' => $icon->category()->hex(),
                 'label' => is_string($entry['label'] ?? null) && $entry['label'] !== ''
                     ? $entry['label']
                     : $icon->label(),
@@ -378,6 +401,8 @@ readonly class TechRiderPdfRenderer
             'aspect_ratio' => is_numeric($aspectRatio) ? (float) $aspectRatio : self::DEFAULT_ASPECT_RATIO,
             'elements' => $elements,
             'legend' => $legend,
+            'symbol_stroke_width' => self::SYMBOL_STROKE_WIDTH,
+            'symbol_size_percent' => self::SYMBOL_SIZE_PERCENT,
         ];
     }
 
@@ -414,6 +439,22 @@ readonly class TechRiderPdfRenderer
     private function iconPath(TechRiderStagePlotIcon $icon): string
     {
         return $this->projectDir . '/' . self::ICON_DIRECTORY . $icon->imagePath();
+    }
+
+    /**
+     * Inlined rather than uploaded as an asset: an SVG behind an <img> cannot see the page's colour
+     * and would print black. A missing file falls back to the PNG rather than failing the export.
+     */
+    private function symbolMarkup(TechRiderStagePlotIcon $icon): ?string
+    {
+        $path = $icon->symbolPath();
+        if ($path === null) {
+            return null;
+        }
+
+        $markup = @file_get_contents($this->projectDir . '/' . $path);
+
+        return $markup === false ? null : trim($markup);
     }
 
     /**

--- a/src/State/Provider/BandSpace/TechRider/TechRiderStagePlotIconProvider.php
+++ b/src/State/Provider/BandSpace/TechRider/TechRiderStagePlotIconProvider.php
@@ -41,6 +41,7 @@ readonly class TechRiderStagePlotIconProvider implements ProviderInterface
         $resource->label = $icon->label();
         $resource->category = $icon->category()->value;
         $resource->categoryLabel = $icon->category()->label();
+        $resource->categoryColour = $icon->category()->hex();
         $resource->imageUrl = $icon->imagePath();
 
         return $resource;

--- a/templates/pdf/tech_rider/_stage_plot.html.twig
+++ b/templates/pdf/tech_rider/_stage_plot.html.twig
@@ -12,7 +12,11 @@
                     class="stage-item"
                     style="left:{{ element.left }}%;top:{{ element.top }}%;width:{{ element.width }}%"
                 >
-                    <img src="{{ element.image }}" alt="" style="transform:rotate({{ element.rotation }}deg)">
+                    {% if element.symbol %}
+                        <span class="stage-symbol" style="transform:rotate({{ element.rotation }}deg);color:{{ element.symbol_colour }};--sp-stroke:{{ item.symbol_stroke_width }};width:{{ item.symbol_size_percent }}%">{{ element.symbol|raw }}</span>
+                    {% else %}
+                        <img src="{{ element.image }}" alt="" style="transform:rotate({{ element.rotation }}deg)">
+                    {% endif %}
                     {% if element.label %}
                         <span class="stage-label"{% if element.colour %} style="color:{{ element.colour }}"{% endif %}>{{ element.label }}</span>
                     {% endif %}
@@ -25,7 +29,11 @@
             <ul class="legend">
                 {% for entry in item.legend %}
                     <li>
-                        <img src="{{ entry.image }}" alt="">
+                        {% if entry.symbol %}
+                            <span class="legend-symbol" style="color:{{ entry.symbol_colour }};--sp-stroke:{{ item.symbol_stroke_width }}">{{ entry.symbol|raw }}</span>
+                        {% else %}
+                            <img src="{{ entry.image }}" alt="">
+                        {% endif %}
                         <span>{{ entry.label }}</span>
                     </li>
                 {% endfor %}

--- a/templates/pdf/tech_rider/rider.html.twig
+++ b/templates/pdf/tech_rider/rider.html.twig
@@ -163,6 +163,9 @@
         .stage-item { position: absolute; transform: translate(-50%, -50%); }
         {# The rotation sits on the image so the label underneath stays level whatever the icon does. #}
         .stage-item img { display: block; width: 100%; }
+        {# The symbol is inlined, not an <img>, so that currentColor can reach it. #}
+        .stage-item .stage-symbol { display: block; margin: 0 auto; }
+        .stage-item .stage-symbol svg { display: block; width: 100%; height: auto; }
         .stage-label {
             position: absolute;
             top: 100%;
@@ -197,6 +200,8 @@
         }
         .legend li { display: flex; align-items: center; gap: 2mm; font-size: 8pt; }
         .legend img { width: 5mm; }
+        .legend .legend-symbol { display: block; flex: none; width: 5mm; }
+        .legend .legend-symbol svg { display: block; width: 100%; height: auto; }
 
         .contact-lines { margin: 0 0 3mm; padding: 0; list-style: none; }
         .contact-lines li { padding: 1.2mm 0; border-bottom: 1px solid var(--rule); }

--- a/tests/Api/BandSpace/TechRider/TechRiderPdfExportTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderPdfExportTest.php
@@ -7,6 +7,7 @@ use App\Entity\BandSpace\TechRider;
 use App\Enum\BandSpace\TechRiderColour;
 use App\Enum\BandSpace\TechRiderItemType;
 use App\Enum\BandSpace\TechRiderPatchDirection;
+use App\Enum\BandSpace\TechRiderStagePlotIcon;
 use App\Repository\BandSpace\TechRiderRepository;
 use App\Service\BandSpace\TechRider\TechRiderPdfRenderer;
 use App\Tests\ApiTestAssertionsTrait;
@@ -316,6 +317,55 @@ class TechRiderPdfExportTest extends ApiTestCase
         yield 'not opted in' => [false];
     }
 
+    /**
+     * A drawn symbol is inlined with both calibration constants applied, and does not also drag its
+     * now unused placeholder PNG into the upload.
+     *
+     * The constants are the point of this batch: they get tuned after a test print, so a template
+     * that stopped reading them would quietly pin the artwork at today's values.
+     */
+    public function test_a_drawn_symbol_is_inlined_and_carries_the_calibration_constants(): void
+    {
+        [, $bandSpace, $rider] = $this->seed();
+        $icon = TechRiderStagePlotIcon::DrumKit;
+        self::assertNotNull($icon->symbolPath(), 'This test needs an icon that has a drawn symbol');
+
+        $this->seedStagePlot($rider, $icon);
+        $call = $this->render($bandSpace, $rider)->lastCall();
+        $html = $call['documents']['index.html'];
+
+        $this->assertStringContainsString('viewBox="0 0 64 64"', $html, 'The symbol must be inlined');
+        $this->assertStringContainsString(
+            '--sp-stroke:' . TechRiderPdfRenderer::SYMBOL_STROKE_WIDTH,
+            $html,
+            'The stroke constant must reach the page',
+        );
+        $this->assertStringContainsString(
+            'width:' . TechRiderPdfRenderer::SYMBOL_SIZE_PERCENT . '%',
+            $html,
+            'The size constant must reach the page',
+        );
+        $this->assertArrayNotHasKey(
+            $icon->value . '.png',
+            $call['assets'],
+            'An icon with a drawn symbol must not upload its placeholder PNG as well',
+        );
+    }
+
+    /** The other half of the set still travels as an uploaded PNG, which the symbol branch must not break. */
+    public function test_an_icon_with_no_symbol_still_uploads_its_png(): void
+    {
+        [, $bandSpace, $rider] = $this->seed();
+        $icon = TechRiderStagePlotIcon::Keyboard;
+        self::assertNull($icon->symbolPath(), 'This test needs an icon that has no drawn symbol yet');
+
+        $this->seedStagePlot($rider, $icon);
+        $call = $this->render($bandSpace, $rider)->lastCall();
+
+        $this->assertArrayHasKey($icon->value . '.png', $call['assets']);
+        $this->assertStringNotContainsString('viewBox="0 0 64 64"', $call['documents']['index.html']);
+    }
+
     /** Reachable before a file is picked, and again after the referenced file is deleted (SET NULL). */
     public function test_a_document_item_with_no_file_says_so(): void
     {
@@ -446,6 +496,23 @@ class TechRiderPdfExportTest extends ApiTestCase
     }
 
     /** Renders through the service so a rider can be exercised without loginUser's one-request life. */
+    private function seedStagePlot(object $rider, TechRiderStagePlotIcon $icon): void
+    {
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::StagePlot,
+            'title' => 'Plan de scène',
+            'position' => 0,
+            'content' => [
+                'version' => 1,
+                'stage' => ['aspect_ratio' => 1.4],
+                'elements' => [
+                    ['id' => 'a', 'icon' => $icon->value, 'x' => 0.5, 'y' => 0.5, 'scale' => 1.0, 'rotation' => 0],
+                ],
+            ],
+        ])->create();
+    }
+
     private function render(object $bandSpace, object $rider): RecordingGotenbergClient
     {
         $gotenberg = self::getContainer()->get(RecordingGotenbergClient::class);

--- a/tests/Api/BandSpace/TechRider/TechRiderStagePlotIconCollectionTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderStagePlotIconCollectionTest.php
@@ -57,6 +57,7 @@ class TechRiderStagePlotIconCollectionTest extends ApiTestCase
             'label' => 'Batterie',
             'category' => 'instrument',
             'category_label' => 'Instruments',
+            'category_colour' => '#059669',
             'image_url' => '/images/band_space/stage_plot/drum_kit.png',
         ], $drumKit[0]);
     }
@@ -129,6 +130,7 @@ class TechRiderStagePlotIconCollectionTest extends ApiTestCase
             'label' => 'Batterie',
             'category' => 'instrument',
             'category_label' => 'Instruments',
+            'category_colour' => '#059669',
             'image_url' => '/images/band_space/stage_plot/drum_kit.png',
         ]);
     }

--- a/tests/Integration/TechRider/TechRiderPdfRenderTest.php
+++ b/tests/Integration/TechRider/TechRiderPdfRenderTest.php
@@ -4,6 +4,8 @@ namespace App\Tests\Integration\TechRider;
 
 use App\Entity\BandSpace\TechRider;
 use App\Enum\BandSpace\TechRiderColour;
+use App\Enum\BandSpace\TechRiderStagePlotIcon;
+use App\Enum\BandSpace\TechRiderStagePlotIconCategory;
 use App\Enum\BandSpace\TechRiderItemType;
 use App\Repository\BandSpace\TechRiderRepository;
 use App\Service\BandSpace\TechRider\TechRiderPdfRenderer;
@@ -17,6 +19,7 @@ use App\Tests\Factory\BandSpace\TechRiderFactory;
 use App\Tests\Factory\BandSpace\TechRiderItemFactory;
 use App\Tests\Factory\User\UserFactory;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpClient\HttpClient;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -121,12 +124,88 @@ class TechRiderPdfRenderTest extends ApiTestCase
 
         $this->assertStringStartsWith('%PDF-', $pdf);
         $this->assertCount(2, $this->pageSizes($pdf), 'A cover and the plot');
-        // The icons are uploaded assets referenced by bare filename, so an embedded image is the
-        // proof they resolved. A broken reference renders a page that is silently empty.
+    }
+
+    /**
+     * That a drawn symbol reaches the page in the right colour, which is the whole point of inlining
+     * it rather than referencing it: an SVG behind an <img> cannot see the page's colour at all.
+     *
+     * The plot carries one element with no label and no legend, so the symbol is the only coloured
+     * thing on the page. An earlier version of this asserted against a plot that had both, and the
+     * colours it was matching turned out to be the label's and the legend's: Chromium emits a colour
+     * for text as readily as for a path, so the assertion passed with the symbol drawing black.
+     */
+    #[DataProvider('symbolColourProvider')]
+    public function test_a_symbol_draws_in_the_colour_the_element_resolves_to(
+        ?TechRiderColour $elementColour,
+        string $expectedHex,
+        string $unexpectedHex,
+    ): void {
+        [$bandSpace, $rider] = $this->seed();
+        $element = ['id' => 'a', 'icon' => 'drum_kit', 'x' => 0.5, 'y' => 0.5, 'scale' => 2.0, 'rotation' => 0];
+        if ($elementColour instanceof TechRiderColour) {
+            $element['colour'] = $elementColour->value;
+        }
+
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::StagePlot,
+            'title' => 'Plan de scène',
+            'position' => 0,
+            'content' => ['version' => 1, 'stage' => ['aspect_ratio' => 1.4], 'elements' => [$element]],
+        ])->create();
+
+        $streams = $this->contentStreams($this->render($bandSpace, $rider));
+
+        $this->assertMatchesRegularExpression($this->strokeColourPattern($expectedHex), $streams);
+        $this->assertDoesNotMatchRegularExpression($this->strokeColourPattern($unexpectedHex), $streams);
+    }
+
+    /**
+     * @return iterable<string, array{TechRiderColour|null, string, string}>
+     */
+    public static function symbolColourProvider(): iterable
+    {
+        yield 'no colour of its own falls back to the category' => [
+            null,
+            TechRiderStagePlotIconCategory::Instrument->hex(),
+            TechRiderColour::Green->hex(),
+        ];
+
+        yield 'its own colour overrides the category' => [
+            TechRiderColour::Green,
+            TechRiderColour::Green->hex(),
+            TechRiderStagePlotIconCategory::Instrument->hex(),
+        ];
+    }
+
+    /** The other half of the set is still placeholder PNGs, and they have to keep working. */
+    public function test_a_plot_using_an_icon_with_no_symbol_still_embeds_its_png(): void
+    {
+        [$bandSpace, $rider] = $this->seed();
+        $icon = TechRiderStagePlotIcon::Keyboard;
+        self::assertNull($icon->symbolPath(), 'This test needs an icon that has no drawn symbol yet');
+
+        TechRiderItemFactory::new([
+            'techRider' => $rider,
+            'type' => TechRiderItemType::StagePlot,
+            'title' => 'Plan de scène',
+            'position' => 0,
+            'content' => [
+                'version' => 1,
+                'stage' => ['aspect_ratio' => 1.4],
+                'elements' => [
+                    ['id' => 'a', 'icon' => $icon->value, 'x' => 0.5, 'y' => 0.3, 'scale' => 1.0, 'rotation' => 0, 'label' => 'Clavier'],
+                ],
+            ],
+        ])->create();
+
+        $pdf = $this->render($bandSpace, $rider);
+
         $this->assertMatchesRegularExpression(
             '#/Subtype\s*/Image#',
             $pdf,
-            'The stage plot icons must be embedded in the document',
+            'An icon with no drawn symbol must still be uploaded and embedded as its PNG',
         );
     }
 
@@ -245,6 +324,44 @@ class TechRiderPdfRenderTest extends ApiTestCase
 
             return $width > 500 ? 'portrait-a4' : 'attachment-a5';
         }, $matches);
+    }
+
+    /**
+     * The page content, inflated. Chromium compresses it, so vector drawing is invisible in the raw
+     * bytes: an assertion made on those would pass or fail on whether the text happened to compress
+     * the same way, which is not what it claims to test.
+     */
+    private function contentStreams(string $pdf): string
+    {
+        preg_match_all('#stream\r?\n(.*?)endstream#s', $pdf, $matches);
+
+        $inflated = '';
+        foreach ($matches[1] as $stream) {
+            $decoded = @gzuncompress(trim($stream, "\r\n"));
+            if ($decoded !== false) {
+                $inflated .= $decoded . "\n";
+            }
+        }
+
+        self::assertNotSame('', $inflated, 'No content stream could be inflated, so nothing was checked');
+
+        return $inflated;
+    }
+
+    /**
+     * How a PDF writes this colour as a stroke. Derived from the hex rather than pinned, so changing
+     * a colour moves the test with it. Chromium drops the leading zero and keeps 4 decimals.
+     */
+    private function strokeColourPattern(string $hex): string
+    {
+        [$r, $g, $b] = sscanf($hex, '#%02x%02x%02x');
+
+        $component = static fn (int $value): string => preg_quote(
+            substr(sprintf('%.4f', $value / 255), 1),
+            '#',
+        );
+
+        return sprintf('#0?%s\s+0?%s\s+0?%s\s+RG#', $component($r), $component($g), $component($b));
     }
 
     private function requireGotenberg(): void

--- a/tests/Unit/Enum/BandSpace/TechRiderStagePlotIconArtworkTest.php
+++ b/tests/Unit/Enum/BandSpace/TechRiderStagePlotIconArtworkTest.php
@@ -64,6 +64,115 @@ class TechRiderStagePlotIconArtworkTest extends TestCase
         }
     }
 
+    /** Same seam as the PNGs, for the half of the set that has real artwork. */
+    public function test_every_declared_symbol_has_a_file_on_disk(): void
+    {
+        $missing = [];
+        foreach (TechRiderStagePlotIcon::cases() as $icon) {
+            $path = $icon->symbolPath();
+            if ($path !== null && !is_file($this->projectPath($path))) {
+                $missing[] = $icon->value;
+            }
+        }
+
+        self::assertSame([], $missing, sprintf(
+            'These icons declare a symbol with no file. Add {slug}.svg to %s.',
+            TechRiderStagePlotIcon::SYMBOL_DIRECTORY,
+        ));
+    }
+
+    /** The other direction: a drawn symbol nothing declares is invisible, so it looks like a bug. */
+    public function test_every_symbol_file_on_disk_is_declared(): void
+    {
+        $files = glob($this->projectPath(TechRiderStagePlotIcon::SYMBOL_DIRECTORY) . '/*.svg');
+        self::assertIsArray($files);
+        self::assertNotEmpty($files);
+
+        $declared = [];
+        foreach (TechRiderStagePlotIcon::cases() as $icon) {
+            if ($icon->symbolPath() !== null) {
+                $declared[] = $icon->value;
+            }
+        }
+
+        $orphans = [];
+        foreach ($files as $file) {
+            $slug = basename($file, '.svg');
+            if (!in_array($slug, $declared, true)) {
+                $orphans[] = $slug;
+            }
+        }
+
+        self::assertSame([], $orphans, sprintf(
+            'These symbol files are not declared by any case, so nothing renders them. Add them to %s::symbolPath().',
+            TechRiderStagePlotIcon::class,
+        ));
+    }
+
+    /**
+     * Both failures are silent otherwise: a hardcoded colour just ignores its category, and a
+     * literal stroke-width opts that one file out of the calibration constant.
+     */
+    public function test_every_symbol_takes_its_colour_and_stroke_from_the_page(): void
+    {
+        foreach (TechRiderStagePlotIcon::cases() as $icon) {
+            $path = $icon->symbolPath();
+            if ($path === null) {
+                continue;
+            }
+
+            $markup = file_get_contents($this->projectPath($path));
+            self::assertIsString($markup);
+
+            self::assertStringContainsString('currentColor', $markup, sprintf(
+                '%s must take its colour from the page.',
+                $icon->value,
+            ));
+            self::assertDoesNotMatchRegularExpression(
+                '/(#[0-9a-f]{3,8}\b|\brgba?\(|\bhsla?\()/i',
+                $markup,
+                sprintf('%s hardcodes a colour, so it cannot follow its category.', $icon->value),
+            );
+            self::assertDoesNotMatchRegularExpression(
+                '/stroke-width\s*=\s*"/',
+                $markup,
+                sprintf(
+                    '%s sets stroke-width as an attribute, which var() cannot reach. Use style="stroke-width:var(--sp-stroke, 2)".',
+                    $icon->value,
+                ),
+            );
+            self::assertStringContainsString('var(--sp-stroke', $markup, sprintf(
+                '%s does not follow the calibration constant.',
+                $icon->value,
+            ));
+        }
+    }
+
+    /**
+     * Callers size an icon by width alone and let height follow, which is only safe while every icon
+     * is square. A tall one would overflow the fixed box the picker and the legend give it.
+     */
+    public function test_every_icon_is_square(): void
+    {
+        foreach (TechRiderStagePlotIcon::cases() as $icon) {
+            [$width, $height] = getimagesize($this->publicPath($icon->imagePath()));
+            self::assertSame($width, $height, sprintf('%s.png is not square.', $icon->value));
+
+            $path = $icon->symbolPath();
+            if ($path === null) {
+                continue;
+            }
+
+            $markup = file_get_contents($this->projectPath($path));
+            self::assertIsString($markup);
+            self::assertMatchesRegularExpression(
+                '/viewBox="0 0 (\\d+(?:\\.\\d+)?) \\1"/',
+                $markup,
+                sprintf('%s.svg must have a square viewBox.', $icon->value),
+            );
+        }
+    }
+
     public function test_every_icon_has_a_distinct_label(): void
     {
         $labels = array_map(
@@ -77,7 +186,12 @@ class TechRiderStagePlotIconArtworkTest extends TestCase
 
     private function publicPath(string $imagePath): string
     {
+        return $this->projectPath('public' . $imagePath);
+    }
+
+    private function projectPath(string $relativePath): string
+    {
         // tests/Unit/Enum/BandSpace -> project root
-        return \dirname(__DIR__, 4) . '/public' . $imagePath;
+        return \dirname(__DIR__, 4) . '/' . $relativePath;
     }
 }

--- a/tests/Unit/Validator/BandSpace/TechRider/TechRiderStagePlotLimitsTest.php
+++ b/tests/Unit/Validator/BandSpace/TechRider/TechRiderStagePlotLimitsTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Validator\BandSpace\TechRider;
 
+use App\Service\BandSpace\TechRider\TechRiderPdfRenderer;
 use App\Validator\BandSpace\TechRider\TechRiderStagePlot;
 use PHPUnit\Framework\TestCase;
 
@@ -32,6 +33,11 @@ class TechRiderStagePlotLimitsTest extends TestCase
             'MAX_SCALE' => TechRiderStagePlot::MAX_SCALE,
             'MIN_ASPECT_RATIO' => TechRiderStagePlot::MIN_ASPECT_RATIO,
             'MAX_ASPECT_RATIO' => TechRiderStagePlot::MAX_ASPECT_RATIO,
+            // Not limits but geometry: the PDF redraws the plot from the same numbers, so a plot
+            // that drifts here prints at a different size or weight than the editor showed.
+            'BASE_ICON_PERCENT' => TechRiderPdfRenderer::BASE_ICON_PERCENT,
+            'SYMBOL_STROKE_WIDTH' => TechRiderPdfRenderer::SYMBOL_STROKE_WIDTH,
+            'SYMBOL_SIZE_PERCENT' => TechRiderPdfRenderer::SYMBOL_SIZE_PERCENT,
         ];
     }
 


### PR DESCRIPTION
Closes #836.

Every file in `public/images/band_space/stage_plot/` is a generated placeholder: a rounded square in the category colour with the label's initials. Seven types now have real artwork. The other fourteen keep their placeholder and render exactly as they did.

| Symbol | Types |
|---|---|
| Drum kit | `drum_kit` |
| Amplifier | `guitar_amp` (6 knobs), `bass_amp` (4 knobs) |
| Wedge monitor | `wedge_monitor` |
| Mic on a stand | `vocal_mic` |
| PAR can | `par_can` |
| 220v power socket | `power_socket` |

The two amps share a drawing but get a file each, so `bass_amp` can diverge later without a code change.

## Why the symbols are inlined rather than referenced

An SVG behind an `<img>` is an isolated document: the host page's `color` never reaches it, so `currentColor` resolves to black. Measured through Gotenberg rather than assumed. Under `color:#e11d48`, an inline `<svg>` renders `(225,29,72)` and the same file behind an `<img>` renders `(0,0,0)`.

So all six call sites inline the markup: the canvas, the palette, the legend row, the legend dropdown option, and both stage plot sites in the Twig. One `.svg` per slug under `assets/icons/stage_plot/` is the single source: Vue inlines it with Vite's native `import.meta.glob(..., { query: '?raw' })`, the PDF renderer reads the same file from disk. No new dependency, and no URL is involved, which is why these do not need the stable unhashed `public/` path the PNGs do.

A symbol takes the element's own colour when it has one, otherwise its category's. Those four category colours previously existed only as pixels in the placeholders and as a table in a README, so they move into `TechRiderStagePlotIconCategory::hex()` and reach the front end as a new `category_colour` field on the icon catalogue.

## Calibration

This batch exists to be printed and judged before the remaining fourteen are drawn, so the two visual parameters are tunable in one edit each:

| Constant | Value | Meaning |
|---|---|---|
| `SYMBOL_STROKE_WIDTH` | 1.4 | viewBox units on a 64 canvas, so 0.24mm of ink at scale 1 |
| `SYMBOL_SIZE_PERCENT` | 100 | symbol width as a share of the element box |

They live in `assets/js/constants/stagePlot.js`, mirrored as public constants on `TechRiderPdfRenderer`, and `TechRiderStagePlotLimitsTest` fails if the two files drift. `BASE_ICON_PERCENT` moves into that same constants file: it was declared in `StagePlotCanvas.vue` while the PHP comment claimed it lived in `stagePlot.js`, so the comment was wrong and the three geometry numbers now sit together.

Inside each file, thinner strokes and filled details are `calc()` multiples of `var(--sp-stroke)` rather than fixed, so one edit moves the whole set. Presentation attributes cannot take `var()`, which is why the widths are set through `style`.

## Verification

Printed geometry, since that is what this artwork is for: A4 content width is 182mm, an element is `BASE_ICON_PERCENT` wide times its scale, so 10.9mm at scale 1. Every symbol was rendered through the real pipeline and rasterised at 300dpi at scales 0.5 through 4.

Three tests are worth pointing at:

- `TechRiderStagePlotIconArtworkTest` fails a symbol that hardcodes a colour or sets a literal `stroke-width` attribute. Both failures are otherwise silent: the first just ignores its category, the second opts one file out of the calibration constant so tuning moves six icons and leaves the seventh behind. It also pins that every icon is square, which is the invariant callers lean on when they size an icon by width and let height follow.
- `TechRiderPdfRenderTest` proves a symbol reaches the page in the right colour, both when it falls back to its category and when the element overrides it. The plot it renders carries one element with no label and no legend on purpose. An earlier version of that test asserted against a plot with both, and the colours it matched turned out to be the label's and the legend's: Chromium emits a colour operator for text as readily as for a path, so it passed with the symbol drawing black.
- `TechRiderPdfExportTest` pins that both constants reach the page and that an icon with a symbol does not also upload its now unused PNG, while one without still does.

Eight mutations against the renderer and template were killed, plus two against the square check.

## Not in this batch

The remaining fourteen icons, which come after the print. Follow-ups are filed separately.
