### PR TITLE
fix(M-815): open band space settings to members and gate admin controls

### DIFF
--- a/assets/js/components/BandSpace/BandSidebar.vue
+++ b/assets/js/components/BandSpace/BandSidebar.vue
@@ -74,7 +74,6 @@
 import { computed } from 'vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
 import { BAND_SPACE_ROUTES, NAVIGATION_ITEMS } from '../../constants/bandSpace.js'
-import { useBandSpaceStore } from '../../store/bandSpace/bandSpace.js'
 import { useUserSecurityStore } from '../../store/user/security.js'
 
 const props = defineProps({
@@ -87,21 +86,15 @@ const collapsed = defineModel('collapsed', { type: Boolean, default: false })
 const emit = defineEmits(['navigate'])
 
 const { currentSpaceId } = useBandSpaceNavigation()
-const bandSpaceStore = useBandSpaceStore()
 const userSecurityStore = useUserSecurityStore()
 
-const visibleItems = computed(() => {
-  const space = bandSpaceStore.getById(currentSpaceId.value)
-  // Two independent gates. `role` is membership in this space; `superAdminOnly` marks a
-  // module that is merged but not yet announced and is dropped when it is released.
-  const items = NAVIGATION_ITEMS.filter(
-    (item) => !item.superAdminOnly || userSecurityStore.isSuperAdmin
-  )
-  if (space?.role === 'admin') {
-    return items
-  }
-  return items.filter((item) => item.route !== BAND_SPACE_ROUTES.PARAMETERS)
-})
+// `superAdminOnly` marks a module that is merged but not yet announced and is dropped when it is
+// released. Membership role is deliberately not a gate: « Paramètres » is where a member quits the
+// space and sets their stage name and instruments, so every member gets the entry, and the page
+// itself hides whatever is admin only.
+const visibleItems = computed(() =>
+  NAVIGATION_ITEMS.filter((item) => !item.superAdminOnly || userSecurityStore.isSuperAdmin)
+)
 
 const workItems = computed(() =>
   visibleItems.value.filter((item) => item.route !== BAND_SPACE_ROUTES.PARAMETERS)

--- a/assets/js/components/BandSpace/Settings/ActiveSharesSection.vue
+++ b/assets/js/components/BandSpace/Settings/ActiveSharesSection.vue
@@ -59,13 +59,15 @@
         </template>
       </Column>
 
-      <Column header="" headerStyle="width:5rem">
+      <Column v-if="isAdmin" header="" headerStyle="width:5rem">
         <template #body="{ data }">
           <Button
             icon="pi pi-trash"
             size="small"
             severity="danger"
             text
+            v-tooltip.top="'Révoquer le lien'"
+            aria-label="Révoquer le lien de partage"
             @click="confirmRevoke(data)"
           />
         </template>
@@ -85,12 +87,16 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { onMounted } from 'vue'
 import { useRoute } from 'vue-router'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 
 const route = useRoute()
 const filesStore = useBandFilesStore()
 const confirm = useConfirm()
 const toast = useToast()
+// Every member may read the list, only an admin may revoke a link, so the column is dropped rather
+// than offering a button the server would refuse.
+const { isAdmin } = useBandSpaceNavigation()
 // Wipe previous space's files-store state synchronously before first render
 // so switching from A's Settings/Shares to B's doesn't flash A's shares.
 filesStore.clear()
@@ -116,12 +122,12 @@ function confirmRevoke(share) {
     rejectLabel: 'Annuler',
     acceptClass: 'p-button-danger',
     accept: async () => {
-      await filesStore.revokeShare(bandSpaceId, share.id)
-      toast.add({
-        severity: 'success',
-        summary: 'Lien révoqué',
-        life: 3000
-      })
+      try {
+        await filesStore.revokeShare(bandSpaceId, share.id)
+        toast.add({ severity: 'success', summary: 'Lien révoqué', life: 3000 })
+      } catch (e) {
+        toast.add({ severity: 'error', summary: e.message, life: 5000 })
+      }
     }
   })
 }

--- a/assets/js/components/BandSpace/Settings/MembersSection.vue
+++ b/assets/js/components/BandSpace/Settings/MembersSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col gap-6">
-    <!-- Invite form -->
-    <div class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-6">
+    <!-- Invite form, admin only: the server refuses an invitation sent by a plain member -->
+    <div v-if="isAdmin" class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-6">
       <h3 class="text-base font-semibold text-surface-800 dark:text-surface-100 mb-4">
         Inviter un membre
       </h3>
@@ -123,7 +123,9 @@
               :aria-label="`Modifier le nom de scène et les instruments de ${member.display_name}`"
               @click="openProfileDialog(member)"
             />
-            <template v-if="!isMe(member)">
+            <!-- Promoting, demoting and excluding are admin only server side, so a member is not
+                 offered a button that would come back as a red toast. -->
+            <template v-if="isAdmin && !isMe(member)">
             <Button
               v-if="member.role === 'user'"
               icon="pi pi-arrow-up"
@@ -203,6 +205,7 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
 import { BAND_SPACE_ROUTES } from '../../../constants/bandSpace.js'
 import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandSpaceSettingsStore } from '../../../store/bandSpace/bandSpaceSettings.js'
@@ -216,6 +219,10 @@ const toast = useToast()
 const settingsStore = useBandSpaceSettingsStore()
 const bandSpaceStore = useBandSpaceStore()
 const userSecurityStore = useUserSecurityStore()
+// The role comes from the space rather than from the roster, like the parent view and the « Zone de
+// danger » do: the space list is loaded before this page renders, so the gate is settled on first
+// paint and the decision below on whether to ask for the invitations cannot be taken too early.
+const { isAdmin } = useBandSpaceNavigation()
 // Wipe previous space's members/invitations synchronously before first
 // render to avoid flashing A's roster when switching to B's Settings.
 settingsStore.clear()
@@ -229,8 +236,6 @@ const isMe = (member) => member.username === userSecurityStore.user?.username
 
 const profileDialogOpen = ref(false)
 const profileTarget = ref(null)
-
-const isAdmin = computed(() => settingsStore.members.find((m) => isMe(m))?.role === 'admin')
 
 function canEditProfile(member) {
   return isMe(member) || isAdmin.value
@@ -352,9 +357,17 @@ function handleLeave() {
   })
 }
 
-onMounted(() => {
-  settingsStore.loadMembers(bandSpaceId)
-  settingsStore.loadInvitations(bandSpaceId)
+onMounted(async () => {
+  try {
+    await settingsStore.loadMembers(bandSpaceId)
+    // Listing the invitations is admin only server side, so asking for them as a plain member would
+    // buy nothing but a 403.
+    if (isAdmin.value) {
+      await settingsStore.loadInvitations(bandSpaceId)
+    }
+  } catch (e) {
+    toast.add({ severity: 'error', summary: e.message, life: 5000 })
+  }
 })
 
 onUnmounted(() => {

--- a/assets/js/composables/useBandSpaceNavigation.js
+++ b/assets/js/composables/useBandSpaceNavigation.js
@@ -15,6 +15,10 @@ export function useBandSpaceNavigation() {
     return bandSpaceStore.getById(currentSpaceId.value)
   })
 
+  // The membership role rides along with the space list, which the band layout loads before it
+  // renders anything, so this is already settled by the time a view or a section reads it.
+  const isAdmin = computed(() => currentSpace.value?.role === 'admin')
+
   function getLastSpaceId() {
     return localStorage.getItem(LAST_BAND_SPACE_KEY)
   }
@@ -65,6 +69,7 @@ export function useBandSpaceNavigation() {
   return {
     currentSpaceId,
     currentSpace,
+    isAdmin,
     getLastSpaceId,
     setLastSpaceId,
     clearLastSpaceId,

--- a/assets/js/constants/bandSpace.js
+++ b/assets/js/constants/bandSpace.js
@@ -40,6 +40,46 @@ export const SECTION_NAMES = {
   [BAND_SPACE_ROUTES.INDEX]: 'Band Space'
 }
 
+/**
+ * The « Paramètres » page tabs, in display order. `adminOnly` is the only gate, and nothing carries
+ * it today: leaving the space, the stage name and instruments dialog, the roster, the activity log
+ * and the storage quota are all member level, which is why the sidebar entry is shown to every
+ * member and not only to admins.
+ */
+export const BAND_SPACE_SETTINGS_SECTIONS = Object.freeze([
+  { key: 'members', label: 'Membres', adminOnly: false },
+  { key: 'activity', label: "Journal d'activité", adminOnly: false },
+  { key: 'shares', label: 'Partages actifs', adminOnly: false },
+  { key: 'storage', label: 'Stockage', adminOnly: false },
+  { key: 'general', label: 'Général', adminOnly: false },
+  { key: 'danger', label: 'Zone de danger', adminOnly: false }
+])
+
+/**
+ * Takes the sections rather than reading the constant directly, so the exclusion branch stays
+ * provable the day a section is finally flagged `adminOnly`. Filtering the frozen constant here
+ * would leave an inverted predicate undetectable for as long as nothing carries the flag.
+ */
+export function filterSectionsByRole(sections, isAdmin) {
+  return sections.filter((section) => !section.adminOnly || isAdmin)
+}
+
+export function visibleSettingsSections(isAdmin) {
+  return filterSectionsByRole(BAND_SPACE_SETTINGS_SECTIONS, isAdmin)
+}
+
+/**
+ * The section to show for a `?section=` value: the requested one when the role may see it, the
+ * first visible one otherwise. Every entry point goes through here (the deep links from the
+ * deletion banner and the dashboard activity widget, and the re-check when the role finally
+ * arrives with the space list), so a member can never land on a tab reserved for admins.
+ */
+export function resolveSettingsSection(requestedKey, isAdmin) {
+  const sections = visibleSettingsSections(isAdmin)
+
+  return sections.find((section) => section.key === requestedKey)?.key ?? sections[0]?.key ?? null
+}
+
 export const NAVIGATION_ITEMS = Object.freeze([
   { label: 'Dashboard', route: BAND_SPACE_ROUTES.DASHBOARD, icon: 'pi-th-large' },
   { label: 'Agenda', route: BAND_SPACE_ROUTES.AGENDA, icon: 'pi-calendar' },

--- a/assets/js/constants/bandSpace.test.js
+++ b/assets/js/constants/bandSpace.test.js
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  BAND_SPACE_ROUTES,
+  BAND_SPACE_SETTINGS_SECTIONS,
+  filterSectionsByRole,
+  NAVIGATION_ITEMS,
+  resolveSettingsSection,
+  visibleSettingsSections
+} from './bandSpace.js'
+
+/**
+ * The role gating of the « Paramètres » page, which is why the section list and its two helpers
+ * live here rather than inside Settings.vue: choosing what a role may see is arithmetic on an
+ * array, and there is no component harness in this project to test the rendering itself.
+ *
+ * Run with `npm test`.
+ */
+
+describe('the Paramètres sidebar entry', () => {
+  // The bug this file was written for: the entry used to be dropped for anyone who was not an
+  // admin, which left a member with no way to reach « Quitter le Band Space » or their stage name.
+  it('is a plain navigation item, hidden from nobody', () => {
+    const parameters = NAVIGATION_ITEMS.find((item) => item.route === BAND_SPACE_ROUTES.PARAMETERS)
+
+    assert.ok(parameters)
+    assert.equal(parameters.superAdminOnly, undefined)
+  })
+})
+
+describe('visibleSettingsSections', () => {
+  it('gives an admin every section', () => {
+    assert.deepEqual(visibleSettingsSections(true), [...BAND_SPACE_SETTINGS_SECTIONS])
+  })
+
+  it('never hands a member a section flagged admin only', () => {
+    assert.ok(visibleSettingsSections(false).every((section) => !section.adminOnly))
+  })
+
+  it('leaves a member the member level sections', () => {
+    const keys = visibleSettingsSections(false).map((section) => section.key)
+
+    for (const key of ['members', 'activity', 'storage']) {
+      assert.ok(keys.includes(key), `« ${key} » must stay reachable for a member`)
+    }
+  })
+})
+
+describe('resolveSettingsSection', () => {
+  it('honours a deep link a member is allowed to follow', () => {
+    // The pending deletion banner points here, and the dashboard activity widget at ?section=activity.
+    assert.equal(resolveSettingsSection('danger', false), 'danger')
+    assert.equal(resolveSettingsSection('activity', false), 'activity')
+  })
+
+  it('falls back to the first visible section without a query', () => {
+    assert.equal(resolveSettingsSection(undefined, false), 'members')
+    assert.equal(resolveSettingsSection(undefined, true), 'members')
+  })
+
+  it('falls back when the query names a section that does not exist', () => {
+    assert.equal(resolveSettingsSection('does-not-exist', false), 'members')
+  })
+
+  it('refuses to land a member on an admin only section', () => {
+    // Vacuous while nothing is flagged, and deliberately so: it starts biting the day a section is.
+    for (const section of BAND_SPACE_SETTINGS_SECTIONS.filter((s) => s.adminOnly)) {
+      assert.notEqual(resolveSettingsSection(section.key, false), section.key)
+      assert.equal(resolveSettingsSection(section.key, true), section.key)
+    }
+  })
+
+  it('hides an admin only section from a member', () => {
+    // Synthetic sections, because the real ones carry no flag yet and this is the branch that
+    // stops a member reaching a tab reserved for admins. An inverted predicate fails here.
+    const sections = [
+      { key: 'members', label: 'Membres', adminOnly: false },
+      { key: 'billing', label: 'Facturation', adminOnly: true }
+    ]
+
+    assert.deepEqual(
+      filterSectionsByRole(sections, false).map((section) => section.key),
+      ['members']
+    )
+    assert.deepEqual(
+      filterSectionsByRole(sections, true).map((section) => section.key),
+      ['members', 'billing']
+    )
+  })
+
+  it('always has a fallback to offer a member', () => {
+    // The guarantee behind the assertions above: the first section is never admin only, so the
+    // fallback can never come back empty.
+    assert.equal(BAND_SPACE_SETTINGS_SECTIONS[0].adminOnly, false)
+    assert.notEqual(resolveSettingsSection(undefined, false), null)
+  })
+})

--- a/assets/js/views/BandSpace/Settings.vue
+++ b/assets/js/views/BandSpace/Settings.vue
@@ -52,27 +52,21 @@ import ComingSoonSection from '../../components/BandSpace/Settings/ComingSoonSec
 import DangerZoneSection from '../../components/BandSpace/Settings/DangerZoneSection.vue'
 import MembersSection from '../../components/BandSpace/Settings/MembersSection.vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
+import {
+  BAND_SPACE_SETTINGS_SECTIONS,
+  resolveSettingsSection,
+  visibleSettingsSections
+} from '../../constants/bandSpace.js'
 
-const { currentSpace } = useBandSpaceNavigation()
+const { isAdmin } = useBandSpaceNavigation()
 const route = useRoute()
 
-const isAdmin = computed(() => currentSpace.value?.role === 'admin')
+const visibleSections = computed(() => visibleSettingsSections(isAdmin.value))
 
-const allSections = [
-  { key: 'members', label: 'Membres', adminOnly: false },
-  { key: 'activity', label: "Journal d'activité", adminOnly: false },
-  { key: 'shares', label: 'Partages actifs', adminOnly: false },
-  { key: 'storage', label: 'Stockage', adminOnly: false },
-  { key: 'general', label: 'Général', adminOnly: false },
-  { key: 'danger', label: 'Zone de danger', adminOnly: false }
-]
-
-const visibleSections = computed(() => allSections.filter((s) => !s.adminOnly || isAdmin.value))
-
-const activeSection = ref(allSections.find((s) => s.key === route.query.section)?.key ?? 'members')
+const activeSection = ref(resolveSettingsSection(route.query.section, isAdmin.value))
 
 const activeSectionLabel = computed(
-  () => allSections.find((s) => s.key === activeSection.value)?.label ?? ''
+  () => BAND_SPACE_SETTINGS_SECTIONS.find((s) => s.key === activeSection.value)?.label ?? ''
 )
 
 // The deletion banner links here with ?section=danger, and it is shown on the settings page too. Vue
@@ -81,16 +75,16 @@ const activeSectionLabel = computed(
 watch(
   () => route.query.section,
   (section) => {
-    const match = allSections.find((s) => s.key === section)
+    const match = visibleSections.value.find((s) => s.key === section)
     if (match) {
       activeSection.value = match.key
     }
   }
 )
 
-watch(visibleSections, (sections) => {
-  if (!sections.find((s) => s.key === activeSection.value)) {
-    activeSection.value = sections[0]?.key ?? 'members'
-  }
+// The role only arrives with the space list, so the visible set can shrink after the first render.
+// Re-resolving keeps the current section when it is still allowed and falls back otherwise.
+watch(visibleSections, () => {
+  activeSection.value = resolveSettingsSection(activeSection.value, isAdmin.value)
 })
 </script>


### PR DESCRIPTION
Closes #815. Also covers item 3 of #822.

## The bug

`BandSidebar.vue` only rendered the "Paramètres" entry when the role was admin, so a plain member had no link to it anywhere, on desktop or mobile.

Everything member-level lives behind that page, and every section is declared `adminOnly: false`, so the intent was clearly that members reach it: leaving the band space, the stage name and instruments dialog (which the tech rider needs), the roster, the activity log and the storage quota. `DangerZoneSection` even told non-admins to leave "depuis la section « Membres »", a section they could not open. The only ways in were accidental: the dashboard activity widget's "Tout voir" and the pending-deletion banner.

A member who wanted out of a band had to guess a URL.

## Why the fix is bigger than un-hiding a link

The page was not coherent for a member. The Members section rendered the invite form and the promote, demote and kick buttons to everyone, and the server refused each click with a red toast. The invitations list is admin-only, and it was fetched unconditionally, so every non-admin page load produced a guaranteed 403 as an unhandled promise rejection.

So this also gates those controls on the role and skips the invitations fetch for non-admins rather than catching its error after the fact. The same defect was present in `ActiveSharesSection`, whose revoke column rendered for members with no catch on the handler, so it is fixed too.

The section list and the role filtering moved into `constants/bandSpace.js` so they could be unit tested, since there is no Vue component test harness here. `resolveSettingsSection` also stops a member landing on an admin-only tab through a `?section=` deep link.

## Not a security change

This only changes what the client renders. Every admin action behind these controls is independently enforced server-side by the existing checkers, which was verified rather than assumed during review. The value here is that a member stops being offered actions that will be refused.

## Fixed during review

- the role filter read the frozen section constant directly, so the branch that hides an admin-only section could not be exercised by any test while nothing carries the flag. It now takes the sections as an argument and is tested with synthetic data, so an inverted predicate fails
- `isAdmin` was being computed identically in yet more places. It moved into `useBandSpaceNavigation`, which already owns the current space, for the files this change touches

## Tests

29 JS tests, lint and build clean. No backend change.
