### PR TITLE
fix(M-811): order a task column against its full contents on reorder

### DIFF
--- a/assets/js/components/BandSpace/Task/TaskBoard.vue
+++ b/assets/js/components/BandSpace/Task/TaskBoard.vue
@@ -9,8 +9,10 @@
       :categories="categories"
       :band-space-id="bandSpaceId"
       @open-task="$emit('open-task', $event)"
-      @reorder="(status, ids) => $emit('reorder', status, ids)"
-      @status-change="(taskId, status, newIndex) => $emit('status-change', taskId, status, newIndex)"
+      @reorder="(status, ids, movedId) => $emit('reorder', status, ids, movedId)"
+      @status-change="
+        (taskId, status, visibleIndex) => $emit('status-change', taskId, status, visibleIndex)
+      "
       @show-all-done="$emit('show-all-done')"
     />
   </div>

--- a/assets/js/components/BandSpace/Task/TaskCard.vue
+++ b/assets/js/components/BandSpace/Task/TaskCard.vue
@@ -138,9 +138,10 @@ const toast = useToast()
 const popoverRef = ref()
 const actionMenuRef = ref()
 
-// Touch fallback for the drag-only kanban: build "Déplacer vers ..." items
-// for the statuses that aren't the task's current one. Appends to the end
-// of the target column (newIndex = current count in that column).
+// Touch fallback for the drag-only kanban, and the only way to change a status while a
+// server-side filter has drag turned off: build "Déplacer vers ..." items for the statuses that
+// aren't the task's current one. There is no drop point, so the task goes to the end of the
+// target column.
 const STATUS_OPTIONS = [
   { value: 'todo', label: 'À faire' },
   { value: 'in_progress', label: 'En cours' },
@@ -156,11 +157,8 @@ const actionMenuItems = computed(() => {
 })
 
 async function moveToStatus(newStatus) {
-  const newIndex = tasksStore.tasks.filter(
-    (t) => t.status === newStatus && !t.archive_datetime
-  ).length
   try {
-    await tasksStore.moveTaskToColumn(props.bandSpaceId, props.task.id, newStatus, newIndex)
+    await tasksStore.moveTaskToColumn(props.bandSpaceId, props.task.id, newStatus, null)
   } catch {
     toast.add({
       severity: 'error',

--- a/assets/js/components/BandSpace/Task/TaskColumn.vue
+++ b/assets/js/components/BandSpace/Task/TaskColumn.vue
@@ -10,7 +10,7 @@
       v-model="localTasks"
       group="tasks"
       :animation="200"
-      :disabled="tasksStore.isSelectionMode"
+      :disabled="tasksStore.isSelectionMode || tasksStore.isReorderDisabled"
       ghost-class="opacity-30"
       :data-status="status"
       class="flex flex-col gap-2 min-h-[100px]"
@@ -96,12 +96,14 @@ function handleDragEnd(event) {
   const toStatus = event.to?.dataset?.status
 
   if (fromStatus === toStatus) {
-    // Same-column reorder: localTasks is already updated by v-model
-    const orderedIds = localTasks.value.map((t) => t.id)
-    emit('reorder', props.status, orderedIds)
+    // Same-column reorder: localTasks is already updated by v-model. It holds the column as this
+    // member sees it, which a filter can cut down, so the store replays the drag against the
+    // whole column before writing any position.
+    const visibleOrderedIds = localTasks.value.map((t) => t.id)
+    emit('reorder', props.status, visibleOrderedIds, taskId)
   } else {
-    // Cross-column move: @end fires on the source column
-    // Pass the drop index so the store can compute the correct order
+    // Cross-column move: @end fires on the source column, so only the drop index is known here.
+    // The store resolves it against the whole destination column, hidden tasks included.
     emit('status-change', taskId, toStatus, event.newIndex)
   }
 }

--- a/assets/js/store/bandSpace/bandSpaceTasks.js
+++ b/assets/js/store/bandSpace/bandSpaceTasks.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, reactive, readonly, ref } from 'vue'
 import bandSpaceSettingsApi from '../../api/bandSpace/band-space-settings.js'
 import bandSpaceTasksApi from '../../api/bandSpace/band-space-tasks.js'
+import { orderColumnAfterDrag, toPositions } from '../../utils/taskOrdering.js'
 import { useUserSecurityStore } from '../user/security.js'
 
 export const useBandTasksStore = defineStore('bandTasks', () => {
@@ -57,6 +58,30 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
       done: filtered.filter((t) => t.status === 'done').sort(sortByPosition)
     }
   })
+
+  /**
+   * The query, the due-date range and "En retard" are applied by the server: fetchTasks replaces
+   * tasks.value with the matching subset, so the rest of a column is simply not in memory and no
+   * ordering covering it can be built. Positions are absolute, so writing one anyway would give
+   * the visible tasks numbers the hidden ones already hold and scramble the board for every
+   * member. Reordering is therefore refused, and the columns are not draggable, while any of
+   * those filters is on. The other filters hide tasks the store still holds, so they are fine.
+   */
+  const isReorderDisabled = computed(
+    () =>
+      filters.query.trim() !== '' ||
+      Boolean(filters.dueDateFrom) ||
+      Boolean(filters.dueDateTo) ||
+      filters.overdue === true
+  )
+
+  /** Every task of a column, hidden ones included, in board order. */
+  function columnOrderedIds(status) {
+    return tasks.value
+      .filter((t) => t.status === status && !t.archive_datetime)
+      .sort((a, b) => a.position - b.position)
+      .map((t) => t.id)
+  }
 
   const activeTask = computed(() => {
     if (!activeTaskId.value) return null
@@ -202,18 +227,27 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
     }
   }
 
-  async function moveTaskToColumn(bandSpaceId, taskId, newStatus, newIndex) {
+  /**
+   * `visibleIndex` is where the card landed in the destination column as the user sees it, or
+   * null to append, which is what the "Déplacer vers" menu asks for since it has no drop point.
+   */
+  async function moveTaskToColumn(bandSpaceId, taskId, newStatus, visibleIndex = null) {
     const snapshot = [...tasks.value]
-    const destinationIds = tasks.value
-      .filter((t) => t.status === newStatus && !t.archive_datetime && t.id !== taskId)
-      .sort((a, b) => a.position - b.position)
-      .map((t) => t.id)
-    destinationIds.splice(newIndex, 0, taskId)
-    const positions = destinationIds.map((id, index) => ({ id, position: index }))
+
+    // Under a server-side filter the rest of the destination column is not in memory, so no
+    // ordering can be sent. An empty payload asks the server to append the task instead, which
+    // is the one placement it can work out on its own.
+    const orderedIds = isReorderDisabled.value
+      ? null
+      : destinationOrder(newStatus, taskId, visibleIndex)
+    const positions = orderedIds === null ? [] : toPositions(orderedIds)
+    // Where the card is drawn until the server answers with the position it really got.
+    const movedPosition =
+      orderedIds === null ? tasksByStatus.value[newStatus].length : orderedIds.indexOf(taskId)
 
     tasks.value = tasks.value.map((t) => {
+      if (t.id === taskId) return { ...t, status: newStatus, position: movedPosition }
       const pos = positions.find((p) => p.id === t.id)
-      if (t.id === taskId) return { ...t, status: newStatus, position: newIndex }
       return pos ? { ...t, position: pos.position } : t
     })
 
@@ -224,6 +258,20 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
       tasks.value = snapshot
       throw e
     }
+  }
+
+  /** The whole destination column with the incoming task in place, hidden tasks included. */
+  function destinationOrder(newStatus, taskId, visibleIndex) {
+    const columnIds = columnOrderedIds(newStatus).filter((id) => id !== taskId)
+    // No drop point: the end of the column, which is what the server does with an empty payload.
+    if (visibleIndex === null) {
+      return [...columnIds, taskId]
+    }
+
+    const visibleIds = tasksByStatus.value[newStatus].map((t) => t.id).filter((id) => id !== taskId)
+    visibleIds.splice(visibleIndex, 0, taskId)
+
+    return orderColumnAfterDrag(columnIds, visibleIds, taskId)
   }
 
   async function deleteTask(bandSpaceId, taskId) {
@@ -248,13 +296,25 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
     tasks.value = [updated, ...tasks.value]
   }
 
-  async function reorderTasks(bandSpaceId, status, orderedIds) {
-    const positions = orderedIds.map((id, index) => ({ id, position: index }))
+  /**
+   * `visibleOrderedIds` is the column as the user sees it after the drag, which the category,
+   * assignee, priority and "Mes tâches" filters can cut down. The payload has to cover the whole
+   * column, so the drag is replayed against it here.
+   */
+  async function reorderTasks(bandSpaceId, status, visibleOrderedIds, movedTaskId) {
+    // The columns are not draggable while a server-side filter is on, so this is a backstop.
+    if (isReorderDisabled.value) return
+
+    const orderedIds = orderColumnAfterDrag(
+      columnOrderedIds(status),
+      visibleOrderedIds,
+      movedTaskId
+    )
+    const positions = toPositions(orderedIds)
 
     // Optimistic update
     const snapshot = [...tasks.value]
     tasks.value = tasks.value.map((t) => {
-      if (t.status !== status) return t
       const pos = positions.find((p) => p.id === t.id)
       return pos ? { ...t, position: pos.position } : t
     })
@@ -383,6 +443,7 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
     loadError: readonly(loadError),
     isLoadingActiveTask: readonly(isLoadingActiveTask),
     activeTaskError: readonly(activeTaskError),
+    isReorderDisabled,
     tasksByStatus,
     activeTask,
     fetchTasks,

--- a/assets/js/utils/taskOrdering.js
+++ b/assets/js/utils/taskOrdering.js
@@ -1,0 +1,77 @@
+/**
+ * Kanban column ordering.
+ *
+ * A reorder is persisted as absolute positions covering a whole column, but the board often
+ * shows only part of one: the category, assignee, priority and "Mes tâches" filters hide cards
+ * that are still held in memory. Renumbering the visible cards 0..k-1 would hand them the
+ * numbers the hidden cards already own, and the column would come back scrambled for every
+ * member. These helpers rebuild the ordering of the whole column from a drag that happened
+ * inside a partial view of it.
+ *
+ * They live here rather than in the store or the component because a drag gesture needs a
+ * browser, but the arithmetic behind it does not.
+ */
+
+/**
+ * Index of the nearest id of `candidates` that `orderedIds` still holds, or -1.
+ *
+ * @param {string[]} orderedIds
+ * @param {string[]} candidates Scanned from the end, so nearest wins.
+ * @returns {number}
+ */
+function lastKnownIndex(orderedIds, candidates) {
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const index = orderedIds.indexOf(candidates[i])
+    if (index !== -1) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+/**
+ * Places `movedId` inside `fullOrderedIds` at the spot the drag implies.
+ *
+ * A drag only ever says something about the cards the user could see: the moved card must end
+ * up below the visible card above the drop point and above the visible card below it. That
+ * leaves a range of slots when cards are hidden in between, and the one closest to where the
+ * card already sat is taken, so hidden cards are never stepped over for nothing and dropping a
+ * card back where it started writes the column unchanged. A card arriving from another column
+ * has no such slot, so it goes directly under the visible card it was dropped on.
+ *
+ * @param {string[]} fullOrderedIds Every task id of the column, in board order. It may omit
+ *   `movedId` when the task is arriving from another column.
+ * @param {string[]} visibleOrderedIds The ids the user saw, in their order after the drag.
+ * @param {string} movedId The dragged task.
+ * @returns {string[]} The complete column ordering.
+ */
+export function orderColumnAfterDrag(fullOrderedIds, visibleOrderedIds, movedId) {
+  const visibleIndex = visibleOrderedIds.indexOf(movedId)
+  if (visibleIndex === -1) {
+    return [...fullOrderedIds]
+  }
+
+  const withoutMoved = fullOrderedIds.filter((id) => id !== movedId)
+
+  const above = lastKnownIndex(withoutMoved, visibleOrderedIds.slice(0, visibleIndex))
+  const below = lastKnownIndex(withoutMoved, visibleOrderedIds.slice(visibleIndex + 1).reverse())
+
+  const lowest = above + 1
+  const highest = Math.max(lowest, below === -1 ? withoutMoved.length : below)
+
+  const previousSlot = fullOrderedIds.indexOf(movedId)
+  const preferred = previousSlot === -1 ? lowest : previousSlot
+
+  withoutMoved.splice(Math.min(Math.max(preferred, lowest), highest), 0, movedId)
+
+  return withoutMoved
+}
+
+/**
+ * @param {string[]} orderedIds
+ * @returns {{id: string, position: number}[]} The payload both write endpoints expect.
+ */
+export function toPositions(orderedIds) {
+  return orderedIds.map((id, index) => ({ id, position: index }))
+}

--- a/assets/js/utils/taskOrdering.test.js
+++ b/assets/js/utils/taskOrdering.test.js
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { orderColumnAfterDrag, toPositions } from './taskOrdering.js'
+
+/**
+ * These pin the fix for the reorder corruption: a drag made inside a filtered column used to be
+ * persisted as absolute positions covering only the visible cards, which handed them the numbers
+ * the hidden cards already held and scrambled the column for every member.
+ *
+ * Run with `npm test`. Node's own runner, so this costs no dependency. The drag wiring itself
+ * still has no coverage, because that would need jsdom and a component harness.
+ */
+
+describe('orderColumnAfterDrag', () => {
+  describe('with no filter, where every card is visible', () => {
+    it('moves a card to the top', () => {
+      assert.deepEqual(orderColumnAfterDrag(['a', 'b', 'c'], ['c', 'a', 'b'], 'c'), ['c', 'a', 'b'])
+    })
+
+    it('moves a card to the bottom', () => {
+      assert.deepEqual(orderColumnAfterDrag(['a', 'b', 'c'], ['b', 'c', 'a'], 'a'), ['b', 'c', 'a'])
+    })
+
+    it('returns the same order when the card is dropped where it started', () => {
+      assert.deepEqual(orderColumnAfterDrag(['a', 'b', 'c'], ['a', 'b', 'c'], 'b'), ['a', 'b', 'c'])
+    })
+  })
+
+  describe('with a filter hiding part of the column', () => {
+    // The bug this fixes: only a, c and e are on screen. Sending [a, e, c] renumbered 0..2 gave
+    // e position 1, which b already held, so the column ordered on a tie-break afterwards.
+    it('produces an ordering covering the hidden cards, not just the visible subset', () => {
+      const ordering = orderColumnAfterDrag(['a', 'b', 'c', 'd', 'e'], ['a', 'e', 'c'], 'e')
+
+      assert.deepEqual(ordering, ['a', 'b', 'e', 'c', 'd'])
+      assert.deepEqual([...ordering].sort(), ['a', 'b', 'c', 'd', 'e'])
+    })
+
+    it('stops the moved card above the first visible card, not above the hidden ones', () => {
+      assert.deepEqual(orderColumnAfterDrag(['a', 'b', 'c', 'd'], ['c', 'b'], 'c'), [
+        'a',
+        'c',
+        'b',
+        'd'
+      ])
+    })
+
+    it('stops the moved card below the last visible card, not below the hidden ones', () => {
+      assert.deepEqual(orderColumnAfterDrag(['a', 'b', 'c', 'd'], ['c', 'a'], 'a'), [
+        'b',
+        'c',
+        'a',
+        'd'
+      ])
+    })
+
+    it('writes the column unchanged when the card was dropped back where it started', () => {
+      assert.deepEqual(orderColumnAfterDrag(['a', 'b', 'c', 'd'], ['b', 'd'], 'b'), [
+        'a',
+        'b',
+        'c',
+        'd'
+      ])
+    })
+  })
+
+  describe('across columns', () => {
+    it('splices the incoming card into the full destination column', () => {
+      assert.deepEqual(orderColumnAfterDrag(['x', 'y', 'z'], ['x', 'm', 'z'], 'm'), [
+        'x',
+        'm',
+        'y',
+        'z'
+      ])
+    })
+
+    it('appends the incoming card when it was dropped below every visible card', () => {
+      assert.deepEqual(orderColumnAfterDrag(['x', 'y', 'z'], ['x', 'z', 'm'], 'm'), [
+        'x',
+        'y',
+        'z',
+        'm'
+      ])
+    })
+
+    it('handles an empty destination column', () => {
+      assert.deepEqual(orderColumnAfterDrag([], ['m'], 'm'), ['m'])
+    })
+  })
+
+  it('leaves the column untouched when the moved card is not in the visible order', () => {
+    assert.deepEqual(orderColumnAfterDrag(['a', 'b'], ['a', 'b'], 'ghost'), ['a', 'b'])
+  })
+
+  it('ignores a visible neighbour the column no longer holds', () => {
+    assert.deepEqual(orderColumnAfterDrag(['a', 'b', 'c'], ['gone', 'c', 'a'], 'c'), [
+      'c',
+      'a',
+      'b'
+    ])
+  })
+
+  it('does not mutate its inputs', () => {
+    const fullOrderedIds = ['a', 'b', 'c']
+    const visibleOrderedIds = ['c', 'a']
+
+    orderColumnAfterDrag(fullOrderedIds, visibleOrderedIds, 'c')
+
+    assert.deepEqual(fullOrderedIds, ['a', 'b', 'c'])
+    assert.deepEqual(visibleOrderedIds, ['c', 'a'])
+  })
+})
+
+describe('toPositions', () => {
+  // The server rejects anything that is not a contiguous 0..n-1 sequence, so the index is the
+  // position and nothing is carried over from the task's previous number.
+  it('numbers the column from zero without a gap', () => {
+    assert.deepEqual(toPositions(['a', 'b', 'c']), [
+      { id: 'a', position: 0 },
+      { id: 'b', position: 1 },
+      { id: 'c', position: 2 }
+    ])
+  })
+
+  it('returns an empty payload for an empty column', () => {
+    assert.deepEqual(toPositions([]), [])
+  })
+})

--- a/assets/js/views/BandSpace/Tasks.vue
+++ b/assets/js/views/BandSpace/Tasks.vue
@@ -96,16 +96,28 @@
       </div>
 
       <!-- Kanban board -->
-      <TaskBoard
-        v-else
-        :tasks-by-status="tasksStore.tasksByStatus"
-        :categories="tasksStore.categories"
-        :band-space-id="bandSpaceId"
-        @open-task="handleOpenTask"
-        @reorder="handleReorder"
-        @status-change="handleStatusChange"
-        @show-all-done="showAllDone = true"
-      />
+      <div v-else>
+        <Message
+          v-if="tasksStore.isReorderDisabled"
+          severity="info"
+          :closable="false"
+          class="mb-3"
+        >
+          Réorganisation désactivée : la recherche, le filtre d'échéance et « En retard » masquent
+          des tâches qui ne sont pas chargées, et un déplacement décalerait ces tâches masquées.
+          Effacez ces filtres pour réordonner le tableau. Le menu d'une carte permet toujours de
+          changer son statut.
+        </Message>
+        <TaskBoard
+          :tasks-by-status="tasksStore.tasksByStatus"
+          :categories="tasksStore.categories"
+          :band-space-id="bandSpaceId"
+          @open-task="handleOpenTask"
+          @reorder="handleReorder"
+          @status-change="handleStatusChange"
+          @show-all-done="showAllDone = true"
+        />
+      </div>
     </div>
 
     <!-- Task detail drawer -->
@@ -230,19 +242,40 @@ function handleFilterUpdate(key, value) {
   tasksStore.setFilter(key, value)
 }
 
-async function handleReorder(status, orderedIds) {
+/**
+ * The server refuses a payload that no longer matches the column, which is what happens when
+ * somebody else archived, deleted or moved one of its tasks since this board was loaded. The board
+ * is stale rather than wrong, so it is reloaded before the user tries again: retrying against the
+ * same stale column would only be refused a second time.
+ */
+async function resyncAfterRejectedDrag(summary) {
+  toast.add({
+    severity: 'warn',
+    summary,
+    detail: "Le tableau a été modifié entre temps, il vient d'être rechargé.",
+    life: 5000
+  })
+
   try {
-    await tasksStore.reorderTasks(bandSpaceId, status, orderedIds)
+    await tasksStore.fetchTasks(bandSpaceId)
   } catch {
-    toast.add({ severity: 'error', summary: 'Impossible de réordonner les tâches', life: 5000 })
+    toast.add({ severity: 'error', summary: 'Rechargement du tableau impossible', life: 5000 })
   }
 }
 
-async function handleStatusChange(taskId, newStatus, newIndex) {
+async function handleReorder(status, visibleOrderedIds, movedTaskId) {
   try {
-    await tasksStore.moveTaskToColumn(bandSpaceId, taskId, newStatus, newIndex)
+    await tasksStore.reorderTasks(bandSpaceId, status, visibleOrderedIds, movedTaskId)
   } catch {
-    toast.add({ severity: 'error', summary: 'Impossible de déplacer la tâche', life: 5000 })
+    await resyncAfterRejectedDrag('Impossible de réordonner les tâches')
+  }
+}
+
+async function handleStatusChange(taskId, newStatus, visibleIndex) {
+  try {
+    await tasksStore.moveTaskToColumn(bandSpaceId, taskId, newStatus, visibleIndex)
+  } catch {
+    await resyncAfterRejectedDrag('Impossible de déplacer la tâche')
   }
 }
 

--- a/src/Procedure/BandSpace/TaskMoveProcedure.php
+++ b/src/Procedure/BandSpace/TaskMoveProcedure.php
@@ -10,6 +10,7 @@ use App\Enum\BandSpace\BandSpaceTaskActivityType;
 use App\Enum\BandSpace\TaskStatus;
 use App\Repository\BandSpace\TaskRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\TaskColumnPositionsGuard;
 use DateTime;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
@@ -20,12 +21,14 @@ readonly class TaskMoveProcedure
     public function __construct(
         private EntityManagerInterface $entityManager,
         private TaskRepository $taskRepository,
+        private TaskColumnPositionsGuard $columnPositionsGuard,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
     ) {
     }
 
     /**
-     * @param array<int, array{id: string, position: int}> $positions
+     * @param array<int, array{id: string, position: int}> $positions the whole destination column,
+     *        or empty to append the task to it when the client could not build that ordering
      */
     public function move(
         BandSpace $bandSpace,
@@ -35,9 +38,11 @@ readonly class TaskMoveProcedure
         User $user,
     ): Task {
         $task = $this->taskRepository->findOneByIdAndBandSpace($taskId, $bandSpace);
-        if (!$task instanceof \App\Entity\BandSpace\Task) {
+        if (!$task instanceof Task) {
             throw new BadRequestHttpException(sprintf('Tâche %s introuvable dans ce Band Space', $taskId));
         }
+
+        $targetStatus = TaskStatus::from($newStatus);
 
         $requestedIds = array_column($positions, 'id');
         $foundTasks = $this->taskRepository->findByIdsAndBandSpace($requestedIds, $bandSpace);
@@ -48,35 +53,53 @@ readonly class TaskMoveProcedure
             throw new BadRequestHttpException(sprintf('Tâche %s introuvable dans ce Band Space', reset($missingIds)));
         }
 
-        return $this->entityManager->wrapInTransaction(function () use ($task, $newStatus, $positions, $user): Task {
-            $oldStatus = $task->status->value;
-            if ($oldStatus !== $newStatus) {
-                $task->status = TaskStatus::from($newStatus);
-                $task->completedDatetime = $task->status === TaskStatus::Done ? new DateTimeImmutable() : null;
-                $this->bandSpaceActivityRecorder->record(
-                    bandSpace: $task->bandSpace,
-                    module: BandSpaceModule::Task,
-                    type: BandSpaceTaskActivityType::StatusChanged,
-                    resourceId: $task->id,
-                    actor: $user,
-                    payload: ['from' => $oldStatus, 'to' => $newStatus],
-                );
-            }
+        if ($positions !== []) {
+            $this->columnPositionsGuard->assertCoversColumn(
+                $bandSpace,
+                $targetStatus,
+                $requestedIds,
+                (string) $task->id,
+            );
+        }
 
-            foreach ($positions as $item) {
-                if ($item['id'] === (string) $task->id) {
-                    $task->position = $item['position'];
-                    break;
+        return $this->entityManager->wrapInTransaction(
+            function () use ($bandSpace, $task, $targetStatus, $positions, $user): Task {
+                $oldStatus = $task->status->value;
+                if ($oldStatus !== $targetStatus->value) {
+                    $task->status = $targetStatus;
+                    $task->completedDatetime = $task->status === TaskStatus::Done ? new DateTimeImmutable() : null;
+                    $this->bandSpaceActivityRecorder->record(
+                        bandSpace: $task->bandSpace,
+                        module: BandSpaceModule::Task,
+                        type: BandSpaceTaskActivityType::StatusChanged,
+                        resourceId: $task->id,
+                        actor: $user,
+                        payload: ['from' => $oldStatus, 'to' => $targetStatus->value],
+                    );
                 }
+
+                if ($positions === []) {
+                    // The end of the destination column. Whether or not the status change has
+                    // reached the database by now, the highest position it holds plus one is above
+                    // every number in use there, so the task cannot land on a taken one.
+                    $task->position = $this->taskRepository->findNextPositionInColumn($bandSpace, $targetStatus);
+                } else {
+                    foreach ($positions as $item) {
+                        if ($item['id'] === (string) $task->id) {
+                            $task->position = $item['position'];
+                            break;
+                        }
+                    }
+
+                    $this->taskRepository->bulkUpdatePositions($positions);
+                }
+
+                $task->updateDatetime = new DateTime();
+
+                $this->entityManager->flush();
+
+                return $task;
             }
-
-            $task->updateDatetime = new DateTime();
-
-            $this->taskRepository->bulkUpdatePositions($positions);
-
-            $this->entityManager->flush();
-
-            return $task;
-        });
+        );
     }
 }

--- a/src/Repository/BandSpace/TaskRepository.php
+++ b/src/Repository/BandSpace/TaskRepository.php
@@ -89,6 +89,44 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
+     * The tasks a kanban column currently holds: same band space, same status, not archived.
+     * Reorder and move payloads are checked against it, see TaskColumnPositionsGuard.
+     *
+     * @return Task[]
+     */
+    public function findActiveColumn(BandSpace $bandSpace, TaskStatus $status): array
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.bandSpace = :bandSpace')
+            ->andWhere('t.status = :status')
+            ->andWhere('t.archiveDatetime IS NULL')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('status', $status)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Where a task joining a column goes when the client sent no ordering, which happens while a
+     * server-side task filter hides part of that column from it: the end, so the task cannot take
+     * a number one of the hidden tasks already holds.
+     */
+    public function findNextPositionInColumn(BandSpace $bandSpace, TaskStatus $status): int
+    {
+        $highestPosition = $this->createQueryBuilder('t')
+            ->select('MAX(t.position)')
+            ->where('t.bandSpace = :bandSpace')
+            ->andWhere('t.status = :status')
+            ->andWhere('t.archiveDatetime IS NULL')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('status', $status)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $highestPosition === null ? 0 : (int) $highestPosition + 1;
+    }
+
+    /**
      * @param array<int, array{id: string, position: int}> $positions
      */
     public function bulkUpdatePositions(array $positions): void

--- a/src/Service/BandSpace/TaskColumnPositionsGuard.php
+++ b/src/Service/BandSpace/TaskColumnPositionsGuard.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\Task;
+use App\Enum\BandSpace\TaskStatus;
+use App\Repository\BandSpace\TaskRepository;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Reorder and move payloads carry absolute positions. A payload naming only part of a column
+ * renumbers that part from 0 and leaves the tasks it omitted holding those same numbers, so the
+ * board falls back on its tie-break instead of the requested order, for every member of the band
+ * space, and a refresh does not repair it. That is exactly what a filtered board used to send, so
+ * both write paths prove the payload covers the whole column before anything is written.
+ *
+ * The shape rule (unique ids forming a contiguous 0..n-1) is enforced by TaskReorderPositions and
+ * TaskMovePayload; this is the membership half, which needs the band space.
+ */
+readonly class TaskColumnPositionsGuard
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+    ) {
+    }
+
+    /**
+     * @param string[] $requestedIds ids carried by the payload
+     * @param string|null $joiningTaskId a task arriving from another column: the payload names it
+     *                                   but the column does not hold it yet
+     */
+    public function assertCoversColumn(
+        BandSpace $bandSpace,
+        TaskStatus $status,
+        array $requestedIds,
+        ?string $joiningTaskId = null,
+    ): void {
+        $columnIds = array_map(
+            static fn(Task $task): string => (string) $task->id,
+            $this->taskRepository->findActiveColumn($bandSpace, $status),
+        );
+
+        if ($joiningTaskId !== null) {
+            $columnIds[] = $joiningTaskId;
+        }
+
+        $expectedIds = array_values(array_unique($columnIds));
+        $actualIds = array_values($requestedIds);
+        sort($expectedIds);
+        sort($actualIds);
+
+        if ($expectedIds !== $actualIds) {
+            throw new UnprocessableEntityHttpException(
+                'Les positions doivent couvrir exactement les tâches de cette colonne',
+            );
+        }
+    }
+}

--- a/src/State/Processor/BandSpace/TaskReorderProcessor.php
+++ b/src/State/Processor/BandSpace/TaskReorderProcessor.php
@@ -9,6 +9,7 @@ use App\Entity\BandSpace\Task;
 use App\Entity\User;
 use App\Repository\BandSpace\TaskRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\TaskColumnPositionsGuard;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -22,6 +23,7 @@ readonly class TaskReorderProcessor implements ProcessorInterface
     public function __construct(
         private BandSpaceMemberChecker $memberChecker,
         private TaskRepository $taskRepository,
+        private TaskColumnPositionsGuard $columnPositionsGuard,
         private Security $security,
     ) {
     }
@@ -38,6 +40,7 @@ readonly class TaskReorderProcessor implements ProcessorInterface
 
         [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
+        /** @var string[] $requestedIds every entry is a string id, TaskReorderPositions checked */
         $requestedIds = array_column($data->positions, 'id');
         $foundTasks = $this->taskRepository->findByIdsAndBandSpace($requestedIds, $bandSpace);
         $foundIds = array_map(fn(\App\Entity\BandSpace\Task $task): string => (string) $task->id, $foundTasks);
@@ -51,6 +54,14 @@ readonly class TaskReorderProcessor implements ProcessorInterface
         if (count($statuses) > 1) {
             throw new UnprocessableEntityHttpException('Toutes les tâches doivent avoir le même statut');
         }
+
+        $firstTask = current($foundTasks);
+        if (!$firstTask instanceof Task) {
+            // Unreachable: the payload is never empty and every id it named was just resolved.
+            throw new BadRequestHttpException('Aucune tâche à réordonner');
+        }
+
+        $this->columnPositionsGuard->assertCoversColumn($bandSpace, $firstTask->status, $requestedIds);
 
         $this->taskRepository->bulkUpdatePositions($data->positions);
     }

--- a/src/Validator/BandSpace/TaskMovePayload.php
+++ b/src/Validator/BandSpace/TaskMovePayload.php
@@ -4,14 +4,24 @@ namespace App\Validator\BandSpace;
 
 use Symfony\Component\Validator\Constraint;
 
+/**
+ * Shape check on a move payload.
+ *
+ * An empty positions list is allowed and means "put the task at the end of its new column". It is
+ * all a client can ask for while a server-side task filter hides part of that column from it, and
+ * it is the one placement the server can work out on its own. A non-empty list has to be the whole
+ * destination column, so it must carry unique ids forming a contiguous 0..n-1 sequence. Membership
+ * of that column is checked by TaskColumnPositionsGuard, which knows the band space.
+ */
 #[\Attribute]
 class TaskMovePayload extends Constraint
 {
     public const string ERROR_CODE = 'music_all_a3e8b210-7c2f-4f5d-9b1e-3a8c5d6e7f8a';
 
-    public string $emptyMessage = 'Les positions sont requises';
     public string $invalidItemMessage = 'Chaque position doit contenir un id (UUID) et une position (entier)';
     public string $taskNotInPositionsMessage = 'La tâche déplacée doit figurer dans les positions';
+    public string $duplicateIdMessage = 'Chaque tâche ne peut apparaître qu\'une seule fois';
+    public string $notContiguousMessage = 'Les positions doivent former une séquence 0..n-1 sans trou ni doublon';
 
     public function getTargets(): string
     {

--- a/src/Validator/BandSpace/TaskMovePayloadValidator.php
+++ b/src/Validator/BandSpace/TaskMovePayloadValidator.php
@@ -19,12 +19,8 @@ class TaskMovePayloadValidator extends ConstraintValidator
             return;
         }
 
+        // No ordering at all means "append to the destination column", which the server resolves.
         if ($value->positions === []) {
-            $this->context->buildViolation($constraint->emptyMessage)
-                ->atPath('positions')
-                ->setCode(TaskMovePayload::ERROR_CODE)
-                ->addViolation();
-
             return;
         }
 
@@ -50,6 +46,30 @@ class TaskMovePayloadValidator extends ConstraintValidator
         }
 
         $positionIds = array_column($value->positions, 'id');
+
+        // A duplicate would pass the column-membership check, which compares sets, and then leave
+        // one of the positions the payload named unused.
+        if (count(array_unique($positionIds)) !== count($positionIds)) {
+            $this->context->buildViolation($constraint->duplicateIdMessage)
+                ->atPath('positions')
+                ->setCode(TaskMovePayload::ERROR_CODE)
+                ->addViolation();
+
+            return;
+        }
+
+        $positionValues = array_column($value->positions, 'position');
+        $expected = range(0, count($positionValues) - 1);
+        sort($positionValues);
+        if ($positionValues !== $expected) {
+            $this->context->buildViolation($constraint->notContiguousMessage)
+                ->atPath('positions')
+                ->setCode(TaskMovePayload::ERROR_CODE)
+                ->addViolation();
+
+            return;
+        }
+
         if (!in_array($value->taskId, $positionIds, true)) {
             $this->context->buildViolation($constraint->taskNotInPositionsMessage)
                 ->atPath('task_id')

--- a/src/Validator/BandSpace/TaskReorderPositions.php
+++ b/src/Validator/BandSpace/TaskReorderPositions.php
@@ -4,6 +4,13 @@ namespace App\Validator\BandSpace;
 
 use Symfony\Component\Validator\Constraint;
 
+/**
+ * Shape check on a reorder payload. Modelled on TechRiderItemPositions.
+ *
+ * Requires unique ids forming a contiguous 0..n-1 sequence, so a payload cannot leave two tasks
+ * of a column sharing a position. Membership of the column is checked by TaskColumnPositionsGuard,
+ * which is the only thing that knows the band space.
+ */
 #[\Attribute]
 class TaskReorderPositions extends Constraint
 {
@@ -11,6 +18,8 @@ class TaskReorderPositions extends Constraint
 
     public string $emptyMessage = 'Les positions sont requises';
     public string $invalidItemMessage = 'Chaque position doit contenir un id (UUID) et une position (entier)';
+    public string $duplicateIdMessage = 'Chaque tâche ne peut apparaître qu\'une seule fois';
+    public string $notContiguousMessage = 'Les positions doivent former une séquence 0..n-1 sans trou ni doublon';
 
     public function getTargets(): string
     {

--- a/src/Validator/BandSpace/TaskReorderPositionsValidator.php
+++ b/src/Validator/BandSpace/TaskReorderPositionsValidator.php
@@ -28,6 +28,7 @@ class TaskReorderPositionsValidator extends ConstraintValidator
             return;
         }
 
+        $shapeOk = true;
         foreach ($value->positions as $index => $item) {
             $valid = is_array($item)
                 && array_key_exists('id', $item)
@@ -36,11 +37,38 @@ class TaskReorderPositionsValidator extends ConstraintValidator
                 && is_int($item['position']);
 
             if (!$valid) {
+                $shapeOk = false;
                 $this->context->buildViolation($constraint->invalidItemMessage)
                     ->atPath("positions[$index]")
                     ->setCode(TaskReorderPositions::ERROR_CODE)
                     ->addViolation();
             }
+        }
+
+        if (!$shapeOk) {
+            return;
+        }
+
+        // A duplicate would pass the column-membership check in the processor, which compares
+        // sets, and then leave one of the positions it named unused.
+        $ids = array_column($value->positions, 'id');
+        if (count(array_unique($ids)) !== count($ids)) {
+            $this->context->buildViolation($constraint->duplicateIdMessage)
+                ->atPath('positions')
+                ->setCode(TaskReorderPositions::ERROR_CODE)
+                ->addViolation();
+
+            return;
+        }
+
+        $positionValues = array_column($value->positions, 'position');
+        $expected = range(0, count($positionValues) - 1);
+        sort($positionValues);
+        if ($positionValues !== $expected) {
+            $this->context->buildViolation($constraint->notContiguousMessage)
+                ->atPath('positions')
+                ->setCode(TaskReorderPositions::ERROR_CODE)
+                ->addViolation();
         }
     }
 }

--- a/tests/Api/BandSpace/Task/TaskMoveTest.php
+++ b/tests/Api/BandSpace/Task/TaskMoveTest.php
@@ -170,6 +170,124 @@ class TaskMoveTest extends ApiTestCase
         $this->assertNotNull($taskRepo->find($taskId)->completedDatetime);
     }
 
+    /**
+     * The board cannot order a column it only partly holds, which is the case while a server-side
+     * task filter is on. It sends no ordering at all then, and the task goes to the end of its new
+     * column rather than taking a number one of the tasks it cannot see already holds.
+     */
+    public function test_move_task_without_positions_appends_to_the_destination_column(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $moved = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 0])->create();
+        $first = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::InProgress, 'position' => 0])->create();
+        $second = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::InProgress, 'position' => 1])->create();
+
+        $movedId = (string) $moved->id;
+        $firstId = (string) $first->id;
+        $secondId = (string) $second->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/move',
+            [
+                'task_id' => $movedId,
+                'status' => 'in_progress',
+                'positions' => [],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Task',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $movedId,
+            '@type' => 'Task',
+            'id' => $movedId,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => $moved->title,
+            'status' => 'in_progress',
+            'priority' => 'normal',
+            'created_by_id' => (string) $user->id,
+            'created_by_username' => $user->username,
+            'assignees' => [],
+            'position' => 2,
+            'creation_datetime' => $moved->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $this->getResponseAsArray()['update_datetime'],
+            'comment_count' => 0,
+            'file_count' => 0,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $this->assertSame(TaskStatus::InProgress, $taskRepo->find($movedId)->status);
+        $this->assertSame(2, $taskRepo->find($movedId)->position);
+        // The tasks already there keep their numbers: an append rewrites nothing else.
+        $this->assertSame(0, $taskRepo->find($firstId)->position);
+        $this->assertSame(1, $taskRepo->find($secondId)->position);
+    }
+
+    /**
+     * A destination ordering that names only part of the column would renumber that part and
+     * leave the rest holding the same numbers, which is the corruption the reorder guard stops.
+     */
+    public function test_move_task_rejects_a_partial_destination_column(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $moved = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 0])->create();
+        $first = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::InProgress, 'position' => 0])->create();
+        $hidden = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::InProgress, 'position' => 1])->create();
+
+        $movedId = (string) $moved->id;
+        $firstId = (string) $first->id;
+        $hiddenId = (string) $hidden->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/move',
+            [
+                'task_id' => $movedId,
+                'status' => 'in_progress',
+                'positions' => [
+                    ['id' => $firstId, 'position' => 0],
+                    ['id' => $movedId, 'position' => 1],
+                ],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Les positions doivent couvrir exactement les tâches de cette colonne',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Les positions doivent couvrir exactement les tâches de cette colonne',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $this->assertSame(TaskStatus::Todo, $taskRepo->find($movedId)->status);
+        $this->assertSame(0, $taskRepo->find($movedId)->position);
+        $this->assertSame(0, $taskRepo->find($firstId)->position);
+        $this->assertSame(1, $taskRepo->find($hiddenId)->position);
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findForResource($bandSpace, BandSpaceModule::Task, $moved->id));
+    }
+
     public function test_move_task_not_member(): void
     {
         $owner = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/Task/TaskReorderTest.php
+++ b/tests/Api/BandSpace/Task/TaskReorderTest.php
@@ -10,6 +10,7 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\TaskFactory;
 use App\Tests\Factory\User\UserFactory;
+use App\Validator\BandSpace\TaskReorderPositions;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -75,14 +76,24 @@ class TaskReorderTest extends ApiTestCase
             '/api/band_spaces/' . $bandSpace->id . '/tasks/reorder',
             [
                 'positions' => [
-                    ['id' => $todoId, 'position' => 5],
-                    ['id' => $inProgressId, 'position' => 6],
+                    ['id' => $todoId, 'position' => 0],
+                    ['id' => $inProgressId, 'position' => 1],
                 ],
             ],
             ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Toutes les tâches doivent avoir le même statut',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Toutes les tâches doivent avoir le même statut',
+        ]);
 
         self::getContainer()->get(EntityManagerInterface::class)->clear();
         $taskRepo = self::getContainer()->get(TaskRepository::class);
@@ -145,6 +156,204 @@ class TaskReorderTest extends ApiTestCase
         $taskRepo = self::getContainer()->get(TaskRepository::class);
         $this->assertSame(0, $taskRepo->find($ownId)->position);
         $this->assertSame(5, $taskRepo->find($foreignId)->position);
+    }
+
+    /**
+     * The regression this endpoint exists to stop. A board filtered down to two of the three
+     * "À faire" tasks used to send only those two, renumbered 0 and 1, which handed them numbers
+     * the third one already held. The column then ordered on its tie-break, for every member of
+     * the band space, and a refresh did not repair it.
+     */
+    public function test_reorder_rejects_a_payload_that_leaves_a_task_of_the_column_out(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $a = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 0])->create();
+        $b = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 1])->create();
+        $hidden = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 2])->create();
+
+        $aId = (string) $a->id;
+        $bId = (string) $b->id;
+        $hiddenId = (string) $hidden->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/reorder',
+            [
+                'positions' => [
+                    ['id' => $bId, 'position' => 0],
+                    ['id' => $aId, 'position' => 1],
+                ],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Les positions doivent couvrir exactement les tâches de cette colonne',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Les positions doivent couvrir exactement les tâches de cette colonne',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $this->assertSame(0, $taskRepo->find($aId)->position);
+        $this->assertSame(1, $taskRepo->find($bId)->position);
+        $this->assertSame(2, $taskRepo->find($hiddenId)->position);
+    }
+
+    /**
+     * Archived tasks are off the board, so the payload cannot name them and must not have to.
+     */
+    public function test_reorder_covers_the_column_without_its_archived_tasks(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $a = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 0])->create();
+        $b = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 1])->create();
+        $archived = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Todo,
+            'position' => 2,
+            'archiveDatetime' => new \DateTimeImmutable('-1 day'),
+        ])->create();
+
+        $aId = (string) $a->id;
+        $bId = (string) $b->id;
+        $archivedId = (string) $archived->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/reorder',
+            [
+                'positions' => [
+                    ['id' => $bId, 'position' => 0],
+                    ['id' => $aId, 'position' => 1],
+                ],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $this->assertSame(1, $taskRepo->find($aId)->position);
+        $this->assertSame(0, $taskRepo->find($bId)->position);
+        $this->assertSame(2, $taskRepo->find($archivedId)->position);
+    }
+
+    public function test_reorder_rejects_non_contiguous_positions(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $a = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 0])->create();
+        $b = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 1])->create();
+
+        $aId = (string) $a->id;
+        $bId = (string) $b->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/reorder',
+            [
+                'positions' => [
+                    ['id' => $aId, 'position' => 0],
+                    ['id' => $bId, 'position' => 5],
+                ],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . TaskReorderPositions::ERROR_CODE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'positions',
+                    'message' => 'Les positions doivent former une séquence 0..n-1 sans trou ni doublon',
+                    'code' => TaskReorderPositions::ERROR_CODE,
+                ],
+            ],
+            'detail' => 'positions: Les positions doivent former une séquence 0..n-1 sans trou ni doublon',
+            'type' => '/validation_errors/' . TaskReorderPositions::ERROR_CODE,
+            'title' => 'An error occurred',
+            'description' => 'positions: Les positions doivent former une séquence 0..n-1 sans trou ni doublon',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $this->assertSame(0, $taskRepo->find($aId)->position);
+        $this->assertSame(1, $taskRepo->find($bId)->position);
+    }
+
+    public function test_reorder_rejects_a_duplicated_task(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $a = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 0])->create();
+        $b = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 1])->create();
+
+        $aId = (string) $a->id;
+        $bId = (string) $b->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/reorder',
+            [
+                'positions' => [
+                    ['id' => $aId, 'position' => 0],
+                    ['id' => $bId, 'position' => 1],
+                    ['id' => $aId, 'position' => 2],
+                ],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . TaskReorderPositions::ERROR_CODE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'positions',
+                    'message' => 'Chaque tâche ne peut apparaître qu\'une seule fois',
+                    'code' => TaskReorderPositions::ERROR_CODE,
+                ],
+            ],
+            'detail' => 'positions: Chaque tâche ne peut apparaître qu\'une seule fois',
+            'type' => '/validation_errors/' . TaskReorderPositions::ERROR_CODE,
+            'title' => 'An error occurred',
+            'description' => 'positions: Chaque tâche ne peut apparaître qu\'une seule fois',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $this->assertSame(0, $taskRepo->find($aId)->position);
+        $this->assertSame(1, $taskRepo->find($bId)->position);
     }
 
     public function test_reorder_rejects_empty_positions(): void


### PR DESCRIPTION
Closes #811.

## The bug

Reordering was computed on the filtered subset of tasks but persisted as absolute positions. Filter the board (or search), drag one card, clear the filter: the visible tasks had been renumbered 0..k-1, colliding with the hidden ones that already held those numbers. The column then fell back on its tie-break for every member of the band space, and a refresh did not repair it.

A single user with no concurrency was enough to trigger it, which is what separates this from #588.

## The fix, in two layers

**Client.** A pure `orderColumnAfterDrag(fullOrderedIds, visibleOrderedIds, movedId)` replays the drag against the complete column held in the store. It does not use a naive "insert after the visible predecessor" anchor, because that makes a drop-in-place jump the card over hidden rows above it. The drag instead defines a range of valid slots, bounded by whichever neighbours were actually visible, and the slot closest to where the card already sat is taken.

Under a server-side filter (`query`, `overdue`, due-date range) the hidden rows are genuinely not in memory, so no correct full ordering can be built. Drag is disabled there with an explanation rather than writing a payload that cannot be right.

**Server.** `TaskColumnPositionsGuard` refuses any payload that does not cover the whole active column, mirroring the `TechRiderItemReorderProcessor` precedent rather than inventing a third style. The validators gained duplicate-id and contiguity rules.

## API note

The move endpoint now accepts an empty `positions` list, meaning "append to the end of the destination column", resolved server-side with `MAX(position) + 1`. This keeps the card menu's "Déplacer vers" working while drag is disabled under a filter. That menu previously computed an index from a filtered count, which was another instance of the same bug.

An empty payload is still rejected on the reorder endpoint, so it cannot be used to sidestep the guard.

## Fixed during review

- the disabled-drag notice listed the search and due-date filters but not "En retard", which is also one of the triggers, so toggling only that gave an unexplained non-draggable board
- a drag rejected because another member archived or moved a task since the board loaded showed a generic error and left the board stale. It now reloads the board and says so, since retrying against the same stale column would just be refused again

## Tests

15 unit cases on the pure ordering function (full column, filtered subset, clamping against hidden neighbours, drop-in-place, cross-column, empty destination, stale neighbour, input immutability) and 6 API tests covering the core regression, archived exclusion, contiguity, duplicates, append-on-empty and a partial destination.

`test_reorder_rejects_mixed_statuses` used positions 5 and 6, which the new contiguity rule rejects first, so it would have kept passing for the wrong reason. It now uses 0 and 1 and asserts the mixed-status message it was written for.

Full suite 2076 green, PHPStan level 8 clean.

## Known gap, not addressed here

`TaskUpdateProcedure` still lets a plain `PATCH` write an arbitrary `position` with no coverage or contiguity check. It is pre-existing and unreachable from the current frontend, but it can reproduce the same symptom through another door, so it deserves its own issue rather than silently widening this one.
