### PR TITLE
fix(M-818): detach a file when the source it hangs on is deleted

### DIFF
--- a/assets/js/components/BandSpace/Files/AttachedFilesSection.vue
+++ b/assets/js/components/BandSpace/Files/AttachedFilesSection.vue
@@ -87,7 +87,7 @@ const props = defineProps({
   canAttach: { type: Boolean, default: true }
 })
 
-const emit = defineEmits(['attached', 'detached'])
+const emit = defineEmits(['attached', 'detached', 'count'])
 
 const router = useRouter()
 const confirm = useConfirm()
@@ -102,6 +102,14 @@ watch(
   () => {
     loadFiles()
   },
+  { immediate: true }
+)
+
+// Watched rather than emitted from loadFiles(): detaching splices the list in place without reloading,
+// and a parent warning "n fichiers seront détachés" has to follow every path, not just the reloads.
+watch(
+  () => attachedFiles.value.length,
+  (count) => emit('count', count),
   { immediate: true }
 )
 

--- a/assets/js/components/BandSpace/Files/FileActivityFeed.vue
+++ b/assets/js/components/BandSpace/Files/FileActivityFeed.vue
@@ -34,6 +34,25 @@ defineProps({
   activities: { type: Array, default: () => [] }
 })
 
+// Worded so they read correctly after « à » or « de » without contracting, which lets the attach,
+// detach and source_deleted sentences share one list.
+const SOURCE_NOUNS = {
+  task: 'la tâche',
+  finance: "l'entrée financière",
+  note: 'la note',
+  song: 'la chanson',
+  setlist: 'la setlist'
+}
+
+function sourceNoun(activity) {
+  return SOURCE_NOUNS[activity.payload?.source_type] ?? null
+}
+
+function quotedSourceLabel(activity) {
+  const label = activity.payload?.source_label
+  return label ? ` « ${label} »` : ''
+}
+
 const FILE_ACTIVITY_LABELS = {
   uploaded: () => 'a téléversé le fichier',
   archived: () => 'a archivé le fichier',
@@ -69,21 +88,18 @@ const FILE_ACTIVITY_LABELS = {
   share_revoked: () => 'a révoqué un lien de partage',
   public_accessed: () => 'le lien public a été consulté',
   attached: (a) => {
-    const type = a.payload?.source_type
-    const label = a.payload?.source_label
-    if (type === 'task')
-      return label ? `a attaché le fichier à la tâche ${label}` : 'a attaché le fichier à une tâche'
-    if (type === 'finance')
-      return label
-        ? `a attaché le fichier à l'entrée ${label}`
-        : 'a attaché le fichier à une entrée financière'
-    return 'a attaché le fichier'
+    const noun = sourceNoun(a)
+    return noun ? `a attaché le fichier à ${noun}${quotedSourceLabel(a)}` : 'a attaché le fichier'
   },
   detached: (a) => {
-    const type = a.payload?.source_type
-    if (type === 'task') return 'a détaché le fichier de la tâche'
-    if (type === 'finance') return "a détaché le fichier de l'entrée financière"
-    return 'a détaché le fichier'
+    const noun = sourceNoun(a)
+    return noun ? `a détaché le fichier de ${noun}${quotedSourceLabel(a)}` : 'a détaché le fichier'
+  },
+  // The file was released because its source was deleted, not because somebody detached it: saying so
+  // keeps the actor from being credited with an action they never took.
+  source_deleted: (a) => {
+    const noun = sourceNoun(a) ?? 'la ressource associée'
+    return `a supprimé ${noun}${quotedSourceLabel(a)}, le fichier a été détaché`
   }
 }
 

--- a/assets/js/components/BandSpace/Finance/FinanceDrawer.vue
+++ b/assets/js/components/BandSpace/Finance/FinanceDrawer.vue
@@ -165,6 +165,7 @@
           source-type="finance"
           :source-id="props.entry.id"
           :can-attach="canEditEntry"
+          @count="attachedFileCount = $event"
         />
       </div>
 
@@ -212,6 +213,7 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, nextTick, reactive, ref, watch } from 'vue'
 import { useBandSpaceFinanceStore } from '../../../store/bandSpace/bandSpaceFinance.js'
+import { attachedFilesNotice } from '../../../utils/attachedFilesNotice.js'
 import { centsToCurrency, currencyToCents } from '../../../utils/currency.js'
 import AttachedFilesSection from '../Files/AttachedFilesSection.vue'
 import SplitManager from './SplitManager.vue'
@@ -230,6 +232,7 @@ const toast = useToast()
 const financeStore = useBandSpaceFinanceStore()
 const splitManagerRef = ref(null)
 const formError = ref(null)
+const attachedFileCount = ref(0)
 
 const visibleModel = computed({
   get: () => props.visible,
@@ -478,7 +481,7 @@ async function handleSave() {
 
 function handleDelete() {
   confirm.require({
-    message: 'Es-tu sûr de vouloir supprimer cette entrée ?',
+    message: `Es-tu sûr de vouloir supprimer cette entrée ?${attachedFilesNotice(attachedFileCount.value)}`,
     header: 'Confirmer la suppression',
     icon: 'pi pi-exclamation-triangle',
     rejectLabel: 'Annuler',

--- a/assets/js/components/BandSpace/Task/TaskBulkActionBar.vue
+++ b/assets/js/components/BandSpace/Task/TaskBulkActionBar.vue
@@ -110,6 +110,7 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
 import { useBandTasksStore } from '../../../store/bandSpace/bandSpaceTasks.js'
+import { attachedFilesNotice } from '../../../utils/attachedFilesNotice.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -175,8 +176,11 @@ function handleAssignees() {
 
 function confirmDelete() {
   const count = tasksStore.selectedTaskIds.size
+  const attachedFileCount = tasksStore.tasks
+    .filter((task) => tasksStore.selectedTaskIds.has(task.id))
+    .reduce((total, task) => total + (task.file_count ?? 0), 0)
   confirm.require({
-    message: `Supprimer ${count} tâche${count > 1 ? 's' : ''} ? Cette action est irréversible.`,
+    message: `Supprimer ${count} tâche${count > 1 ? 's' : ''} ? Cette action est irréversible.${attachedFilesNotice(attachedFileCount)}`,
     header: 'Confirmer la suppression',
     icon: 'pi pi-exclamation-triangle',
     acceptLabel: 'Supprimer',

--- a/assets/js/components/BandSpace/Task/TaskDetail.vue
+++ b/assets/js/components/BandSpace/Task/TaskDetail.vue
@@ -224,6 +224,7 @@ import { useToast } from 'primevue/usetoast'
 import { computed, ref, watch } from 'vue'
 import bandSpaceTasksApi from '../../../api/bandSpace/band-space-tasks.js'
 import { useBandTasksStore } from '../../../store/bandSpace/bandSpaceTasks.js'
+import { attachedFilesNotice } from '../../../utils/attachedFilesNotice.js'
 import AttachedFilesSection from '../Files/AttachedFilesSection.vue'
 import TaskActivityFeed from './TaskActivityFeed.vue'
 import TaskCommentForm from './TaskCommentForm.vue'
@@ -469,7 +470,7 @@ async function handleUnarchive() {
 
 function handleDelete() {
   confirm.require({
-    message: 'Es-tu sûr de vouloir supprimer cette tâche ?',
+    message: `Es-tu sûr de vouloir supprimer cette tâche ?${attachedFilesNotice(task.value?.file_count)}`,
     header: 'Confirmer la suppression',
     icon: 'pi pi-exclamation-triangle',
     rejectLabel: 'Annuler',

--- a/assets/js/utils/attachedFilesNotice.js
+++ b/assets/js/utils/attachedFilesNotice.js
@@ -1,0 +1,19 @@
+/**
+ * The sentence appended to a delete confirmation when the task or entry being deleted has files
+ * attached to it.
+ *
+ * Deleting the source detaches its files but never deletes them: they stay in the library and keep
+ * counting against the band's quota. Saying so at the point of no return is the only way the member
+ * learns the space was not reclaimed.
+ *
+ * @param {number|null|undefined} count number of files attached to the source
+ * @returns {string} an empty string when there is nothing attached, so it can be concatenated blindly
+ */
+export function attachedFilesNotice(count) {
+  if (!count || count < 1) return ''
+  if (count === 1) {
+    return ' Le fichier attaché sera détaché mais restera dans Fichiers.'
+  }
+
+  return ` Les ${count} fichiers attachés seront détachés mais resteront dans Fichiers.`
+}

--- a/assets/js/utils/attachedFilesNotice.test.js
+++ b/assets/js/utils/attachedFilesNotice.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { attachedFilesNotice } from './attachedFilesNotice.js'
+
+/**
+ * The warning appended to a delete confirmation when the source being deleted holds files.
+ *
+ * Run with `npm test`.
+ */
+
+describe('attachedFilesNotice', () => {
+  it('says nothing when the source holds no file', () => {
+    assert.equal(attachedFilesNotice(0), '')
+  })
+
+  it('says nothing when the count is unknown', () => {
+    assert.equal(attachedFilesNotice(null), '')
+    assert.equal(attachedFilesNotice(undefined), '')
+  })
+
+  it('stays singular for a single file', () => {
+    assert.equal(
+      attachedFilesNotice(1),
+      ' Le fichier attaché sera détaché mais restera dans Fichiers.'
+    )
+  })
+
+  it('counts and pluralises beyond one file', () => {
+    assert.equal(
+      attachedFilesNotice(3),
+      ' Les 3 fichiers attachés seront détachés mais resteront dans Fichiers.'
+    )
+  })
+})

--- a/assets/js/views/BandSpace/Notes.vue
+++ b/assets/js/views/BandSpace/Notes.vue
@@ -185,7 +185,7 @@ async function handleReloadNote() {
 function handleDelete(noteId) {
   confirm.require({
     message:
-      'Êtes-vous sûr de vouloir supprimer cette note ? Les sous-notes seront également supprimées.',
+      'Êtes-vous sûr de vouloir supprimer cette note ? Les sous-notes seront également supprimées. Les images qui s’y trouvent resteront dans Fichiers.',
     header: 'Confirmer la suppression',
     icon: 'pi pi-exclamation-triangle',
     rejectLabel: 'Annuler',

--- a/src/Command/BandSpace/PruneOrphanFileAttachmentsCommand.php
+++ b/src/Command/BandSpace/PruneOrphanFileAttachmentsCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\BandSpace;
+
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Service\BandSpace\File\BandSpaceFileSourceTypes;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Clears the attachment rows left behind by sources deleted before #818 closed the leak.
+ *
+ * band_space_file_attachment.source_id has no foreign key, so until that fix every deleted task, note
+ * or finance entry left its attachments in place. An attachment nothing points at is not harmless: the
+ * file it names cannot be deleted (BandSpaceFileDeleteProcessor refuses to trash an attached file) and
+ * the detach endpoint that would release it answers 404, its source being gone. The file is stuck in
+ * the band's quota for good, and this command is the only way out for the rows already in that state.
+ *
+ * Only the attachment row goes. The file stays in the library, exactly as it does when a source is
+ * deleted today, and becomes deletable again through the normal flow.
+ *
+ * Safe to re-run: it deletes only what it finds orphaned at that moment, so a second run over a clean
+ * database deletes nothing. A soft-deleted source (an archived Song, Setlist or Task) still has its
+ * row and is therefore never treated as an orphan.
+ */
+#[AsCommand(
+    name: 'app:band-space:prune-orphan-attachments',
+    description: 'Delete band space file attachments whose task, note, finance entry, song or setlist no longer exists',
+)]
+class PruneOrphanFileAttachmentsCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly BandSpaceFileAttachmentRepository $attachmentRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would be deleted without deleting anything');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $isDryRun = (bool) $input->getOption('dry-run');
+        if ($isDryRun) {
+            $output->writeln('<comment>Dry run: nothing will be deleted</comment>');
+        }
+
+        $total = 0;
+
+        foreach (BandSpaceFileSourceTypes::ENTITY_BY_TYPE as $sourceType => $sourceEntityClass) {
+            $orphans = $this->attachmentRepository->findOrphansBySourceType($sourceType, $sourceEntityClass);
+            if ($orphans === []) {
+                continue;
+            }
+
+            $output->writeln(sprintf('  %s: %d orphan attachment(s)', $sourceType, count($orphans)));
+            $total += count($orphans);
+
+            if ($isDryRun) {
+                continue;
+            }
+
+            // No activity is recorded. These detachments happened whenever the source was deleted,
+            // possibly months ago and by a member who has since left; dating them today, in a feed the
+            // band reads as a timeline, would be a worse lie than saying nothing.
+            foreach ($orphans as $orphan) {
+                $this->entityManager->remove($orphan);
+            }
+            $this->entityManager->flush();
+        }
+
+        $output->writeln(sprintf(
+            '<info>%s %d orphan attachment(s)</info>',
+            $isDryRun ? 'Would delete' : 'Deleted',
+            $total,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Enum/BandSpace/BandSpaceFileActivityType.php
+++ b/src/Enum/BandSpace/BandSpaceFileActivityType.php
@@ -20,4 +20,10 @@ enum BandSpaceFileActivityType: string
     case PublicAccessed = 'public_accessed';
     case Attached = 'attached';
     case Detached = 'detached';
+    /**
+     * The file was detached because the task, note or finance entry it hung on was deleted, not because
+     * a member detached it. Distinct from Detached so the feed can say why the link disappeared instead
+     * of crediting the deleter with an action they never took.
+     */
+    case SourceDeleted = 'source_deleted';
 }

--- a/src/Procedure/BandSpace/TaskBulkDeleteProcedure.php
+++ b/src/Procedure/BandSpace/TaskBulkDeleteProcedure.php
@@ -7,6 +7,7 @@ use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\User;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\TaskRepository;
+use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -16,6 +17,7 @@ readonly class TaskBulkDeleteProcedure
     public function __construct(
         private EntityManagerInterface $entityManager,
         private TaskRepository $taskRepository,
+        private BandSpaceFileSourceDetacher $fileSourceDetacher,
     ) {
     }
 
@@ -43,7 +45,14 @@ readonly class TaskBulkDeleteProcedure
             }
         }
 
-        $this->entityManager->wrapInTransaction(function () use ($tasks): void {
+        $titlesByTaskId = [];
+        foreach ($tasks as $task) {
+            $titlesByTaskId[(string) $task->id] = $task->title;
+        }
+
+        $this->entityManager->wrapInTransaction(function () use ($bandSpace, $tasks, $titlesByTaskId, $user): void {
+            $this->fileSourceDetacher->detachDeletedSources($bandSpace, 'task', $titlesByTaskId, $user);
+
             foreach ($tasks as $task) {
                 $this->entityManager->remove($task);
             }

--- a/src/Repository/BandSpace/BandSpaceFileAttachmentRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileAttachmentRepository.php
@@ -83,6 +83,55 @@ class BandSpaceFileAttachmentRepository extends ServiceEntityRepository
     }
 
     /**
+     * Every attachment hanging on the given sources, file fetch-joined because the caller needs the file
+     * id of each row it is about to drop.
+     *
+     * @param string[] $sourceIds
+     *
+     * @return BandSpaceFileAttachment[]
+     */
+    public function findBySource(string $sourceType, array $sourceIds): array
+    {
+        if (count($sourceIds) === 0) {
+            return [];
+        }
+
+        return $this->createQueryBuilder('a')
+            ->addSelect('bsf')
+            ->innerJoin('a.bandSpaceFile', 'bsf')
+            ->where('a.sourceType = :sourceType')
+            ->andWhere('a.sourceId IN (:sourceIds)')
+            ->setParameter('sourceType', $sourceType)
+            ->setParameter('sourceIds', $sourceIds)
+            ->orderBy('a.attachedDatetime', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Attachments pointing at a source row that no longer exists.
+     *
+     * source_id carries no foreign key, so nothing at database level can tell these apart from live
+     * rows: the caller has to say which entity the ids were supposed to point at. A soft-deleted source
+     * (an archived Song, Setlist or Task) still has its row, so it is deliberately NOT an orphan here.
+     *
+     * @param class-string $sourceEntityClass
+     *
+     * @return BandSpaceFileAttachment[]
+     */
+    public function findOrphansBySourceType(string $sourceType, string $sourceEntityClass): array
+    {
+        return $this->getEntityManager()
+            ->createQuery(
+                'SELECT a FROM App\Entity\BandSpace\BandSpaceFileAttachment a
+                 WHERE a.sourceType = :sourceType
+                 AND NOT EXISTS (SELECT 1 FROM ' . $sourceEntityClass . ' source WHERE source.id = a.sourceId)'
+            )
+            ->setParameter('sourceType', $sourceType)
+            ->getResult();
+    }
+
+    /**
      * @param string[] $sourceIds
      *
      * @return array<string, int> source id => unique non-archived file count

--- a/src/Repository/BandSpace/BandSpaceNoteRepository.php
+++ b/src/Repository/BandSpace/BandSpaceNoteRepository.php
@@ -41,6 +41,43 @@ class BandSpaceNoteRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    /**
+     * The note plus every note underneath it, whatever the depth, as id => title.
+     *
+     * Deleting a note takes its whole subtree with it: band_space_note.parent_id is ON DELETE CASCADE,
+     * so the descendants vanish at database level without Doctrine ever loading them. Anything that has
+     * to clean up after those rows (their file attachments) needs the ids and titles beforehand.
+     *
+     * Raw SQL because a recursive CTE has no DQL equivalent; the alternative is one query per level.
+     *
+     * @return array<string, string>
+     */
+    public function findSelfAndDescendantTitles(BandSpaceNote $note): array
+    {
+        $sql = <<<'SQL'
+            WITH RECURSIVE descendants(id, title) AS (
+                SELECT id, title FROM band_space_note WHERE id = :rootId
+                UNION ALL
+                SELECT n.id, n.title
+                FROM band_space_note n
+                INNER JOIN descendants d ON n.parent_id = d.id
+            )
+            SELECT id, title FROM descendants
+        SQL;
+
+        $rows = $this->getEntityManager()->getConnection()->executeQuery(
+            $sql,
+            ['rootId' => (string) $note->id],
+        )->fetchAllAssociative();
+
+        $titles = [];
+        foreach ($rows as $row) {
+            $titles[(string) $row['id']] = (string) $row['title'];
+        }
+
+        return $titles;
+    }
+
     public function getNextPosition(BandSpace $bandSpace, ?BandSpaceNote $parent): int
     {
         $qb = $this->createQueryBuilder('n')

--- a/src/Repository/BandSpace/FinanceEntryRepository.php
+++ b/src/Repository/BandSpace/FinanceEntryRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository\BandSpace;
 
 use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\FinanceCategory;
 use App\Entity\BandSpace\FinanceEntry;
 use App\Entity\BandSpace\FinanceRecurrence;
 use App\Enum\BandSpace\FinanceEntryStatus;
@@ -259,26 +260,93 @@ class FinanceEntryRepository extends ServiceEntityRepository
     }
 
     /**
-     * Drops the entries a recurrence had already planned past a given date, used when the recurrence is
-     * switched off because the member it belongs to left the band.
+     * Id => label of the planned entries deletePlannedByRecurrence() would drop, same predicate.
+     *
+     * A projection, not a hydration: the only caller detaches the files hanging on those entries before
+     * the bulk delete removes them, and for that it needs an id and something to name the source with.
+     *
+     * @return array<string, string>
+     */
+    public function findPlannedLabelsByRecurrence(FinanceRecurrence $recurrence, ?\DateTimeInterface $after = null): array
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->select('e.id AS id', 'e.label AS label')
+            ->where('e.recurrence = :recurrence')
+            ->andWhere('e.status = :status')
+            ->setParameter('recurrence', $recurrence)
+            ->setParameter('status', FinanceEntryStatus::Planned);
+
+        if ($after instanceof \DateTimeInterface) {
+            $qb->andWhere('e.date > :after')->setParameter('after', $after);
+        }
+
+        $rows = $qb->getQuery()->getArrayResult();
+
+        $labels = [];
+        foreach ($rows as $row) {
+            $labels[(string) $row['id']] = (string) $row['label'];
+        }
+
+        return $labels;
+    }
+
+    /**
+     * Id => label of every entry filed under a category, whatever its status.
+     *
+     * `finance_entry.category_id` is `ON DELETE CASCADE` and `FinanceCategory` declares no inverse
+     * collection, so deleting a category takes its entries with it in the database without Doctrine
+     * ever loading them. The caller needs this list to detach the files hanging on those entries
+     * first, since nothing afterwards can name a source that no longer exists.
+     *
+     * @return array<string, string>
+     */
+    public function findLabelsByCategory(FinanceCategory $category): array
+    {
+        $rows = $this->createQueryBuilder('e')
+            ->select('e.id AS id', 'e.label AS label')
+            ->where('e.category = :category')
+            ->setParameter('category', $category)
+            ->getQuery()
+            ->getArrayResult();
+
+        $labels = [];
+        foreach ($rows as $row) {
+            $labels[(string) $row['id']] = (string) $row['label'];
+        }
+
+        return $labels;
+    }
+
+    /**
+     * Drops the entries a recurrence had already planned, either all of them (the recurrence itself is
+     * being deleted) or only those past a date (the recurrence was shortened, or switched off because
+     * the member it belongs to left the band).
      *
      * Deliberately a bulk DQL delete rather than an ORM remove(): a stopped recurrence can carry years
      * of planned rows and hydrating them only to delete them is pointless work. The consequence the
      * caller has to know about is that no lifecycle event fires and already-loaded FinanceEntry objects
      * stay in Doctrine's identity map, so anything re-reading them in the same process still sees them.
+     * The file attachments of those entries have no foreign key either, so the caller has to clear them
+     * itself, through BandSpaceFileSourceDetacher, before calling this.
      */
-    public function deleteFuturePlannedByRecurrence(FinanceRecurrence $recurrence, \DateTimeInterface $after): void
+    public function deletePlannedByRecurrence(FinanceRecurrence $recurrence, ?\DateTimeInterface $after = null): void
     {
-        $this->getEntityManager()
-            ->createQuery(
-                'DELETE FROM App\Entity\BandSpace\FinanceEntry e
-                 WHERE e.recurrence = :recurrence
-                 AND e.date > :after
-                 AND e.status = :status'
-            )
+        $dql = 'DELETE FROM App\Entity\BandSpace\FinanceEntry e
+                WHERE e.recurrence = :recurrence
+                AND e.status = :status';
+
+        if ($after instanceof \DateTimeInterface) {
+            $dql .= ' AND e.date > :after';
+        }
+
+        $query = $this->getEntityManager()->createQuery($dql)
             ->setParameter('recurrence', $recurrence)
-            ->setParameter('after', $after)
-            ->setParameter('status', FinanceEntryStatus::Planned)
-            ->execute();
+            ->setParameter('status', FinanceEntryStatus::Planned);
+
+        if ($after instanceof \DateTimeInterface) {
+            $query->setParameter('after', $after);
+        }
+
+        $query->execute();
     }
 }

--- a/src/Service/BandSpace/File/BandSpaceFileSourceDetacher.php
+++ b/src/Service/BandSpace/File/BandSpaceFileSourceDetacher.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace\File;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Cuts the file attachments of a source that is being hard-deleted (#818).
+ *
+ * band_space_file_attachment.source_id is polymorphic and carries no foreign key, so nothing cascades
+ * when a task, a note or a finance entry is removed. Left behind, the attachment row keeps the file
+ * pinned forever: BandSpaceFileDeleteProcessor refuses to trash an attached file, and the detach
+ * endpoint that would release it 404s because its source is gone. The file then eats quota for good.
+ *
+ * The file itself is deliberately kept. It is a first-class object of the library, with its own
+ * versions, tags, folder and share links, and it may hang on several sources at once; destroying it
+ * because one of them went away would be an unrequested deletion of somebody else's data. Instead it
+ * becomes a plain unattached file, visible under the "Manuel" source filter and deletable through the
+ * normal flow, and the band is told through a source_deleted entry in the file's activity feed.
+ *
+ * One implementation rather than one per delete processor: the rule (an attachment never outlives its
+ * source, and the file feed always says so) is the same everywhere, and a source that forgets to apply
+ * it produces a leak nothing in the application can undo.
+ */
+readonly class BandSpaceFileSourceDetacher
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceFileAttachmentRepository $attachmentRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+    ) {
+    }
+
+    /**
+     * Call this before the source rows go, while their labels can still be read. Nothing is flushed
+     * here: the removals join the caller's own unit of work so the source and its attachments disappear
+     * together, or not at all.
+     *
+     * @param array<string, string> $labelsBySourceId id of every source about to be deleted, mapped to
+     *                                                the name the activity feed should show for it
+     * @param User                  $actor            required, not optional: BandSpaceFileActivityBuilder
+     *                                                drops activities with no actor, so an anonymous
+     *                                                entry here would leave the band unaware the file
+     *                                                had been detached at all
+     */
+    public function detachDeletedSources(
+        BandSpace $bandSpace,
+        string $sourceType,
+        array $labelsBySourceId,
+        User $actor,
+    ): void {
+        if (count($labelsBySourceId) === 0) {
+            return;
+        }
+
+        $attachments = $this->attachmentRepository->findBySource($sourceType, array_keys($labelsBySourceId));
+        $now = new DateTime();
+
+        foreach ($attachments as $attachment) {
+            $file = $attachment->bandSpaceFile;
+            $sourceId = (string) $attachment->sourceId;
+
+            $this->entityManager->remove($attachment);
+            $file->updateDatetime = $now;
+
+            $this->activityRecorder->record(
+                $bandSpace,
+                BandSpaceModule::File,
+                BandSpaceFileActivityType::SourceDeleted,
+                resourceId: (string) $file->id,
+                actor: $actor,
+                payload: [
+                    'source_type' => $sourceType,
+                    'source_id' => $sourceId,
+                    'source_label' => $labelsBySourceId[$sourceId] ?? null,
+                ],
+            );
+        }
+    }
+}

--- a/src/Service/BandSpace/File/BandSpaceFileSourceTypes.php
+++ b/src/Service/BandSpace/File/BandSpaceFileSourceTypes.php
@@ -2,6 +2,12 @@
 
 namespace App\Service\BandSpace\File;
 
+use App\Entity\BandSpace\BandSpaceNote;
+use App\Entity\BandSpace\FinanceEntry;
+use App\Entity\BandSpace\Setlist;
+use App\Entity\BandSpace\Song;
+use App\Entity\BandSpace\Task;
+
 /**
  * Single source of truth for the BandSpaceFileAttachment.sourceType allowlist.
  * Referenced by both the generic upload processor (attachedSourceType field)
@@ -12,4 +18,22 @@ namespace App\Service\BandSpace\File;
 final class BandSpaceFileSourceTypes
 {
     public const array ALL = ['task', 'finance', 'note', 'song', 'setlist'];
+
+    /**
+     * The entity a sourceId points at, per source type. There is no foreign key on
+     * band_space_file_attachment.source_id (the column is polymorphic), so this map is the only thing
+     * that can tell app:band-space:prune-orphan-attachments which table to look the source up in.
+     *
+     * Must list exactly the same keys as ALL; the attribute-argument rules make it impossible to derive
+     * one from the other with array_keys().
+     *
+     * @var array<string, class-string>
+     */
+    public const array ENTITY_BY_TYPE = [
+        'task' => Task::class,
+        'finance' => FinanceEntry::class,
+        'note' => BandSpaceNote::class,
+        'song' => Song::class,
+        'setlist' => Setlist::class,
+    ];
 }

--- a/src/Service/BandSpace/PersonalRecurrenceDeactivator.php
+++ b/src/Service/BandSpace/PersonalRecurrenceDeactivator.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Service\BandSpace;
 
 use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\User;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
+use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use DateTime;
 
 /**
@@ -24,10 +26,16 @@ readonly class PersonalRecurrenceDeactivator
     public function __construct(
         private FinanceRecurrenceRepository $financeRecurrenceRepository,
         private FinanceEntryRepository $financeEntryRepository,
+        private BandSpaceFileSourceDetacher $fileSourceDetacher,
     ) {
     }
 
-    public function deactivateForMember(BandSpaceMembership $membership): void
+    /**
+     * @param User $actor whoever triggered the departure: the member themselves, or the admin who
+     *                    removed them. The file feed drops activities with no actor, so the detached
+     *                    files would go unreported without one.
+     */
+    public function deactivateForMember(BandSpaceMembership $membership, User $actor): void
     {
         $now = new DateTime();
 
@@ -35,7 +43,13 @@ readonly class PersonalRecurrenceDeactivator
             $recurrence->isActive = false;
             $recurrence->updateDatetime = new DateTime();
 
-            $this->financeEntryRepository->deleteFuturePlannedByRecurrence($recurrence, $now);
+            $this->fileSourceDetacher->detachDeletedSources(
+                $membership->bandSpace,
+                'finance',
+                $this->financeEntryRepository->findPlannedLabelsByRecurrence($recurrence, $now),
+                $actor,
+            );
+            $this->financeEntryRepository->deletePlannedByRecurrence($recurrence, $now);
         }
     }
 }

--- a/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
+++ b/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
@@ -92,7 +92,7 @@ readonly class WithdrawUserFromBandSpacesProcedure
         $membership->status = MembershipStatus::Left;
         $membership->leftDatetime = new DateTime();
 
-        $this->personalRecurrenceDeactivator->deactivateForMember($membership);
+        $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
 
         $this->bandSpaceActivityRecorder->record(
             bandSpace: $bandSpace,

--- a/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
@@ -54,23 +54,27 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
             throw new ConflictHttpException('Vous devez promouvoir un autre membre administrateur avant de quitter');
         }
 
-        $membership->status = MembershipStatus::Left;
-        $membership->leftDatetime = new DateTime();
+        // One transaction: deactivating the personal recurrences drops their planned entries through a
+        // bulk DQL delete that reaches the database immediately, while the membership and the files
+        // detached alongside it wait for the flush. Unwrapped, a flush that failed would leave the
+        // entries gone, their attachments orphaned and the member still in the band.
+        $this->entityManager->wrapInTransaction(function () use ($bandSpace, $membership, $user): void {
+            $membership->status = MembershipStatus::Left;
+            $membership->leftDatetime = new DateTime();
 
-        $this->personalRecurrenceDeactivator->deactivateForMember($membership);
+            $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
 
-        $this->bandSpaceActivityRecorder->record(
-            bandSpace: $bandSpace,
-            module: BandSpaceModule::Settings,
-            type: BandSpaceSettingsActivityType::MemberLeft,
-            resourceId: $user->id,
-            actor: $user,
-            payload: [
-                'target_user_id' => $user->id,
-                'target_username' => $user->username,
-            ],
-        );
-
-        $this->entityManager->flush();
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $bandSpace,
+                module: BandSpaceModule::Settings,
+                type: BandSpaceSettingsActivityType::MemberLeft,
+                resourceId: $user->id,
+                actor: $user,
+                payload: [
+                    'target_user_id' => $user->id,
+                    'target_username' => $user->username,
+                ],
+            );
+        });
     }
 }

--- a/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
@@ -60,24 +60,28 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
             throw new ConflictHttpException('Vous ne pouvez pas vous exclure vous-même. Utilisez la fonction "Quitter"');
         }
 
-        $membership->status = MembershipStatus::Kicked;
-        $membership->leftDatetime = new DateTime();
+        // One transaction: deactivating the personal recurrences drops their planned entries through a
+        // bulk DQL delete that reaches the database immediately, while the membership and the files
+        // detached alongside it wait for the flush. Unwrapped, a flush that failed would leave the
+        // entries gone, their attachments orphaned and the member still in the band.
+        $this->entityManager->wrapInTransaction(function () use ($bandSpace, $membership, $user): void {
+            $membership->status = MembershipStatus::Kicked;
+            $membership->leftDatetime = new DateTime();
 
-        $this->personalRecurrenceDeactivator->deactivateForMember($membership);
+            $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
 
-        $this->bandSpaceActivityRecorder->record(
-            bandSpace: $bandSpace,
-            module: BandSpaceModule::Settings,
-            type: BandSpaceSettingsActivityType::MemberRemoved,
-            resourceId: $membership->user->id,
-            actor: $user,
-            payload: [
-                'target_user_id' => $membership->user->id,
-                'target_username' => $membership->user->username,
-            ],
-        );
-
-        $this->entityManager->flush();
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $bandSpace,
+                module: BandSpaceModule::Settings,
+                type: BandSpaceSettingsActivityType::MemberRemoved,
+                resourceId: $membership->user->id,
+                actor: $user,
+                payload: [
+                    'target_user_id' => $membership->user->id,
+                    'target_username' => $membership->user->username,
+                ],
+            );
+        });
 
         // Best-effort notification dispatched after the commit (epic #689 contract).
         $this->eventDispatcher->dispatch(new BandSpaceMemberRemovedEvent($membership, $user));

--- a/src/State/Processor/BandSpace/BandSpaceNoteDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceNoteDeleteProcessor.php
@@ -11,6 +11,7 @@ use App\Enum\BandSpace\BandSpaceNoteActivityType;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -25,6 +26,7 @@ readonly class BandSpaceNoteDeleteProcessor implements ProcessorInterface
         private BandSpaceMemberChecker $memberChecker,
         private BandSpaceNoteRepository $bandSpaceNoteRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private BandSpaceFileSourceDetacher $fileSourceDetacher,
         private Security $security,
     ) {
     }
@@ -51,6 +53,15 @@ readonly class BandSpaceNoteDeleteProcessor implements ProcessorInterface
             resourceId: $note->id,
             actor: $user,
             payload: ['title' => $note->title],
+        );
+
+        // The sub-notes go too, by database cascade, and every image dropped in one of them is an
+        // attachment of that sub-note rather than of this one: the whole subtree has to be released.
+        $this->fileSourceDetacher->detachDeletedSources(
+            $bandSpace,
+            'note',
+            $this->bandSpaceNoteRepository->findSelfAndDescendantTitles($note),
+            $user,
         );
 
         $this->entityManager->remove($note);

--- a/src/State/Processor/BandSpace/FinanceCategoryDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceCategoryDeleteProcessor.php
@@ -9,8 +9,10 @@ use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceFinanceActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\FinanceCategoryRepository;
+use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Security\BandSpace\BandSpaceAdminChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -24,7 +26,9 @@ readonly class FinanceCategoryDeleteProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceAdminChecker $adminChecker,
         private FinanceCategoryRepository $financeCategoryRepository,
+        private FinanceEntryRepository $financeEntryRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private BandSpaceFileSourceDetacher $fileSourceDetacher,
         private Security $security,
     ) {
     }
@@ -51,6 +55,16 @@ readonly class FinanceCategoryDeleteProcessor implements ProcessorInterface
             resourceId: $category->id,
             actor: $user,
             payload: ['name' => $category->name],
+        );
+
+        // `finance_entry.category_id` is ON DELETE CASCADE and the category declares no inverse
+        // collection, so its entries go with it in the database without Doctrine ever loading them.
+        // Their files have to be detached first, while the entries can still be named.
+        $this->fileSourceDetacher->detachDeletedSources(
+            $bandSpace,
+            'finance',
+            $this->financeEntryRepository->findLabelsByCategory($category),
+            $user,
         );
 
         $this->entityManager->remove($category);

--- a/src/State/Processor/BandSpace/FinanceEntryDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntryDeleteProcessor.php
@@ -13,6 +13,7 @@ use App\Enum\BandSpace\FinanceEntryStatus;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -29,6 +30,7 @@ readonly class FinanceEntryDeleteProcessor implements ProcessorInterface
         private BandSpaceMemberChecker $memberChecker,
         private FinanceEntryRepository $financeEntryRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private BandSpaceFileSourceDetacher $fileSourceDetacher,
         private Security $security,
     ) {
     }
@@ -63,6 +65,13 @@ readonly class FinanceEntryDeleteProcessor implements ProcessorInterface
             resourceId: $entry->id,
             actor: $user,
             payload: ['label' => $entry->label, 'amount' => $entry->amount],
+        );
+
+        $this->fileSourceDetacher->detachDeletedSources(
+            $bandSpace,
+            'finance',
+            [(string) $entry->id => $entry->label],
+            $user,
         );
 
         $this->entityManager->remove($entry);

--- a/src/State/Processor/BandSpace/FinanceRecurrenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceDeleteProcessor.php
@@ -8,10 +8,11 @@ use App\ApiResource\BandSpace\Finance\FinanceRecurrenceResource;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceFinanceActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
-use App\Enum\BandSpace\FinanceEntryStatus;
+use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -25,7 +26,9 @@ readonly class FinanceRecurrenceDeleteProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private FinanceRecurrenceRepository $financeRecurrenceRepository,
+        private FinanceEntryRepository $financeEntryRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private BandSpaceFileSourceDetacher $fileSourceDetacher,
         private Security $security,
     ) {
     }
@@ -45,25 +48,29 @@ readonly class FinanceRecurrenceDeleteProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Récurrence introuvable');
         }
 
-        $this->entityManager->createQuery(
-            'DELETE FROM App\Entity\BandSpace\FinanceEntry e
-             WHERE e.recurrence = :recurrence
-             AND e.status = :status'
-        )
-            ->setParameter('recurrence', $recurrence)
-            ->setParameter('status', FinanceEntryStatus::Planned)
-            ->execute();
+        // One transaction, because the entries go out through a bulk DQL delete that reaches the
+        // database immediately while the detached attachments wait for the flush. Unwrapped, a flush
+        // that failed would leave the entries gone and their attachments behind, which is exactly the
+        // orphan this change exists to stop.
+        $this->entityManager->wrapInTransaction(function () use ($bandSpace, $recurrence, $user): void {
+            $this->fileSourceDetacher->detachDeletedSources(
+                $bandSpace,
+                'finance',
+                $this->financeEntryRepository->findPlannedLabelsByRecurrence($recurrence),
+                $user,
+            );
+            $this->financeEntryRepository->deletePlannedByRecurrence($recurrence);
 
-        $this->bandSpaceActivityRecorder->record(
-            bandSpace: $bandSpace,
-            module: BandSpaceModule::Finance,
-            type: BandSpaceFinanceActivityType::RecurrenceDeleted,
-            resourceId: $recurrence->id,
-            actor: $user,
-            payload: ['label' => $recurrence->label],
-        );
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $bandSpace,
+                module: BandSpaceModule::Finance,
+                type: BandSpaceFinanceActivityType::RecurrenceDeleted,
+                resourceId: $recurrence->id,
+                actor: $user,
+                payload: ['label' => $recurrence->label],
+            );
 
-        $this->entityManager->remove($recurrence);
-        $this->entityManager->flush();
+            $this->entityManager->remove($recurrence);
+        });
     }
 }

--- a/src/State/Processor/BandSpace/FinanceRecurrenceUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceUpdateProcessor.php
@@ -10,12 +10,13 @@ use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceFinanceActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\FinanceEntryScope;
-use App\Enum\BandSpace\FinanceEntryStatus;
 use App\Enum\BandSpace\FinanceEntryType;
 use App\Enum\BandSpace\RecurrenceInterval;
+use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use App\Service\BandSpace\RecurrenceEntryGenerator;
 use App\Service\Builder\BandSpace\FinanceRecurrenceBuilder;
 use DateTime;
@@ -33,9 +34,11 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private FinanceRecurrenceRepository $financeRecurrenceRepository,
+        private FinanceEntryRepository $financeEntryRepository,
         private FinanceRecurrenceBuilder $financeRecurrenceBuilder,
         private RecurrenceEntryGenerator $recurrenceEntryGenerator,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private BandSpaceFileSourceDetacher $fileSourceDetacher,
         private Security $security,
         private RequestStack $requestStack,
     ) {
@@ -89,56 +92,70 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
             $recurrence->isActive = $data->isActive;
         }
 
-        $endDateChanged = false;
-        $oldEndDateString = $recurrence->endDate->format('Y-m-d');
-        $newEndDateString = $oldEndDateString;
-        if (array_key_exists('end_date', $requestPayload)) {
-            $oldEndDate = $recurrence->endDate;
-            $newEndDate = new DateTime($data->endDate);
-
-            $recurrence->endDate = $newEndDate;
-            $newEndDateString = $newEndDate->format('Y-m-d');
-            $endDateChanged = $oldEndDateString !== $newEndDateString;
-
-            if ($newEndDate > $oldEndDate) {
-                $fromDate = $this->nextIntervalDate($oldEndDate, $recurrence->interval);
-                $member = $recurrence->scope === FinanceEntryScope::Personal ? $currentMembership : null;
-                $entries = $this->recurrenceEntryGenerator->generateEntries($recurrence, $member, $fromDate);
-
-                foreach ($entries as $entry) {
-                    $this->entityManager->persist($entry);
-                }
-            } elseif ($newEndDate < $oldEndDate) {
-                $this->entityManager->createQuery(
-                    'DELETE FROM App\Entity\BandSpace\FinanceEntry e
-                     WHERE e.recurrence = :recurrence
-                     AND e.date > :afterDate
-                     AND e.status = :status'
-                )
-                    ->setParameter('recurrence', $recurrence)
-                    ->setParameter('afterDate', $newEndDate)
-                    ->setParameter('status', FinanceEntryStatus::Planned)
-                    ->execute();
-            }
-        }
-
-        $recurrence->updateDatetime = new DateTime();
-
-        $this->recordChanges(
+        // From here to the flush runs in one transaction: shortening the end date drops the entries
+        // past it through a bulk DQL delete that reaches the database immediately, while the files
+        // detached alongside them wait for the flush. Unwrapped, a flush that failed would leave the
+        // entries gone and their attachments orphaned, which is the leak this change exists to stop.
+        $this->entityManager->wrapInTransaction(function () use (
             $recurrence,
+            $data,
+            $requestPayload,
+            $bandSpace,
             $user,
+            $currentMembership,
             $oldLabel,
             $oldType,
             $oldAmount,
             $oldScope,
             $oldInterval,
             $oldIsActive,
-            $endDateChanged,
-            $oldEndDateString,
-            $newEndDateString,
-        );
+        ): void {
+            $endDateChanged = false;
+            $oldEndDateString = $recurrence->endDate->format('Y-m-d');
+            $newEndDateString = $oldEndDateString;
+            if (array_key_exists('end_date', $requestPayload)) {
+                $oldEndDate = $recurrence->endDate;
+                $newEndDate = new DateTime($data->endDate);
 
-        $this->entityManager->flush();
+                $recurrence->endDate = $newEndDate;
+                $newEndDateString = $newEndDate->format('Y-m-d');
+                $endDateChanged = $oldEndDateString !== $newEndDateString;
+
+                if ($newEndDate > $oldEndDate) {
+                    $fromDate = $this->nextIntervalDate($oldEndDate, $recurrence->interval);
+                    $member = $recurrence->scope === FinanceEntryScope::Personal ? $currentMembership : null;
+                    $entries = $this->recurrenceEntryGenerator->generateEntries($recurrence, $member, $fromDate);
+
+                    foreach ($entries as $entry) {
+                        $this->entityManager->persist($entry);
+                    }
+                } elseif ($newEndDate < $oldEndDate) {
+                    $this->fileSourceDetacher->detachDeletedSources(
+                        $bandSpace,
+                        'finance',
+                        $this->financeEntryRepository->findPlannedLabelsByRecurrence($recurrence, $newEndDate),
+                        $user,
+                    );
+                    $this->financeEntryRepository->deletePlannedByRecurrence($recurrence, $newEndDate);
+                }
+            }
+
+            $recurrence->updateDatetime = new DateTime();
+
+            $this->recordChanges(
+                $recurrence,
+                $user,
+                $oldLabel,
+                $oldType,
+                $oldAmount,
+                $oldScope,
+                $oldInterval,
+                $oldIsActive,
+                $endDateChanged,
+                $oldEndDateString,
+                $newEndDateString,
+            );
+        });
 
         return $this->financeRecurrenceBuilder->buildItem($recurrence);
     }

--- a/src/State/Processor/BandSpace/TaskDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/TaskDeleteProcessor.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\TaskRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -23,6 +24,7 @@ readonly class TaskDeleteProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private TaskRepository $taskRepository,
+        private BandSpaceFileSourceDetacher $fileSourceDetacher,
         private Security $security,
     ) {
     }
@@ -48,6 +50,13 @@ readonly class TaskDeleteProcessor implements ProcessorInterface
         if (!$isCreator && $membership->role !== Role::Admin) {
             throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut supprimer cette tâche');
         }
+
+        $this->fileSourceDetacher->detachDeletedSources(
+            $membership->bandSpace,
+            'task',
+            [(string) $task->id => $task->title],
+            $user,
+        );
 
         $this->entityManager->remove($task);
         $this->entityManager->flush();

--- a/tests/Api/BandSpace/BandSpaceNoteDeleteTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteDeleteTest.php
@@ -6,15 +6,20 @@ namespace App\Tests\Api\BandSpace;
 
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\BandSpaceNoteFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileAttachmentFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
 use App\Tests\Factory\User\UserFactory;
 use App\Enum\BandSpace\MembershipStatus;
 use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -81,6 +86,108 @@ class BandSpaceNoteDeleteTest extends ApiTestCase
         $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
         $this->assertNull($noteRepository->find($parentNoteId));
         $this->assertNull($noteRepository->find($childId));
+    }
+
+    public function test_delete_note_detaches_its_files_and_leaves_them_deletable(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Répétition'])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $attachment = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file,
+            'sourceType' => 'note',
+            'sourceId' => Uuid::fromString((string) $note->id),
+            'attachedBy' => $user,
+        ]);
+        $noteId = (string) $note->id;
+        $fileId = (string) $file->id;
+        $attachmentId = (string) $attachment->id;
+
+        $this->client->loginUser($user);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $noteId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $attachmentRepository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNull($attachmentRepository->find($attachmentId));
+
+        $fileRepository = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNotNull($fileRepository->find($fileId));
+        $this->assertNull($fileRepository->find($fileId)->archiveDatetime);
+
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::File, $fileId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('source_deleted', $activities[0]->type);
+        $this->assertSame([
+            'source_type' => 'note',
+            'source_id' => $noteId,
+            'source_label' => 'Répétition',
+        ], $activities[0]->payload);
+
+        // The regression this test exists for. BandSpaceFileDeleteProcessor refuses with a 422 while
+        // findByFile returns anything, and that used to be permanent: the detach endpoint 404s once
+        // the source is gone, so no call could ever release the file. The endpoint is not exercised
+        // here because the stateless api firewall allows one authenticated request per test and it
+        // went to the deletion above, so the guard's own query stands in for it.
+        $this->assertSame([], $attachmentRepository->findByFile($fileRepository->find($fileId)));
+    }
+
+    public function test_delete_note_detaches_the_files_of_its_descendants(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $parent = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Tournée'])->create();
+        $child = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Paris', 'parent' => $parent])->create();
+        $grandChild = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Backline', 'parent' => $child])->create();
+
+        $childFile = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $grandChildFile = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+
+        $childAttachment = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $childFile,
+            'sourceType' => 'note',
+            'sourceId' => Uuid::fromString((string) $child->id),
+            'attachedBy' => $user,
+        ]);
+        $grandChildAttachment = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $grandChildFile,
+            'sourceType' => 'note',
+            'sourceId' => Uuid::fromString((string) $grandChild->id),
+            'attachedBy' => $user,
+        ]);
+
+        $childAttachmentId = (string) $childAttachment->id;
+        $grandChildAttachmentId = (string) $grandChildAttachment->id;
+        $grandChildFileId = (string) $grandChildFile->id;
+        $grandChildId = (string) $grandChild->id;
+
+        $this->client->loginUser($user);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $parent->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $attachmentRepository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNull($attachmentRepository->find($childAttachmentId));
+        $this->assertNull($attachmentRepository->find($grandChildAttachmentId));
+
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::File, $grandChildFileId);
+        $this->assertCount(1, $activities);
+        $this->assertSame([
+            'source_type' => 'note',
+            'source_id' => $grandChildId,
+            'source_label' => 'Backline',
+        ], $activities[0]->payload);
     }
 
     public function test_delete_not_found(): void

--- a/tests/Api/BandSpace/Finance/FinanceCategoryDeleteTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceCategoryDeleteTest.php
@@ -5,15 +5,24 @@ declare(strict_types=1);
 namespace App\Tests\Api\BandSpace\Finance;
 
 use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\FinanceEntryScope;
+use App\Enum\BandSpace\FinanceEntryStatus;
+use App\Enum\BandSpace\FinanceEntryType;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\FinanceCategoryRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileAttachmentFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
 use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
+use App\Tests\Factory\BandSpace\FinanceEntryFactory;
 use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\Uid\Uuid;
 use App\Enum\BandSpace\MembershipStatus;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -52,6 +61,58 @@ class FinanceCategoryDeleteTest extends ApiTestCase
         $this->assertCount(1, $activities);
         $this->assertSame('category_deleted', $activities[0]->type);
         $this->assertSame(['name' => 'To Delete'], $activities[0]->payload);
+    }
+
+    /**
+     * `finance_entry.category_id` is ON DELETE CASCADE and the category holds no inverse collection,
+     * so its entries vanish in the database without Doctrine ever loading them. Their attachments
+     * have to go too: an attachment naming an entry that no longer exists locks its file forever,
+     * because the delete endpoint refuses an attached file and the detach endpoint 404s.
+     */
+    public function test_delete_category_detaches_the_files_of_the_entries_it_cascades(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio'])->create();
+        $entry = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Mixage',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Paid,
+            'scope' => FinanceEntryScope::Band,
+            'amount' => 12000,
+            'date' => new \DateTime('2026-03-01'),
+        ])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin])->create();
+        $attachment = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file,
+            'sourceType' => 'finance',
+            'sourceId' => Uuid::fromString((string) $entry->id),
+            'attachedBy' => $admin,
+        ]);
+
+        $categoryId = (string) $category->id;
+        $fileId = (string) $file->id;
+        $attachmentId = (string) $attachment->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/categories/' . $categoryId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $attachmentRepository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNull($attachmentRepository->find($attachmentId));
+
+        $fileRepository = self::getContainer()->get(BandSpaceFileRepository::class);
+        $reloadedFile = $fileRepository->find($fileId);
+        $this->assertNotNull($reloadedFile, 'The file outlives the category: it belongs to the library');
+        $this->assertNull($reloadedFile->archiveDatetime);
+
+        // The condition BandSpaceFileDeleteProcessor guards on: anything here and the file is stuck.
+        $this->assertSame([], $attachmentRepository->findByFile($reloadedFile));
     }
 
     public function test_delete_category_as_non_admin_member_returns_403(): void

--- a/tests/Api/BandSpace/Finance/FinanceEntryDeleteTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceEntryDeleteTest.php
@@ -9,16 +9,21 @@ use App\Enum\BandSpace\FinanceEntryScope;
 use App\Enum\BandSpace\FinanceEntryStatus;
 use App\Enum\BandSpace\FinanceEntryType;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileAttachmentFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
 use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
 use App\Tests\Factory\BandSpace\FinanceEntryFactory;
 use App\Tests\Factory\User\UserFactory;
 use App\Enum\BandSpace\MembershipStatus;
 use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -67,6 +72,70 @@ class FinanceEntryDeleteTest extends ApiTestCase
         $this->assertCount(1, $activities);
         $this->assertSame('entry_deleted', $activities[0]->type);
         $this->assertSame(['label' => 'Mixage', 'amount' => 50000], $activities[0]->payload);
+    }
+
+    public function test_delete_entry_detaches_its_files_and_leaves_them_deletable(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $category = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Studio',
+            'position' => 0,
+        ])->create();
+
+        $entry = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Mixage',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Band,
+            'amount' => 50000,
+        ])->create();
+
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $attachment = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file,
+            'sourceType' => 'finance',
+            'sourceId' => Uuid::fromString((string) $entry->id),
+            'attachedBy' => $user,
+        ]);
+        $entryId = (string) $entry->id;
+        $fileId = (string) $file->id;
+        $attachmentId = (string) $attachment->id;
+
+        $this->client->loginUser($user);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entryId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $attachmentRepository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNull($attachmentRepository->find($attachmentId));
+
+        $fileRepository = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNotNull($fileRepository->find($fileId));
+        $this->assertNull($fileRepository->find($fileId)->archiveDatetime);
+
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::File, $fileId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('source_deleted', $activities[0]->type);
+        $this->assertSame([
+            'source_type' => 'finance',
+            'source_id' => $entryId,
+            'source_label' => 'Mixage',
+        ], $activities[0]->payload);
+
+        // The regression this test exists for. BandSpaceFileDeleteProcessor refuses with a 422 while
+        // findByFile returns anything, and that used to be permanent: the detach endpoint 404s once
+        // the source is gone, so no call could ever release the file. The endpoint is not exercised
+        // here because the stateless api firewall allows one authenticated request per test and it
+        // went to the deletion above, so the guard's own query stands in for it.
+        $this->assertSame([], $attachmentRepository->findByFile($fileRepository->find($fileId)));
     }
 
     public function test_delete_entry_not_member(): void

--- a/tests/Api/BandSpace/Task/TaskBulkDeleteTest.php
+++ b/tests/Api/BandSpace/Task/TaskBulkDeleteTest.php
@@ -3,13 +3,18 @@
 namespace App\Tests\Api\BandSpace\Task;
 
 use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\TaskRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileAttachmentFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
 use App\Tests\Factory\BandSpace\TaskFactory;
 use App\Tests\Factory\User\UserFactory;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -68,6 +73,64 @@ class TaskBulkDeleteTest extends ApiTestCase
         self::getContainer()->get('doctrine')->getManager()->clear();
         $repo = self::getContainer()->get(TaskRepository::class);
         $this->assertNull($repo->find($taskId));
+    }
+
+    public function test_bulk_delete_detaches_the_files_of_every_deleted_task(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $task1 = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $task2 = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $keptTask = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+
+        $file1 = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $file2 = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $keptFile = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+
+        $attachment1 = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file1,
+            'sourceType' => 'task',
+            'sourceId' => Uuid::fromString((string) $task1->id),
+            'attachedBy' => $user,
+        ]);
+        $attachment2 = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file2,
+            'sourceType' => 'task',
+            'sourceId' => Uuid::fromString((string) $task2->id),
+            'attachedBy' => $user,
+        ]);
+        $keptAttachment = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $keptFile,
+            'sourceType' => 'task',
+            'sourceId' => Uuid::fromString((string) $keptTask->id),
+            'attachedBy' => $user,
+        ]);
+
+        $attachment1Id = (string) $attachment1->id;
+        $attachment2Id = (string) $attachment2->id;
+        $keptAttachmentId = (string) $keptAttachment->id;
+        $file1Id = (string) $file1->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/bulk_delete',
+            ['task_ids' => [(string) $task1->id, (string) $task2->id]],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        $attachmentRepository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNull($attachmentRepository->find($attachment1Id));
+        $this->assertNull($attachmentRepository->find($attachment2Id));
+        $this->assertNotNull($attachmentRepository->find($keptAttachmentId));
+
+        $fileRepository = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNotNull($fileRepository->find($file1Id));
+        $this->assertNull($fileRepository->find($file1Id)->archiveDatetime);
     }
 
     public function test_bulk_delete_rolls_back_when_user_does_not_own_one_task(): void

--- a/tests/Api/BandSpace/Task/TaskDeleteTest.php
+++ b/tests/Api/BandSpace/Task/TaskDeleteTest.php
@@ -2,13 +2,21 @@
 
 namespace App\Tests\Api\BandSpace\Task;
 
+use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileAttachmentFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
 use App\Tests\Factory\BandSpace\TaskFactory;
 use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -54,6 +62,61 @@ class TaskDeleteTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+    }
+
+    public function test_delete_task_detaches_its_files_and_leaves_them_deletable(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $task = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'title' => 'Signer le contrat'])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $attachment = BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file,
+            'sourceType' => 'task',
+            'sourceId' => Uuid::fromString((string) $task->id),
+            'attachedBy' => $user,
+        ]);
+        $taskId = (string) $task->id;
+        $fileId = (string) $file->id;
+        $attachmentId = (string) $attachment->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $taskId,
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $attachmentRepository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNull($attachmentRepository->find($attachmentId));
+
+        $fileRepository = self::getContainer()->get(BandSpaceFileRepository::class);
+        $reloadedFile = $fileRepository->find($fileId);
+        $this->assertNotNull($reloadedFile, 'The file survives its task: it belongs to the library, not to the task');
+        $this->assertNull($reloadedFile->archiveDatetime);
+
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::File, $fileId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('source_deleted', $activities[0]->type);
+        $this->assertSame([
+            'source_type' => 'task',
+            'source_id' => $taskId,
+            'source_label' => 'Signer le contrat',
+        ], $activities[0]->payload);
+
+        // The regression this test exists for. BandSpaceFileDeleteProcessor refuses with a 422 while
+        // findByFile returns anything, and that used to be permanent: the detach endpoint 404s once
+        // the source is gone, so no call could ever release the file. The endpoint is not exercised
+        // here because the stateless api firewall allows one authenticated request per test and it
+        // went to the deletion above, so the guard's own query stands in for it.
+        $this->assertSame([], $attachmentRepository->findByFile($reloadedFile));
     }
 
     public function test_delete_task_by_non_creator_non_admin(): void

--- a/tests/Integration/Command/BandSpace/PruneOrphanFileAttachmentsCommandTest.php
+++ b/tests/Integration/Command/BandSpace/PruneOrphanFileAttachmentsCommandTest.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Integration\Command\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceNoteFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileAttachmentFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\SetlistFactory;
+use App\Tests\Factory\BandSpace\SongFactory;
+use App\Tests\Factory\BandSpace\TaskFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+
+#[ResetDatabase]
+class PruneOrphanFileAttachmentsCommandTest extends KernelTestCase
+{
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        parent::setUp();
+
+        $application = new Application(self::$kernel);
+        $command = $application->find('app:band-space:prune-orphan-attachments');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function test_removes_only_attachments_whose_source_is_gone(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $liveTask = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        $liveNote = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace])->create();
+
+        $orphanTaskAttachmentId = $this->attach($bandSpace, $user, 'task', (string) Uuid::uuid4());
+        $orphanNoteAttachmentId = $this->attach($bandSpace, $user, 'note', (string) Uuid::uuid4());
+        $liveTaskAttachmentId = $this->attach($bandSpace, $user, 'task', (string) $liveTask->id);
+        $liveNoteAttachmentId = $this->attach($bandSpace, $user, 'note', (string) $liveNote->id);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('task: 1 orphan attachment(s)', $output);
+        $this->assertStringContainsString('note: 1 orphan attachment(s)', $output);
+        $this->assertStringContainsString('Deleted 2 orphan attachment(s)', $output);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNull($repository->find($orphanTaskAttachmentId));
+        $this->assertNull($repository->find($orphanNoteAttachmentId));
+        $this->assertNotNull($repository->find($liveTaskAttachmentId));
+        $this->assertNotNull($repository->find($liveNoteAttachmentId));
+    }
+
+    public function test_keeps_attachments_of_soft_deleted_songs_and_setlists(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $archivedSong = SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'archiveDatetime' => new \DateTimeImmutable('-2 days'),
+        ])->create();
+        $archivedSetlist = SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'archiveDatetime' => new \DateTimeImmutable('-2 days'),
+        ])->create();
+        $archivedTask = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'archiveDatetime' => new \DateTimeImmutable('-2 days'),
+        ])->create();
+
+        $songAttachmentId = $this->attach($bandSpace, $user, 'song', (string) $archivedSong->id);
+        $setlistAttachmentId = $this->attach($bandSpace, $user, 'setlist', (string) $archivedSetlist->id);
+        $taskAttachmentId = $this->attach($bandSpace, $user, 'task', (string) $archivedTask->id);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Deleted 0 orphan attachment(s)', $this->commandTester->getDisplay());
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNotNull($repository->find($songAttachmentId), 'An archived song still has its row, so it is not an orphan');
+        $this->assertNotNull($repository->find($setlistAttachmentId));
+        $this->assertNotNull($repository->find($taskAttachmentId));
+    }
+
+    public function test_dry_run_reports_without_deleting_and_the_run_is_repeatable(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $orphanId = $this->attach($bandSpace, $user, 'finance', (string) Uuid::uuid4());
+
+        $this->commandTester->execute(['--dry-run' => true]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Would delete 1 orphan attachment(s)', $this->commandTester->getDisplay());
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNotNull($repository->find($orphanId));
+
+        $this->commandTester->execute([]);
+        $this->assertStringContainsString('Deleted 1 orphan attachment(s)', $this->commandTester->getDisplay());
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Deleted 0 orphan attachment(s)', $this->commandTester->getDisplay());
+    }
+
+    public function test_leaves_the_file_itself_alone(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+        BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file,
+            'sourceType' => 'task',
+            'sourceId' => Uuid::uuid4(),
+            'attachedBy' => $user,
+        ]);
+        $fileId = (string) $file->id;
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $reloaded = self::getContainer()->get(BandSpaceFileRepository::class)->find($fileId);
+        $this->assertNotNull($reloaded);
+        $this->assertNull($reloaded->archiveDatetime);
+    }
+
+    private function attach(BandSpace $bandSpace, User $user, string $sourceType, string $sourceId): string
+    {
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+
+        return (string) BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file,
+            'sourceType' => $sourceType,
+            'sourceId' => Uuid::fromString($sourceId),
+            'attachedBy' => $user,
+        ])->id;
+    }
+}


### PR DESCRIPTION
Closes #818.

## ⚠️ Conflicts with #851 (M-813)

Both branches touch `FinanceRecurrenceUpdateProcessor`, `FinanceEntryRepository` and `PersonalRecurrenceDeactivator`. Each merges cleanly into master on its own, so whichever goes second needs a rebase.

## ⚠️ Deploy step

Rows are already orphaned in production. After deploying:

```
bin/console app:band-space:prune-orphan-attachments --dry-run
bin/console app:band-space:prune-orphan-attachments
```

Idempotent, and a soft-deleted song, setlist or archived task is never treated as an orphan.

## The bug

`BandSpaceFileAttachment.sourceId` has no foreign key, so hard-deleting a source left the attachment row behind, and the file became permanently undeletable: the delete endpoint refuses any attached file with a 422, and the detach endpoint 404s because the source is gone. The file consumed the 5 GB quota forever, and the UI showed "Attaché à —" with a disabled delete button.

## Six hard-delete paths, not three

The issue named task, note and finance entry. The audit found three more, all real because nothing stops a file being attached to a planned entry:

- `FinanceRecurrenceDeleteProcessor`
- `FinanceRecurrenceUpdateProcessor` when the end date is shortened
- `FinanceEntryRepository::deletePlannedByRecurrence` via `PersonalRecurrenceDeactivator`, i.e. leave, kick and account deletion

Song and setlist are safe because they soft-delete, and a whole band space purge is safe because the file and its attachment vanish in the same database cascade.

All are wired to one `BandSpaceFileSourceDetacher`, extracted on its seventh call site rather than speculatively.

## The file is kept, not archived

Only the attachment row goes. A file can hang on several sources, so archiving it because one of them died would delete data the others still use. Because that must not be silent, three surfaces say so: a new `source_deleted` activity naming the deleted source, a warning in the delete confirmations when files are attached, and the file activity feed.

## Fixed during review

Two blockers.

- **An eighth path: `FinanceCategoryDeleteProcessor`.** `finance_entry.category_id` is `ON DELETE CASCADE` and `FinanceCategory` declares no inverse collection, so deleting a category takes its entries with it in the database without Doctrine ever loading them, orphaning every attached file. Deterministic, and the existing tests never seeded an entry before deleting a category so nothing caught it. Now detaches first, with a regression test.
- **The detacher's atomicity promise was false at four call sites.** It deliberately does not flush so it joins the caller's unit of work, but where it is paired with the bulk DQL delete that reaches the database immediately, a failing flush would leave the entries gone and their attachments behind: this bug, reappearing through its own fix. `FinanceRecurrenceDeleteProcessor`, `FinanceRecurrenceUpdateProcessor`, `BandSpaceLeaveProcessor` and `BandSpaceMemberDeleteProcessor` are now wrapped in a transaction, following the `DeleteAccountProcedure` precedent.

## Also

Two inline DQL deletes moved into the repository with the ORM-bypass caveat documented, clearing two of the "known exceptions" listed in CLAUDE.md.

## Tests

The regression that matters is asserted as the exact condition `BandSpaceFileDeleteProcessor` guards on, so it pins the precondition rather than a status code that could be 204 for unrelated reasons. Targeted 271, full suite 2113, PHPStan level 8 clean.

## Not fixed here

`BandSpaceFolderDeleteProcessor` with a cascade strategy archives files by raw SQL without checking attachments, so an attached file can still land in the trash. Different bug, already noted in the files batch #823.
