### PR TITLE
fix(M-817): revoke task assignments and notifications when a member departs

### DIFF
--- a/assets/js/components/BandSpace/Task/TaskDetail.vue
+++ b/assets/js/components/BandSpace/Task/TaskDetail.vue
@@ -310,11 +310,26 @@ watch(task, async () => {
     editPriority.value = task.value.priority
     editCategoryId.value = task.value.category_id
     editDueDate.value = task.value.due_date ? new Date(task.value.due_date) : null
-    editAssigneeIds.value = task.value.assignees.map((a) => a.id)
+    editAssigneeIds.value = assigneeIdsStillInTheBand()
     return
   }
   populateForm()
 })
+
+/**
+ * The picker only offers the current roster, so an assignment left over from a member who is no
+ * longer in the band renders as no chip at all while staying in the model, and saving any other
+ * change writes it straight back. Dropping it here means the next edit of the task clears it.
+ */
+function assigneeIdsStillInTheBand() {
+  const assignedIds = task.value.assignees.map((a) => a.id)
+  // An empty roster means it has not loaded, never that the band is empty: reading it the other way
+  // would have the next save wipe every assignee off the task.
+  if (members.value.length === 0) return assignedIds
+
+  const rosterIds = new Set(members.value.map((m) => m.user_id))
+  return assignedIds.filter((id) => rosterIds.has(id))
+}
 
 function populateForm() {
   if (!task.value) return
@@ -323,7 +338,7 @@ function populateForm() {
   editPriority.value = task.value.priority
   editCategoryId.value = task.value.category_id
   editDueDate.value = task.value.due_date ? new Date(task.value.due_date) : null
-  editAssigneeIds.value = task.value.assignees.map((a) => a.id)
+  editAssigneeIds.value = assigneeIdsStillInTheBand()
   editDescription.value = task.value.description || ''
   lastPopulatedId.value = task.value.id
 }

--- a/assets/js/components/BandSpace/Task/TaskFilterBar.vue
+++ b/assets/js/components/BandSpace/Task/TaskFilterBar.vue
@@ -101,6 +101,21 @@
         </button>
       </div>
 
+      <!-- Unassigned filter: the tasks nobody is on, incl. those a departed member left behind -->
+      <button
+        type="button"
+        class="text-xs px-2 py-1 rounded border transition-colors"
+        :class="
+          filters.unassigned
+            ? 'bg-primary text-primary-contrast border-primary'
+            : 'border-surface-200 dark:border-surface-600 text-surface-500 hover:border-surface-400'
+        "
+        @click="$emit('update-filter', 'unassigned', !filters.unassigned)"
+      >
+        <i class="pi pi-user-minus text-[10px] mr-1"></i>
+        Non assignées
+      </button>
+
       <!-- Priority filters -->
       <div class="flex items-center gap-1">
         <button

--- a/assets/js/store/bandSpace/bandSpaceTasks.js
+++ b/assets/js/store/bandSpace/bandSpaceTasks.js
@@ -16,6 +16,7 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
   const filters = reactive({
     categoryId: null,
     assigneeId: null,
+    unassigned: false,
     priority: null,
     myTasks: false,
     showArchived: false,
@@ -45,6 +46,9 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
       if (filters.categoryId && task.category_id !== filters.categoryId) return false
       if (filters.assigneeId && !task.assignees.some((a) => a.id === filters.assigneeId))
         return false
+      // Work nobody is on. A member leaving the band comes off their tasks, which can leave some
+      // with an empty avatar row, and this is how the rest of the band finds them again.
+      if (filters.unassigned && task.assignees.length > 0) return false
       if (filters.priority && task.priority !== filters.priority) return false
       if (filters.myTasks && !task.assignees.some((a) => a.id === currentUserId)) return false
       return true
@@ -415,6 +419,7 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
     selectedTaskIds.value = new Set()
     filters.categoryId = null
     filters.assigneeId = null
+    filters.unassigned = false
     filters.priority = null
     filters.myTasks = false
     filters.showArchived = false

--- a/src/EventSubscriber/BandSpaceInvitationRespondedListener.php
+++ b/src/EventSubscriber/BandSpaceInvitationRespondedListener.php
@@ -7,6 +7,7 @@ namespace App\EventSubscriber;
 use App\Enum\BandSpace\InvitationStatus;
 use App\Enum\Notification\NotificationType;
 use App\Event\BandSpaceInvitationRespondedEvent;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Service\Notification\NotificationCreator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -17,12 +18,18 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
  * is dispatched after the response is committed, and this listener swallows + logs any failure so it
  * can never roll back or 500 the accept/decline. The responder is excluded defensively - an inviter
  * cannot invite themselves, so inviter != responder by construction.
+ *
+ * An inviter who has since left the space is skipped (#817). A pending invitation outlives the
+ * membership that sent it, and the auto-accept path stretches that gap indefinitely: an invitation
+ * sent to an email address sits Pending until the addressee happens to register. Telling somebody
+ * who is no longer in the band who just joined it is news about a space they can no longer open.
  */
 #[AsEventListener]
 readonly class BandSpaceInvitationRespondedListener
 {
     public function __construct(
         private NotificationCreator $notificationCreator,
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
         private LoggerInterface $logger,
     ) {
     }
@@ -45,6 +52,10 @@ readonly class BandSpaceInvitationRespondedListener
         }
 
         try {
+            if (!$this->bandSpaceMembershipRepository->isMember($invitation->bandSpace, $inviter)) {
+                return;
+            }
+
             $this->notificationCreator->create($inviter, $type, [
                 'band_space_id' => (string) $invitation->bandSpace->id,
                 'band_space_name' => $invitation->bandSpace->name,

--- a/src/EventSubscriber/BandSpaceMemberRoleChangedListener.php
+++ b/src/EventSubscriber/BandSpaceMemberRoleChangedListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\EventSubscriber;
 
+use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\Notification\NotificationType;
 use App\Event\BandSpaceMemberRoleChangedEvent;
 use App\Service\Notification\NotificationCreator;
@@ -33,6 +34,14 @@ readonly class BandSpaceMemberRoleChangedListener
         $actor = $event->actor;
 
         if ((string) $membership->user->id === (string) $actor->id) {
+            return;
+        }
+
+        // A closed membership can still have its role patched - the update processor resolves the
+        // member by id, not by status - and a role nobody can exercise is not news worth a bell
+        // (#817). The successor promoted when an account is deleted is Active by the time this runs,
+        // so the promotion that matters still gets through.
+        if ($membership->status !== MembershipStatus::Active) {
             return;
         }
 

--- a/src/EventSubscriber/BandSpaceTaskCommentedListener.php
+++ b/src/EventSubscriber/BandSpaceTaskCommentedListener.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Enum\Notification\NotificationType;
 use App\Event\BandSpaceTaskCommentedEvent;
 use App\Repository\BandSpace\TaskCommentRepository;
+use App\Repository\UserRepository;
 use App\Service\Notification\NotificationCreator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -19,6 +20,12 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
  * per the epic #689 resilience contract: the event is dispatched after the comment is committed, and
  * the whole body (incl. the prior-commenter query) is wrapped so a failure can never roll back or
  * 500 the comment. The comment author is excluded; createForRecipients dedupes by user id.
+ *
+ * The three candidate sources are all read off the task's own graph, so every one of them can name
+ * somebody who has since left the band: a creator, an assignee or a past commenter keeps their row
+ * long after their membership is closed (#817). The candidates are therefore resolved through
+ * findActiveBandSpaceMembersByIds rather than notified directly, the same query the mention path
+ * uses, so a departed member stops hearing about a space they are no longer in.
  */
 #[AsEventListener]
 readonly class BandSpaceTaskCommentedListener
@@ -26,6 +33,7 @@ readonly class BandSpaceTaskCommentedListener
     public function __construct(
         private NotificationCreator $notificationCreator,
         private TaskCommentRepository $taskCommentRepository,
+        private UserRepository $userRepository,
         private LoggerInterface $logger,
     ) {
     }
@@ -47,9 +55,20 @@ readonly class BandSpaceTaskCommentedListener
                 ...$this->taskCommentRepository->findCommentAuthorsByTask($task),
             ];
 
-            $recipients = array_filter(
-                $candidates,
-                static fn (?User $user): bool => $user instanceof User && !isset($excludedIds[(string) $user->id]),
+            $candidateIds = [];
+            foreach ($candidates as $candidate) {
+                if (!$candidate instanceof User) {
+                    continue;
+                }
+                $candidateId = (string) $candidate->id;
+                if (!isset($excludedIds[$candidateId])) {
+                    $candidateIds[$candidateId] = $candidateId;
+                }
+            }
+
+            $recipients = $this->userRepository->findActiveBandSpaceMembersByIds(
+                $task->bandSpace,
+                array_values($candidateIds),
             );
             if ($recipients === []) {
                 return;

--- a/src/Repository/BandSpace/AgendaEntryRepository.php
+++ b/src/Repository/BandSpace/AgendaEntryRepository.php
@@ -86,7 +86,12 @@ class AgendaEntryRepository extends ServiceEntityRepository
             return [];
         }
 
+        // The band space comes along because the notification enricher reads it on every row to work
+        // out whether the reader may still be shown a live title and date, and one proxy load per
+        // entry would undo the point of fetching them in a single query.
         return $this->createQueryBuilder('a')
+            ->innerJoin('a.bandSpace', 'bs')
+            ->addSelect('bs')
             ->where('a.id IN (:ids)')
             ->setParameter('ids', $ids)
             ->getQuery()

--- a/src/Repository/BandSpace/BandSpaceMembershipRepository.php
+++ b/src/Repository/BandSpace/BandSpaceMembershipRepository.php
@@ -157,6 +157,40 @@ class BandSpaceMembershipRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    /**
+     * Which of these band spaces the user is still an active member of.
+     *
+     * One query for a whole notification page: read-time enrichment refreshes band space data as it
+     * stands right now, so it may only do that for the spaces the reader can still open.
+     *
+     * @param string[] $bandSpaceIds
+     * @return array<string, true> band space id => true, for an isset() lookup at the call site
+     */
+    public function findActiveBandSpaceIdsForUser(User $user, array $bandSpaceIds): array
+    {
+        if ($bandSpaceIds === []) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('m')
+            ->select('IDENTITY(m.bandSpace) AS band_space_id')
+            ->where('m.user = :user')
+            ->andWhere('m.bandSpace IN (:bandSpaceIds)')
+            ->andWhere('m.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('bandSpaceIds', $bandSpaceIds)
+            ->setParameter('status', MembershipStatus::Active)
+            ->getQuery()
+            ->getArrayResult();
+
+        $activeIds = [];
+        foreach ($rows as $row) {
+            $activeIds[(string) $row['band_space_id']] = true;
+        }
+
+        return $activeIds;
+    }
+
     public function findMembershipIncludingInactive(BandSpace $bandSpace, User $user): ?BandSpaceMembership
     {
         return $this->createQueryBuilder('m')

--- a/src/Repository/BandSpace/TaskRepository.php
+++ b/src/Repository/BandSpace/TaskRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository\BandSpace;
 
 use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\Task;
+use App\Entity\User;
 use App\Enum\BandSpace\TaskStatus;
 use App\Repository\BandSpace\Filter\TaskFilter;
 use DateTimeImmutable;
@@ -189,9 +190,37 @@ class TaskRepository extends ServiceEntityRepository
             return [];
         }
 
+        // The band space comes along because the enricher reads it on every row to work out whether
+        // the reader may still be shown a live title, and one proxy load per task would undo the
+        // point of fetching them in a single query.
         return $this->createQueryBuilder('t')
+            ->innerJoin('t.bandSpace', 'bs')
+            ->addSelect('bs')
             ->where('t.id IN (:ids)')
             ->setParameter('ids', $ids)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Every task of a band space one user is currently assigned to, archived and done ones included:
+     * an assignment says who is on the hook today, so a member on their way out comes off all of them.
+     *
+     * The join filters, it deliberately does not `addSelect('a')`: hydrating the assignee collection
+     * through a join that only matches one member would leave each task holding a partial collection,
+     * and flushing that would drop the co-assignees the query never selected.
+     *
+     * @return Task[]
+     */
+    public function findByBandSpaceAndAssignee(BandSpace $bandSpace, User $assignee): array
+    {
+        return $this->createQueryBuilder('t')
+            ->innerJoin('t.assignees', 'a')
+            ->where('t.bandSpace = :bandSpace')
+            ->andWhere('a.id = :assigneeId')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('assigneeId', (string) $assignee->id)
+            ->orderBy('t.creationDatetime', 'ASC')
             ->getQuery()
             ->getResult();
     }

--- a/src/Service/BandSpace/TaskAssignmentRevoker.php
+++ b/src/Service/BandSpace/TaskAssignmentRevoker.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceTaskActivityType;
+use App\Repository\BandSpace\TaskRepository;
+
+/**
+ * Takes a member who is on their way out off every task of the space they were assigned to, whether
+ * they left, were removed by an admin or deleted their MusicAll account.
+ *
+ * An assignment is a statement about who is on the hook now, not a record of who did what: somebody
+ * who is no longer in the band is on the hook for nothing, so the assignment goes everywhere,
+ * archived and done tasks included. What actually happened is kept: the comments they wrote, the
+ * tasks they created and the authorship of both stay untouched, and each revoked assignment is
+ * written to the task activity feed as an `assignee_removed` entry, exactly like an admin clearing
+ * the assignee by hand. That entry names the member and the task, so the band keeps the fact that
+ * they were on it and can see when it stopped.
+ *
+ * A task left with nobody on it is not reassigned and nobody is notified about it. Picking a new
+ * owner is the band's call, not the app's, and one bell per orphaned task would turn removing a busy
+ * member into a burst of notifications. The work stays findable instead: the activity feed carries
+ * every revocation, and the board has a « Non assigné » filter for the tasks that came out of it
+ * with no one on them.
+ *
+ * Shared by the three departure paths so a member who disappears one way does not keep their
+ * assignments while a member who disappears another way loses them.
+ */
+readonly class TaskAssignmentRevoker
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+    ) {
+    }
+
+    /**
+     * Mutates the assignee collections without flushing, so the caller commits the whole departure
+     * at once.
+     */
+    public function revokeForMember(BandSpaceMembership $membership, User $actor): void
+    {
+        $departingUser = $membership->user;
+        $departingUserId = (string) $departingUser->id;
+
+        foreach ($this->taskRepository->findByBandSpaceAndAssignee($membership->bandSpace, $departingUser) as $task) {
+            // Matched by id rather than handed the user object, as TaskUpdateProcedure does when an
+            // admin clears an assignee by hand: the removal must not hinge on the collection having
+            // hydrated the very instance we are holding.
+            foreach ($task->assignees as $assignee) {
+                if ((string) $assignee->id === $departingUserId) {
+                    $task->assignees->removeElement($assignee);
+
+                    break;
+                }
+            }
+
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $membership->bandSpace,
+                module: BandSpaceModule::Task,
+                type: BandSpaceTaskActivityType::AssigneeRemoved,
+                resourceId: $task->id,
+                actor: $actor,
+                payload: [
+                    'assignee_id' => $departingUser->id,
+                    'assignee_username' => $departingUser->username,
+                ],
+            );
+        }
+    }
+}

--- a/src/Service/Notification/Enricher/AbstractTaskTitleEnricher.php
+++ b/src/Service/Notification/Enricher/AbstractTaskTitleEnricher.php
@@ -3,24 +3,35 @@
 namespace App\Service\Notification\Enricher;
 
 use App\ApiResource\Notification\UserNotification;
+use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\TaskRepository;
 
 /**
  * Shared read-time refresh of `payload.task_title` to the live task title, so a task notification
  * stays findable on the board after the task is renamed (there is no per-task deep-link, so the
- * title is load-bearing for navigation). Batched: one `id IN (...)` query for the whole page.
+ * title is load-bearing for navigation). Batched: two queries for the whole page, whatever its size.
  * A deleted task keeps its last-known stored title (graceful staleness). Subclasses bind the type.
+ *
+ * The refresh follows the reader's current access (#817). Notifications outlive the membership that
+ * earned them - nothing prunes the feed when somebody leaves a band space - so without this the
+ * stored payload would become a live window on the titles of a board they can no longer open, one
+ * that keeps updating every time they pull down their notifications. A recipient who is no longer an
+ * active member keeps the title as it stood when the notification was written: their own history,
+ * frozen where it belongs. Active members see exactly what they saw before.
  */
 abstract readonly class AbstractTaskTitleEnricher
 {
-    public function __construct(private TaskRepository $taskRepository)
-    {
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+    ) {
     }
 
     /**
      * @param UserNotification[] $notifications
      */
-    public function enrich(array $notifications): void
+    public function enrich(array $notifications, User $recipient): void
     {
         $ids = [];
         foreach ($notifications as $notification) {
@@ -34,9 +45,29 @@ abstract readonly class AbstractTaskTitleEnricher
             return;
         }
 
+        $tasks = $this->taskRepository->findByIds($ids);
+        if ($tasks === []) {
+            return;
+        }
+
+        // Read off the task rather than the payload: the band space a task belongs to is a fact of
+        // the task, and a payload written by a past release cannot be relied on to carry it.
+        $bandSpaceIds = [];
+        foreach ($tasks as $task) {
+            $bandSpaceId = (string) $task->bandSpace->id;
+            $bandSpaceIds[$bandSpaceId] = $bandSpaceId;
+        }
+
+        $activeBandSpaceIds = $this->bandSpaceMembershipRepository->findActiveBandSpaceIdsForUser(
+            $recipient,
+            array_values($bandSpaceIds),
+        );
+
         $titlesById = [];
-        foreach ($this->taskRepository->findByIds($ids) as $task) {
-            $titlesById[(string) $task->id] = $task->title;
+        foreach ($tasks as $task) {
+            if (isset($activeBandSpaceIds[(string) $task->bandSpace->id])) {
+                $titlesById[(string) $task->id] = $task->title;
+            }
         }
 
         foreach ($notifications as $notification) {

--- a/src/Service/Notification/Enricher/AgendaEntryNotificationEnricher.php
+++ b/src/Service/Notification/Enricher/AgendaEntryNotificationEnricher.php
@@ -3,19 +3,27 @@
 namespace App\Service\Notification\Enricher;
 
 use App\ApiResource\Notification\UserNotification;
+use App\Entity\User;
 use App\Enum\Notification\NotificationType;
 use App\Repository\BandSpace\AgendaEntryRepository;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
 
 /**
  * Refreshes a band-space agenda-entry notification's `entry_title` + `event_datetime` at feed-read
  * (#722), so it stays accurate after the entry is renamed or rescheduled. The agenda has no
- * per-entry/per-date deep-link, so both fields are load-bearing. Batched: one `id IN (...)` query for
- * the whole page. A deleted entry keeps its last-known stored values (graceful staleness).
+ * per-entry/per-date deep-link, so both fields are load-bearing. Batched: two queries for the whole
+ * page. A deleted entry keeps its last-known stored values (graceful staleness).
+ *
+ * Like the task-title refresh, it follows the reader's current access (#817): a recipient who has
+ * left the band space keeps the title and date as they stood when they were told, rather than a live
+ * feed of where and when the band is now rehearsing.
  */
 readonly class AgendaEntryNotificationEnricher implements NotificationEnricherInterface
 {
-    public function __construct(private AgendaEntryRepository $agendaEntryRepository)
-    {
+    public function __construct(
+        private AgendaEntryRepository $agendaEntryRepository,
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+    ) {
     }
 
     public function getType(): NotificationType
@@ -26,7 +34,7 @@ readonly class AgendaEntryNotificationEnricher implements NotificationEnricherIn
     /**
      * @param UserNotification[] $notifications
      */
-    public function enrich(array $notifications): void
+    public function enrich(array $notifications, User $recipient): void
     {
         $ids = [];
         foreach ($notifications as $notification) {
@@ -40,9 +48,27 @@ readonly class AgendaEntryNotificationEnricher implements NotificationEnricherIn
             return;
         }
 
+        $entries = $this->agendaEntryRepository->findByIds($ids);
+        if ($entries === []) {
+            return;
+        }
+
+        $bandSpaceIds = [];
+        foreach ($entries as $entry) {
+            $bandSpaceId = (string) $entry->bandSpace->id;
+            $bandSpaceIds[$bandSpaceId] = $bandSpaceId;
+        }
+
+        $activeBandSpaceIds = $this->bandSpaceMembershipRepository->findActiveBandSpaceIdsForUser(
+            $recipient,
+            array_values($bandSpaceIds),
+        );
+
         $entriesById = [];
-        foreach ($this->agendaEntryRepository->findByIds($ids) as $entry) {
-            $entriesById[(string) $entry->id] = $entry;
+        foreach ($entries as $entry) {
+            if (isset($activeBandSpaceIds[(string) $entry->bandSpace->id])) {
+                $entriesById[(string) $entry->id] = $entry;
+            }
         }
 
         foreach ($notifications as $notification) {

--- a/src/Service/Notification/Enricher/BandSpaceInvitationNotificationEnricher.php
+++ b/src/Service/Notification/Enricher/BandSpaceInvitationNotificationEnricher.php
@@ -3,6 +3,7 @@
 namespace App\Service\Notification\Enricher;
 
 use App\Entity\BandSpace\BandSpaceInvitation;
+use App\Entity\User;
 use App\Enum\BandSpace\InvitationStatus;
 use App\Enum\Notification\NotificationType;
 use App\Repository\BandSpace\BandSpaceInvitationRepository;
@@ -12,6 +13,10 @@ use App\Repository\BandSpace\BandSpaceInvitationRepository;
  * invitation notification, so the frontend drops stale Accepter/Décliner once the
  * invite is accepted/declined/cancelled/expired. Batched: one `token IN (...)`
  * query for the whole page.
+ *
+ * Deliberately not gated on membership, unlike the task and agenda enrichers: the recipient here is
+ * the invitee, who is by definition not a member of the space yet. Gating it would leave a dead
+ * Accepter button on an invitation that has already been cancelled (#817).
  */
 readonly class BandSpaceInvitationNotificationEnricher implements NotificationEnricherInterface
 {
@@ -24,7 +29,7 @@ readonly class BandSpaceInvitationNotificationEnricher implements NotificationEn
         return NotificationType::BandSpaceInvitation;
     }
 
-    public function enrich(array $notifications): void
+    public function enrich(array $notifications, User $recipient): void
     {
         $tokens = [];
         foreach ($notifications as $notification) {

--- a/src/Service/Notification/Enricher/NotificationEnricherInterface.php
+++ b/src/Service/Notification/Enricher/NotificationEnricherInterface.php
@@ -3,12 +3,17 @@
 namespace App\Service\Notification\Enricher;
 
 use App\ApiResource\Notification\UserNotification;
+use App\Entity\User;
 use App\Enum\Notification\NotificationType;
 
 /**
  * Read-time, per-type enricher: receives every feed DTO of its type and augments
  * their payload in place (e.g. live status), doing a single bulk query - no N+1.
  * Implementations are tagged `app.notification_enricher` (see config/services.yaml).
+ *
+ * The recipient comes along because enrichment is relative to who is reading: refreshing a payload
+ * hands out data as it stands right now, and what somebody is still allowed to see can have changed
+ * since the notification was written (#817).
  */
 interface NotificationEnricherInterface
 {
@@ -16,6 +21,7 @@ interface NotificationEnricherInterface
 
     /**
      * @param UserNotification[] $notifications all of getType()
+     * @param User $recipient the user whose feed is being read; every notification belongs to them
      */
-    public function enrich(array $notifications): void;
+    public function enrich(array $notifications, User $recipient): void;
 }

--- a/src/Service/Notification/NotificationFeedEnricher.php
+++ b/src/Service/Notification/NotificationFeedEnricher.php
@@ -3,6 +3,7 @@
 namespace App\Service\Notification;
 
 use App\ApiResource\Notification\UserNotification;
+use App\Entity\User;
 use App\Service\Notification\Enricher\NotificationEnricherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
@@ -34,8 +35,10 @@ readonly class NotificationFeedEnricher
 
     /**
      * @param UserNotification[] $notifications
+     * @param User $recipient the user whose feed this is; enrichment is relative to what they may
+     *                        still see, so every enricher gets told who is reading
      */
-    public function enrich(array $notifications): void
+    public function enrich(array $notifications, User $recipient): void
     {
         $groups = [];
         foreach ($notifications as $notification) {
@@ -52,7 +55,7 @@ readonly class NotificationFeedEnricher
             // stored point-in-time payload, never 500 the whole feed (epic #689 contract).
             // Isolated per type so one broken enricher can't take down the others.
             try {
-                $enricher->enrich($group);
+                $enricher->enrich($group, $recipient);
             } catch (\Throwable $e) {
                 $this->logger->error('Notification feed enrichment failed; serving stored payload', [
                     'type' => $type,

--- a/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
+++ b/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
@@ -15,6 +15,7 @@ use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\BandSpaceDeletionScheduler;
 use App\Service\BandSpace\PersonalRecurrenceDeactivator;
+use App\Service\BandSpace\TaskAssignmentRevoker;
 use DateTime;
 
 /**
@@ -54,6 +55,7 @@ readonly class WithdrawUserFromBandSpacesProcedure
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
         private BandSpaceDeletionScheduler $bandSpaceDeletionScheduler,
         private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
+        private TaskAssignmentRevoker $taskAssignmentRevoker,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
     ) {
     }
@@ -93,6 +95,7 @@ readonly class WithdrawUserFromBandSpacesProcedure
         $membership->leftDatetime = new DateTime();
 
         $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
+        $this->taskAssignmentRevoker->revokeForMember($membership, $user);
 
         $this->bandSpaceActivityRecorder->record(
             bandSpace: $bandSpace,

--- a/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
@@ -13,6 +13,7 @@ use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\PersonalRecurrenceDeactivator;
+use App\Service\BandSpace\TaskAssignmentRevoker;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -30,6 +31,7 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
         private BandSpaceRepository $bandSpaceRepository,
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
         private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
+        private TaskAssignmentRevoker $taskAssignmentRevoker,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
     ) {
@@ -63,6 +65,7 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
             $membership->leftDatetime = new DateTime();
 
             $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
+            $this->taskAssignmentRevoker->revokeForMember($membership, $user);
 
             $this->bandSpaceActivityRecorder->record(
                 bandSpace: $bandSpace,

--- a/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
@@ -14,6 +14,7 @@ use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Security\BandSpace\BandSpaceAdminChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\PersonalRecurrenceDeactivator;
+use App\Service\BandSpace\TaskAssignmentRevoker;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -31,6 +32,7 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
         private BandSpaceAdminChecker $adminChecker,
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
         private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
+        private TaskAssignmentRevoker $taskAssignmentRevoker,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
         private EventDispatcherInterface $eventDispatcher,
@@ -69,6 +71,7 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
             $membership->leftDatetime = new DateTime();
 
             $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
+            $this->taskAssignmentRevoker->revokeForMember($membership, $user);
 
             $this->bandSpaceActivityRecorder->record(
                 bandSpace: $bandSpace,

--- a/src/State/Provider/Notification/NotificationCollectionProvider.php
+++ b/src/State/Provider/Notification/NotificationCollectionProvider.php
@@ -42,7 +42,7 @@ readonly class NotificationCollectionProvider implements ProviderInterface
         $entities = $this->notificationRepository->findForRecipient($user, $limit, $offset);
         $totalItems = $this->notificationRepository->countForRecipient($user);
         $dtos = $this->notificationBuilder->buildFromList($entities);
-        $this->feedEnricher->enrich($dtos);
+        $this->feedEnricher->enrich($dtos, $user);
 
         return new TraversablePaginator(new \ArrayIterator($dtos), $page, $limit, $totalItems);
     }

--- a/src/State/Provider/Notification/NotificationItemProvider.php
+++ b/src/State/Provider/Notification/NotificationItemProvider.php
@@ -40,7 +40,7 @@ readonly class NotificationItemProvider implements ProviderInterface
         }
 
         $dto = $this->notificationBuilder->buildFromEntity($notification);
-        $this->feedEnricher->enrich([$dto]);
+        $this->feedEnricher->enrich([$dto], $user);
 
         return $dto;
     }

--- a/tests/Api/BandSpace/BandSpaceInvitationAcceptTest.php
+++ b/tests/Api/BandSpace/BandSpaceInvitationAcceptTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Api\BandSpace;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\InvitationStatus;
+use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\BandSpace\Role;
 use App\Enum\Notification\NotificationType;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
@@ -263,6 +264,48 @@ class BandSpaceInvitationAcceptTest extends ApiTestCase
 
         // The accepter (actor) receives nothing.
         $this->assertCount(0, $notificationRepository->findForRecipient($invitee, 10, 0));
+    }
+
+    public function test_accept_does_not_notify_an_inviter_who_has_left_the_band_space(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $formerAdmin = UserFactory::new()->create(['username' => 'former_admin', 'email' => 'former@example.com']);
+        $invitee = UserFactory::new()->create(['username' => 'invitee', 'email' => 'invitee@example.com']);
+        $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $formerAdmin,
+            'role' => Role::Admin,
+            'status' => MembershipStatus::Left,
+            'leftDatetime' => new \DateTime('2026-01-02 10:00:00'),
+        ])->create();
+
+        // A pending invitation outlives the membership that sent it, so by the time it is answered
+        // the inviter can be gone.
+        $invitation = BandSpaceInvitationFactory::new([
+            'bandSpace' => $bandSpace,
+            'invitedBy' => $formerAdmin,
+            'email' => 'invitee@example.com',
+            'existingUser' => $invitee,
+            'expirationDatetime' => (new \DateTime())->modify('+7 days'),
+        ])->create();
+
+        $this->client->loginUser($invitee);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/invitations/' . $invitation->token . '/accept',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+        $this->assertResponseIsSuccessful();
+
+        // The invitation still works, it is only the notification about it that is dropped.
+        $this->assertTrue(
+            self::getContainer()->get(BandSpaceMembershipRepository::class)->isMember($bandSpace, $invitee),
+        );
+        $this->assertCount(0, self::getContainer()->get(NotificationRepository::class)->findAll());
     }
 
     public function test_notification_failure_does_not_break_the_accept(): void

--- a/tests/Api/BandSpace/BandSpaceLeaveTest.php
+++ b/tests/Api/BandSpace/BandSpaceLeaveTest.php
@@ -6,11 +6,14 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Repository\BandSpace\TaskRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\TaskFactory;
 use App\Tests\Factory\User\UserFactory;
+use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -52,6 +55,58 @@ class BandSpaceLeaveTest extends ApiTestCase
             $activities[0]->payload,
         );
         $this->assertSame($member->id, $activities[0]->actor?->id);
+    }
+
+    public function test_leaving_revokes_the_member_task_assignments(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $sharedTask = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Réserver la salle',
+            'assignees' => new ArrayCollection([$member, $admin]),
+        ])->create();
+        $soleTask = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Envoyer le dossier',
+            'assignees' => new ArrayCollection([$member]),
+        ])->create();
+
+        $sharedTaskId = (string) $sharedTask->id;
+        $soleTaskId = (string) $soleTask->id;
+
+        $this->client->loginUser($member);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/leave',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $taskRepository = self::getContainer()->get(TaskRepository::class);
+        $this->assertCount(0, $taskRepository->findByBandSpaceAndAssignee($bandSpace, $member));
+        $this->assertCount(1, $taskRepository->findByBandSpaceAndAssignee($bandSpace, $admin));
+
+        // The member who quit is the actor of their own departure, here as in the settings feed.
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        foreach ([$sharedTaskId, $soleTaskId] as $taskId) {
+            $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::Task, $taskId);
+            $this->assertCount(1, $activities);
+            $this->assertSame('assignee_removed', $activities[0]->type);
+            $this->assertSame(
+                ['assignee_id' => $member->id, 'assignee_username' => 'member_user'],
+                $activities[0]->payload,
+            );
+            $this->assertSame($member->id, $activities[0]->actor?->id);
+        }
     }
 
     public function test_admin_can_leave_when_other_admins_exist(): void

--- a/tests/Api/BandSpace/BandSpaceMemberDeleteTest.php
+++ b/tests/Api/BandSpace/BandSpaceMemberDeleteTest.php
@@ -2,15 +2,22 @@
 
 namespace App\Tests\Api\BandSpace;
 
+use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\Role;
+use App\Enum\BandSpace\TaskStatus;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Repository\BandSpace\TaskCommentRepository;
+use App\Repository\BandSpace\TaskRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\TaskCommentFactory;
+use App\Tests\Factory\BandSpace\TaskFactory;
 use App\Tests\Factory\User\UserFactory;
+use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -49,6 +56,87 @@ class BandSpaceMemberDeleteTest extends ApiTestCase
             $activities[0]->payload,
         );
         $this->assertSame($admin->id, $activities[0]->actor?->id);
+    }
+
+    public function test_kick_revokes_the_member_task_assignments(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $other = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $memberMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other, 'role' => Role::User])->create();
+
+        $sharedTask = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Réserver la salle',
+            'assignees' => new ArrayCollection([$member, $other]),
+        ])->create();
+        $soleTask = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Envoyer le dossier',
+            'assignees' => new ArrayCollection([$member]),
+        ])->create();
+        // Done and archived work is covered too: an assignment says who is on the hook now, and
+        // somebody who is out of the band is on the hook for nothing.
+        $archivedTask = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Imprimer les affiches',
+            'status' => TaskStatus::Done,
+            'archiveDatetime' => new \DateTimeImmutable('2026-01-05 10:00:00'),
+            'assignees' => new ArrayCollection([$member]),
+        ])->create();
+        TaskCommentFactory::new([
+            'task' => $sharedTask,
+            'author' => $member,
+            'content' => 'Je m\'y mets demain',
+            'creationDatetime' => new \DateTime('2026-01-01 10:00:00'),
+        ])->create();
+
+        $sharedTaskId = (string) $sharedTask->id;
+        $soleTaskId = (string) $soleTask->id;
+        $archivedTaskId = (string) $archivedTask->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/members/' . $memberMembership->id
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $taskRepository = self::getContainer()->get(TaskRepository::class);
+        $this->assertCount(0, $taskRepository->findByBandSpaceAndAssignee($bandSpace, $member));
+        // The member who stayed keeps the task they shared: only the departing one comes off.
+        $this->assertCount(1, $taskRepository->findByBandSpaceAndAssignee($bandSpace, $other));
+
+        $reloadedShared = $taskRepository->findOneByIdAndBandSpace($sharedTaskId, $bandSpace);
+        $this->assertNotNull($reloadedShared);
+        $this->assertSame(
+            [(string) $other->id],
+            array_map(static fn (User $user): string => (string) $user->id, $reloadedShared->assignees->toArray()),
+        );
+
+        // What happened is kept: the comment they wrote and its authorship survive the departure.
+        $comments = self::getContainer()->get(TaskCommentRepository::class)->findByTask($reloadedShared);
+        $this->assertCount(1, $comments);
+        $this->assertSame((string) $member->id, (string) $comments[0]->author->id);
+
+        // Every revocation lands in the task's own activity feed, so the band can see the work that
+        // came free and when.
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        foreach ([$sharedTaskId, $soleTaskId, $archivedTaskId] as $taskId) {
+            $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::Task, $taskId);
+            $this->assertCount(1, $activities);
+            $this->assertSame('assignee_removed', $activities[0]->type);
+            $this->assertSame(
+                ['assignee_id' => $member->id, 'assignee_username' => 'member_user'],
+                $activities[0]->payload,
+            );
+            $this->assertSame($admin->id, $activities[0]->actor?->id);
+        }
     }
 
     public function test_cannot_kick_self(): void

--- a/tests/Api/BandSpace/BandSpaceMemberUpdateRoleTest.php
+++ b/tests/Api/BandSpace/BandSpaceMemberUpdateRoleTest.php
@@ -3,8 +3,10 @@
 namespace App\Tests\Api\BandSpace;
 
 use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\Notification\NotificationRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
@@ -69,6 +71,55 @@ class BandSpaceMemberUpdateRoleTest extends ApiTestCase
             $activities[0]->payload,
         );
         $this->assertSame($admin->id, $activities[0]->actor?->id);
+    }
+
+    public function test_changing_the_role_of_a_removed_member_notifies_nobody(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $removed = UserFactory::new()->create(['username' => 'removed_user', 'email' => 'removed@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin, 'creationDatetime' => new \DateTime('2024-01-01 10:00:00')])->create();
+        // A closed membership can still be patched: the update processor resolves the member by id,
+        // not by status.
+        $removedMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $removed,
+            'role' => Role::User,
+            'status' => MembershipStatus::Kicked,
+            'leftDatetime' => new \DateTime('2024-06-01 10:00:00'),
+            'creationDatetime' => new \DateTime('2024-01-02 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/members/' . $removedMembership->id,
+            ['role' => 'admin'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceMember',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/members/' . $removedMembership->id,
+            '@type' => 'BandSpaceMember',
+            'id' => $removedMembership->id,
+            'band_space_id' => $bandSpace->id,
+            'user_id' => $removed->id,
+            'username' => 'removed_user',
+            'role' => 'admin',
+            'stage_name' => null,
+            'display_name' => 'removed_user',
+            'instruments' => [],
+            'profile_picture_url' => null,
+            'creation_datetime' => '2024-01-02T10:00:00+00:00',
+            'status' => 'kicked',
+            'left_datetime' => '2024-06-01T10:00:00+00:00',
+        ]);
+
+        // A role nobody can exercise is not news worth a bell.
+        $this->assertCount(0, self::getContainer()->get(NotificationRepository::class)->findAll());
     }
 
     public function test_demote_admin_to_user(): void

--- a/tests/Api/BandSpace/Task/TaskCommentNotificationTest.php
+++ b/tests/Api/BandSpace/Task/TaskCommentNotificationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Api\BandSpace\Task;
 
 use App\Entity\User;
+use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\Notification\NotificationType;
 use App\Repository\BandSpace\TaskCommentRepository;
 use App\Repository\Notification\NotificationRepository;
@@ -279,6 +280,87 @@ class TaskCommentNotificationTest extends ApiTestCase
 
         // The author gets nothing.
         $this->assertCount(0, $notificationRepository->findForRecipient($author, 10, 0));
+    }
+
+    public function test_comment_does_not_notify_a_participant_who_left_the_band_space(): void
+    {
+        $author = UserFactory::new()->asBaseUser()->create();
+        $bob = UserFactory::new()->create(['username' => 'bob', 'email' => 'bob@test.com']);
+        $gone = UserFactory::new()->create(['username' => 'gone', 'email' => 'gone@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'The Rockers']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bob])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $gone,
+            'status' => MembershipStatus::Kicked,
+            'leftDatetime' => new \DateTime('2026-01-02 10:00:00'),
+        ])->create();
+        // The departed member is a participant three times over: they created the task, they were
+        // assigned to it and they commented on it. Departure clears the assignment going forward,
+        // but an assignment predating the fix, the authorship of the task and the comment they wrote
+        // all still name them, so the fan-out has to be the one refusing to notify them.
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $gone,
+            'assignees' => new ArrayCollection([$gone, $bob]),
+            'title' => 'Ma tâche',
+        ])->create();
+        TaskCommentFactory::new([
+            'task' => $task,
+            'author' => $gone,
+            'creationDatetime' => new \DateTime('2026-01-01 10:00:00'),
+        ])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $taskId = (string) $task->id;
+        $content = 'On reprend cette tâche';
+
+        $this->client->loginUser($author);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/tasks/' . $taskId . '/comments',
+            ['content' => $content],
+            self::HEADERS
+        );
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $comments = self::getContainer()->get(TaskCommentRepository::class)->findByTask($task);
+        $authorComment = end($comments);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TaskComment',
+            '@id' => '/api/band_spaces/' . $bandSpaceId . '/tasks/' . $taskId . '/comments/' . $authorComment->id,
+            '@type' => 'TaskComment',
+            'id' => $authorComment->id,
+            'band_space_id' => $bandSpaceId,
+            'task_id' => $taskId,
+            'author_id' => $author->id,
+            'author_username' => $author->username,
+            'author_profile_picture_url' => null,
+            'content' => $content,
+            'creation_datetime' => $authorComment->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => null,
+        ]);
+
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+
+        // The member who is still in the band keeps hearing about the task they are on.
+        $bobNotifications = $notificationRepository->findForRecipient($bob, 10, 0);
+        $this->assertCount(1, $bobNotifications);
+        $this->assertSame(NotificationType::TaskComment, $bobNotifications[0]->type);
+        $this->assertSame([
+            'band_space_id' => $bandSpaceId,
+            'task_id' => $taskId,
+            'task_title' => 'Ma tâche',
+            'comment_id' => (string) $authorComment->id,
+            'actor_id' => (string) $author->id,
+            'actor_username' => $author->username,
+        ], $bobNotifications[0]->payload);
+
+        // The one who is out hears nothing, and nobody else was notified either.
+        $this->assertCount(0, $notificationRepository->findForRecipient($gone, 10, 0));
+        $this->assertCount(0, $notificationRepository->findForRecipient($author, 10, 0));
+        $this->assertCount(1, $notificationRepository->findAll());
     }
 
     public function test_comment_with_no_other_participant_creates_no_notification(): void

--- a/tests/Api/Notification/UserNotificationTest.php
+++ b/tests/Api/Notification/UserNotificationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Api\Notification;
 
 use App\Enum\BandSpace\InvitationStatus;
+use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\Notification\NotificationType;
 use App\Repository\Notification\NotificationRepository;
 use App\Tests\ApiTestAssertionsTrait;
@@ -12,6 +13,7 @@ use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\AgendaEntryFactory;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceInvitationFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\TaskFactory;
 use App\Tests\Factory\Notification\NotificationFactory;
 use App\Tests\Factory\User\UserFactory;
@@ -579,6 +581,8 @@ class UserNotificationTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        // The refresh follows the reader's access: only a member is shown the title as it stands now.
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $task = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'title' => 'Titre actuel'])->create();
         $notification = NotificationFactory::new([
             'recipient' => $user,
@@ -626,6 +630,7 @@ class UserNotificationTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $task = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'title' => 'Titre actuel'])->create();
         $notification = NotificationFactory::new([
             'recipient' => $user,
@@ -675,6 +680,7 @@ class UserNotificationTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $task = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'title' => 'Titre actuel'])->create();
         $notification = NotificationFactory::new([
             'recipient' => $user,
@@ -724,6 +730,7 @@ class UserNotificationTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -766,6 +773,132 @@ class UserNotificationTest extends ApiTestCase
                         'agenda_entry_id' => (string) $entry->id,
                         'entry_title' => 'Titre actuel',
                         'event_datetime' => '2026-08-15T20:00:00+00:00',
+                        'actor_id' => 'actor-1',
+                        'actor_username' => 'creator',
+                    ],
+                    'read_datetime' => null,
+                    'creation_datetime' => $notification->creationDatetime->format(\DATE_ATOM),
+                ],
+            ],
+        ]);
+    }
+
+    public function test_task_notification_keeps_the_stored_title_for_a_former_member(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $user,
+            'status' => MembershipStatus::Kicked,
+            'leftDatetime' => new \DateTime('2026-05-02 10:00:00'),
+        ])->create();
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Titre renommé après le départ',
+        ])->create();
+        $notification = NotificationFactory::new([
+            'recipient' => $user,
+            'type' => NotificationType::TaskComment,
+            'payload' => [
+                'band_space_id' => (string) $bandSpace->id,
+                'task_id' => (string) $task->id,
+                'task_title' => 'Titre au moment de la notification',
+                'comment_id' => 'comment-1',
+                'actor_id' => 'actor-1',
+                'actor_username' => 'commenter',
+            ],
+            'creationDatetime' => new \DateTimeImmutable('2026-05-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/user/notifications', [], ['HTTP_ACCEPT' => 'application/ld+json']);
+
+        // The notification stays in their own history, frozen where it belongs: nothing prunes the
+        // feed when somebody leaves a band space, so without this the payload would go on refreshing
+        // itself from a board they can no longer open.
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/UserNotification',
+            '@id' => '/api/user/notifications',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/user/notifications/' . $notification->id,
+                    '@type' => 'UserNotification',
+                    'id' => (string) $notification->id,
+                    'type' => 'task_comment',
+                    'payload' => [
+                        'band_space_id' => (string) $bandSpace->id,
+                        'task_id' => (string) $task->id,
+                        'task_title' => 'Titre au moment de la notification',
+                        'comment_id' => 'comment-1',
+                        'actor_id' => 'actor-1',
+                        'actor_username' => 'commenter',
+                    ],
+                    'read_datetime' => null,
+                    'creation_datetime' => $notification->creationDatetime->format(\DATE_ATOM),
+                ],
+            ],
+        ]);
+    }
+
+    public function test_agenda_entry_notification_keeps_the_stored_title_for_a_former_member(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $user,
+            'status' => MembershipStatus::Left,
+            'leftDatetime' => new \DateTime('2026-05-02 10:00:00'),
+        ])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition chez Paul',
+            'eventDatetime' => new \DateTimeImmutable('2026-08-15T20:00:00+00:00'),
+        ])->create();
+        $notification = NotificationFactory::new([
+            'recipient' => $user,
+            'type' => NotificationType::BandSpaceAgendaEntryCreated,
+            'payload' => [
+                'band_space_id' => (string) $bandSpace->id,
+                'band_space_name' => 'The Rockers',
+                'agenda_entry_id' => (string) $entry->id,
+                'entry_title' => 'Titre au moment de la notification',
+                'event_datetime' => '2020-01-01T10:00:00+00:00',
+                'actor_id' => 'actor-1',
+                'actor_username' => 'creator',
+            ],
+            'creationDatetime' => new \DateTimeImmutable('2026-05-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/user/notifications', [], ['HTTP_ACCEPT' => 'application/ld+json']);
+
+        // Neither the title nor the date is refreshed: where and when the band rehearses now is no
+        // longer their business.
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/UserNotification',
+            '@id' => '/api/user/notifications',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/user/notifications/' . $notification->id,
+                    '@type' => 'UserNotification',
+                    'id' => (string) $notification->id,
+                    'type' => 'band_space_agenda_entry_created',
+                    'payload' => [
+                        'band_space_id' => (string) $bandSpace->id,
+                        'band_space_name' => 'The Rockers',
+                        'agenda_entry_id' => (string) $entry->id,
+                        'entry_title' => 'Titre au moment de la notification',
+                        'event_datetime' => '2020-01-01T10:00:00+00:00',
                         'actor_id' => 'actor-1',
                         'actor_username' => 'creator',
                     ],

--- a/tests/Api/User/DeleteAccountBandSpaceTest.php
+++ b/tests/Api/User/DeleteAccountBandSpaceTest.php
@@ -18,6 +18,7 @@ use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
+use App\Repository\BandSpace\TaskRepository;
 use App\Repository\Notification\NotificationRepository;
 use App\Service\Procedure\User\DeleteAccountProcedure;
 use App\Tests\ApiTestAssertionsTrait;
@@ -27,7 +28,9 @@ use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
 use App\Tests\Factory\BandSpace\FinanceEntryFactory;
 use App\Tests\Factory\BandSpace\FinanceRecurrenceFactory;
+use App\Tests\Factory\BandSpace\TaskFactory;
 use App\Tests\Factory\User\UserFactory;
+use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -242,6 +245,57 @@ class DeleteAccountBandSpaceTest extends ApiTestCase
 
         // Nobody was promoted, so nobody is told anything.
         $this->assertCount(0, self::getContainer()->get(NotificationRepository::class)->findForRecipient($admin, 10, 0));
+    }
+
+    public function test_deleting_an_account_revokes_its_task_assignments_in_every_space(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'mate@test.com']);
+
+        $firstSpace = BandSpaceFactory::new()->create(['name' => 'Premier groupe']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $firstSpace, 'user' => $bandMate, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $firstSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $secondSpace = BandSpaceFactory::new()->create(['name' => 'Second groupe']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $secondSpace, 'user' => $bandMate, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $secondSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $firstTask = TaskFactory::new([
+            'bandSpace' => $firstSpace,
+            'title' => 'Réserver la salle',
+            'assignees' => new ArrayCollection([$member, $bandMate]),
+        ])->create();
+        $secondTask = TaskFactory::new([
+            'bandSpace' => $secondSpace,
+            'title' => 'Envoyer le dossier',
+            'assignees' => new ArrayCollection([$member]),
+        ])->create();
+
+        $memberId = (string) $member->id;
+        $firstTaskId = (string) $firstTask->id;
+        $secondTaskId = (string) $secondTask->id;
+
+        $this->deleteAccount($member);
+
+        // Every space the account belonged to, not just the first one the sweep happens to reach.
+        $taskRepository = self::getContainer()->get(TaskRepository::class);
+        $this->assertCount(0, $taskRepository->findByBandSpaceAndAssignee($firstSpace, $member));
+        $this->assertCount(0, $taskRepository->findByBandSpaceAndAssignee($secondSpace, $member));
+        $this->assertCount(1, $taskRepository->findByBandSpaceAndAssignee($firstSpace, $bandMate));
+
+        // The activity payload carries the anonymized handle, like the departure itself: erasing an
+        // account must not scatter fresh copies of the old username through the band's history.
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        foreach ([[$firstSpace, $firstTaskId], [$secondSpace, $secondTaskId]] as [$space, $taskId]) {
+            $activities = $activityRepository->findForResource($space, BandSpaceModule::Task, $taskId);
+            $this->assertCount(1, $activities);
+            $this->assertSame('assignee_removed', $activities[0]->type);
+            $this->assertSame($memberId, (string) $activities[0]->actor->id);
+            $this->assertSame(
+                ['assignee_id' => $memberId, 'assignee_username' => 'deleted_' . $memberId],
+                $activities[0]->payload,
+            );
+        }
     }
 
     public function test_no_space_is_left_without_an_admin_or_a_deletion_scheduled(): void

--- a/tests/Unit/Service/Notification/NotificationFeedEnricherTest.php
+++ b/tests/Unit/Service/Notification/NotificationFeedEnricherTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Service\Notification;
 
 use App\ApiResource\Notification\UserNotification;
+use App\Entity\User;
 use App\Enum\Notification\NotificationType;
 use App\Service\Notification\Enricher\NotificationEnricherInterface;
 use App\Service\Notification\NotificationFeedEnricher;
@@ -15,15 +16,21 @@ class NotificationFeedEnricherTest extends TestCase
 {
     public function test_a_failing_enricher_degrades_to_stored_payload_and_never_breaks_the_feed(): void
     {
+        $reader = new User();
+        $seenRecipients = [];
+
         $failing = $this->enricherFor(
             NotificationType::BandSpaceTaskAssignment,
-            static function (array $notifications): void {
+            static function (array $notifications, User $recipient) use (&$seenRecipients): void {
+                $seenRecipients[] = $recipient;
+
                 throw new \RuntimeException('boom');
             },
         );
         $healthy = $this->enricherFor(
             NotificationType::BandSpaceInvitation,
-            static function (array $notifications): void {
+            static function (array $notifications, User $recipient) use (&$seenRecipients): void {
+                $seenRecipients[] = $recipient;
                 foreach ($notifications as $notification) {
                     $notification->payload['invitation_status'] = 'expired';
                 }
@@ -37,12 +44,14 @@ class NotificationFeedEnricherTest extends TestCase
         $logger->expects($this->once())->method('error');
 
         $enricher = new NotificationFeedEnricher([$failing, $healthy], $logger);
-        $enricher->enrich([$brokenGroup, $healthyGroup]);
+        $enricher->enrich([$brokenGroup, $healthyGroup], $reader);
 
         // The failing enricher's group keeps its stored point-in-time payload; no exception bubbled up.
         self::assertSame(['task_title' => 'Titre stocké'], $brokenGroup->payload);
         // A failure in one type does not stop other types from being enriched.
         self::assertSame(['invitation_status' => 'expired'], $healthyGroup->payload);
+        // Every enricher is told who is reading: what a payload may be refreshed with depends on it.
+        self::assertSame([$reader, $reader], $seenRecipients);
     }
 
     private function enricherFor(NotificationType $type, \Closure $enrich): NotificationEnricherInterface
@@ -59,9 +68,9 @@ class NotificationFeedEnricherTest extends TestCase
                 return $this->type;
             }
 
-            public function enrich(array $notifications): void
+            public function enrich(array $notifications, User $recipient): void
             {
-                ($this->enrich)($notifications);
+                ($this->enrich)($notifications, $recipient);
             }
         };
     }


### PR DESCRIPTION
Closes #817.

## ⚠️ Deploy step (cosmetic, not gating)

Rows already in `task_assignee` for members removed before this ships are not cleaned by the code. Run once after deploy, ideally checking the count first:

```sql
SELECT COUNT(*) FROM task_assignee ta
INNER JOIN task t ON t.id = ta.task_id
LEFT JOIN band_space_membership m
  ON m.band_space_id = t.band_space_id AND m.user_id = ta.user_id AND m.status = 'active'
WHERE m.id IS NULL;

DELETE ta FROM task_assignee ta
INNER JOIN task t ON t.id = ta.task_id
LEFT JOIN band_space_membership m
  ON m.band_space_id = t.band_space_id AND m.user_id = ta.user_id AND m.status = 'active'
WHERE m.id IS NULL;
```

Not shipped as a migration because `down()` cannot restore deleted rows. Worth being precise about the urgency: this is **not** a residual leak. Every suppression below evaluates current membership at read time, so departed members stop receiving notifications about all existing data the moment this deploys. The stale rows only leave ghost avatar chips on old cards.

## The bug

A member removed from a band space kept their task assignments and kept receiving live notifications from that space.

- nothing touched `task_assignee`, and the ghost avatars could not even be filtered for, because the filter chips are built from the active roster
- the comment fan-out resolved creator, assignees and prior commenters with no membership check
- worse, the task-title enricher re-read the **current** title on every feed read, so a removed member's notification list kept showing live data from a space they were kicked out of

The mention path was already guarded, which is what showed the fan-out gap was an oversight rather than a decision.

## Why this is bigger than the ticket

Three additions, each traceable to a real need rather than gold-plating:

- **Account deletion is a third departure path.** M-814 merged just before this branch and creates the same gap. Fixing only kick and leave would knowingly leave a live path broken, so a shared `TaskAssignmentRevoker` is wired into all three.
- **The interface change is mechanical, not optional.** `NotificationEnricherInterface::enrich()` now takes the recipient, because you cannot gate on "is the reader still a member" without telling the enricher who the reader is.
- **The bug is a pattern**, notifying off a stale relationship instead of current membership, so all 11 listeners were audited. Three were fixed: the reported comment fan-out, invitation-responded (a pending invitation outlives the membership that sent it, indefinitely on the auto-accept path) and role-changed (an admin can patch the role of an already-kicked membership).

Two listeners were deliberately left: their producer resolves membership in the same synchronous request that dispatches the event, so there is no window for staleness. That is a real distinction from the three fixed, not an assertion.

The same enricher fix was applied to agenda notifications, which leaked a live rehearsal title and datetime. The invitation enricher is deliberately **not** gated, since its recipient is by definition not a member and gating it would leave a dead Accept button.

## Tasks left unassigned

Not auto-reassigned, which is the band's call, and not notified, since one bell per orphaned task turns removing a busy member into a burst. Instead each revocation is written to the task activity feed, and a new "Non assignées" board filter makes them findable, which did not exist before.

## Fixed during review

The frontend guard against resubmitting stale assignee ids was wired into only one of two call sites. `populateForm()`, which covers the two dominant paths, still read the raw list, so opening a legacy task and adding an assignee would resubmit the departed member, who would then be in neither the added nor removed set and never get cleared. The comment promised self-healing that would not have happened.

## Tests

Coverage proves both directions: a removed participant is not notified **and** an active one still is, in the same test with a full payload assertion, so over-filtering would fail loudly rather than silently. 947 targeted tests, full suite 2111, PHPStan level 8 clean.

## Reported, not fixed

`MembersSection.vue` never reads `member.status`, so the admin roster cannot show who was removed, and `AgendaAggregator` builds the same unfiltered assignee triple for agenda rows.
