### PR TITLE
fix(M-816): page through the band space file list and its trash

### DIFF
--- a/assets/js/api/bandSpace/band-space-files.js
+++ b/assets/js/api/bandSpace/band-space-files.js
@@ -17,6 +17,7 @@ export default {
       uploaderId,
       sort,
       order,
+      page,
       itemsPerPage,
       archived
     } = {}
@@ -32,6 +33,7 @@ export default {
     if (uploaderId) params.uploader_id = uploaderId
     if (sort) params.sort = sort
     if (order) params.order = order
+    if (page) params.page = page
     if (itemsPerPage) params.itemsPerPage = itemsPerPage
     if (archived) params.archived = 'true'
 

--- a/assets/js/components/BandSpace/Files/FileMoveDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileMoveDialog.vue
@@ -103,10 +103,10 @@ async function handleConfirm() {
   globalError.value = null
   try {
     await bandSpaceFilesApi.updateFile(props.bandSpaceId, props.file.id, {
-      folder_id: targetFolderId.value
+      folder_id: targetFolderId.value ?? null
     })
-    filesStore.fetchFiles(props.bandSpaceId)
-    emit('moved', { fileId: props.file.id, folderId: targetFolderId.value })
+    filesStore.applyFileMoved(props.file.id, targetFolderId.value ?? null)
+    emit('moved', { fileId: props.file.id, folderId: targetFolderId.value ?? null })
     visible.value = false
   } catch (e) {
     globalError.value = e.message

--- a/assets/js/composables/useFolderDragDrop.js
+++ b/assets/js/composables/useFolderDragDrop.js
@@ -120,7 +120,7 @@ export async function applyMove(
       toast.add({ severity: 'success', summary: 'Dossier déplacé', life: 2500 })
     } else if (source.type === 'file') {
       await filesApi.updateFile(bandSpaceId, source.id, { folder_id: targetFolderId })
-      filesStore.fetchFiles(bandSpaceId)
+      filesStore.applyFileMoved(source.id, targetFolderId)
       toast.add({ severity: 'success', summary: 'Fichier déplacé', life: 2500 })
     }
   } catch (e) {

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -1,6 +1,14 @@
 import { defineStore } from 'pinia'
 import { computed, reactive, readonly, ref } from 'vue'
 import bandSpaceFilesApi from '../../api/bandSpace/band-space-files.js'
+import {
+  FILES_PAGE_SIZE,
+  fileCountLabel,
+  hasMoreToLoad,
+  mergePage,
+  nextPageToLoad,
+  queryKeyOf
+} from '../../utils/filePagination.js'
 
 export const TRASH_FOLDER_ID = 'trash'
 
@@ -33,6 +41,13 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   })
 
   const isLoadingFiles = ref(false)
+  // A filter change on a list that already has rows swaps its content with no skeleton, so this
+  // drives a visible refreshing state instead of the content changing under the user in silence.
+  const isRefreshingFiles = ref(false)
+  const isLoadingMoreFiles = ref(false)
+  // Fingerprint of the query the loaded pages belong to, so a page resolving after the filters
+  // moved is recognised as continuing a list that is no longer on screen.
+  const loadedQueryKey = ref(null)
   const isLoadingFolders = ref(false)
   const isLoadingTags = ref(false)
   const isLoadingQuota = ref(false)
@@ -46,6 +61,9 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   const isUploadingVersion = ref(false)
   const isRollingBack = ref(false)
   const loadError = ref(null)
+  // Kept apart from loadError, which replaces the whole panel: a further page failing must not take
+  // away the rows the user is already reading.
+  const loadMoreError = ref(null)
   const activeFileError = ref(null)
 
   let filesRequestId = 0
@@ -56,6 +74,9 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   // Served by the quota endpoint so the interface quotes the same window the purge enforces.
   const trashRetentionDays = computed(() => quota.value?.trash_retention_days ?? 30)
 
+  const hasMoreFiles = computed(() => hasMoreToLoad(files.value.length, totalFiles.value))
+  const filesCountLabel = computed(() => fileCountLabel(files.value.length, totalFiles.value))
+
   const activeFile = computed(() => {
     if (!activeFileId.value) return null
     return activeFileFull.value && activeFileFull.value.id === activeFileId.value
@@ -63,25 +84,71 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
       : files.value.find((f) => f.id === activeFileId.value) || null
   })
 
+  /** Loads the first page, replacing whatever was on screen. Every filter change comes through here. */
   async function fetchFiles(bandSpaceId) {
     const requestId = ++filesRequestId
     isLoadingFiles.value = files.value.length === 0
+    isRefreshingFiles.value = true
     loadError.value = null
+    loadMoreError.value = null
 
-    const params = buildFileParams()
+    const params = buildFileParams(1)
 
     try {
       const result = await bandSpaceFilesApi.getFiles(bandSpaceId, params)
       if (requestId !== filesRequestId) return
       files.value = result.member ?? []
       totalFiles.value = result.totalItems ?? 0
+      loadedQueryKey.value = queryKeyOf(params)
     } catch (e) {
       if (requestId !== filesRequestId) return
       loadError.value = e.message
     } finally {
       if (requestId === filesRequestId) {
         isLoadingFiles.value = false
+        isRefreshingFiles.value = false
       }
+    }
+  }
+
+  /**
+   * Appends the next page. The page number comes from the rows already held rather than a counter,
+   * so a file deleted, restored or moved out of the list since the last page cannot open a gap the
+   * next request steps over. See utils/filePagination.js.
+   */
+  async function fetchMoreFiles(bandSpaceId) {
+    if (isLoadingMoreFiles.value || isRefreshingFiles.value || !hasMoreFiles.value) return
+
+    const requestId = ++filesRequestId
+    const params = buildFileParams(nextPageToLoad(files.value.length, FILES_PAGE_SIZE))
+    const requestedQueryKey = queryKeyOf(params)
+    isLoadingMoreFiles.value = true
+    loadMoreError.value = null
+
+    try {
+      const result = await bandSpaceFilesApi.getFiles(bandSpaceId, params)
+      if (requestId !== filesRequestId || requestedQueryKey !== loadedQueryKey.value) return
+      const heldBefore = files.value.length
+      files.value = mergePage(files.value, result.member ?? [])
+      totalFiles.value = result.totalItems ?? totalFiles.value
+
+      // A page that brings nothing new while the server still reports more is the signature of a row
+      // that somebody else slipped in behind the window. The page number is derived from how many
+      // rows are held, so it stops moving too, and every further click re-requests this same offset
+      // for good. Rebuilding from the first page is the only thing that can reach the new row.
+      if (files.value.length === heldBefore && hasMoreFiles.value) {
+        isLoadingMoreFiles.value = false
+        await fetchFiles(bandSpaceId)
+
+        return
+      }
+    } catch (e) {
+      if (requestId !== filesRequestId) return
+      loadMoreError.value = e.message
+    } finally {
+      // Cleared unconditionally: only one further page is ever in flight, and a filter change
+      // superseding this one must not leave the button spinning for good.
+      isLoadingMoreFiles.value = false
     }
   }
 
@@ -125,15 +192,17 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     }
   }
 
-  function buildFileParams() {
+  function buildFileParams(page) {
     // The trash ignores every filter, before they are even read. Its filter bar is hidden, so a search
     // or tag left over from browsing a folder would silently narrow the trash with no visible control to
     // clear it, and someone hunting for the file they just deleted would find it apparently missing.
+    // It pages exactly like the live listing does: without that, a trashed file past the fiftieth is
+    // unrestorable and app:band-space:purge eventually destroys it.
     if (activeFolderId.value === TRASH_FOLDER_ID) {
-      return { archived: true }
+      return { archived: true, page, itemsPerPage: FILES_PAGE_SIZE }
     }
 
-    const params = {}
+    const params = { page, itemsPerPage: FILES_PAGE_SIZE }
     const trimmed = filters.query.trim()
     if (trimmed) params.query = trimmed
     if (filters.mime) params.mime = filters.mime
@@ -230,6 +299,31 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     } finally {
       isSavingFile.value = false
     }
+  }
+
+  /**
+   * A file changed folder, from the move dialog or from a drag and drop. Patching the loaded rows
+   * rather than refetching keeps the pages the user already loaded: a move made after paging deep
+   * into the list would otherwise snap it back to the first page.
+   *
+   * The root and the virtual source folders list the whole space whatever folder a file sits in, so
+   * only a real folder view has to drop the row, and only when the file landed somewhere else.
+   */
+  function applyFileMoved(fileId, targetFolderId) {
+    const isRealFolderView =
+      typeof activeFolderId.value === 'string' &&
+      activeFolderId.value !== TRASH_FOLDER_ID &&
+      !activeFolderId.value.startsWith('virtual:')
+
+    if (isRealFolderView && activeFolderId.value !== targetFolderId) {
+      files.value = files.value.filter((f) => f.id !== fileId)
+      totalFiles.value = Math.max(0, totalFiles.value - 1)
+      return
+    }
+
+    files.value = files.value.map((f) =>
+      f.id === fileId ? { ...f, folder_id: targetFolderId } : f
+    )
   }
 
   async function fetchArchivedCount(bandSpaceId) {
@@ -394,6 +488,9 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   function clear() {
     files.value = []
     totalFiles.value = 0
+    loadedQueryKey.value = null
+    isRefreshingFiles.value = false
+    isLoadingMoreFiles.value = false
     folders.value = []
     virtualFolders.value = []
     tags.value = []
@@ -411,12 +508,15 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     filters.sort = 'date'
     filters.order = 'desc'
     loadError.value = null
+    loadMoreError.value = null
     activeFileError.value = null
   }
 
   return {
     files: readonly(files),
     totalFiles: readonly(totalFiles),
+    hasMoreFiles,
+    filesCountLabel,
     archivedCount: readonly(archivedCount),
     trashRetentionDays,
     folders: readonly(folders),
@@ -426,10 +526,13 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     activeFolderId: readonly(activeFolderId),
     filters: readonly(filters),
     isLoadingFiles: readonly(isLoadingFiles),
+    isRefreshingFiles: readonly(isRefreshingFiles),
+    isLoadingMoreFiles: readonly(isLoadingMoreFiles),
     isLoadingFolders: readonly(isLoadingFolders),
     isLoadingTags: readonly(isLoadingTags),
     isLoadingQuota: readonly(isLoadingQuota),
     loadError: readonly(loadError),
+    loadMoreError: readonly(loadMoreError),
     activeFileId: readonly(activeFileId),
     activeFile,
     fileActivities: readonly(fileActivities),
@@ -449,12 +552,14 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     isDeletingFile: readonly(isDeletingFile),
     activeFileError: readonly(activeFileError),
     fetchFiles,
+    fetchMoreFiles,
     fetchFolders,
     fetchTags,
     fetchQuota,
     fetchFileById,
     fetchFileActivities,
     updateFile,
+    applyFileMoved,
     deleteFile,
     fetchArchivedCount,
     restoreFile,

--- a/assets/js/utils/filePagination.js
+++ b/assets/js/utils/filePagination.js
@@ -1,0 +1,123 @@
+/**
+ * Page bookkeeping for the band space file list and its trash.
+ *
+ * The collection is offset paginated server side and the list mutates under the user while later
+ * pages are already on screen: files get uploaded, deleted, restored from the trash, or moved out
+ * of the folder being browsed. Offset paging normally loses rows when that happens, because the
+ * server window slides left by one for every row that disappears while the client keeps counting
+ * pages from a number those mutations never touched.
+ *
+ * The next page is therefore derived from how many rows are actually loaded, and pages are merged
+ * by id rather than blindly concatenated. Delete one of the 50 loaded rows and the next request
+ * goes back to page 1: merging drops the 49 rows already held and keeps the one that slid into the
+ * window, instead of stepping straight over it. That is what stops a file in the trash becoming
+ * unreachable, which matters because app:band-space:purge destroys what the user cannot restore.
+ *
+ * That covers rows the list itself removed. It does NOT cover a row another member inserts behind
+ * the window, which lands wherever its creation date falls: the loaded count then stops growing, so
+ * the derived page stops moving and the same offset is requested from then on. The store watches
+ * for that exact signature, a page bringing nothing new while the server still reports more, and
+ * rebuilds from the first page rather than trusting these maths to converge on their own.
+ */
+
+/**
+ * Rows per request. Sent explicitly as itemsPerPage, so the server takes it from here rather than
+ * the two sides having to agree on a number neither can see. Capped server side at 200.
+ */
+export const FILES_PAGE_SIZE = 50
+
+/**
+ * The page to request next, derived from the rows already held rather than from a counter.
+ *
+ * @param {number} loadedCount rows currently in the list
+ * @param {number} pageSize
+ * @returns {number} 1 based page number
+ */
+export function nextPageToLoad(loadedCount, pageSize = FILES_PAGE_SIZE) {
+  if (pageSize <= 0) {
+    return 1
+  }
+
+  return Math.floor(Math.max(0, loadedCount) / pageSize) + 1
+}
+
+/**
+ * Whether the server holds rows the list has not loaded yet.
+ *
+ * @param {number} loadedCount
+ * @param {number} total totalItems reported by the collection
+ * @returns {boolean}
+ */
+export function hasMoreToLoad(loadedCount, total) {
+  return loadedCount < total
+}
+
+/**
+ * Merge a freshly fetched page into the loaded rows: known ids are refreshed in place, unknown ids
+ * are appended. Returns a new array and never mutates its inputs.
+ *
+ * Merging rather than concatenating is what makes a repeated page harmless, and repeated pages are
+ * the price of the self correcting page maths above.
+ *
+ * @param {Array<{id: string}>} loaded
+ * @param {Array<{id: string}>} incoming
+ * @returns {Array<{id: string}>}
+ */
+export function mergePage(loaded, incoming) {
+  const merged = [...loaded]
+  const indexById = new Map(merged.map((item, index) => [item.id, index]))
+
+  for (const item of incoming) {
+    const knownIndex = indexById.get(item.id)
+    if (knownIndex === undefined) {
+      indexById.set(item.id, merged.length)
+      merged.push(item)
+    } else {
+      merged[knownIndex] = item
+    }
+  }
+
+  return merged
+}
+
+/**
+ * A stable fingerprint of the request parameters, ignoring the page itself. Two calls describing
+ * the same folder, filters and sort share a key whatever order the object was built in.
+ *
+ * The loaded pages belong to exactly one key. When the user changes a filter while a further page
+ * is in flight, the key moves and the late response can be recognised as describing a list that is
+ * no longer on screen, rather than being appended to rows it has nothing to do with.
+ *
+ * @param {Record<string, unknown>} params
+ * @returns {string}
+ */
+export function queryKeyOf(params) {
+  const entries = Object.keys(params)
+    .filter((key) => key !== 'page')
+    .sort()
+    .map((key) => [key, params[key] ?? null])
+
+  return JSON.stringify(entries)
+}
+
+/**
+ * How many files exist, and how many of them are on screen. Rendered above the list so a truncated
+ * view can never pass for the whole of it.
+ *
+ * @param {number} loadedCount
+ * @param {number} total
+ * @returns {string} empty when there is nothing to announce
+ */
+export function fileCountLabel(loadedCount, total) {
+  if (total <= 0) {
+    return ''
+  }
+
+  if (loadedCount >= total) {
+    return total > 1 ? `${total} fichiers` : `${total} fichier`
+  }
+
+  return loadedCount > 1
+    ? `${loadedCount} fichiers affichés sur ${total}`
+    : `${loadedCount} fichier affiché sur ${total}`
+}

--- a/assets/js/utils/filePagination.test.js
+++ b/assets/js/utils/filePagination.test.js
@@ -1,0 +1,340 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  FILES_PAGE_SIZE,
+  fileCountLabel,
+  hasMoreToLoad,
+  mergePage,
+  nextPageToLoad,
+  queryKeyOf
+} from './filePagination.js'
+
+/**
+ * These pin the paging of the band space file list, and above all of its trash: the list stopped at
+ * the first 50 rows with no paginator and no count, so a band with more than 50 files in the trash
+ * could not reach the older ones before app:band-space:purge destroyed them.
+ *
+ * Run with `npm test`. Node's own runner, so this costs no dependency. The Vue wiring itself still
+ * has no coverage, because that would need jsdom and a component harness.
+ */
+
+/** A file row as the collection returns it, reduced to what the paging cares about. */
+function row(id, name = id) {
+  return { id, original_name: name }
+}
+
+/** `count` rows named r0, r1, ... */
+function rows(count, prefix = 'r') {
+  return Array.from({ length: count }, (_, index) => row(`${prefix}${index}`))
+}
+
+describe('nextPageToLoad', () => {
+  it('asks for the first page when nothing is loaded', () => {
+    assert.equal(nextPageToLoad(0), 1)
+  })
+
+  it('asks for the second page once a full page is held', () => {
+    assert.equal(nextPageToLoad(FILES_PAGE_SIZE), 2)
+  })
+
+  it('keeps asking for the same page across a partial page', () => {
+    assert.equal(nextPageToLoad(1), 1)
+    assert.equal(nextPageToLoad(FILES_PAGE_SIZE - 1), 1)
+  })
+
+  it('counts pages from the rows held, not from a click counter', () => {
+    assert.equal(nextPageToLoad(2 * FILES_PAGE_SIZE), 3)
+    assert.equal(nextPageToLoad(2 * FILES_PAGE_SIZE + 1), 3)
+  })
+
+  // The trash case. Restoring a file removes it from the server window as well as from the list, so
+  // page 2 would start one row further along than it should and step over a file for good.
+  it('steps back to the page holding the gap when a loaded row is removed', () => {
+    assert.equal(nextPageToLoad(FILES_PAGE_SIZE - 1), 1)
+    assert.equal(nextPageToLoad(2 * FILES_PAGE_SIZE - 3), 2)
+  })
+
+  it('honours a page size of its own', () => {
+    assert.equal(nextPageToLoad(0, 10), 1)
+    assert.equal(nextPageToLoad(9, 10), 1)
+    assert.equal(nextPageToLoad(10, 10), 2)
+    assert.equal(nextPageToLoad(25, 10), 3)
+  })
+
+  it('never divides by a page size of zero', () => {
+    assert.equal(nextPageToLoad(40, 0), 1)
+    assert.equal(nextPageToLoad(40, -5), 1)
+  })
+
+  it('treats a negative row count as an empty list', () => {
+    assert.equal(nextPageToLoad(-3), 1)
+  })
+})
+
+describe('hasMoreToLoad', () => {
+  it('sees the rest of a truncated collection', () => {
+    assert.equal(hasMoreToLoad(50, 128), true)
+  })
+
+  it('stops once every row is held', () => {
+    assert.equal(hasMoreToLoad(128, 128), false)
+  })
+
+  it('stops on an empty collection', () => {
+    assert.equal(hasMoreToLoad(0, 0), false)
+  })
+
+  // A total that lags behind after several local removals must not offer a page that is not there.
+  it('stops when more rows are held than the total claims', () => {
+    assert.equal(hasMoreToLoad(51, 50), false)
+  })
+})
+
+describe('mergePage', () => {
+  it('appends a page of unseen rows in order', () => {
+    const merged = mergePage([row('a'), row('b')], [row('c'), row('d')])
+
+    assert.deepEqual(
+      merged.map((item) => item.id),
+      ['a', 'b', 'c', 'd']
+    )
+  })
+
+  it('keeps a row that arrives twice once', () => {
+    const merged = mergePage([row('a'), row('b')], [row('b'), row('c')])
+
+    assert.deepEqual(
+      merged.map((item) => item.id),
+      ['a', 'b', 'c']
+    )
+  })
+
+  it('refreshes a known row in place rather than moving it to the end', () => {
+    const merged = mergePage(
+      [row('a', 'old.pdf'), row('b', 'b.pdf')],
+      [row('a', 'renamed.pdf'), row('c', 'c.pdf')]
+    )
+
+    assert.deepEqual(
+      merged.map((item) => item.original_name),
+      ['renamed.pdf', 'b.pdf', 'c.pdf']
+    )
+  })
+
+  it('leaves both inputs untouched', () => {
+    const loaded = [row('a')]
+    const incoming = [row('b')]
+
+    mergePage(loaded, incoming)
+
+    assert.equal(loaded.length, 1)
+    assert.equal(incoming.length, 1)
+  })
+
+  it('returns the loaded rows when the page comes back empty', () => {
+    assert.deepEqual(
+      mergePage([row('a')], []).map((item) => item.id),
+      ['a']
+    )
+  })
+})
+
+describe('queryKeyOf', () => {
+  it('ignores the page, so pages of one query share a key', () => {
+    assert.equal(queryKeyOf({ folderId: 'f1', page: 1 }), queryKeyOf({ folderId: 'f1', page: 4 }))
+  })
+
+  it('ignores the order the parameters were built in', () => {
+    assert.equal(
+      queryKeyOf({ query: 'master', sort: 'name', order: 'asc' }),
+      queryKeyOf({ order: 'asc', sort: 'name', query: 'master' })
+    )
+  })
+
+  // The reset on filter change case: every one of these must retarget the list.
+  it('moves when the folder changes', () => {
+    assert.notEqual(queryKeyOf({ folderId: 'f1' }), queryKeyOf({ folderId: 'f2' }))
+  })
+
+  it('moves when the search text changes', () => {
+    assert.notEqual(queryKeyOf({ query: 'master' }), queryKeyOf({ query: 'rider' }))
+  })
+
+  it('moves when the sort changes', () => {
+    assert.notEqual(
+      queryKeyOf({ sort: 'date', order: 'desc' }),
+      queryKeyOf({ sort: 'date', order: 'asc' })
+    )
+  })
+
+  it('moves when a filter is added', () => {
+    assert.notEqual(queryKeyOf({ sort: 'date' }), queryKeyOf({ sort: 'date', tagId: 't1' }))
+  })
+
+  it('moves between the live files and the trash', () => {
+    assert.notEqual(queryKeyOf({ sort: 'date' }), queryKeyOf({ archived: true }))
+  })
+
+  it('treats a cleared filter as no filter at all', () => {
+    assert.equal(queryKeyOf({ tagId: null }), queryKeyOf({ tagId: undefined }))
+  })
+})
+
+describe('fileCountLabel', () => {
+  it('says nothing about an empty collection', () => {
+    assert.equal(fileCountLabel(0, 0), '')
+  })
+
+  it('gives the plain total once everything is on screen', () => {
+    assert.equal(fileCountLabel(128, 128), '128 fichiers')
+  })
+
+  it('agrees in the singular', () => {
+    assert.equal(fileCountLabel(1, 1), '1 fichier')
+  })
+
+  it('admits how much of the collection is missing', () => {
+    assert.equal(fileCountLabel(50, 128), '50 fichiers affichés sur 128')
+  })
+
+  it('agrees in the singular on a single loaded row', () => {
+    assert.equal(fileCountLabel(1, 40), '1 fichier affiché sur 40')
+  })
+})
+
+/**
+ * The pieces working together, over the sequences that used to lose files. Each step is exactly
+ * what the store does: pick a page from the rows held, merge the answer, then ask whether anything
+ * is left.
+ */
+describe('paging a mutating collection', () => {
+  /** The server view of an ordered collection, answering an offset page like the API does. */
+  function serverPage(all, page, pageSize = FILES_PAGE_SIZE) {
+    const offset = (page - 1) * pageSize
+
+    return all.slice(offset, offset + pageSize)
+  }
+
+  it('walks a stable collection to the end without repeating or dropping a row', () => {
+    const all = rows(128)
+    let loaded = serverPage(all, 1)
+
+    while (hasMoreToLoad(loaded.length, all.length)) {
+      loaded = mergePage(loaded, serverPage(all, nextPageToLoad(loaded.length)))
+    }
+
+    assert.deepEqual(
+      loaded.map((item) => item.id),
+      all.map((item) => item.id)
+    )
+  })
+
+  // The bug that made this feature necessary, reproduced from the trash: restore files off the
+  // first page and every file behind the window must still be reachable.
+  it('reaches every file after rows are restored out of the loaded page', () => {
+    const server = rows(120)
+    let loaded = serverPage(server, 1)
+    let total = server.length
+
+    // Restore the first three rows: gone from the server list and from the loaded rows alike.
+    for (const restoredId of ['r0', 'r1', 'r2']) {
+      server.splice(
+        server.findIndex((item) => item.id === restoredId),
+        1
+      )
+      loaded = loaded.filter((item) => item.id !== restoredId)
+      total -= 1
+    }
+
+    assert.equal(loaded.length, FILES_PAGE_SIZE - 3)
+    // Back to page 1, which is where the gap the removals opened now sits.
+    assert.equal(nextPageToLoad(loaded.length), 1)
+
+    while (hasMoreToLoad(loaded.length, total)) {
+      loaded = mergePage(loaded, serverPage(server, nextPageToLoad(loaded.length)))
+    }
+
+    assert.deepEqual(
+      loaded.map((item) => item.id),
+      server.map((item) => item.id)
+    )
+  })
+
+  it('reaches every file after one is uploaded ahead of the loaded page', () => {
+    const server = rows(120)
+    let loaded = serverPage(server, 1)
+    let total = server.length
+
+    // An upload lands at the top of a date descending list, in the store and on the server alike.
+    const uploaded = row('fresh')
+    server.unshift(uploaded)
+    loaded = [uploaded, ...loaded]
+    total += 1
+
+    while (hasMoreToLoad(loaded.length, total)) {
+      loaded = mergePage(loaded, serverPage(server, nextPageToLoad(loaded.length)))
+    }
+
+    assert.deepEqual(
+      loaded.map((item) => item.id),
+      server.map((item) => item.id)
+    )
+  })
+
+  // The classic reset on filter change bug: a further page resolving after the user changed a
+  // filter must not be merged into the list, which no longer holds the rows that page continues.
+  it('drops a page that describes the query the user just left', () => {
+    const inFlight = { sort: 'date', order: 'desc', page: 2 }
+    const inFlightKey = queryKeyOf(inFlight)
+
+    // The user opens a folder while page 2 of the root listing is still in flight, so the list is
+    // replaced by the first page of the folder and the key it belongs to moves with it.
+    let loaded = rows(3, 'folder-')
+    const loadedKey = queryKeyOf({ sort: 'date', order: 'desc', folderId: 'f1', page: 1 })
+
+    const applyLatePage = (page) => {
+      if (inFlightKey !== loadedKey) {
+        return
+      }
+      loaded = mergePage(loaded, page)
+    }
+    applyLatePage(rows(50, 'root-'))
+
+    assert.deepEqual(
+      loaded.map((item) => item.id),
+      ['folder-0', 'folder-1', 'folder-2']
+    )
+  })
+
+  /**
+   * The limit of the derived page maths, pinned so the store's resync cannot be quietly dropped as
+   * redundant later. Another member restoring an old file inserts it behind the window rather than
+   * at the front, so the loaded count stops growing, the derived page stops moving with it, and
+   * clicking again re-requests the same offset from then on. The store watches for exactly this,
+   * a page bringing nothing new while more is still reported, and rebuilds from the first page.
+   */
+  it('stalls on a row inserted behind the window, which is why the store resyncs', () => {
+    const server = rows(120)
+    let loaded = serverPage(server, 1)
+    let total = server.length
+
+    server.splice(40, 0, row('inserted-behind-the-window'))
+    total += 1
+
+    let productiveRequests = 0
+    for (let i = 0; i < 5 && hasMoreToLoad(loaded.length, total); i++) {
+      const heldBefore = loaded.length
+      loaded = mergePage(loaded, serverPage(server, nextPageToLoad(loaded.length)))
+      if (loaded.length === heldBefore) break
+      productiveRequests++
+    }
+
+    assert.equal(productiveRequests, 1, 'one page lands, then the offset repeats forever')
+    assert.equal(
+      loaded.some((item) => item.id === 'inserted-behind-the-window'),
+      false,
+      'the inserted row cannot be reached by paging alone'
+    )
+    assert.equal(hasMoreToLoad(loaded.length, total), true, 'while the server still reports more')
+  })
+})

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -117,27 +117,67 @@
         </div>
 
         <div class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700">
-          <FileTrashList
-            v-if="isTrashActive"
-            :band-space-id="bandSpaceId"
-            :files="filesStore.files"
-            :is-loading="filesStore.isLoadingFiles"
-            :is-admin="isAdmin"
-          />
-          <FileList
-            v-else
-            :folders="inlineFolders"
-            @open-folder="handleFolderSelect"
-            :band-space-id="bandSpaceId"
-            :files="filesStore.files"
-            :is-loading="filesStore.isLoadingFiles"
-            :empty-message="emptyMessage"
-            @select="handleFileSelect"
-            @open-rename="handleOpenRename"
-            @open-share="handleOpenShare"
-            @open-versions="handleOpenVersions"
-            @open-move="handleOpenMove"
-          />
+          <!-- The count and the load more control sit here rather than inside the two lists: both
+               page identically, and the trash needs it most, since a file it cannot reach is a file
+               app:band-space:purge eventually destroys. -->
+          <div
+            v-if="filesStore.totalFiles > 0"
+            class="flex items-center justify-between gap-3 pb-3 mb-1 border-b border-surface-100 dark:border-surface-800"
+          >
+            <p
+              class="text-xs text-surface-600 dark:text-surface-300 tabular-nums"
+              aria-live="polite"
+            >
+              {{ filesStore.filesCountLabel }}
+            </p>
+            <span
+              v-if="filesStore.isRefreshingFiles"
+              class="flex items-center gap-2 text-xs text-surface-600 dark:text-surface-300"
+            >
+              <i class="pi pi-spin pi-spinner" aria-hidden="true"></i>
+              Actualisation…
+            </span>
+          </div>
+
+          <div
+            :class="filesStore.isRefreshingFiles ? 'opacity-50 transition-opacity' : ''"
+            :aria-busy="filesStore.isRefreshingFiles ? 'true' : 'false'"
+          >
+            <FileTrashList
+              v-if="isTrashActive"
+              :band-space-id="bandSpaceId"
+              :files="filesStore.files"
+              :is-loading="filesStore.isLoadingFiles"
+              :is-admin="isAdmin"
+            />
+            <FileList
+              v-else
+              :folders="inlineFolders"
+              @open-folder="handleFolderSelect"
+              :band-space-id="bandSpaceId"
+              :files="filesStore.files"
+              :is-loading="filesStore.isLoadingFiles"
+              :empty-message="emptyMessage"
+              @select="handleFileSelect"
+              @open-rename="handleOpenRename"
+              @open-share="handleOpenShare"
+              @open-versions="handleOpenVersions"
+              @open-move="handleOpenMove"
+            />
+          </div>
+
+          <div v-if="filesStore.hasMoreFiles" class="flex flex-col items-center gap-2 mt-4">
+            <Message v-if="filesStore.loadMoreError" severity="error" :closable="false">
+              {{ filesStore.loadMoreError }}
+            </Message>
+            <Button
+              label="Charger plus"
+              :loading="filesStore.isLoadingMoreFiles"
+              severity="secondary"
+              outlined
+              @click="handleLoadMore"
+            />
+          </div>
         </div>
       </section>
     </div>
@@ -325,6 +365,10 @@ function loadAll() {
 function handleFolderSelect(folderId) {
   filesStore.setActiveFolder(folderId)
   filesStore.fetchFiles(bandSpaceId.value)
+}
+
+function handleLoadMore() {
+  filesStore.fetchMoreFiles(bandSpaceId.value)
 }
 
 function handleFilterUpdate({ key, value }) {

--- a/src/ApiResource/BandSpace/File/BandSpaceFileResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileResource.php
@@ -35,6 +35,9 @@ use App\State\Provider\BandSpace\File\BandSpaceTaskFileCollectionProvider;
             openapi: new Operation(tags: ['Band Space File']),
             paginationEnabled: true,
             paginationItemsPerPage: 50,
+            // The list pages client side, so the page size belongs to the caller rather than being a
+            // number the two sides have to agree on without seeing each other. Capped just below.
+            paginationClientItemsPerPage: true,
             paginationMaximumItemsPerPage: 200,
             security: "is_granted('ROLE_USER')",
             name: 'api_band_space_files_get_collection',

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -8,6 +8,7 @@ use App\Entity\BandSpace\BandSpaceFolder;
 use App\Repository\BandSpace\Filter\BandSpaceFileFilter;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -21,6 +22,8 @@ class BandSpaceFileRepository extends ServiceEntityRepository
     }
 
     /**
+     * One page of files, tags and uploader included.
+     *
      * @return BandSpaceFile[]
      */
     public function findByBandSpace(BandSpace $bandSpace, BandSpaceFileFilter $filter): array
@@ -36,7 +39,14 @@ class BandSpaceFileRepository extends ServiceEntityRepository
         $qb->setMaxResults($filter->limit)
             ->setFirstResult($filter->offset);
 
-        return $qb->getQuery()->getResult();
+        // Paginator, not getResult(): the tags fetch join turns one file into one row per tag, so a
+        // plain LIMIT cuts the window mid file and returns fewer files than asked for. The count
+        // beside this one counts distinct files, so the shortfall reads as a page the caller has
+        // already seen and the files behind it are never requested again.
+        /** @var BandSpaceFile[] $files */
+        $files = iterator_to_array(new Paginator($qb->getQuery()), false);
+
+        return $files;
     }
 
     public function countByBandSpace(BandSpace $bandSpace, BandSpaceFileFilter $filter): int
@@ -233,5 +243,11 @@ class BandSpaceFileRepository extends ServiceEntityRepository
             'size' => $qb->orderBy('cv.size', $direction),
             default => $qb->orderBy('bsf.creationDatetime', $direction),
         };
+
+        // Ties are the rule rather than the exception here: a batch upload stamps one creation
+        // datetime on every file in it, and two files can share a size or a name. Without a total
+        // order the database may put a tied row on two consecutive pages and on neither of them, so
+        // paging would quietly drop files. The id settles every tie.
+        $qb->addOrderBy('bsf.id', $direction);
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceFileCollectionTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileCollectionTest.php
@@ -2,6 +2,12 @@
 
 namespace App\Tests\Api\BandSpace\File;
 
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\BandSpace\Filter\BandSpaceFileFilter;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
@@ -243,6 +249,116 @@ class BandSpaceFileCollectionTest extends ApiTestCase
         $this->assertCount(10, $response['member']);
     }
 
+    public function test_list_honours_a_client_page_size(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->createFiles($bandSpace, $user, [
+            'oldest.pdf' => '2026-01-01 10:00:00',
+            'middle.pdf' => '2026-01-02 10:00:00',
+            'newest.pdf' => '2026-01-03 10:00:00',
+        ]);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/files?itemsPerPage=2', [], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(3, $response['totalItems']);
+        $this->assertSame(['newest.pdf', 'middle.pdf'], array_column($response['member'], 'original_name'));
+    }
+
+    /**
+     * The tags fetch join turns one file into one row per tag, so paging over the joined rows rather
+     * than over distinct files handed back short pages and stepped over the overflow on the next one.
+     */
+    public function test_pages_do_not_drop_files_carrying_several_tags(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $tags = [];
+        foreach (['masters', 'live', 'demos'] as $tagName) {
+            $tags[] = BandSpaceFileTagFactory::new(['bandSpace' => $bandSpace, 'name' => $tagName])->create();
+        }
+
+        foreach ($this->createFiles($bandSpace, $user, [
+            'file-a.pdf' => '2026-03-01 10:00:00',
+            'file-b.pdf' => '2026-03-02 10:00:00',
+            'file-c.pdf' => '2026-03-03 10:00:00',
+            'file-d.pdf' => '2026-03-04 10:00:00',
+        ]) as $file) {
+            foreach ($tags as $tag) {
+                $file->tags->add($tag);
+            }
+            \Zenstruck\Foundry\Persistence\save($file);
+        }
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/files?itemsPerPage=2&page=1', [], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $firstPage = $this->getResponseAsArray();
+        $this->assertSame(4, $firstPage['totalItems']);
+        $this->assertSame(['file-d.pdf', 'file-c.pdf'], array_column($firstPage['member'], 'original_name'));
+
+        // The api firewall is stateless, so an authenticated session does not survive into a second
+        // request. Later pages are read through the repository the provider itself calls, which is
+        // also where the fix lives: without the Paginator the tag join cuts the page short here.
+        $this->assertSame(['file-b.pdf', 'file-a.pdf'], $this->pageOfNames($bandSpace, 2, 2));
+    }
+
+    /**
+     * One page of the live file list, straight from the repository the collection provider calls.
+     *
+     * @return list<string> the original names, in the order the query returned them
+     */
+    private function pageOfNames(BandSpace $bandSpace, int $limit, int $offset): array
+    {
+        $bandSpace = self::getContainer()->get(BandSpaceRepository::class)->find($bandSpace->id);
+        $files = self::getContainer()->get(BandSpaceFileRepository::class)->findByBandSpace(
+            $bandSpace,
+            new BandSpaceFileFilter(limit: $limit, offset: $offset),
+        );
+
+        return array_map(static fn(BandSpaceFile $file): string => $file->originalName, $files);
+    }
+
+    /**
+     * The trash is the sharp edge: app:band-space:purge destroys what a member cannot reach to restore.
+     */
+    public function test_trash_pages_past_the_first_page(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        foreach ([
+            'trashed-a.pdf' => '2026-05-01 10:00:00',
+            'trashed-b.pdf' => '2026-05-02 10:00:00',
+            'trashed-c.pdf' => '2026-05-03 10:00:00',
+        ] as $name => $createdAt) {
+            BandSpaceFileFactory::new([
+                'bandSpace' => $bandSpace,
+                'createdBy' => $user,
+                'originalName' => $name,
+                'creationDatetime' => new \DateTime($createdAt),
+                'archiveDatetime' => new \DateTimeImmutable($createdAt),
+            ])->create();
+        }
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/files?archived=true&itemsPerPage=2&page=2', [], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(3, $response['totalItems']);
+        $this->assertSame(['trashed-a.pdf'], array_column($response['member'], 'original_name'));
+    }
+
     public function test_list_excludes_archived(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();
@@ -287,5 +403,28 @@ class BandSpaceFileCollectionTest extends ApiTestCase
             'type' => '/errors/403',
             'description' => "Vous n'êtes pas membre de ce Band Space",
         ]);
+    }
+
+    /**
+     * Creation datetimes are pinned rather than left to the faker: they decide which file lands on
+     * which page, and the default sort is on them.
+     *
+     * @param array<string, string> $creationDatetimeByName
+     *
+     * @return BandSpaceFile[] in the order given
+     */
+    private function createFiles(BandSpace $bandSpace, User $user, array $creationDatetimeByName): array
+    {
+        $files = [];
+        foreach ($creationDatetimeByName as $name => $createdAt) {
+            $files[] = BandSpaceFileFactory::new([
+                'bandSpace' => $bandSpace,
+                'createdBy' => $user,
+                'originalName' => $name,
+                'creationDatetime' => new \DateTime($createdAt),
+            ])->create();
+        }
+
+        return $files;
     }
 }

--- a/tests/Integration/Repository/BandSpace/BandSpaceFileRepositoryPagingTest.php
+++ b/tests/Integration/Repository/BandSpace/BandSpaceFileRepositoryPagingTest.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\Filter\BandSpaceFileFilter;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileTagFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * Paging lives in the query, so it is exercised against the repository rather than through the
+ * endpoint: the collection provider adds nothing but the member check and the offset arithmetic,
+ * and both are already pinned by the API tests for this collection.
+ */
+#[ResetDatabase]
+class BandSpaceFileRepositoryPagingTest extends KernelTestCase
+{
+    /**
+     * A batch upload stamps one creation datetime on every file in it. Ordering on that alone leaves
+     * a tied group up to the database, which may hand the same row to two pages and to neither.
+     */
+    public function test_pages_do_not_repeat_or_drop_files_sharing_a_creation_datetime(): void
+    {
+        [$bandSpace, $user] = $this->createBandSpace();
+        $this->createFiles($bandSpace, $user, [
+            'tie-a.pdf' => '2026-04-01 12:00:00',
+            'tie-b.pdf' => '2026-04-01 12:00:00',
+            'tie-c.pdf' => '2026-04-01 12:00:00',
+            'tie-d.pdf' => '2026-04-01 12:00:00',
+        ]);
+
+        $names = [...$this->pageOfNames($bandSpace, 2, 0), ...$this->pageOfNames($bandSpace, 2, 2)];
+
+        sort($names);
+        $this->assertSame(['tie-a.pdf', 'tie-b.pdf', 'tie-c.pdf', 'tie-d.pdf'], $names);
+    }
+
+    /**
+     * The tags collection is fetch joined, so one file becomes one row per tag. Applying the limit to
+     * those rows cut a page short, and the shortfall read to the client as "nothing left to load".
+     */
+    public function test_a_page_holds_its_full_size_when_files_carry_several_tags(): void
+    {
+        [$bandSpace, $user] = $this->createBandSpace();
+
+        $tags = new ArrayCollection([
+            BandSpaceFileTagFactory::new(['bandSpace' => $bandSpace, 'name' => 'masters'])->create(),
+            BandSpaceFileTagFactory::new(['bandSpace' => $bandSpace, 'name' => 'live'])->create(),
+            BandSpaceFileTagFactory::new(['bandSpace' => $bandSpace, 'name' => 'demos'])->create(),
+        ]);
+
+        foreach ([
+            'file-a.pdf' => '2026-03-01 10:00:00',
+            'file-b.pdf' => '2026-03-02 10:00:00',
+            'file-c.pdf' => '2026-03-03 10:00:00',
+            'file-d.pdf' => '2026-03-04 10:00:00',
+        ] as $name => $createdAt) {
+            BandSpaceFileFactory::new([
+                'bandSpace' => $bandSpace,
+                'createdBy' => $user,
+                'originalName' => $name,
+                'creationDatetime' => new \DateTime($createdAt),
+                'tags' => $tags,
+            ])->create();
+        }
+
+        $this->assertSame(['file-d.pdf', 'file-c.pdf'], $this->pageOfNames($bandSpace, 2, 0));
+        $this->assertSame(['file-b.pdf', 'file-a.pdf'], $this->pageOfNames($bandSpace, 2, 2));
+    }
+
+    /**
+     * @return array{0: BandSpace, 1: User}
+     */
+    private function createBandSpace(): array
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        return [BandSpaceFactory::new()->create(), $user];
+    }
+
+    /**
+     * @param array<string, string> $creationDatetimeByName
+     */
+    private function createFiles(BandSpace $bandSpace, User $user, array $creationDatetimeByName): void
+    {
+        foreach ($creationDatetimeByName as $name => $createdAt) {
+            BandSpaceFileFactory::new([
+                'bandSpace' => $bandSpace,
+                'createdBy' => $user,
+                'originalName' => $name,
+                'creationDatetime' => new \DateTime($createdAt),
+            ])->create();
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function pageOfNames(BandSpace $bandSpace, int $limit, int $offset): array
+    {
+        $files = static::getContainer()->get(BandSpaceFileRepository::class)->findByBandSpace(
+            $bandSpace,
+            new BandSpaceFileFilter(limit: $limit, offset: $offset),
+        );
+
+        return array_map(static fn(BandSpaceFile $file): string => $file->originalName, $files);
+    }
+}


### PR DESCRIPTION
Closes #816.

## The bug

The Files UI never paged. The collection is server-paginated at 50, the store never sent `page`, and no view rendered a paginator, so file 51 onward simply did not exist for the user: the list just ended, with no indicator.

The sharp edge was the trash. Past 50 trashed files the older ones could never be restored, and `app:band-space:purge` destroys them after the retention window. Permanent data loss caused purely by a missing affordance.

## Explicit "Charger plus", not a paginator

A numbered paginator swaps the page out from under a drag, and the list is a drop target. Auto infinite scroll would make anything below the list unreachable, since rows are not virtualised. "Charger plus" is also already the idiom in the activity section.

The page number is derived from how many rows are loaded rather than from a click counter, and pages are merged by id. That is self-healing for rows the list itself removed: delete one of 50 and the next request goes back to page 1, where the merge keeps only the row that slid into the window instead of stepping over it.

## Three backend changes, each a latent bug

1. **`itemsPerPage` was silently ignored.** `client_items_per_page` defaults to false, so `paginationMaximumItemsPerPage: 200` was dead config. As a side effect this also fixes `RepertoireView.vue`, which already assumed a 200 page size that was never honoured.
2. **`findByBandSpace` applied LIMIT/OFFSET over a fetch-joined to-many.** The `tags` join turns one file into one row per tag, so a page of tagged files returned fewer than 50 files while the count was correct, and the shortfall read to the client as "nothing left". Now wrapped in Doctrine's `Paginator`. This method is shared by five providers, hence the full-suite run.
3. **The sort had no tiebreaker.** A batch upload stamps one datetime on every file, and with a partial order the database may hand the same row to two pages and to neither. An `id` tiebreaker is now applied to every sort branch, in the same direction.

## Fixed during review

**The paging could stall permanently.** The self-healing argument holds for rows the client removed itself, but not for a row another member restores or archives: that lands wherever its creation date falls, mid-window. The loaded count then stops growing, so the derived page stops moving with it, and every further click re-requests the same offset forever, with "Charger plus" visible and inert. Worst in the trash, where the sort is decorrelated from when something was trashed.

The store now watches for that exact signature, a page bringing back nothing new while the server still reports more, and rebuilds from the first page. The limit of the derived-page maths is pinned as a test so the resync cannot later be deleted as redundant, and the module docblock no longer claims a guarantee it does not have.

Also moved: two tests that made zero HTTP calls now live in `tests/Integration/Repository/BandSpace/BandSpaceFileRepositoryPagingTest.php`. The stateless firewall justifies not making a second HTTP request; it does not justify an HTTP-free test sitting in `tests/Api`.

## Also

Dragging a file used to trigger a full refetch, which with paging would snap a long list back to 50. It now patches the loaded rows. `totalFiles` was in the store and rendered nowhere; it drives a count line above the list.

## Tests

95 JS tests, 207 file API tests, 2 new integration tests, full suite 2108, PHPStan level 8 clean.

## Note for #568

That issue copies this shape to tasks, comments and activities. The stall above is worth knowing about before it is reproduced three more times.
