### PR TITLE
fix(M-810): keep the series anchor when editing a recurring occurrence

### DIFF
--- a/assets/js/components/BandSpace/Agenda/AgendaEntryDrawer.vue
+++ b/assets/js/components/BandSpace/Agenda/AgendaEntryDrawer.vue
@@ -16,6 +16,25 @@
         {{ formError }}
       </Message>
 
+      <!--
+        A recurring entry has no per-occurrence storage, so this form always edits the series. Say so
+        before anything is typed rather than after the fact, and name the series start: it is the one
+        thing the occurrence on screen does not reveal.
+      -->
+      <div
+        v-if="isSeriesOccurrence"
+        class="flex gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-100"
+      >
+        <i class="pi pi-info-circle mt-0.5 flex-shrink-0" aria-hidden="true" />
+        <div>
+          <p>
+            Cet événement fait partie d’une série&nbsp;: vos modifications s’appliqueront à toutes
+            les occurrences, passées comme futures.
+          </p>
+          <p class="mt-1">Début de la série&nbsp;: {{ seriesStartLabel }}.</p>
+        </div>
+      </div>
+
       <div class="flex flex-col gap-1">
         <label for="agenda-title" class="text-sm font-medium">
           Titre <span class="text-red-500">*</span>
@@ -59,6 +78,9 @@
         </div>
         <small v-if="fieldErrors.eventDatetime" class="text-red-500">
           {{ fieldErrors.eventDatetime }}
+        </small>
+        <small v-if="isSeriesOccurrence" class="text-surface-500 dark:text-surface-400">
+          Date de cette occurrence. La déplacer décale toute la série d’autant.
         </small>
       </div>
 
@@ -200,6 +222,41 @@
     </form>
   </Drawer>
 
+  <!--
+    Only shown for the two saves that restructure the series, so a typo fix stays a single click.
+    There is no scope choice to make: "cette occurrence seulement" would need a per-occurrence
+    override the model does not have, and offering it would mean writing the whole series anyway.
+  -->
+  <Dialog
+    v-model:visible="showSeriesSaveDialog"
+    modal
+    :header="seriesSaveDialog.header"
+    :style="{ width: '28rem' }"
+    :closable="!agendaStore.isSaving"
+  >
+    <p class="text-sm text-surface-700 dark:text-surface-200">
+      {{ seriesSaveDialog.message }}
+    </p>
+    <p class="text-sm text-surface-500 dark:text-surface-400 mt-2">
+      {{ seriesSaveDialog.detail }}
+    </p>
+    <template #footer>
+      <Button
+        label="Annuler"
+        severity="secondary"
+        text
+        :disabled="agendaStore.isSaving"
+        @click="showSeriesSaveDialog = false"
+      />
+      <Button
+        :label="seriesSaveDialog.acceptLabel"
+        :severity="seriesSaveDialog.acceptSeverity"
+        :loading="agendaStore.isSaving"
+        @click="confirmSeriesSave"
+      />
+    </template>
+  </Dialog>
+
   <Dialog
     v-model:visible="showDeleteScopeDialog"
     modal
@@ -252,7 +309,8 @@
 </template>
 
 <script setup>
-import { format } from 'date-fns'
+import { differenceInCalendarDays, format, parseISO } from 'date-fns'
+import { fr } from 'date-fns/locale'
 import Button from 'primevue/button'
 import Checkbox from 'primevue/checkbox'
 import DatePicker from 'primevue/datepicker'
@@ -267,6 +325,11 @@ import Textarea from 'primevue/textarea'
 import { useConfirm } from 'primevue/useconfirm'
 import { computed, nextTick, reactive, ref, watch } from 'vue'
 import { useBandAgendaStore } from '../../../store/bandSpace/bandSpaceAgenda.js'
+import {
+  agendaSeriesSubmission,
+  SERIES_IMPACT_NONE,
+  SERIES_IMPACT_RECURRENCE_REMOVED
+} from '../../../utils/agendaSeriesEdit.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -352,6 +415,36 @@ watch(
 
 const isEditMode = computed(() => props.agendaItem !== null && props.agendaItem.source === 'manual')
 
+// The agenda expands a series into occurrences that all share one `source_id`, so editing any of
+// them edits the series. `datetime` is the occurrence on screen, `series_start_datetime` the anchor
+// it was expanded from.
+const isSeriesOccurrence = computed(
+  () => isEditMode.value && props.agendaItem.metadata?.is_recurring_occurrence === true
+)
+const seriesAnchorStart = computed(() => toDate(props.agendaItem?.metadata?.series_start_datetime))
+const occurrenceStart = computed(() => toDate(props.agendaItem?.datetime))
+const seriesStartLabel = computed(() => formatEventMoment(seriesAnchorStart.value))
+
+/**
+ * An all day entry is pinned to UTC midnight whatever offset it was created with, so reading it back
+ * as an instant lands on the previous day west of UTC: Guadeloupe and Martinique are UTC-4, which
+ * makes that a real French user shown the wrong day and weekday for the series start. The date
+ * portion is taken as written instead, the way the agenda range helper already does it.
+ */
+function toDate(isoString) {
+  if (!isoString) return null
+  if (props.agendaItem?.is_all_day === true) return parseISO(isoString.slice(0, 10))
+
+  return new Date(isoString)
+}
+
+function formatEventMoment(date) {
+  if (!date) return ''
+  return form.isAllDay
+    ? format(date, 'EEEE d MMMM yyyy', { locale: fr })
+    : format(date, "EEEE d MMMM yyyy 'à' HH:mm", { locale: fr })
+}
+
 const eventTimeText = computed({
   get: () => (form.eventDatetime ? format(form.eventDatetime, 'HH:mm') : ''),
   set: (val) => {
@@ -421,6 +514,8 @@ watch(isVisible, (visible) => {
   fieldErrors.endDatetime = null
   fieldErrors.recurrenceUntilDate = null
   fieldErrors.recurrenceMonthlyMode = null
+  showSeriesSaveDialog.value = false
+  pendingSubmission.value = null
 
   skipShiftEnd = true
   if (props.agendaItem && props.agendaItem.source === 'manual') {
@@ -471,7 +566,13 @@ async function handleSubmit() {
       fieldErrors.recurrenceUntilDate = 'Veuillez spécifier une date de fin de récurrence.'
       return
     }
-    if (form.eventDatetime && form.recurrenceUntilDate < form.eventDatetime) {
+    // Calendar days, like the server-side rule: the horizon is a date at midnight, so comparing it
+    // as an instant rejects an evening event on the horizon day itself. That is the last occurrence
+    // of a series, and it would be the one occurrence nobody could edit.
+    if (
+      form.eventDatetime &&
+      differenceInCalendarDays(form.recurrenceUntilDate, form.eventDatetime) < 0
+    ) {
       fieldErrors.recurrenceUntilDate =
         'La date de fin doit être postérieure ou égale au premier événement.'
       return
@@ -482,21 +583,40 @@ async function handleSubmit() {
     }
   }
 
-  const serializeStart = () => {
-    if (!form.eventDatetime) return null
-    return form.isAllDay
-      ? format(form.eventDatetime, 'yyyy-MM-dd')
-      : form.eventDatetime.toISOString()
-  }
-  const serializeEnd = () => {
-    if (!form.endDatetime) return null
-    return form.isAllDay ? format(form.endDatetime, 'yyyy-MM-dd') : form.endDatetime.toISOString()
+  const submission = agendaSeriesSubmission({
+    anchorStart: seriesAnchorStart.value,
+    occurrenceStart: occurrenceStart.value,
+    formStart: form.eventDatetime,
+    formEnd: form.endDatetime,
+    isAllDay: form.isAllDay,
+    keepsRecurrence: form.recurrenceFrequency !== null
+  })
+
+  if (submission.impact === SERIES_IMPACT_NONE) {
+    await persistEntry(submission)
+    return
   }
 
+  // Moving the series or collapsing it touches occurrences the user is not looking at, so it is
+  // spelled out and confirmed first.
+  pendingSubmission.value = submission
+  showSeriesSaveDialog.value = true
+}
+
+function serializeDatetime(date) {
+  if (!date) return null
+  return form.isAllDay ? format(date, 'yyyy-MM-dd') : date.toISOString()
+}
+
+async function persistEntry(submission) {
   const payload = {
     title: form.title.trim(),
-    eventDatetime: serializeStart(),
-    endDatetime: serializeEnd(),
+    // A start of `undefined` means the occurrence on screen was not moved: leaving the key out of
+    // the merge patch is what keeps the series anchored where it is.
+    ...(submission.start === undefined
+      ? {}
+      : { eventDatetime: serializeDatetime(submission.start) }),
+    endDatetime: serializeDatetime(submission.end),
     isAllDay: form.isAllDay,
     location: form.location.trim() === '' ? null : form.location.trim(),
     description: form.description.trim() === '' ? null : form.description.trim(),
@@ -538,6 +658,39 @@ async function handleSubmit() {
     }
     formError.value = error?.message ?? 'Impossible d’enregistrer l’événement'
   }
+}
+
+const showSeriesSaveDialog = ref(false)
+const pendingSubmission = ref(null)
+
+const seriesSaveDialog = computed(() => {
+  const submission = pendingSubmission.value
+
+  if (submission?.impact === SERIES_IMPACT_RECURRENCE_REMOVED) {
+    return {
+      header: 'Supprimer la récurrence',
+      message: `Il ne restera qu’un seul événement, le ${formatEventMoment(submission.start)}.`,
+      detail: 'Toutes les autres occurrences de la série seront supprimées.',
+      acceptLabel: 'Supprimer la récurrence',
+      acceptSeverity: 'danger'
+    }
+  }
+
+  return {
+    header: 'Décaler toute la série',
+    message: `La série commencera le ${formatEventMoment(submission?.start)} au lieu du ${seriesStartLabel.value}.`,
+    detail: 'Toutes les occurrences seront décalées d’autant, y compris celles déjà passées.',
+    acceptLabel: 'Décaler la série',
+    acceptSeverity: null
+  }
+})
+
+async function confirmSeriesSave() {
+  if (pendingSubmission.value === null) return
+
+  // persistEntry reports its own failures in the drawer, so the dialog closes either way.
+  await persistEntry(pendingSubmission.value)
+  showSeriesSaveDialog.value = false
 }
 
 const showDeleteScopeDialog = ref(false)

--- a/assets/js/utils/agendaSeriesEdit.js
+++ b/assets/js/utils/agendaSeriesEdit.js
@@ -1,0 +1,97 @@
+import { addDays, differenceInCalendarDays } from 'date-fns'
+
+/**
+ * What a save from the agenda drawer must send when the drawer was opened on one occurrence of a
+ * recurring series.
+ *
+ * The agenda expands a series client-side: every occurrence carries the same `source_id`, so a
+ * PATCH from the 9 March occurrence writes onto the series itself. The drawer nevertheless shows
+ * 9 March, and sending that back as the series start moves the anchor from 5 January to 9 March,
+ * which deletes the January and February occurrences. Hence the two rules below.
+ *
+ * 1. The date field is the date of the occurrence on screen. Leaving it alone must leave the anchor
+ *    alone, so the start is left out of the request entirely: a merge patch without the key keeps
+ *    the stored value.
+ * 2. Moving it moves the whole series by the same amount, because there is no per-occurrence
+ *    override to write to (`AgendaEntryException` only records cancellations). Moving an occurrence
+ *    one day later turns a Monday series into a Tuesday series.
+ *
+ * Dropping the recurrence is the exception to rule 1: there is no series left to anchor, so the one
+ * remaining event keeps the date the drawer is showing.
+ */
+
+/** The save changes nothing beyond the fields it edits, so it needs no confirmation. */
+export const SERIES_IMPACT_NONE = 'none'
+/** Every occurrence moves, the past ones included. */
+export const SERIES_IMPACT_SHIFT = 'shift'
+/** The series collapses to a single event and the other occurrences go. */
+export const SERIES_IMPACT_RECURRENCE_REMOVED = 'recurrence_removed'
+
+function isDate(value) {
+  return value instanceof Date && !Number.isNaN(value.getTime())
+}
+
+/**
+ * An all-day entry is stored at UTC midnight and serialised back as a bare date, so only the
+ * calendar day counts. Shifting it by a millisecond delta is off by an hour whenever the anchor and
+ * the occurrence sit in different daylight saving periods, which lands the anchor on the wrong day.
+ * Counting calendar days holds in every timezone.
+ */
+function shiftDatetime(base, from, to, isAllDay) {
+  if (isAllDay) {
+    return addDays(base, differenceInCalendarDays(to, from))
+  }
+
+  return new Date(base.getTime() + (to.getTime() - from.getTime()))
+}
+
+function hasMoved(from, to, isAllDay) {
+  return isAllDay ? differenceInCalendarDays(to, from) !== 0 : to.getTime() !== from.getTime()
+}
+
+/**
+ * Which start and end a save must carry, and what the save does to the series.
+ *
+ * `anchorStart` is the series' stored start (`metadata.series_start_datetime`) and
+ * `occurrenceStart` the occurrence the drawer was opened on; both are absent for a one-off entry
+ * and for a creation, which then submit the form as typed.
+ *
+ * A `start` of `undefined` means "leave the key out of the request". Any other value, `null`
+ * included, is sent as is.
+ *
+ * @returns {{ start: Date|null|undefined, end: Date|null, impact: string }}
+ */
+export function agendaSeriesSubmission({
+  anchorStart,
+  occurrenceStart,
+  formStart,
+  formEnd,
+  isAllDay = false,
+  keepsRecurrence = false
+}) {
+  const asTyped = {
+    start: isDate(formStart) ? formStart : null,
+    end: isDate(formEnd) ? formEnd : null
+  }
+  const isSeriesOccurrence = isDate(anchorStart) && isDate(occurrenceStart)
+
+  if (!isSeriesOccurrence || !isDate(formStart)) {
+    return { ...asTyped, impact: SERIES_IMPACT_NONE }
+  }
+
+  // No series to anchor any more: the single event that remains keeps the date on screen, which is
+  // the occurrence the user was looking at when they turned the repetition off.
+  if (!keepsRecurrence) {
+    return { ...asTyped, impact: SERIES_IMPACT_RECURRENCE_REMOVED }
+  }
+
+  const moved = hasMoved(occurrenceStart, formStart, isAllDay)
+  const start = moved ? shiftDatetime(anchorStart, occurrenceStart, formStart, isAllDay) : undefined
+  // The end follows the start and keeps whatever duration the form shows, so editing only the end
+  // time restretches every occurrence without touching the anchor.
+  const end = isDate(formEnd)
+    ? shiftDatetime(start ?? anchorStart, formStart, formEnd, isAllDay)
+    : null
+
+  return { start, end, impact: moved ? SERIES_IMPACT_SHIFT : SERIES_IMPACT_NONE }
+}

--- a/assets/js/utils/agendaSeriesEdit.test.js
+++ b/assets/js/utils/agendaSeriesEdit.test.js
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  agendaSeriesSubmission,
+  SERIES_IMPACT_NONE,
+  SERIES_IMPACT_RECURRENCE_REMOVED,
+  SERIES_IMPACT_SHIFT
+} from './agendaSeriesEdit.js'
+
+/**
+ * The rule that keeps a recurring series intact when one of its occurrences is edited. Dates are
+ * built with local constructors so the assertions hold in whatever timezone the runner uses.
+ *
+ * Run with `npm test`.
+ */
+
+// Weekly rehearsal: anchored Monday 5 January 2026 at 20:00, opened on the 9 March occurrence.
+const ANCHOR_START = new Date(2026, 0, 5, 20, 0)
+const OCCURRENCE_START = new Date(2026, 2, 9, 20, 0)
+
+function series(overrides) {
+  return agendaSeriesSubmission({
+    anchorStart: ANCHOR_START,
+    occurrenceStart: OCCURRENCE_START,
+    formStart: OCCURRENCE_START,
+    formEnd: null,
+    isAllDay: false,
+    keepsRecurrence: true,
+    ...overrides
+  })
+}
+
+describe('editing an occurrence without touching its date', () => {
+  // The bug this whole module exists for: sending the occurrence back as the series start moved the
+  // anchor from 5 January to 9 March and dropped the nine occurrences before it.
+  it('leaves the start out of the request so the anchor survives a typo fix', () => {
+    const submission = series({})
+
+    assert.equal(submission.start, undefined)
+    assert.equal(submission.impact, SERIES_IMPACT_NONE)
+  })
+
+  it('leaves the start out even when the form is a distinct Date with the same instant', () => {
+    const submission = series({ formStart: new Date(OCCURRENCE_START.getTime()) })
+
+    assert.equal(submission.start, undefined)
+  })
+
+  it('restretches every occurrence when only the end time is edited', () => {
+    // 20:00 to 22:00 on screen, so the series must run 20:00 to 22:00 from its own anchor.
+    const submission = series({ formEnd: new Date(2026, 2, 9, 22, 0) })
+
+    assert.equal(submission.start, undefined)
+    assert.deepEqual(submission.end, new Date(2026, 0, 5, 22, 0))
+    assert.equal(submission.impact, SERIES_IMPACT_NONE)
+  })
+
+  it('clears the end when the form has none', () => {
+    const submission = series({ formEnd: null })
+
+    assert.equal(submission.end, null)
+  })
+})
+
+describe('moving the occurrence moves the whole series by the same amount', () => {
+  it('turns a Monday series into a Tuesday series', () => {
+    const submission = series({ formStart: new Date(2026, 2, 10, 20, 0) })
+
+    assert.deepEqual(submission.start, new Date(2026, 0, 6, 20, 0))
+    assert.equal(submission.impact, SERIES_IMPACT_SHIFT)
+  })
+
+  it('applies a time-only change to the anchor', () => {
+    const submission = series({ formStart: new Date(2026, 2, 9, 21, 30) })
+
+    assert.deepEqual(submission.start, new Date(2026, 0, 5, 21, 30))
+    assert.equal(submission.impact, SERIES_IMPACT_SHIFT)
+  })
+
+  it('moves the series backwards too', () => {
+    const submission = series({ formStart: new Date(2026, 2, 8, 20, 0) })
+
+    assert.deepEqual(submission.start, new Date(2026, 0, 4, 20, 0))
+  })
+
+  it('carries the end along with the moved start, duration intact', () => {
+    const submission = series({
+      formStart: new Date(2026, 2, 10, 20, 0),
+      formEnd: new Date(2026, 2, 10, 22, 0)
+    })
+
+    assert.deepEqual(submission.start, new Date(2026, 0, 6, 20, 0))
+    assert.deepEqual(submission.end, new Date(2026, 0, 6, 22, 0))
+  })
+
+  it('takes the new duration when the move and the end are edited together', () => {
+    const submission = series({
+      formStart: new Date(2026, 2, 10, 20, 0),
+      formEnd: new Date(2026, 2, 10, 23, 30)
+    })
+
+    assert.deepEqual(submission.end, new Date(2026, 0, 6, 23, 30))
+  })
+})
+
+describe('all-day series, which only the calendar day counts for', () => {
+  // Stored at UTC midnight, so the parsed occurrence sits at an offset that differs from the
+  // anchor's whenever the two fall in different daylight saving periods. A millisecond delta then
+  // reads as 22 or 23 hours and lands the anchor a day short; counting calendar days does not.
+  const ALL_DAY_ANCHOR = new Date(2026, 0, 5, 1, 0) // January, UTC+1 in Paris
+  const ALL_DAY_OCCURRENCE = new Date(2026, 6, 6, 2, 0) // July, UTC+2 in Paris
+
+  it('moves the anchor exactly one day when the occurrence moves one day', () => {
+    const submission = agendaSeriesSubmission({
+      anchorStart: ALL_DAY_ANCHOR,
+      occurrenceStart: ALL_DAY_OCCURRENCE,
+      // A date picker that resets the time to local midnight would make this 22 hours, not 24.
+      formStart: new Date(2026, 6, 7, 0, 0),
+      formEnd: null,
+      isAllDay: true,
+      keepsRecurrence: true
+    })
+
+    assert.equal(submission.impact, SERIES_IMPACT_SHIFT)
+    assert.equal(submission.start.getFullYear(), 2026)
+    assert.equal(submission.start.getMonth(), 0)
+    assert.equal(submission.start.getDate(), 6)
+  })
+
+  it('sees no move when only the time part differs from the stored occurrence', () => {
+    const submission = agendaSeriesSubmission({
+      anchorStart: ALL_DAY_ANCHOR,
+      occurrenceStart: ALL_DAY_OCCURRENCE,
+      formStart: new Date(2026, 6, 6, 0, 0),
+      formEnd: null,
+      isAllDay: true,
+      keepsRecurrence: true
+    })
+
+    assert.equal(submission.start, undefined)
+    assert.equal(submission.impact, SERIES_IMPACT_NONE)
+  })
+
+  it('keeps a multi-day span in days rather than in hours', () => {
+    const submission = agendaSeriesSubmission({
+      anchorStart: ALL_DAY_ANCHOR,
+      occurrenceStart: ALL_DAY_OCCURRENCE,
+      formStart: new Date(2026, 6, 6, 0, 0),
+      formEnd: new Date(2026, 6, 8, 0, 0),
+      isAllDay: true,
+      keepsRecurrence: true
+    })
+
+    assert.equal(submission.start, undefined)
+    assert.equal(submission.end.getMonth(), 0)
+    assert.equal(submission.end.getDate(), 7)
+  })
+})
+
+describe('turning the repetition off', () => {
+  it('keeps the single remaining event on the date the drawer is showing', () => {
+    const submission = series({ keepsRecurrence: false })
+
+    assert.deepEqual(submission.start, OCCURRENCE_START)
+    assert.equal(submission.impact, SERIES_IMPACT_RECURRENCE_REMOVED)
+  })
+
+  it('keeps an edited date rather than the occurrence it replaced', () => {
+    const formStart = new Date(2026, 2, 12, 18, 0)
+    const submission = series({ formStart, keepsRecurrence: false })
+
+    assert.deepEqual(submission.start, formStart)
+    assert.equal(submission.impact, SERIES_IMPACT_RECURRENCE_REMOVED)
+  })
+})
+
+describe('entries that are not an occurrence of a series', () => {
+  it('submits the form as typed for a one-off entry', () => {
+    const formStart = new Date(2026, 2, 9, 20, 0)
+    const submission = agendaSeriesSubmission({
+      anchorStart: null,
+      occurrenceStart: null,
+      formStart,
+      formEnd: null,
+      keepsRecurrence: false
+    })
+
+    assert.deepEqual(submission.start, formStart)
+    assert.equal(submission.end, null)
+    assert.equal(submission.impact, SERIES_IMPACT_NONE)
+  })
+
+  it('submits the form as typed when a one-off entry becomes a series', () => {
+    const formStart = new Date(2026, 2, 9, 20, 0)
+    const submission = agendaSeriesSubmission({
+      anchorStart: null,
+      occurrenceStart: null,
+      formStart,
+      formEnd: null,
+      keepsRecurrence: true
+    })
+
+    assert.deepEqual(submission.start, formStart)
+    assert.equal(submission.impact, SERIES_IMPACT_NONE)
+  })
+
+  it('sends a null start rather than omitting it when the form has no date', () => {
+    // Omitting it would turn a missing required field into a silent no-op instead of the
+    // validation error the form relies on.
+    const submission = agendaSeriesSubmission({
+      anchorStart: null,
+      occurrenceStart: null,
+      formStart: null,
+      formEnd: null,
+      keepsRecurrence: false
+    })
+
+    assert.equal(submission.start, null)
+    assert.equal(submission.impact, SERIES_IMPACT_NONE)
+  })
+
+  it('submits as typed when the series metadata is missing or unusable', () => {
+    const formStart = new Date(2026, 2, 9, 20, 0)
+
+    assert.deepEqual(
+      agendaSeriesSubmission({
+        anchorStart: new Date('nonsense'),
+        occurrenceStart: OCCURRENCE_START,
+        formStart,
+        formEnd: null,
+        keepsRecurrence: true
+      }).start,
+      formStart
+    )
+    assert.deepEqual(
+      agendaSeriesSubmission({
+        anchorStart: ANCHOR_START,
+        occurrenceStart: undefined,
+        formStart,
+        formEnd: null,
+        keepsRecurrence: true
+      }).start,
+      formStart
+    )
+  })
+})

--- a/src/Service/BandSpace/AgendaAggregator.php
+++ b/src/Service/BandSpace/AgendaAggregator.php
@@ -88,6 +88,14 @@ readonly class AgendaAggregator
             'recurrence_monthly_mode' => $entry->recurrenceMonthlyMode?->value,
             'recurrence_until_date' => $entry->recurrenceUntilDate?->format('Y-m-d'),
             'series_id' => $isRecurringOccurrence ? (string) $entry->id : null,
+            // The stored anchor, which an expanded occurrence otherwise hides: `datetime` above is
+            // the occurrence, and every occurrence carries the same `source_id`. The editor needs
+            // the anchor to move a whole series by however much the user moved the occurrence they
+            // opened, instead of writing that occurrence's date onto the anchor - which silently
+            // drops every occurrence before it.
+            'series_start_datetime' => $isRecurringOccurrence
+                ? $entry->eventDatetime->format(DateTimeInterface::ATOM)
+                : null,
         ];
 
         return $item;

--- a/tests/Api/BandSpace/Agenda/AgendaGetCollectionTest.php
+++ b/tests/Api/BandSpace/Agenda/AgendaGetCollectionTest.php
@@ -93,6 +93,7 @@ class AgendaGetCollectionTest extends ApiTestCase
                         'recurrence_monthly_mode' => null,
                         'recurrence_until_date' => null,
                         'series_id' => null,
+                        'series_start_datetime' => null,
                     ],
                 ],
                 [
@@ -462,6 +463,9 @@ class AgendaGetCollectionTest extends ApiTestCase
             'recurrence_monthly_mode' => null,
             'recurrence_until_date' => '2026-02-28',
             'series_id' => $entry->id,
+            // The anchor, which is before the requested window: the editor needs it to shift a
+            // series instead of writing an occurrence's date onto it.
+            'series_start_datetime' => '2026-01-04T18:00:00+00:00',
         ];
         $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
             $id = 'manual-' . $entry->id . '-' . $occKey;
@@ -534,6 +538,7 @@ class AgendaGetCollectionTest extends ApiTestCase
             'recurrence_monthly_mode' => 'by_weekday',
             'recurrence_until_date' => '2026-06-30',
             'series_id' => $entry->id,
+            'series_start_datetime' => '2026-01-05T19:00:00+00:00',
         ];
         $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
             $id = 'manual-' . $entry->id . '-' . $occKey;
@@ -606,6 +611,8 @@ class AgendaGetCollectionTest extends ApiTestCase
             'recurrence_monthly_mode' => null,
             'recurrence_until_date' => '2027-12-31',
             'series_id' => $entry->id,
+            // Always the stored anchor, never the clamped occurrence.
+            'series_start_datetime' => '2024-02-29T00:00:00+00:00',
         ];
         $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
             $id = 'manual-' . $entry->id . '-' . $occKey;
@@ -677,6 +684,7 @@ class AgendaGetCollectionTest extends ApiTestCase
             'recurrence_monthly_mode' => null,
             'recurrence_until_date' => '2026-01-25',
             'series_id' => $entry->id,
+            'series_start_datetime' => '2026-01-04T18:00:00+00:00',
         ];
         $member = function (string $occKey, string $datetime, string $endDatetime) use ($entry, $bandSpace, $metadata): array {
             $id = 'manual-' . $entry->id . '-' . $occKey;

--- a/tests/Api/BandSpace/AgendaEntry/AgendaEntryUpdateTest.php
+++ b/tests/Api/BandSpace/AgendaEntry/AgendaEntryUpdateTest.php
@@ -2,8 +2,12 @@
 
 namespace App\Tests\Api\BandSpace\AgendaEntry;
 
+use App\Entity\BandSpace\AgendaEntry;
 use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\AgendaEntryRepository;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Service\BandSpace\AgendaAggregator;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\AgendaEntryFactory;
@@ -367,6 +371,128 @@ class AgendaEntryUpdateTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_update_without_event_datetime_leaves_the_series_anchor_alone(): void
+    {
+        // Weekly rehearsal anchored Monday 5 January. Opening the 9 March occurrence to fix a typo
+        // used to PATCH that occurrence's date onto the series, moving the anchor to 9 March and
+        // dropping every January and February occurrence. The drawer now sends everything except
+        // the start, which is what this payload is.
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétiton hebdomadaire',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-01-05 20:00:00', new \DateTimeZone('UTC')),
+            'recurrenceFrequency' => \App\Enum\BandSpace\AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-06-30'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            [
+                'title' => 'Répétition hebdomadaire',
+                'endDatetime' => null,
+                'isAllDay' => false,
+                'location' => null,
+                'description' => null,
+                'recurrenceFrequency' => 'weekly',
+                'recurrenceUntilDate' => '2026-06-30',
+                'recurrenceMonthlyMode' => null,
+            ],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            '@type' => 'AgendaEntry',
+            'id' => $entry->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Répétition hebdomadaire',
+            'description' => null,
+            'location' => null,
+            'event_datetime' => '2026-01-05T20:00:00+00:00',
+            'end_datetime' => null,
+            'is_all_day' => false,
+            'recurrence_frequency' => 'weekly',
+            'recurrence_until_date' => '2026-06-30',
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        // Read the row back rather than trusting the response: the anchor is what the expansion
+        // runs from, and the entity held by the test is detached once the kernel reboots.
+        $persisted = self::getContainer()->get(AgendaEntryRepository::class)->find($entry->id);
+        $this->assertInstanceOf(AgendaEntry::class, $persisted);
+        $this->assertSame(
+            '2026-01-05T20:00:00+00:00',
+            $persisted->eventDatetime->format(\DateTimeInterface::ATOM),
+        );
+
+        // The processor records an activity for every field it actually writes, so a lone
+        // title_changed is a second, independent proof that the start was never touched.
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepo->findForResource($bandSpace, BandSpaceModule::Agenda, $entry->id);
+        $this->assertCount(1, $activities);
+        $this->assertSame('title_changed', $activities[0]->type);
+    }
+
+    public function test_update_title_only_keeps_the_occurrences_before_the_edited_one(): void
+    {
+        // Same series, seen from the agenda: the four January occurrences must survive a title edit
+        // made from a March one.
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétiton hebdomadaire',
+            'description' => null,
+            'location' => 'Studio',
+            'eventDatetime' => new DateTimeImmutable('2026-01-05 20:00:00', new \DateTimeZone('UTC')),
+            'recurrenceFrequency' => \App\Enum\BandSpace\AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-06-30'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            ['title' => 'Répétition hebdomadaire'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+        $this->assertResponseIsSuccessful();
+
+        // The expansion is read through the aggregator rather than through a second GET, because
+        // loginUser only holds for one request and the single call is spent on the PATCH above,
+        // which is the operation under test. The agenda endpoint itself is covered elsewhere.
+        $bandSpace = self::getContainer()->get(BandSpaceRepository::class)->find($bandSpace->id);
+        $occurrences = self::getContainer()->get(AgendaAggregator::class)->aggregate(
+            $bandSpace,
+            new DateTimeImmutable('2026-01-01', new \DateTimeZone('UTC')),
+            new DateTimeImmutable('2026-01-31 23:59:59', new \DateTimeZone('UTC')),
+        );
+
+        $this->assertSame(
+            ['2026-01-05T20:00:00+00:00', '2026-01-12T20:00:00+00:00', '2026-01-19T20:00:00+00:00', '2026-01-26T20:00:00+00:00'],
+            array_map(static fn($item): string => $item->datetime, $occurrences)
+        );
+        $this->assertSame(
+            ['Répétition hebdomadaire', 'Répétition hebdomadaire', 'Répétition hebdomadaire', 'Répétition hebdomadaire'],
+            array_map(static fn($item): string => $item->title, $occurrences)
+        );
     }
 
     public function test_update_only_recurrence_until_date_extends_existing_series(): void


### PR DESCRIPTION
Closes #810.

## The bug

Editing any occurrence of a recurring series silently deleted every earlier occurrence.

The drawer seeded its date field from the expanded occurrence, always sent `eventDatetime`, and PATCHed the series id. So opening the 9 March occurrence of a series anchored 5 January, fixing a typo in the title and saving moved the anchor to 9 March, and the January and February occurrences vanished for good. There was no scope prompt at all, while the delete flow in the same drawer has a full three way dialog.

## The fix

The backend PATCH was already partial-aware. The bug was entirely that the drawer always sent the date, so it now **omits the key** when the occurrence's date was not moved. Verified the processor keys its decision off the raw wire body, so an absent key genuinely means "do not touch".

## Scope model: the whole series, said up front

`AgendaEntryException` only records cancellations, so there is nowhere to store a per-occurrence override, and "this and following" would need a split that does not exist as a backend operation. That leaves exactly one scope that can be honoured, so a radio dialog offering three would be theatre.

Instead:
- a permanent notice while editing a series, naming the series start, which is the one fact an expanded occurrence never reveals
- a hint under the date field
- a confirm dialog only for the two changes that restructure the series: moving the date, or dropping the recurrence

## Editing the date shifts the series

Interpreted as a shift of the whole series by the delta, not as snapping the anchor onto the occurrence: moving the 9 March occurrence to 10 March turns a Monday series into a Tuesday series. The dialog names the resulting new start date before anything is saved. For all-day entries the shift is counted in calendar days rather than milliseconds, since those are stored at UTC midnight and anchor and occurrence can sit in different DST periods.

This needed the series anchor client-side, so `AgendaAggregator` now publishes `series_start_datetime` in the manual item metadata.

## Fixed during review

The helper reading those datetimes used the native `Date` constructor, which resolves a UTC-midnight all-day value through the local clock and lands a day early west of UTC. Guadeloupe and Martinique are UTC-4, so that is a real French user shown the wrong day and weekday for the series start. It now reads the date portion as written, the way the agenda range helper already does. Suite passes under Europe/Paris, UTC and America/New_York.

## Also

A client-side "until >= event" check compared instants against a midnight horizon, so it rejected an evening event on the horizon's last day, which is the final occurrence of every series. Now compares calendar days, matching the server validator exactly.

## Tests

67 agenda tests, full suite 2105, PHPStan level 8 clean, 78 JS tests including 18 new ones on the shift arithmetic.

One test reads the occurrence expansion through `AgendaAggregator` rather than a second HTTP GET: this project's `api` firewall is `stateless: true`, so only one authenticated request works per test method. I verified that empirically (re-login, `disableReboot` and a bearer JWT all fail) and there is no counter-example anywhere in `tests/Api`.

## Deployment note

Ship the frontend bundle with the backend. A stale bundle degrades to the previous behaviour rather than failing, since `series_start_datetime` is simply absent.
