### PR TITLE
fix(M-819): refetch the agenda with the viewed period after a mutation

### DIFF
--- a/assets/js/components/BandSpace/Agenda/AgendaEntryDrawer.vue
+++ b/assets/js/components/BandSpace/Agenda/AgendaEntryDrawer.vue
@@ -510,12 +510,12 @@ async function handleSubmit() {
   }
 
   try {
-    if (isEditMode.value) {
-      await agendaStore.updateEntry(props.bandSpaceId, props.agendaItem.source_id, payload)
-    } else {
-      await agendaStore.createEntry(props.bandSpaceId, payload)
-    }
-    emit('saved')
+    // The saved entry travels with the event: the view needs its dates to tell whether what was
+    // just saved is inside the period on screen.
+    const saved = isEditMode.value
+      ? await agendaStore.updateEntry(props.bandSpaceId, props.agendaItem.source_id, payload)
+      : await agendaStore.createEntry(props.bandSpaceId, payload)
+    emit('saved', saved)
     isVisible.value = false
   } catch (error) {
     if (error?.violationsByField) {

--- a/assets/js/store/bandSpace/bandSpaceAgenda.js
+++ b/assets/js/store/bandSpace/bandSpaceAgenda.js
@@ -5,15 +5,24 @@ import bandSpaceAgendaApi from '../../api/bandSpace/band-space-agenda.js'
 export const useBandAgendaStore = defineStore('bandAgenda', () => {
   const items = ref([])
   const isLoading = ref(false)
+  const isRefreshing = ref(false)
   const isSaving = ref(false)
   const isDeleting = ref(false)
   const loadError = ref(null)
 
   let requestId = 0
+  // The period the view last asked for. Calling fetchAgenda without one reuses it, so the refetch
+  // that follows every mutation reloads what the user is looking at. Letting the API fall back to
+  // its own window (today + 30 days) instead would wipe the items of a month the user navigated
+  // to, and the agenda would look empty even though the save went through.
+  let currentRange = { from: undefined, to: undefined }
 
-  async function fetchAgenda(bandSpaceId, { from, to } = {}) {
+  async function fetchAgenda(bandSpaceId, range) {
+    const { from, to } = range ?? currentRange
+    currentRange = { from, to }
     const currentRequestId = ++requestId
     isLoading.value = items.value.length === 0
+    isRefreshing.value = true
     loadError.value = null
     try {
       const data = await bandSpaceAgendaApi.getAgenda(bandSpaceId, { from, to })
@@ -25,6 +34,7 @@ export const useBandAgendaStore = defineStore('bandAgenda', () => {
     } finally {
       if (currentRequestId === requestId) {
         isLoading.value = false
+        isRefreshing.value = false
       }
     }
   }
@@ -84,11 +94,13 @@ export const useBandAgendaStore = defineStore('bandAgenda', () => {
   function clear() {
     items.value = []
     loadError.value = null
+    currentRange = { from: undefined, to: undefined }
   }
 
   return {
     items: readonly(items),
     isLoading: readonly(isLoading),
+    isRefreshing: readonly(isRefreshing),
     isSaving: readonly(isSaving),
     isDeleting: readonly(isDeleting),
     loadError: readonly(loadError),

--- a/assets/js/utils/agendaRange.js
+++ b/assets/js/utils/agendaRange.js
@@ -1,0 +1,87 @@
+import { endOfMonth, format, parseISO, startOfMonth } from 'date-fns'
+
+/**
+ * Which period the band space agenda has to show once an entry has been saved.
+ *
+ * This lives outside Agenda.vue because it is the rule that decides whether a save is visible:
+ * get it wrong and the agenda refreshes into a period that does not contain the entry, which
+ * reads as a failed save and gets the user to save again. It is pure date arithmetic, so it is
+ * unit tested without a browser (npm test).
+ */
+
+/** Anything that is not a usable date reads as null, so callers fall back instead of throwing. */
+function toDate(value) {
+  if (!value) return null
+  const date = typeof value === 'string' ? parseISO(value) : value
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null
+
+  return date
+}
+
+/** Local calendar day: the period is day granular, its bounds are 00:00:00 and 23:59:59. */
+function dayKey(date) {
+  return format(date, 'yyyy-MM-dd')
+}
+
+/**
+ * An all day entry is stored as UTC midnight whatever offset it was created with, so reading it
+ * back as an instant lands on the previous day for anyone west of UTC: Guadeloupe and Martinique
+ * are UTC-4, which makes that a real French user rather than a hypothetical one. The date portion
+ * is taken as written instead, the way a date only field like the recurrence horizon already is.
+ */
+function toCalendarDate(value, isAllDay) {
+  if (isAllDay && typeof value === 'string') {
+    return toDate(value.slice(0, 10))
+  }
+
+  return toDate(value)
+}
+
+/**
+ * The days an entry occupies: its start, stretched to the last day of a multi day event or of a
+ * recurring series. Takes the API shape of an agenda entry, so snake_case properties.
+ */
+function entrySpan(entry) {
+  const isAllDay = entry?.is_all_day === true
+  const start = toCalendarDate(entry?.event_datetime, isAllDay)
+  if (!start) return null
+
+  const ownEnd = toCalendarDate(entry?.end_datetime, isAllDay) ?? start
+
+  // Every occurrence keeps the duration of the first one, so a series runs past its horizon by
+  // however long a single occurrence lasts. Taking the horizon as the end would cut that tail off
+  // and report a Monday to Wednesday weekly event as gone two days before it actually is.
+  const horizon = toDate(entry?.recurrence_until_date)
+  const lastEnd = horizon
+    ? new Date(horizon.getTime() + (ownEnd.getTime() - start.getTime()))
+    : ownEnd
+  const end = lastEnd > ownEnd ? lastEnd : ownEnd
+
+  return { start, end: end < start ? start : end }
+}
+
+/**
+ * Whether any day of the entry is on screen. A weekly series that started in June is visible in
+ * September, so the whole span counts and not only the first occurrence.
+ */
+export function isEntryVisibleInRange(entry, from, to) {
+  const span = entrySpan(entry)
+  const rangeStart = toDate(from)
+  const rangeEnd = toDate(to)
+  if (!span || !rangeStart || !rangeEnd) return false
+
+  return dayKey(span.start) <= dayKey(rangeEnd) && dayKey(span.end) >= dayKey(rangeStart)
+}
+
+/**
+ * Where the agenda must point after a save, or null to stay put because the entry is already on
+ * screen. `focusDate` is the entry's own day rather than the month start, so the day and week
+ * views open on the entry instead of on the first of the month.
+ */
+export function agendaViewForSavedEntry(entry, from, to) {
+  const span = entrySpan(entry)
+  if (!span) return null
+  if (isEntryVisibleInRange(entry, from, to)) return null
+
+  return { from: startOfMonth(span.start), to: endOfMonth(span.start), focusDate: span.start }
+}

--- a/assets/js/utils/agendaRange.test.js
+++ b/assets/js/utils/agendaRange.test.js
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { agendaViewForSavedEntry, isEntryVisibleInRange } from './agendaRange.js'
+
+/**
+ * The rule that keeps a just saved event on screen. Datetimes are written without a UTC offset on
+ * purpose: parseISO then reads them as local time, so the assertions hold in whatever timezone the
+ * runner uses.
+ *
+ * Run with `npm test`.
+ */
+
+const SEPTEMBER_FROM = new Date(2026, 8, 1)
+const SEPTEMBER_TO = new Date(2026, 8, 30)
+
+/** An agenda entry as the API returns it, with every optional date explicitly absent. */
+function entry(fields) {
+  return { event_datetime: null, end_datetime: null, recurrence_until_date: null, ...fields }
+}
+
+describe('isEntryVisibleInRange', () => {
+  it('sees an entry starting inside the period', () => {
+    const saved = entry({ event_datetime: '2026-09-20T18:00:00' })
+
+    assert.equal(isEntryVisibleInRange(saved, SEPTEMBER_FROM, SEPTEMBER_TO), true)
+  })
+
+  // The period bounds are day granular, so an evening event on the last day is still inside it.
+  // A plain date comparison against a start of day bound would drop it.
+  it('sees an evening event on the last day of the period', () => {
+    const saved = entry({ event_datetime: '2026-09-30T23:30:00' })
+
+    assert.equal(isEntryVisibleInRange(saved, SEPTEMBER_FROM, SEPTEMBER_TO), true)
+  })
+
+  it('sees an event at the very start of the first day', () => {
+    const saved = entry({ event_datetime: '2026-09-01T00:00:00' })
+
+    assert.equal(isEntryVisibleInRange(saved, SEPTEMBER_FROM, SEPTEMBER_TO), true)
+  })
+
+  it('does not see the days just outside the period', () => {
+    const before = entry({ event_datetime: '2026-08-31T23:00:00' })
+    const after = entry({ event_datetime: '2026-10-01T08:00:00' })
+
+    assert.equal(isEntryVisibleInRange(before, SEPTEMBER_FROM, SEPTEMBER_TO), false)
+    assert.equal(isEntryVisibleInRange(after, SEPTEMBER_FROM, SEPTEMBER_TO), false)
+  })
+
+  it('sees a series that started before the period but still runs through it', () => {
+    const saved = entry({
+      event_datetime: '2026-06-01T20:00:00',
+      recurrence_until_date: '2026-12-31'
+    })
+
+    assert.equal(isEntryVisibleInRange(saved, SEPTEMBER_FROM, SEPTEMBER_TO), true)
+  })
+
+  it('does not see a series that ended before the period', () => {
+    const saved = entry({
+      event_datetime: '2026-01-05T20:00:00',
+      recurrence_until_date: '2026-03-31'
+    })
+
+    assert.equal(isEntryVisibleInRange(saved, SEPTEMBER_FROM, SEPTEMBER_TO), false)
+  })
+
+  it('sees a multi day event that only overlaps the start of the period', () => {
+    const saved = entry({
+      event_datetime: '2026-08-30T10:00:00',
+      end_datetime: '2026-09-02T18:00:00'
+    })
+
+    assert.equal(isEntryVisibleInRange(saved, SEPTEMBER_FROM, SEPTEMBER_TO), true)
+  })
+
+  it('sees nothing when the entry or the period has no usable date', () => {
+    const saved = entry({ event_datetime: '2026-09-20T18:00:00' })
+
+    assert.equal(isEntryVisibleInRange(entry({}), SEPTEMBER_FROM, SEPTEMBER_TO), false)
+    assert.equal(isEntryVisibleInRange(null, SEPTEMBER_FROM, SEPTEMBER_TO), false)
+    assert.equal(isEntryVisibleInRange(saved, null, SEPTEMBER_TO), false)
+    assert.equal(isEntryVisibleInRange(saved, SEPTEMBER_FROM, undefined), false)
+  })
+})
+
+describe('agendaViewForSavedEntry', () => {
+  it('keeps the period when the entry is already on screen', () => {
+    const saved = entry({ event_datetime: '2026-09-20T18:00:00' })
+
+    assert.equal(agendaViewForSavedEntry(saved, SEPTEMBER_FROM, SEPTEMBER_TO), null)
+  })
+
+  it('moves to the month of an entry saved after the period', () => {
+    const saved = entry({ event_datetime: '2026-10-20T18:30:00' })
+
+    assert.deepEqual(agendaViewForSavedEntry(saved, SEPTEMBER_FROM, SEPTEMBER_TO), {
+      from: new Date(2026, 9, 1),
+      to: new Date(2026, 9, 31, 23, 59, 59, 999),
+      // The entry's own day, so the day and week views open on it and not on the 1st.
+      focusDate: new Date(2026, 9, 20, 18, 30)
+    })
+  })
+
+  it('moves to the month of an entry saved before the period', () => {
+    const saved = entry({ event_datetime: '2026-07-04T09:00:00' })
+
+    assert.deepEqual(agendaViewForSavedEntry(saved, SEPTEMBER_FROM, SEPTEMBER_TO), {
+      from: new Date(2026, 6, 1),
+      to: new Date(2026, 6, 31, 23, 59, 59, 999),
+      focusDate: new Date(2026, 6, 4, 9, 0)
+    })
+  })
+
+  it('stays put when the saved response carries no date', () => {
+    assert.equal(agendaViewForSavedEntry(entry({}), SEPTEMBER_FROM, SEPTEMBER_TO), null)
+    assert.equal(agendaViewForSavedEntry(undefined, SEPTEMBER_FROM, SEPTEMBER_TO), null)
+  })
+})
+
+describe('entries that end after their first occurrence', () => {
+  it('keeps a recurring multi day series visible through its last occurrence', () => {
+    // Monday 20:00 to Wednesday 22:00, weekly until 30 November. The last occurrence still runs two
+    // days past that horizon, so a period opening on 1 December does contain it. Reading the
+    // horizon as the end would call it gone and jump the user away from a series they can see.
+    const series = entry({
+      event_datetime: '2026-09-07T20:00:00',
+      end_datetime: '2026-09-09T22:00:00',
+      recurrence_until_date: '2026-11-30'
+    })
+
+    assert.equal(isEntryVisibleInRange(series, new Date(2026, 11, 1), new Date(2026, 11, 31)), true)
+    assert.equal(
+      isEntryVisibleInRange(series, new Date(2026, 11, 3), new Date(2026, 11, 31)),
+      false
+    )
+  })
+
+  it('keeps a plain multi day event visible at the end of its span', () => {
+    const festival = entry({
+      event_datetime: '2026-09-28T10:00:00',
+      end_datetime: '2026-10-02T23:00:00'
+    })
+
+    assert.equal(isEntryVisibleInRange(festival, new Date(2026, 9, 1), new Date(2026, 9, 31)), true)
+  })
+})
+
+describe('all day entries, which the API pins to UTC midnight', () => {
+  // The one case that has to carry a real offset: the API normalises an all day entry to UTC
+  // midnight, so west of UTC an instant reading lands on the day before. Guadeloupe and Martinique
+  // are UTC-4 all year, so the wrong reading shows a French user the previous day.
+  const ALL_DAY_FIRST_OF_SEPTEMBER = entry({
+    event_datetime: '2026-09-01T00:00:00+00:00',
+    is_all_day: true
+  })
+
+  it('reads the day as written rather than shifting it west of UTC', () => {
+    assert.equal(
+      isEntryVisibleInRange(ALL_DAY_FIRST_OF_SEPTEMBER, SEPTEMBER_FROM, SEPTEMBER_TO),
+      true
+    )
+  })
+
+  it('does not jump away from a period that already shows the entry', () => {
+    assert.equal(
+      agendaViewForSavedEntry(ALL_DAY_FIRST_OF_SEPTEMBER, SEPTEMBER_FROM, SEPTEMBER_TO),
+      null
+    )
+  })
+})

--- a/assets/js/views/BandSpace/Agenda.vue
+++ b/assets/js/views/BandSpace/Agenda.vue
@@ -1,7 +1,17 @@
 <template>
   <div class="p-3 sm:p-4">
     <div class="flex items-center justify-between gap-2 mb-4">
-      <h1 class="text-xl sm:text-2xl font-bold">Agenda</h1>
+      <div class="flex items-center gap-2 min-w-0">
+        <h1 class="text-xl sm:text-2xl font-bold">Agenda</h1>
+        <span
+          v-if="isRefreshing"
+          role="status"
+          class="flex items-center gap-1.5 text-sm text-surface-500 dark:text-surface-400"
+        >
+          <i class="pi pi-spin pi-spinner text-xs" aria-hidden="true" />
+          Mise à jour…
+        </span>
+      </div>
       <Button
         icon="pi pi-plus"
         label="Nouvel événement"
@@ -57,126 +67,133 @@
       {{ agendaStore.loadError }}
     </div>
 
-    <template v-else-if="viewMode === 'list'">
-      <div
-        v-if="agendaStore.items.length === 0"
-        class="text-center text-surface-400 italic py-12"
-      >
-        Aucun événement à venir dans cette période
-      </div>
+    <div
+      v-else
+      class="transition-opacity"
+      :class="{ 'opacity-50': isRefreshing }"
+      :aria-busy="isRefreshing"
+    >
+      <template v-if="viewMode === 'list'">
+        <div
+          v-if="agendaStore.items.length === 0"
+          class="text-center text-surface-400 italic py-12"
+        >
+          Aucun événement à venir dans cette période
+        </div>
 
-      <div
-        v-else-if="filteredItems.length === 0"
-        class="text-center text-surface-400 italic py-12"
-      >
-        Aucun événement avec ces filtres
-      </div>
+        <div
+          v-else-if="filteredItems.length === 0"
+          class="text-center text-surface-400 italic py-12"
+        >
+          Aucun événement avec ces filtres
+        </div>
 
-      <div v-else>
-        <div v-for="group in groupedItems" :key="group.date" class="mb-6">
-          <div class="flex items-center gap-2 mb-2 px-2">
-            <span class="text-sm font-semibold text-surface-600 dark:text-surface-300">
-              {{ formatDateLabel(group.date) }}
-            </span>
-            <span class="text-xs text-surface-400">
-              {{ group.items.length }} événement{{ group.items.length > 1 ? 's' : '' }}
-            </span>
-          </div>
-          <div
-            class="bg-surface-0 dark:bg-surface-800 rounded-xl border border-surface-200 dark:border-surface-700 overflow-hidden"
-          >
-            <div
-              v-for="item in group.items"
-              :key="item.id"
-              class="flex items-start gap-3 p-3 border-l-4 border-b border-surface-200 dark:border-surface-700 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-100 dark:hover:bg-surface-700"
-              :class="sourceBorderClass(item.source)"
-              @click="handleItemClick(item)"
-            >
-              <span class="text-sm font-medium tabular-nums text-surface-600 dark:text-surface-300 flex-shrink-0 pt-0.5 whitespace-nowrap">
-                <template v-if="isAllDayItem(item)">
-                  <span class="italic text-xs">Toute la journée</span>
-                </template>
-                <template v-else>
-                  {{ formatTime(item.datetime) }}<template v-if="item.end_datetime"> → {{ formatTime(item.end_datetime) }}</template>
-                </template>
+        <div v-else>
+          <div v-for="group in groupedItems" :key="group.date" class="mb-6">
+            <div class="flex items-center gap-2 mb-2 px-2">
+              <span class="text-sm font-semibold text-surface-600 dark:text-surface-300">
+                {{ formatDateLabel(group.date) }}
               </span>
+              <span class="text-xs text-surface-400">
+                {{ group.items.length }} événement{{ group.items.length > 1 ? 's' : '' }}
+              </span>
+            </div>
+            <div
+              class="bg-surface-0 dark:bg-surface-800 rounded-xl border border-surface-200 dark:border-surface-700 overflow-hidden"
+            >
+              <div
+                v-for="item in group.items"
+                :key="item.id"
+                class="flex items-start gap-3 p-3 border-l-4 border-b border-surface-200 dark:border-surface-700 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-100 dark:hover:bg-surface-700"
+                :class="sourceBorderClass(item.source)"
+                @click="handleItemClick(item)"
+              >
+                <span class="text-sm font-medium tabular-nums text-surface-600 dark:text-surface-300 flex-shrink-0 pt-0.5 whitespace-nowrap">
+                  <template v-if="isAllDayItem(item)">
+                    <span class="italic text-xs">Toute la journée</span>
+                  </template>
+                  <template v-else>
+                    {{ formatTime(item.datetime) }}<template v-if="item.end_datetime"> → {{ formatTime(item.end_datetime) }}</template>
+                  </template>
+                </span>
 
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 flex-wrap">
-                  <span class="font-medium truncate">{{ item.title }}</span>
-                  <span
-                    class="text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0"
-                    :class="sourceBadgeClass(item.source)"
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <span class="font-medium truncate">{{ item.title }}</span>
+                    <span
+                      class="text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0"
+                      :class="sourceBadgeClass(item.source)"
+                    >
+                      {{ sourceLabel(item.source) }}
+                    </span>
+                  </div>
+
+                  <div
+                    v-if="item.description"
+                    class="text-sm text-surface-500 dark:text-surface-400 mt-0.5 line-clamp-2"
                   >
-                    {{ sourceLabel(item.source) }}
-                  </span>
-                </div>
+                    {{ item.description }}
+                  </div>
 
-                <div
-                  v-if="item.description"
-                  class="text-sm text-surface-500 dark:text-surface-400 mt-0.5 line-clamp-2"
-                >
-                  {{ item.description }}
-                </div>
+                  <div v-if="metadataLine(item)" class="text-xs text-surface-400 mt-1">
+                    {{ metadataLine(item) }}
+                  </div>
 
-                <div v-if="metadataLine(item)" class="text-xs text-surface-400 mt-1">
-                  {{ metadataLine(item) }}
-                </div>
-
-                <div
-                  v-if="item.source === 'task' && item.metadata?.assignees?.length"
-                  class="flex items-center gap-1 mt-1.5"
-                >
-                  <Avatar
-                    v-for="a in item.metadata.assignees.slice(0, 3)"
-                    :key="a.id"
-                    :username="a.username"
-                    :picture-url="a.profile_picture_url"
-                    size="sm"
-                  />
-                  <span
-                    v-if="item.metadata.assignees.length > 3"
-                    class="text-xs font-medium text-surface-500 dark:text-surface-400"
+                  <div
+                    v-if="item.source === 'task' && item.metadata?.assignees?.length"
+                    class="flex items-center gap-1 mt-1.5"
                   >
-                    +{{ item.metadata.assignees.length - 3 }}
-                  </span>
+                    <Avatar
+                      v-for="a in item.metadata.assignees.slice(0, 3)"
+                      :key="a.id"
+                      :username="a.username"
+                      :picture-url="a.profile_picture_url"
+                      size="sm"
+                    />
+                    <span
+                      v-if="item.metadata.assignees.length > 3"
+                      class="text-xs font-medium text-surface-500 dark:text-surface-400"
+                    >
+                      +{{ item.metadata.assignees.length - 3 }}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </template>
+      </template>
 
-    <div v-else class="overflow-x-auto">
-      <div
-        class="agenda-fc-theme bg-surface-0 dark:bg-surface-800 rounded-xl border border-surface-200 dark:border-surface-700 p-2 sm:p-4"
-        :class="{ 'min-w-[680px]': viewMode === 'timeGridWeek' }"
-      >
-        <FullCalendar :key="viewMode" :options="calendarOptions">
-          <template #eventContent="arg">
-            <AgendaEventChip :item="arg.event.extendedProps.item" :time-text="arg.timeText" :view-type="arg.view.type" />
-          </template>
-          <template #dayCellTopContent="arg">
-            <template v-if="arg.view.type === 'multiMonthYear'">
-              <span>{{ arg.dayNumberText }}</span>
-              <span
-                v-if="dayEventSources(arg.date).length"
-                class="agenda-year-dots"
-                role="img"
-                :aria-label="yearDotsLabel(dayEventSources(arg.date))"
-              >
-                <span
-                  v-for="(source, index) in dayEventSources(arg.date).slice(0, YEAR_DOT_LIMIT)"
-                  :key="`${source}-${index}`"
-                  class="agenda-year-dot"
-                  :style="{ backgroundColor: SOURCE_COLORS[source] }"
-                />
-              </span>
+      <div v-else class="overflow-x-auto">
+        <div
+          class="agenda-fc-theme bg-surface-0 dark:bg-surface-800 rounded-xl border border-surface-200 dark:border-surface-700 p-2 sm:p-4"
+          :class="{ 'min-w-[680px]': viewMode === 'timeGridWeek' }"
+        >
+          <FullCalendar :key="calendarKey" :options="calendarOptions">
+            <template #eventContent="arg">
+              <AgendaEventChip :item="arg.event.extendedProps.item" :time-text="arg.timeText" :view-type="arg.view.type" />
             </template>
-            <template v-else>{{ arg.dayNumberText }}</template>
-          </template>
-        </FullCalendar>
+            <template #dayCellTopContent="arg">
+              <template v-if="arg.view.type === 'multiMonthYear'">
+                <span>{{ arg.dayNumberText }}</span>
+                <span
+                  v-if="dayEventSources(arg.date).length"
+                  class="agenda-year-dots"
+                  role="img"
+                  :aria-label="yearDotsLabel(dayEventSources(arg.date))"
+                >
+                  <span
+                    v-for="(source, index) in dayEventSources(arg.date).slice(0, YEAR_DOT_LIMIT)"
+                    :key="`${source}-${index}`"
+                    class="agenda-year-dot"
+                    :style="{ backgroundColor: SOURCE_COLORS[source] }"
+                  />
+                </span>
+              </template>
+              <template v-else>{{ arg.dayNumberText }}</template>
+            </template>
+          </FullCalendar>
+        </div>
       </div>
     </div>
 
@@ -185,6 +202,7 @@
       :bandSpaceId="route.params.id"
       :agendaItem="dialogItem"
       :initialDatetime="dialogInitialDatetime"
+      @saved="handleEntrySaved"
     />
   </div>
 </template>
@@ -214,6 +232,7 @@ import {
 import { fr } from 'date-fns/locale'
 import Button from 'primevue/button'
 import ProgressSpinner from 'primevue/progressspinner'
+import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import DateRangePicker from '../../components/Admin/DateRangePicker.vue'
@@ -221,10 +240,12 @@ import AgendaEntryDrawer from '../../components/BandSpace/Agenda/AgendaEntryDraw
 import AgendaEventChip from '../../components/BandSpace/Agenda/AgendaEventChip.vue'
 import Avatar from '../../components/User/Avatar.vue'
 import { useBandAgendaStore } from '../../store/bandSpace/bandSpaceAgenda.js'
-import { formatDateCompactWithYear } from '../../utils/date.js'
+import { agendaViewForSavedEntry } from '../../utils/agendaRange.js'
+import { formatDateCompactWithYear, formatDateLong } from '../../utils/date.js'
 
 const route = useRoute()
 const router = useRouter()
+const toast = useToast()
 const agendaStore = useBandAgendaStore()
 // Wipe any previous space's items synchronously before the first render so
 // switching from /band/A/agenda to /band/B/agenda doesn't flash A's entries
@@ -245,6 +266,10 @@ const viewMode = ref('list')
 // When drilling from the year overview into a day, that day's view must open on the
 // clicked date rather than the current range start; null means "use dateFrom".
 const focusDate = ref(null)
+// The span the calendar grid actually displays, which is not the picked period: the grid pads
+// whole weeks and browsing months only ever widens the period. Saving an entry needs the honest
+// answer, otherwise the agenda stays on a month that does not contain what was just saved.
+const calendarSpan = ref(null)
 const viewModeOptions = [
   { key: 'list', label: 'Planning', icon: 'pi pi-list' },
   { key: 'timeGridDay', label: 'Jour', icon: 'pi pi-clock' },
@@ -342,6 +367,17 @@ const filteredItems = computed(() =>
   agendaStore.items.filter((item) => selectedSources.has(item.source))
 )
 
+// The list view has no grid, so there the picked period is what is on screen.
+const viewedRange = computed(() =>
+  viewMode.value === 'list' || calendarSpan.value === null
+    ? { from: dateFrom.value, to: dateTo.value }
+    : calendarSpan.value
+)
+
+// A reload triggered while entries are already displayed: they stay on screen, dimmed, rather
+// than being swapped out silently. The full spinner only covers the first load.
+const isRefreshing = computed(() => agendaStore.isRefreshing && !agendaStore.isLoading)
+
 const groupedItems = computed(() => {
   const groups = new Map()
   for (const item of filteredItems.value) {
@@ -423,6 +459,13 @@ const calendarEvents = computed(() =>
   }))
 )
 
+// FullCalendar reads initialDate at mount only, so the calendar is remounted whenever the agenda
+// has to jump elsewhere: drilling into a day from the year overview, or an entry saved outside
+// the displayed period.
+const calendarKey = computed(
+  () => `${viewMode.value}-${focusDate.value ? format(focusDate.value, 'yyyy-MM-dd') : ''}`
+)
+
 const calendarOptions = computed(() => ({
   plugins: [classicTheme, dayGridPlugin, timeGridPlugin, multiMonthPlugin, interactionPlugin],
   initialView: viewMode.value === 'list' ? 'dayGridMonth' : viewMode.value,
@@ -468,6 +511,26 @@ function handleDateRangeApply({ from, to }) {
   dateFrom.value = from
   dateTo.value = to
   fetchWithCurrentRange()
+}
+
+// An entry saved outside the displayed period would come back from the API but land in a period
+// nobody is looking at, and the agenda would look like the save failed. Move to the entry's month
+// instead, and say so, so it is never the user who has to guess where it went.
+function handleEntrySaved(savedEntry) {
+  const nextView = agendaViewForSavedEntry(savedEntry, viewedRange.value.from, viewedRange.value.to)
+  if (nextView === null) return
+
+  dateFrom.value = nextView.from
+  dateTo.value = nextView.to
+  focusDate.value = nextView.focusDate
+  fetchWithCurrentRange()
+
+  toast.add({
+    severity: 'success',
+    summary: 'Événement enregistré',
+    detail: `Il a lieu le ${formatDateLong(savedEntry.event_datetime)} : l'agenda affiche maintenant cette période.`,
+    life: 5000
+  })
 }
 
 function selectViewMode(key) {
@@ -539,6 +602,7 @@ function handleDateClick(info) {
 function handleDatesSet(arg) {
   const visibleStart = startOfDay(arg.start)
   const visibleEndInclusive = startOfDay(new Date(arg.end.getTime() - 1))
+  calendarSpan.value = { from: visibleStart, to: visibleEndInclusive }
 
   // The year overview spans a whole year; load it on its own without dragging the shared
   // date-range picker (and every other view's initialDate anchor) out to a Jan-Dec window.


### PR DESCRIPTION
Closes #819.

## The bug

Every mutation in the agenda store ended with a refetch that passed no period, so the API fell back to its default window of today plus 30 days.

Navigate to September, create "Concert le 20/09", save: the store replaced the items with the August window, the grid rendered empty and the list said "Aucun événement à venir dans cette période". The event existed, but the interface said otherwise, which gets a user to save again and produce duplicates. Deleting an occurrence while viewing a distant month did the same.

## The fix

The store remembers the period it was last asked for and reuses it when `fetchAgenda` is called without one. The five mutations were left exactly as they were.

This was chosen over having the drawer emit saved and deleted for the view to handle, because that needs every future mutation to remember to emit and the view to wire it up, so a sixth one would silently reintroduce the bug. With the store owning the period, a bare refetch is correct by construction. Switching band space resets it.

## Saving outside the visible period

The drawer now passes the saved entry back, and if none of its days are on screen the view moves to its month, opens on its own day so the day and week views land on the event rather than the 1st, and says so in a toast. Navigating silently would be almost as confusing as the empty grid this fixes.

Visibility is judged against the calendar grid span rather than the picked period, because the existing logic only ever widens the picked period, so it is a superset of what is actually displayed. Without that, saving a 20 September event while looking at the August grid would have passed the check and still shown nothing.

A refresh indicator was added too, since the list previously changed with no feedback at all.

## Fixed during review

Two genuine bugs in the new date helper, both caught before merge and both now covered by tests that fail against the previous version:

- **all-day entries shifted a day west of UTC.** The API pins them to UTC midnight, so reading them as an instant put them on the previous day for anyone at a negative offset. Guadeloupe and Martinique are UTC-4, so that is a French user seeing the wrong date and being jumped to the wrong month, which is the exact failure this PR exists to remove. The date portion is now read as written when the entry is all-day. The suite passes under Europe/Paris, UTC and America/New_York.
- **`recurrence_until_date` shadowed `end_datetime`.** Every occurrence keeps the duration of the first, so a Monday to Wednesday weekly series runs two days past its horizon. Taking the horizon as the end reported it gone early and triggered a spurious jump. The span now accounts for both.

## Left alone deliberately

The period only ever widens as you browse. That is a separate UX decision, not part of this bug, and the date picker's label is bound to the same values so it cannot disagree with what was fetched.

One redundant refetch remains on a save that triggers a jump: the store's own refetch resolves before the view sets the new period. Request sequencing already guarantees the last request wins, so it costs a round trip and nothing else. Worth revisiting if it shows up in practice.

## Tests

35 JS tests, run green under three timezones. Lint and build clean. No backend change.
