### PR TITLE
fix(M-808): stop entity-encoding note text and drop unsafe note URIs

### DIFF
--- a/src/Service/Builder/BandSpace/BandSpaceNoteBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceNoteBuilder.php
@@ -4,14 +4,31 @@ namespace App\Service\Builder\BandSpace;
 
 use App\ApiResource\BandSpace\BandSpaceNote as BandSpaceNoteDTO;
 use App\Entity\BandSpace\BandSpaceNote as BandSpaceNoteEntity;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 readonly class BandSpaceNoteBuilder
 {
-    public function __construct(
-        private HtmlSanitizerInterface $sanitizer,
-    ) {
-    }
+    /**
+     * The only values in a stored note a browser ever dereferences: an image node's `src` and a link
+     * mark's `href`. A text node is not one of them, which is why text is handed back byte for byte.
+     * TipTap renders it as a DOM text node, so `C'est l'heure` is prose and never markup, and passing
+     * it through an HtmlSanitizer only entity encoded the apostrophe into the note the member reads.
+     */
+    private const array URI_ATTRIBUTES = ['src', 'href'];
+
+    /**
+     * An allowlist, so a scheme nobody thought of is dropped rather than cleaned. Note images are
+     * stored as same origin download paths, which is the leading slash branch. Links are typed by
+     * hand, so http(s) and mailto cover what a member can produce. `data:` is refused alongside
+     * `javascript:` and `vbscript:` because the editor configures the image extension with
+     * `allowBase64: false`, so no note holds an inline image to begin with.
+     *
+     * A leading slash may not be followed by a slash or a backslash, and no backslash is tolerated
+     * anywhere: the WHATWG URL parser normalises `\` to `/` on a special scheme, so `/\evil.example`
+     * resolves exactly like the protocol relative `//evil.example` while still reading as an
+     * internal path. Both have to go, or a member could point a note image at any host they like.
+     */
+    private const string SAFE_URI_PATTERN = '#^(?:https?://|mailto:|/(?![\\\\/]))[^\s<>"\'\\\\]*$#i';
+
     /**
      * @param BandSpaceNoteEntity[] $entities
      * @return BandSpaceNoteDTO[]
@@ -44,7 +61,7 @@ readonly class BandSpaceNoteBuilder
     public function buildItem(BandSpaceNoteEntity $entity): BandSpaceNoteDTO
     {
         $dto = $this->buildListItem($entity);
-        $dto->content = $this->sanitizeContent($entity->content);
+        $dto->content = $this->removeUnsafeUris($entity->content);
 
         return $dto;
     }
@@ -53,32 +70,67 @@ readonly class BandSpaceNoteBuilder
      * @param array<string, mixed>|null $content
      * @return array<string, mixed>|null
      */
-    private function sanitizeContent(?array $content): ?array
+    private function removeUnsafeUris(?array $content): ?array
     {
-        if ($content === null) {
+        // The root is checked like any other node, so "nothing in the returned tree carries a URI the
+        // app could not have produced" holds without an exception at the top.
+        if ($content === null || !$this->hasSafeUris($content)) {
             return null;
         }
 
-        return $this->sanitizeNode($content);
+        return $this->removeUnsafeUrisFromNode($content);
     }
 
     /**
+     * A node or a mark carrying a URI the app could never have produced is dropped whole rather than
+     * emptied: an image without a `src` is nothing, and dropping a link mark leaves the words the
+     * member typed on the page while the unusable target never reaches the DOM.
+     *
      * @param array<string, mixed> $node
      * @return array<string, mixed>
      */
-    private function sanitizeNode(array $node): array
+    private function removeUnsafeUrisFromNode(array $node): array
     {
-        if (isset($node['text']) && is_string($node['text'])) {
-            $node['text'] = $this->sanitizer->sanitize($node['text']);
+        if (isset($node['marks']) && is_array($node['marks'])) {
+            $node['marks'] = array_values(array_filter($node['marks'], $this->hasSafeUris(...)));
         }
 
         if (isset($node['content']) && is_array($node['content'])) {
             $node['content'] = array_map(
-                fn(array $child): array => $this->sanitizeNode($child),
-                $node['content']
+                fn(array $child): array => $this->removeUnsafeUrisFromNode($child),
+                array_values(array_filter($node['content'], $this->hasSafeUris(...)))
             );
         }
 
         return $node;
+    }
+
+    /** @param mixed $element a node or a mark; anything that is not shaped like one is refused */
+    private function hasSafeUris(mixed $element): bool
+    {
+        if (!is_array($element)) {
+            return false;
+        }
+
+        $attributes = $element['attrs'] ?? null;
+        if (!is_array($attributes)) {
+            return true;
+        }
+
+        foreach (self::URI_ATTRIBUTES as $name) {
+            $uri = $attributes[$name] ?? null;
+            if ($uri === null) {
+                continue;
+            }
+
+            // Anything that is not a string is refused rather than waved through: `content` is an
+            // untyped JSON column, so an array or an object here is a shape the editor never wrote,
+            // and an allowlist that trusts what it cannot read is not one.
+            if (!is_string($uri) || preg_match(self::SAFE_URI_PATTERN, trim($uri)) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Api/BandSpace/BandSpaceNoteGetTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteGetTest.php
@@ -56,6 +56,127 @@ class BandSpaceNoteGetTest extends ApiTestCase
         ]);
     }
 
+    /**
+     * The read side is where a note is corrupted for good: the editor is seeded from this response
+     * once at mount, then autosaves it back a couple of seconds later. So a character mangled here
+     * is written to the database on the next keystroke and the note never recovers.
+     */
+    public function test_get_item_preserves_special_characters(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [[
+                        'type' => 'text',
+                        'text' => 'C\'est l\'heure de la répét « Rock & Roll » : écrire à contact@salle.fr, 2+2=4, et on dit "oui" à 100 %',
+                    ]],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        ['type' => 'text', 'marks' => [['type' => 'italic']], 'text' => 'Balances'],
+                        ['type' => 'text', 'text' => ' '],
+                        ['type' => 'text', 'text' => 'à 18h'],
+                    ],
+                ],
+            ],
+        ];
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'content' => $content,
+            'position' => 0,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => $note->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => $content,
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => '2024-01-01T10:00:00+00:00',
+            'update_datetime' => null,
+        ]);
+    }
+
+    public function test_get_item_dangerous_uri_attributes_are_neutralised(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'image', 'attrs' => ['src' => 'javascript:alert(1)']],
+                [
+                    'type' => 'paragraph',
+                    'content' => [[
+                        'type' => 'text',
+                        'marks' => [['type' => 'link', 'attrs' => ['href' => 'vbscript:msgbox(1)']]],
+                        'text' => 'Cliquez ici',
+                    ]],
+                ],
+            ],
+        ];
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'content' => $content,
+            'position' => 0,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => $note->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => [
+                'type' => 'doc',
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'content' => [[
+                            'type' => 'text',
+                            'marks' => [],
+                            'text' => 'Cliquez ici',
+                        ]],
+                    ],
+                ],
+            ],
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => '2024-01-01T10:00:00+00:00',
+            'update_datetime' => null,
+        ]);
+    }
+
     public function test_get_item_not_found(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/BandSpaceNoteUpdateTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteUpdateTest.php
@@ -399,7 +399,12 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
         ]);
     }
 
-    public function test_update_content_xss_is_sanitized(): void
+    /**
+     * A text node is prose, not markup: TipTap renders it as a DOM text node, so text that looks like
+     * a tag stays inert without any escaping. Running it through an HtmlSanitizer used to entity
+     * encode it into the note itself, which is what this pins against coming back.
+     */
+    public function test_update_content_keeps_markup_looking_text_verbatim(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
@@ -411,7 +416,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'position' => 0,
         ])->create();
 
-        $xssContent = [
+        $content = [
             'type' => 'doc',
             'content' => [
                 [
@@ -429,7 +434,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
         $this->client->jsonRequest(
             'PATCH',
             '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
-            ['content' => $xssContent],
+            ['content' => $content],
             ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
         );
 
@@ -437,19 +442,6 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
 
         $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
         $refreshed = $noteRepository->find($note->id);
-        $sanitizedContent = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        ['type' => 'text', 'text' => ''],
-                        ['type' => 'text', 'text' => ''],
-                        ['type' => 'text', 'text' => 'Safe text'],
-                    ],
-                ],
-            ],
-        ];
         $this->assertJsonEquals([
             '@context' => '/api/contexts/BandSpaceNote',
             '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
@@ -459,7 +451,500 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'title' => 'My Note',
             'parent_id' => null,
             'position' => 0,
-            'content' => $sanitizedContent,
+            'content' => $content,
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * Every character an HTML entity encoder touches, in one French sentence: the apostrophe above
+     * all, since in this app it appears in most notes ever written.
+     */
+    public function test_update_content_preserves_special_characters(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'position' => 0,
+        ])->create();
+
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [[
+                        'type' => 'text',
+                        'text' => 'C\'est l\'heure de la répét « Rock & Roll » : écrire à contact@salle.fr, 2+2=4, et on dit "oui" à 100 %',
+                    ]],
+                ],
+            ],
+        ];
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => $content,
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * TipTap emits a standalone space as its own text node whenever a bold run is followed by one.
+     * A sanitiser returned that node as an empty string, which glued the two words together.
+     */
+    public function test_update_content_preserves_whitespace_only_text_node(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'position' => 0,
+        ])->create();
+
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        ['type' => 'text', 'marks' => [['type' => 'bold']], 'text' => 'Répétition'],
+                        ['type' => 'text', 'text' => ' '],
+                        ['type' => 'text', 'text' => 'samedi'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => $content,
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /** A sanitiser stopped at its 20000 byte input budget and silently returned the rest as nothing. */
+    public function test_update_content_preserves_a_text_node_over_twenty_thousand_bytes(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'position' => 0,
+        ])->create();
+
+        // Two bytes per character, so 15000 of them is comfortably past the budget.
+        $longText = str_repeat('é', 15000);
+        $content = [
+            'type' => 'doc',
+            'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $longText]]]],
+        ];
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => $content,
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /** The link goes, the words stay: a member still reads what they typed. */
+    public function test_update_content_drops_link_mark_with_dangerous_href(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'position' => 0,
+        ])->create();
+
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [[
+                        'type' => 'text',
+                        'marks' => [
+                            ['type' => 'bold'],
+                            ['type' => 'link', 'attrs' => ['href' => 'javascript:alert(1)']],
+                        ],
+                        'text' => 'Cliquez ici',
+                    ]],
+                ],
+            ],
+        ];
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => [
+                'type' => 'doc',
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'content' => [[
+                            'type' => 'text',
+                            'marks' => [['type' => 'bold']],
+                            'text' => 'Cliquez ici',
+                        ]],
+                    ],
+                ],
+            ],
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * An image is nothing without its src, so the node goes rather than being emptied. `data:` counts
+     * as dangerous here because the editor sets `allowBase64: false`, so no note ever holds one.
+     */
+    public function test_update_content_drops_image_node_with_dangerous_src(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'position' => 0,
+        ])->create();
+
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'image', 'attrs' => ['src' => 'javascript:alert(1)']],
+                ['type' => 'image', 'attrs' => ['src' => 'data:image/svg+xml;base64,PHN2Zz4=']],
+                ['type' => 'image', 'attrs' => ['src' => '//evil.example/tracker.png']],
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Après']]],
+            ],
+        ];
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => [
+                'type' => 'doc',
+                'content' => [
+                    ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Après']]],
+                ],
+            ],
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * A backslash after the leading slash is the same attack as `//evil.example` wearing a disguise:
+     * the WHATWG URL parser normalises it to a slash, so a browser resolves `/\evil.example/x.png`
+     * against a different host entirely while the value still reads as an internal path. A member
+     * could otherwise point a note image at any host and beacon every reader of the note.
+     */
+    public function test_update_content_drops_backslash_protocol_relative_uris(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'position' => 0,
+        ])->create();
+
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'image', 'attrs' => ['src' => '/\\evil.example/tracker.png']],
+                ['type' => 'image', 'attrs' => ['src' => '/\\/evil.example/tracker.png']],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'Après',
+                            'marks' => [['type' => 'link', 'attrs' => ['href' => '/\\evil.example']]],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => [
+                'type' => 'doc',
+                'content' => [
+                    ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Après', 'marks' => []]]],
+                ],
+            ],
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * `content` is an untyped JSON column, so a caller can put a shape there the editor would never
+     * write. A non string `src` used to skip the allowlist entirely on its `is_string` guard.
+     */
+    public function test_update_content_drops_a_non_string_uri_attribute(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'position' => 0,
+        ])->create();
+
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'image', 'attrs' => ['src' => ['javascript:alert(1)']]],
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Après']]],
+            ],
+        ];
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => [
+                'type' => 'doc',
+                'content' => [
+                    ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Après']]],
+                ],
+            ],
+            'has_children' => false,
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * The other half of the allowlist: an uploaded note image is a same origin path and a typed link
+     * is http(s) or mailto, so all three have to survive untouched.
+     */
+    public function test_update_content_keeps_note_image_path_and_safe_links(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'My Note',
+            'position' => 0,
+        ])->create();
+
+        $imageSrc = '/api/band_spaces/' . $bandSpace->id . '/files/11111111-1111-1111-1111-111111111111/versions/2/download';
+        $content = [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'image', 'attrs' => ['src' => $imageSrc, 'alt' => null, 'title' => null]],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'marks' => [['type' => 'link', 'attrs' => ['href' => 'https://musicall.com/salles?ville=lyon#plan']]],
+                            'text' => 'la salle',
+                        ],
+                        [
+                            'type' => 'text',
+                            'marks' => [['type' => 'link', 'attrs' => ['href' => 'mailto:contact@salle.fr']]],
+                            'text' => 'écrire',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'My Note',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => $content,
             'has_children' => false,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),


### PR DESCRIPTION
Closes #808.

## The bug

`BandSpaceNoteBuilder` ran Symfony's HtmlSanitizer over every TipTap **text** node when building the note DTO. The sanitizer HTML-encodes entities, so a French note came back corrupted: `C'est l'heure` served as `C&#039;est l&#039;heure`, `Rock & Roll` as `Rock &amp; Roll`, and the same for `"`, `+`, `=` and email addresses.

It became permanent rather than cosmetic: the editor is seeded at mount, so the corrupted text was what the next reader loaded, and the 2 second autosave wrote it straight back. The same call also blanked whitespace-only text nodes (gluing words together) and truncated any text node over 20000 bytes.

The pass was protecting the one field that never needed it. TipTap renders text nodes as DOM text, so they are prose and never markup, and there is no `v-html` anywhere on the notes path. Meanwhile it never looked at the attributes a browser actually dereferences.

## The fix

Text nodes are returned byte for byte. In their place, node `src` and mark `href` are checked against an allowlist, and an element carrying a URI the app could not have produced is dropped whole.

The one server-side path that turns TipTap into HTML, `TipTapHtmlRenderer`, escapes every text node itself and only serves tech rider PDFs, so it is unaffected.

## Fixed during review

The first version of the allowlist had a hole worth calling out, because it was introduced by this fix rather than inherited:

- `/(?!/)` rejected the protocol relative `//evil.example` but accepted `/\evil.example`. The WHATWG URL parser normalises the backslash, so a browser resolves that against `https://evil.example` while the value still reads as an internal path. Any member could have pointed a note image at an arbitrary host, which is a silent cross-origin request for every reader of the note. Backslashes are now refused outright.
- a non-string `src` or `href` skipped validation entirely through the `is_string()` guard, i.e. failed open. It now fails closed, matching `TipTapHtmlRenderer`.

Both have regression tests.

## Tests

30 tests over `BandSpaceNoteUpdateTest` and `BandSpaceNoteGetTest`, covering the round trip of French prose and special characters, whitespace-only nodes, a text node over 20000 bytes, the dangerous scheme and backslash cases, non-string attributes, and the legitimate values that must survive (note image paths, https, mailto).

The pre-existing `test_update_content_xss_is_sanitized` asserted the buggy behaviour, so it was rewritten rather than kept.

Full PHPStan level 8 clean.

## Follow-up needed

This stops new corruption but does not repair rows already saved with encoded text. That needs a one-off command, and it cannot blindly decode entities since a member may legitimately have typed `&amp;`. Worth its own issue.
