### PR TITLE
fix(M-814): withdraw a deleted account from its band spaces

### DIFF
--- a/assets/js/views/User/Settings/SettingsGeneral.vue
+++ b/assets/js/views/User/Settings/SettingsGeneral.vue
@@ -174,6 +174,11 @@
         <Message severity="warn" :closable="false">
           Cette action est irréversible. Toutes vos données personnelles seront supprimées.
         </Message>
+        <p class="text-sm text-surface-600 dark:text-surface-400">
+          <span class="font-semibold">Vos Band Spaces :</span> vous quitterez tous vos espaces. Si vous êtes le seul
+          membre de l'un d'eux, sa suppression sera programmée sous 30 jours. Si vous en êtes le dernier
+          administrateur, le membre le plus ancien sera promu administrateur.
+        </p>
         <template v-if="hasPassword">
           <p class="text-sm text-surface-600 dark:text-surface-400">
             Pour confirmer la suppression, veuillez saisir votre mot de passe.

--- a/src/Repository/BandSpace/BandSpaceMembershipRepository.php
+++ b/src/Repository/BandSpace/BandSpaceMembershipRepository.php
@@ -100,6 +100,63 @@ class BandSpaceMembershipRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
+    public function countActiveMembers(BandSpace $bandSpace): int
+    {
+        return (int) $this->createQueryBuilder('m')
+            ->select('COUNT(m.id)')
+            ->where('m.bandSpace = :bandSpace')
+            ->andWhere('m.status = :status')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('status', MembershipStatus::Active)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * Every space the user still belongs to, for the account-deletion sweep. The space comes along
+     * because the caller reads and writes it for each membership.
+     *
+     * @return BandSpaceMembership[]
+     */
+    public function findActiveByUser(User $user): array
+    {
+        return $this->createQueryBuilder('m')
+            ->innerJoin('m.bandSpace', 'bs')
+            ->addSelect('bs')
+            ->where('m.user = :user')
+            ->andWhere('m.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', MembershipStatus::Active)
+            ->orderBy('m.creationDatetime', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * The active member who has been in the space the longest, ignoring one of them.
+     *
+     * Used to pick the successor when the last admin disappears. Ordered by join date and then by id so
+     * two members who joined within the same second still resolve to one and the same successor: the
+     * column is a DATETIME, and a batch of invitations accepted at registration writes identical values.
+     */
+    public function findLongestStandingActiveMemberExcept(BandSpace $bandSpace, BandSpaceMembership $excluded): ?BandSpaceMembership
+    {
+        return $this->createQueryBuilder('m')
+            ->innerJoin('m.user', 'u')
+            ->addSelect('u')
+            ->where('m.bandSpace = :bandSpace')
+            ->andWhere('m.status = :status')
+            ->andWhere('m.id != :excludedId')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('status', MembershipStatus::Active)
+            ->setParameter('excludedId', (string) $excluded->id)
+            ->orderBy('m.creationDatetime', 'ASC')
+            ->addOrderBy('m.id', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function findMembershipIncludingInactive(BandSpace $bandSpace, User $user): ?BandSpaceMembership
     {
         return $this->createQueryBuilder('m')

--- a/src/Repository/BandSpace/FinanceEntryRepository.php
+++ b/src/Repository/BandSpace/FinanceEntryRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository\BandSpace;
 
 use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\FinanceEntry;
+use App\Entity\BandSpace\FinanceRecurrence;
 use App\Enum\BandSpace\FinanceEntryStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -255,5 +256,29 @@ class FinanceEntryRepository extends ServiceEntityRepository
             'username' => $row['username'],
             'total' => (int) $row['total'],
         ], $rows);
+    }
+
+    /**
+     * Drops the entries a recurrence had already planned past a given date, used when the recurrence is
+     * switched off because the member it belongs to left the band.
+     *
+     * Deliberately a bulk DQL delete rather than an ORM remove(): a stopped recurrence can carry years
+     * of planned rows and hydrating them only to delete them is pointless work. The consequence the
+     * caller has to know about is that no lifecycle event fires and already-loaded FinanceEntry objects
+     * stay in Doctrine's identity map, so anything re-reading them in the same process still sees them.
+     */
+    public function deleteFuturePlannedByRecurrence(FinanceRecurrence $recurrence, \DateTimeInterface $after): void
+    {
+        $this->getEntityManager()
+            ->createQuery(
+                'DELETE FROM App\Entity\BandSpace\FinanceEntry e
+                 WHERE e.recurrence = :recurrence
+                 AND e.date > :after
+                 AND e.status = :status'
+            )
+            ->setParameter('recurrence', $recurrence)
+            ->setParameter('after', $after)
+            ->setParameter('status', FinanceEntryStatus::Planned)
+            ->execute();
     }
 }

--- a/src/Service/BandSpace/BandSpaceDeletionScheduler.php
+++ b/src/Service/BandSpace/BandSpaceDeletionScheduler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceSettingsActivityType;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+/**
+ * Puts a space on the deletion clock: stores the due date app:band-space:purge reads and logs the entry
+ * the settings activity feed shows.
+ *
+ * Shared by the admin who asks for the deletion and by the account-deletion sweep that schedules a space
+ * whose last member is gone, so the grace period announced in the privacy policy is defined once.
+ *
+ * Flushing and announcing are left to the caller: both callers already own a transaction boundary, and
+ * the notification has to go out after the commit per the epic #689 contract.
+ */
+readonly class BandSpaceDeletionScheduler
+{
+    /**
+     * Kept in sync with the durations announced in the privacy policy and the terms.
+     */
+    private const int GRACE_PERIOD_DAYS = 30;
+
+    public function __construct(
+        private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+    ) {
+    }
+
+    public function schedule(BandSpace $bandSpace, User $actor): DateTimeImmutable
+    {
+        $scheduledFor = new DateTimeImmutable(sprintf('+%d days', self::GRACE_PERIOD_DAYS));
+        $bandSpace->deletionScheduledDatetime = $scheduledFor;
+
+        $this->bandSpaceActivityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Settings,
+            type: BandSpaceSettingsActivityType::DeletionScheduled,
+            resourceId: (string) $bandSpace->id,
+            actor: $actor,
+            payload: ['scheduled_for' => $scheduledFor->format(DateTimeInterface::ATOM)],
+        );
+
+        return $scheduledFor;
+    }
+}

--- a/src/Service/BandSpace/PersonalRecurrenceDeactivator.php
+++ b/src/Service/BandSpace/PersonalRecurrenceDeactivator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Repository\BandSpace\FinanceEntryRepository;
+use App\Repository\BandSpace\FinanceRecurrenceRepository;
+use DateTime;
+
+/**
+ * Stops the personal finance recurrences of a member who is on their way out, whether they left, were
+ * removed by an admin or deleted their MusicAll account.
+ *
+ * Past entries are kept because the band's books have to stay balanced, only the entries the recurrence
+ * had planned ahead are dropped: nobody owes a monthly contribution for a band they are no longer in.
+ *
+ * Shared by the three departure paths so a member who disappears one way does not keep generating
+ * entries while a member who disappears another way stops.
+ */
+readonly class PersonalRecurrenceDeactivator
+{
+    public function __construct(
+        private FinanceRecurrenceRepository $financeRecurrenceRepository,
+        private FinanceEntryRepository $financeEntryRepository,
+    ) {
+    }
+
+    public function deactivateForMember(BandSpaceMembership $membership): void
+    {
+        $now = new DateTime();
+
+        foreach ($this->financeRecurrenceRepository->findActivePersonalByMember($membership) as $recurrence) {
+            $recurrence->isActive = false;
+            $recurrence->updateDatetime = new DateTime();
+
+            $this->financeEntryRepository->deleteFuturePlannedByRecurrence($recurrence, $now);
+        }
+    }
+}

--- a/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
+++ b/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Procedure\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceSettingsActivityType;
+use App\Enum\BandSpace\MembershipStatus;
+use App\Enum\BandSpace\Role;
+use App\Event\BandSpaceMemberRoleChangedEvent;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\BandSpaceDeletionScheduler;
+use App\Service\BandSpace\PersonalRecurrenceDeactivator;
+use DateTime;
+
+/**
+ * Takes a user out of every band space they still belong to, when they delete their MusicAll account.
+ *
+ * Deleting an account only anonymized the user row, so the membership stayed Active and, more often than
+ * not, Admin. countAdmins() kept counting an account nobody can log into, which made BandSpaceAdminChecker
+ * the door nobody could open: the band could no longer promote, invite, remove anyone or even schedule
+ * the space for deletion. This procedure closes that hole, and every space it touches comes out with at
+ * least one live admin or a deletion already scheduled.
+ *
+ * Three outcomes per space, decided on the state before the departure:
+ *
+ * - the leaver is the only active member: the space would be left with nobody, so it goes on the same
+ *   30-day deletion clock an admin would have started by hand. Members can no longer restore it because
+ *   there are no members, and app:band-space:purge removes the rows and the stored objects on the due date.
+ * - the departure would leave the space without an active admin: the longest-standing remaining member is
+ *   promoted. Longest-standing rather than, say, the most recently active, because join date is a fact the
+ *   band can check and agree with, and the repository breaks ties on the id so the outcome is one and the
+ *   same successor every time.
+ * - anything else: the membership is simply marked as left, exactly as the Quitter button does.
+ *
+ * Runs after the user row has been anonymized on purpose. The activity payloads and the promotion
+ * notification are written with the anonymized handle, so deleting an account does not scatter fresh
+ * copies of the old username through other people's data.
+ *
+ * The promotion is the only thing worth a notification, because it is the only one with both a live
+ * recipient and a consequence: the successor did not ask for the job and is now the only person who can
+ * administer the space. BandSpaceMemberRemovedEvent is deliberately not dispatched, its recipient is the
+ * departing member and that account is gone; neither is BandSpaceDeletionStateChangedEvent, since the
+ * space only gets scheduled when nobody is left to read it. The departure itself lands in the settings
+ * activity feed, which is where the band looks for who came and went.
+ */
+readonly class WithdrawUserFromBandSpacesProcedure
+{
+    public function __construct(
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private BandSpaceDeletionScheduler $bandSpaceDeletionScheduler,
+        private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
+        private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+    ) {
+    }
+
+    /**
+     * Mutates the memberships without flushing, so the caller commits the whole account deletion at once.
+     *
+     * @return list<BandSpaceMemberRoleChangedEvent> the promotions to announce, to be dispatched by the
+     *                                               caller once the commit has gone through
+     */
+    public function process(User $user): array
+    {
+        $promotions = [];
+
+        foreach ($this->bandSpaceMembershipRepository->findActiveByUser($user) as $membership) {
+            $promotion = $this->withdrawFrom($membership, $user);
+
+            if ($promotion instanceof BandSpaceMemberRoleChangedEvent) {
+                $promotions[] = $promotion;
+            }
+        }
+
+        return $promotions;
+    }
+
+    private function withdrawFrom(BandSpaceMembership $membership, User $user): ?BandSpaceMemberRoleChangedEvent
+    {
+        $bandSpace = $membership->bandSpace;
+
+        // Counted before the membership is touched: nothing is flushed yet, so these still describe the
+        // space as it stands with the leaver in it.
+        $activeMemberCount = $this->bandSpaceMembershipRepository->countActiveMembers($bandSpace);
+        $adminsLeftBehind = $this->bandSpaceMembershipRepository->countAdmins($bandSpace)
+            - ($membership->role === Role::Admin ? 1 : 0);
+
+        $membership->status = MembershipStatus::Left;
+        $membership->leftDatetime = new DateTime();
+
+        $this->personalRecurrenceDeactivator->deactivateForMember($membership);
+
+        $this->bandSpaceActivityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Settings,
+            type: BandSpaceSettingsActivityType::MemberLeft,
+            resourceId: $user->id,
+            actor: $user,
+            payload: [
+                'target_user_id' => $user->id,
+                'target_username' => $user->username,
+            ],
+        );
+
+        if ($activeMemberCount === 1) {
+            // Nobody is left to be promoted and nobody is left to restore the space either, so it is put
+            // on the deletion clock rather than kept alive with an empty roster. Guarded because an admin
+            // may already have scheduled it and rescheduling would silently extend their grace period.
+            if (!$bandSpace->isPendingDeletion()) {
+                $this->bandSpaceDeletionScheduler->schedule($bandSpace, $user);
+            }
+
+            return null;
+        }
+
+        if ($adminsLeftBehind > 0) {
+            return null;
+        }
+
+        return $this->promoteSuccessor($membership, $user);
+    }
+
+    private function promoteSuccessor(BandSpaceMembership $membership, User $user): ?BandSpaceMemberRoleChangedEvent
+    {
+        // Excluded by id rather than by status: the departure is not flushed yet, so the query would
+        // otherwise hand the leaver back to itself as its own successor.
+        $successor = $this->bandSpaceMembershipRepository->findLongestStandingActiveMemberExcept(
+            $membership->bandSpace,
+            $membership
+        );
+
+        if (!$successor instanceof BandSpaceMembership) {
+            return null;
+        }
+
+        $previousRole = $successor->role;
+        $successor->role = Role::Admin;
+
+        $this->bandSpaceActivityRecorder->record(
+            bandSpace: $membership->bandSpace,
+            module: BandSpaceModule::Settings,
+            type: BandSpaceSettingsActivityType::MemberRoleChanged,
+            resourceId: $successor->user->id,
+            actor: $user,
+            payload: [
+                'from' => $previousRole->value,
+                'to' => Role::Admin->value,
+                'target_user_id' => $successor->user->id,
+                'target_username' => $successor->user->username,
+            ],
+        );
+
+        // The successor has to be told: they are the only one who can now administer the space, and
+        // nobody chose them. Reuses the role-change notification rather than inventing a type for it.
+        return new BandSpaceMemberRoleChangedEvent($successor, $previousRole, $user);
+    }
+}

--- a/src/Service/Procedure/User/DeleteAccountProcedure.php
+++ b/src/Service/Procedure/User/DeleteAccountProcedure.php
@@ -5,18 +5,43 @@ declare(strict_types=1);
 namespace App\Service\Procedure\User;
 
 use App\Entity\User;
+use App\Event\BandSpaceMemberRoleChangedEvent;
+use App\Service\Procedure\BandSpace\WithdrawUserFromBandSpacesProcedure;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 readonly class DeleteAccountProcedure
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
         private Connection $connection,
+        private WithdrawUserFromBandSpacesProcedure $withdrawUserFromBandSpacesProcedure,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
     public function process(User $user): void
+    {
+        // One transaction, because not every step below waits for the flush: the band space
+        // withdrawal deletes future planned finance entries with a bulk DQL query and the refresh
+        // tokens go out through the connection, so both reach the database straight away. Without
+        // this, a flush that failed would leave a member's finance rows deleted for good while the
+        // account they belong to is still standing.
+        $promotions = $this->entityManager->wrapInTransaction(
+            fn(): array => $this->anonymize($user),
+        );
+
+        // Best-effort notifications dispatched after the commit (epic #689 contract).
+        foreach ($promotions as $promotion) {
+            $this->eventDispatcher->dispatch($promotion);
+        }
+    }
+
+    /**
+     * @return list<BandSpaceMemberRoleChangedEvent> the promotions to announce once committed
+     */
+    private function anonymize(User $user): array
     {
         $oldUsername = $user->username;
         $uuid = $user->id;
@@ -57,12 +82,17 @@ readonly class DeleteAccountProcedure
         $profile->coverPicture = null;
         $profile->socialLinks->clear();
 
+        // Take the account out of its band spaces. Runs after the anonymization so the memberships it
+        // closes and the notification it triggers carry the anonymized handle, not the old username.
+        $promotions = $this->withdrawUserFromBandSpacesProcedure->process($user);
+
         // Delete refresh tokens (stored by username string, not FK)
         $this->connection->executeStatement(
             'DELETE FROM refresh_tokens WHERE username = :oldUsername',
             ['oldUsername' => $oldUsername]
         );
 
-        $this->entityManager->flush();
+        // wrapInTransaction() flushes before it commits, so the caller gets one atomic unit.
+        return $promotions;
     }
 }

--- a/src/State/Processor/BandSpace/BandSpaceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceDeleteProcessor.php
@@ -6,13 +6,10 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\BandSpace\BandSpace as BandSpaceResource;
 use App\Entity\User;
-use App\Enum\BandSpace\BandSpaceModule;
-use App\Enum\BandSpace\BandSpaceSettingsActivityType;
 use App\Event\BandSpaceDeletionStateChangedEvent;
 use App\Security\BandSpace\BandSpaceAdminChecker;
-use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\BandSpaceDeletionScheduler;
 use DateTimeImmutable;
-use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
@@ -27,15 +24,10 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 readonly class BandSpaceDeleteProcessor implements ProcessorInterface
 {
-    /**
-     * Kept in sync with the durations announced in the privacy policy and the terms.
-     */
-    private const int GRACE_PERIOD_DAYS = 30;
-
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceAdminChecker $adminChecker,
-        private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private BandSpaceDeletionScheduler $bandSpaceDeletionScheduler,
         private Security $security,
         private EventDispatcherInterface $eventDispatcher,
     ) {
@@ -55,17 +47,7 @@ readonly class BandSpaceDeleteProcessor implements ProcessorInterface
             throw new ConflictHttpException('La suppression de cet espace est déjà programmée');
         }
 
-        $scheduledFor = new DateTimeImmutable(sprintf('+%d days', self::GRACE_PERIOD_DAYS));
-        $bandSpace->deletionScheduledDatetime = $scheduledFor;
-
-        $this->bandSpaceActivityRecorder->record(
-            bandSpace: $bandSpace,
-            module: BandSpaceModule::Settings,
-            type: BandSpaceSettingsActivityType::DeletionScheduled,
-            resourceId: (string) $bandSpace->id,
-            actor: $user,
-            payload: ['scheduled_for' => $scheduledFor->format(DateTimeInterface::ATOM)],
-        );
+        $this->bandSpaceDeletionScheduler->schedule($bandSpace, $user);
 
         $this->entityManager->flush();
 

--- a/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
@@ -4,18 +4,15 @@ namespace App\State\Processor\BandSpace;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceSettingsActivityType;
-use App\Enum\BandSpace\FinanceEntryScope;
-use App\Enum\BandSpace\FinanceEntryStatus;
 use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
-use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\PersonalRecurrenceDeactivator;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -32,7 +29,7 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceRepository $bandSpaceRepository,
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
-        private FinanceRecurrenceRepository $financeRecurrenceRepository,
+        private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
     ) {
@@ -60,7 +57,7 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
         $membership->status = MembershipStatus::Left;
         $membership->leftDatetime = new DateTime();
 
-        $this->deactivatePersonalRecurrences($membership);
+        $this->personalRecurrenceDeactivator->deactivateForMember($membership);
 
         $this->bandSpaceActivityRecorder->record(
             bandSpace: $bandSpace,
@@ -75,28 +72,5 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
         );
 
         $this->entityManager->flush();
-    }
-
-    private function deactivatePersonalRecurrences(BandSpaceMembership $membership): void
-    {
-        $recurrences = $this->financeRecurrenceRepository->findActivePersonalByMember($membership);
-        $now = new DateTime();
-
-        foreach ($recurrences as $recurrence) {
-            $recurrence->isActive = false;
-            $recurrence->updateDatetime = new DateTime();
-
-            // Delete future planned entries
-            $this->entityManager->createQuery(
-                'DELETE FROM App\Entity\BandSpace\FinanceEntry e
-                 WHERE e.recurrence = :recurrence
-                 AND e.date > :now
-                 AND e.status = :status'
-            )
-            ->setParameter('recurrence', $recurrence)
-            ->setParameter('now', $now)
-            ->setParameter('status', FinanceEntryStatus::Planned)
-            ->execute();
-        }
     }
 }

--- a/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
@@ -5,18 +5,15 @@ namespace App\State\Processor\BandSpace;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\BandSpace\BandSpaceMember;
-use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceSettingsActivityType;
-use App\Enum\BandSpace\FinanceEntryScope;
-use App\Enum\BandSpace\FinanceEntryStatus;
 use App\Enum\BandSpace\MembershipStatus;
 use App\Event\BandSpaceMemberRemovedEvent;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
-use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Security\BandSpace\BandSpaceAdminChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\PersonalRecurrenceDeactivator;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -33,7 +30,7 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceAdminChecker $adminChecker,
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
-        private FinanceRecurrenceRepository $financeRecurrenceRepository,
+        private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
         private EventDispatcherInterface $eventDispatcher,
@@ -66,7 +63,7 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
         $membership->status = MembershipStatus::Kicked;
         $membership->leftDatetime = new DateTime();
 
-        $this->deactivatePersonalRecurrences($membership);
+        $this->personalRecurrenceDeactivator->deactivateForMember($membership);
 
         $this->bandSpaceActivityRecorder->record(
             bandSpace: $bandSpace,
@@ -84,28 +81,5 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
 
         // Best-effort notification dispatched after the commit (epic #689 contract).
         $this->eventDispatcher->dispatch(new BandSpaceMemberRemovedEvent($membership, $user));
-    }
-
-    private function deactivatePersonalRecurrences(BandSpaceMembership $membership): void
-    {
-        $recurrences = $this->financeRecurrenceRepository->findActivePersonalByMember($membership);
-        $now = new DateTime();
-
-        foreach ($recurrences as $recurrence) {
-            $recurrence->isActive = false;
-            $recurrence->updateDatetime = new DateTime();
-
-            // Delete future planned entries
-            $this->entityManager->createQuery(
-                'DELETE FROM App\Entity\BandSpace\FinanceEntry e
-                 WHERE e.recurrence = :recurrence
-                 AND e.date > :now
-                 AND e.status = :status'
-            )
-            ->setParameter('recurrence', $recurrence)
-            ->setParameter('now', $now)
-            ->setParameter('status', FinanceEntryStatus::Planned)
-            ->execute();
-        }
     }
 }

--- a/tests/Api/User/DeleteAccountBandSpaceTest.php
+++ b/tests/Api/User/DeleteAccountBandSpaceTest.php
@@ -1,0 +1,442 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\User;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\FinanceEntry;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\FinanceEntryScope;
+use App\Enum\BandSpace\FinanceEntryStatus;
+use App\Enum\BandSpace\MembershipStatus;
+use App\Enum\BandSpace\Role;
+use App\Enum\Notification\NotificationType;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\BandSpace\FinanceEntryRepository;
+use App\Repository\BandSpace\FinanceRecurrenceRepository;
+use App\Repository\Notification\NotificationRepository;
+use App\Service\Procedure\User\DeleteAccountProcedure;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
+use App\Tests\Factory\BandSpace\FinanceEntryFactory;
+use App\Tests\Factory\BandSpace\FinanceRecurrenceFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * Deleting an account used to anonymize the user row and stop there, leaving an Active/Admin membership
+ * behind that no living account could replace: the last-admin guard kept counting the dead account and
+ * BandSpaceAdminChecker became a door nobody could open (#814).
+ */
+#[ResetDatabase]
+class DeleteAccountBandSpaceTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = [
+        'CONTENT_TYPE' => 'application/ld+json',
+        'HTTP_ACCEPT' => 'application/ld+json',
+    ];
+
+    public function test_sole_member_leaves_the_space_scheduled_for_deletion(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user, 'role' => Role::Admin])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $userId = (string) $user->id;
+
+        $this->deleteAccount($user);
+
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships($bandSpaceId);
+        $this->assertInstanceOf(BandSpace::class, $reloaded);
+        $this->assertNotNull($reloaded->deletionScheduledDatetime);
+        $this->assertSame(
+            (new \DateTimeImmutable('+30 days'))->format('Y-m-d'),
+            $reloaded->deletionScheduledDatetime->format('Y-m-d'),
+        );
+
+        $membershipRepository = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $this->assertSame(0, $membershipRepository->countActiveMembers($reloaded));
+        $this->assertSame(0, $membershipRepository->countAdmins($reloaded));
+
+        $membership = $membershipRepository->findMembershipIncludingInactive($reloaded, $user);
+        $this->assertNotNull($membership);
+        $this->assertSame(MembershipStatus::Left, $membership->status);
+        $this->assertNotNull($membership->leftDatetime);
+
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $scheduleActivities = $activityRepository->findForResource($reloaded, BandSpaceModule::Settings, $bandSpaceId);
+        $this->assertCount(1, $scheduleActivities);
+        $this->assertSame('deletion_scheduled', $scheduleActivities[0]->type);
+
+        $departureActivities = $activityRepository->findForResource($reloaded, BandSpaceModule::Settings, $userId);
+        $this->assertCount(1, $departureActivities);
+        $this->assertSame('member_left', $departureActivities[0]->type);
+        // The payload carries the anonymized handle: erasing an account must not scatter fresh copies of
+        // the old username through the band's history.
+        $this->assertSame([
+            'target_user_id' => $userId,
+            'target_username' => 'deleted_' . $userId,
+        ], $departureActivities[0]->payload);
+    }
+
+    public function test_sole_member_does_not_reschedule_an_already_pending_deletion(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $alreadyScheduledFor = new \DateTimeImmutable('+3 days');
+        $bandSpace = BandSpaceFactory::new()->create([
+            'name' => 'Mon groupe',
+            'deletionScheduledDatetime' => $alreadyScheduledFor,
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user, 'role' => Role::Admin])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->deleteAccount($user);
+
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships($bandSpaceId);
+        $this->assertInstanceOf(BandSpace::class, $reloaded);
+        $this->assertNotNull($reloaded->deletionScheduledDatetime);
+        $this->assertSame(
+            $alreadyScheduledFor->format('Y-m-d'),
+            $reloaded->deletionScheduledDatetime->format('Y-m-d'),
+        );
+
+        // Only the departure is logged, the space was already on the clock.
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($reloaded, BandSpaceModule::Settings, $bandSpaceId);
+        $this->assertCount(0, $activities);
+    }
+
+    public function test_last_admin_departure_promotes_the_longest_standing_member(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $earlyMember = UserFactory::new()->create(['username' => 'early_member', 'email' => 'early@test.com']);
+        $lateMember = UserFactory::new()->create(['username' => 'late_member', 'email' => 'late@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $owner,
+            'role' => Role::Admin,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $earlyMember,
+            'role' => Role::User,
+            'creationDatetime' => new \DateTime('2024-02-01 10:00:00'),
+        ])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $lateMember,
+            'role' => Role::User,
+            'creationDatetime' => new \DateTime('2024-03-01 10:00:00'),
+        ])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->deleteAccount($owner);
+
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships($bandSpaceId);
+        $this->assertInstanceOf(BandSpace::class, $reloaded);
+        // The band keeps running: it is not put on the deletion clock.
+        $this->assertNull($reloaded->deletionScheduledDatetime);
+
+        $membershipRepository = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $this->assertSame(2, $membershipRepository->countActiveMembers($reloaded));
+        $this->assertSame(1, $membershipRepository->countAdmins($reloaded));
+
+        $promoted = $membershipRepository->findMembership($reloaded, $earlyMember);
+        $this->assertNotNull($promoted);
+        $this->assertSame(Role::Admin, $promoted->role);
+
+        $notPromoted = $membershipRepository->findMembership($reloaded, $lateMember);
+        $this->assertNotNull($notPromoted);
+        $this->assertSame(Role::User, $notPromoted->role);
+
+        $ownerMembership = $membershipRepository->findMembershipIncludingInactive($reloaded, $owner);
+        $this->assertNotNull($ownerMembership);
+        $this->assertSame(MembershipStatus::Left, $ownerMembership->status);
+    }
+
+    public function test_promoted_successor_is_notified(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $successor = UserFactory::new()->create(['username' => 'successor', 'email' => 'successor@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $owner,
+            'role' => Role::Admin,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $successor,
+            'role' => Role::User,
+            'creationDatetime' => new \DateTime('2024-02-01 10:00:00'),
+        ])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $ownerId = (string) $owner->id;
+
+        $this->deleteAccount($owner);
+
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+        $notifications = $notificationRepository->findForRecipient($successor, 10, 0);
+        $this->assertCount(1, $notifications);
+        $this->assertSame(NotificationType::BandSpaceRoleChanged, $notifications[0]->type);
+        $this->assertSame([
+            'band_space_id' => $bandSpaceId,
+            'band_space_name' => 'Mon groupe',
+            'from' => 'user',
+            'to' => 'admin',
+            'actor_id' => $ownerId,
+            'actor_username' => 'deleted_' . $ownerId,
+        ], $notifications[0]->payload);
+
+        // The deleted account is never notified about its own departure.
+        $this->assertCount(0, $notificationRepository->findForRecipient($owner, 10, 0));
+    }
+
+    public function test_ordinary_member_departure_only_closes_their_membership(): void
+    {
+        $admin = UserFactory::new()->create(['username' => 'admin_user', 'email' => 'admin@test.com']);
+        $member = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->deleteAccount($member);
+
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)->findOneByIdWithMemberships($bandSpaceId);
+        $this->assertInstanceOf(BandSpace::class, $reloaded);
+        $this->assertNull($reloaded->deletionScheduledDatetime);
+
+        $membershipRepository = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $this->assertSame(1, $membershipRepository->countActiveMembers($reloaded));
+        $this->assertSame(1, $membershipRepository->countAdmins($reloaded));
+
+        $adminMembership = $membershipRepository->findMembership($reloaded, $admin);
+        $this->assertNotNull($adminMembership);
+        $this->assertSame(Role::Admin, $adminMembership->role);
+
+        $memberMembership = $membershipRepository->findMembershipIncludingInactive($reloaded, $member);
+        $this->assertNotNull($memberMembership);
+        $this->assertSame(MembershipStatus::Left, $memberMembership->status);
+
+        // Nobody was promoted, so nobody is told anything.
+        $this->assertCount(0, self::getContainer()->get(NotificationRepository::class)->findForRecipient($admin, 10, 0));
+    }
+
+    public function test_no_space_is_left_without_an_admin_or_a_deletion_scheduled(): void
+    {
+        $leaver = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'mate@test.com']);
+        $otherAdmin = UserFactory::new()->create(['username' => 'other_admin', 'email' => 'other@test.com']);
+
+        $soloSpace = BandSpaceFactory::new()->create(['name' => 'Projet solo']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $soloSpace, 'user' => $leaver, 'role' => Role::Admin])->create();
+
+        $ledSpace = BandSpaceFactory::new()->create(['name' => 'Groupe dirigé']);
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $ledSpace,
+            'user' => $leaver,
+            'role' => Role::Admin,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $ledSpace,
+            'user' => $bandMate,
+            'role' => Role::User,
+            'creationDatetime' => new \DateTime('2024-02-01 10:00:00'),
+        ])->create();
+
+        $guestSpace = BandSpaceFactory::new()->create(['name' => 'Groupe invité']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $guestSpace, 'user' => $otherAdmin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $guestSpace, 'user' => $leaver, 'role' => Role::User])->create();
+
+        $spaceIds = [(string) $soloSpace->id, (string) $ledSpace->id, (string) $guestSpace->id];
+
+        $this->deleteAccount($leaver);
+
+        $bandSpaceRepository = self::getContainer()->get(BandSpaceRepository::class);
+        $membershipRepository = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $pendingDeletionCount = 0;
+
+        foreach ($spaceIds as $spaceId) {
+            $reloaded = $bandSpaceRepository->findOneByIdWithMemberships($spaceId);
+            $this->assertInstanceOf(BandSpace::class, $reloaded);
+
+            if ($reloaded->isPendingDeletion()) {
+                ++$pendingDeletionCount;
+
+                continue;
+            }
+
+            $this->assertGreaterThan(
+                0,
+                $membershipRepository->countActiveMembers($reloaded),
+                sprintf('%s has no active member left', $reloaded->name),
+            );
+            $this->assertGreaterThan(
+                0,
+                $membershipRepository->countAdmins($reloaded),
+                sprintf('%s has no admin left', $reloaded->name),
+            );
+        }
+
+        // Only the space nobody is left in goes on the clock, so the loop above is not passing vacuously.
+        $this->assertSame(1, $pendingDeletionCount);
+
+        // The deleted account belongs to nothing any more.
+        $this->assertSame([], $membershipRepository->findActiveByUser($leaver));
+    }
+
+    public function test_promoted_successor_can_administer_the_space(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $successor = UserFactory::new()->create(['username' => 'successor', 'email' => 'successor@test.com']);
+        $thirdMember = UserFactory::new()->create(['username' => 'third_member', 'email' => 'third@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $owner,
+            'role' => Role::Admin,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $successor,
+            'role' => Role::User,
+            'creationDatetime' => new \DateTime('2024-02-01 10:00:00'),
+        ])->create();
+        $thirdMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $thirdMember,
+            'role' => Role::User,
+            'creationDatetime' => new \DateTime('2024-03-01 10:00:00'),
+        ])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $thirdMembershipId = (string) $thirdMembership->id;
+        $thirdMemberId = (string) $thirdMember->id;
+
+        // Deleted through the procedure rather than the endpoint: loginUser() only holds for a single
+        // request, so spending it on the deletion would leave the assertion below unauthenticated.
+        // The endpoint itself is covered by the other cases in this class.
+        self::getContainer()->get(DeleteAccountProcedure::class)->process($owner);
+
+        // The point of the fix: an admin action is possible again once the founder's account is gone.
+        $this->client->loginUser($successor);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpaceId . '/members/' . $thirdMembershipId,
+            ['role' => 'admin'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceMember',
+            '@id' => '/api/band_spaces/' . $bandSpaceId . '/members/' . $thirdMembershipId,
+            '@type' => 'BandSpaceMember',
+            'id' => $thirdMembershipId,
+            'band_space_id' => $bandSpaceId,
+            'user_id' => $thirdMemberId,
+            'username' => 'third_member',
+            'role' => 'admin',
+            'stage_name' => null,
+            'display_name' => 'third_member',
+            'instruments' => [],
+            'profile_picture_url' => null,
+            'creation_datetime' => '2024-03-01T10:00:00+00:00',
+            'status' => 'active',
+            'left_datetime' => null,
+        ]);
+    }
+
+    public function test_personal_recurrences_of_the_deleted_member_are_stopped(): void
+    {
+        $admin = UserFactory::new()->create(['username' => 'admin_user', 'email' => 'admin@test.com']);
+        $member = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $memberMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $member,
+            'role' => Role::User,
+        ])->create();
+
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Cotisations'])->create();
+        $recurrence = FinanceRecurrenceFactory::new([
+            'category' => $category,
+            'label' => 'Cotisation mensuelle',
+            'scope' => FinanceEntryScope::Personal,
+            'isActive' => true,
+        ])->create();
+
+        FinanceEntryFactory::new([
+            'category' => $category,
+            'recurrence' => $recurrence,
+            'member' => $memberMembership,
+            'scope' => FinanceEntryScope::Personal,
+            'status' => FinanceEntryStatus::Planned,
+            'label' => 'past contribution',
+            'date' => new \DateTime('-1 year'),
+        ])->create();
+        FinanceEntryFactory::new([
+            'category' => $category,
+            'recurrence' => $recurrence,
+            'member' => $memberMembership,
+            'scope' => FinanceEntryScope::Personal,
+            'status' => FinanceEntryStatus::Planned,
+            'label' => 'future contribution',
+            'date' => new \DateTime('+1 year'),
+        ])->create();
+
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->deleteAccount($member);
+
+        $reloadedRecurrence = self::getContainer()->get(FinanceRecurrenceRepository::class)->find($recurrenceId);
+        $this->assertNotNull($reloadedRecurrence);
+        $this->assertFalse($reloadedRecurrence->isActive);
+
+        // The books keep what already happened, only what was planned ahead is dropped.
+        $labels = array_map(
+            static fn (FinanceEntry $entry): string => $entry->label,
+            self::getContainer()->get(FinanceEntryRepository::class)->findByBandSpace($bandSpace),
+        );
+        $this->assertSame(['past contribution'], $labels);
+    }
+
+    private function deleteAccount(User $user): void
+    {
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/users/delete_account',
+            ['password' => 'password'],
+            self::HEADERS
+        );
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+    }
+}


### PR DESCRIPTION
Closes #814.

## The bug

`DeleteAccountProcedure` anonymised the user and never touched `BandSpaceMembership`, so the row stayed `Active` and `Admin`. `countAdmins()` kept counting the deleted account, so the last-admin guard believed the space still had one while no living member could pass `BandSpaceAdminChecker::checkAdmin()`.

A band whose founder deleted their account was frozen permanently: nobody could promote, invite, kick or schedule the space for deletion, and the roster listed `deleted_9f3a...` as an admin. If the deleted user was the only member, the space and its stored objects survived forever, because a deletion could never be scheduled.

This was the only hole in the invariant. Leaving, self-demoting and kicking all enforce it correctly already.

## Behaviour

Decided per space against the state before the departure, then the membership is closed the way the Quitter button closes it.

- **sole active member**: the space goes on the same 30 day grace period an admin would start by hand, so the existing purge eventually removes it. An already scheduled deletion is left alone rather than silently extended.
- **departure would leave no active admin**: the longest-standing remaining active member is promoted, ordered by creation datetime then id so the choice is total and deterministic. The condition also heals a space that already had zero admins from this bug.
- **otherwise**: the membership is closed and nothing else happens.

Only the promoted successor is notified, reusing the existing role-changed event. The withdrawal runs after anonymisation, so that notification names `deleted_<uuid>` rather than re-exposing the erased username. That is deliberate, and it is why the successor's bell reads a little oddly.

## Shared code

Three call sites now share what two of them used to duplicate: `BandSpaceDeletionScheduler` owns the grace period constant and its activity record, and `PersonalRecurrenceDeactivator` owns the finance cleanup that was copy-pasted between leaving and kicking. Both were extracted on their third caller, not speculatively. The bulk finance delete also moved into a repository method with its ORM-bypass caveat documented, clearing one of the known exceptions listed in CLAUDE.md.

`BandSpaceDeleteProcessor` keeps its 409 conflict path and its after-commit event unchanged.

## Fixed during review

The procedure was not atomic. The bulk finance delete and the raw `refresh_tokens` delete both reach the database immediately, while everything else waited on the flush, so a flush that failed would have left a member's future finance entries deleted for good with the account still standing. The whole procedure is now wrapped in one transaction, with event dispatch kept after the commit. Verified this composes with the per-test transaction the test suite uses.

## Tests

8 new API tests: the three cases above, the already-scheduled guard, the successor notification, a multi-space invariant test asserting no space is left without an admin or a scheduled deletion, and the real regression, an admin PATCH succeeding once the founder's account is gone.

That last one calls the procedure directly for setup because `loginUser()` only holds for one request, so the single API call is spent on the assertion that matters. The endpoint itself stays covered by the other cases.

Full suite 2078 green, PHPStan level 8 clean. No migration, no schema change.

## Not addressed here

Invitations sent by the deleted user are left as they are, so a pending invitation can still name an account that no longer exists.
