### PR TITLE
fix(M-827): read the member contribution total the API actually sends

### DIFF
--- a/assets/js/components/BandSpace/Finance/FinanceSidebar.vue
+++ b/assets/js/components/BandSpace/Finance/FinanceSidebar.vue
@@ -17,7 +17,7 @@
           <div class="h-1.5 rounded-full bg-surface-200 dark:bg-surface-700 overflow-hidden">
             <div
               class="h-full rounded-full bg-primary transition-all"
-              :style="{ width: contributionPercent(member.total) + '%' }"
+              :style="{ width: barWidth(member.total) + '%' }"
             ></div>
           </div>
         </div>
@@ -50,6 +50,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { contributionPercent, largestContribution } from '../../../utils/contributionBar.js'
 import { formatAmount } from '../../../utils/currency.js'
 import { formatDateCompact } from '../../../utils/date.js'
 import FinanceStatusDot from './FinanceStatusDot.vue'
@@ -61,14 +62,10 @@ const props = defineProps({
 const memberContributions = computed(() => props.summary?.member_contributions ?? [])
 const upcomingEntries = computed(() => props.summary?.upcoming_entries ?? [])
 
-const maxContribution = computed(() => {
-  if (!memberContributions.value.length) return 0
-  return Math.max(...memberContributions.value.map((m) => m.amount))
-})
+const maxContribution = computed(() => largestContribution(memberContributions.value))
 
-function contributionPercent(amount) {
-  if (maxContribution.value === 0) return 0
-  return Math.round((amount / maxContribution.value) * 100)
+function barWidth(total) {
+  return contributionPercent(total, maxContribution.value)
 }
 
 function formatEntryAmount(entry) {

--- a/assets/js/utils/contributionBar.js
+++ b/assets/js/utils/contributionBar.js
@@ -1,0 +1,44 @@
+/**
+ * The width of a member's contribution bar in the finance sidebar.
+ *
+ * Extracted because the bar rendered at zero width for every band since the feature shipped, next to
+ * amounts that were correct, so it read as "nobody has contributed". The cause was arithmetic on a
+ * field the API does not send: `undefined` produces NaN, NaN is not equal to 0 so it walked straight
+ * through the caller's `=== 0` guard, and `width: NaN%` is simply ignored by the browser.
+ *
+ * Nothing here trusts its input for that reason, and it lives outside the component because there is
+ * no component test harness in this project: a percentage is arithmetic and can be pinned on its own.
+ */
+
+/**
+ * The largest contribution in the set, or 0 when there is nothing usable to compare against.
+ *
+ * @param {Array<{total?: number}>} contributions as the API returns them, so `total`, not `amount`
+ * @returns {number}
+ */
+export function largestContribution(contributions) {
+  const totals = (contributions ?? [])
+    .map((contribution) => contribution?.total)
+    .filter((total) => Number.isFinite(total))
+
+  return totals.length > 0 ? Math.max(...totals) : 0
+}
+
+/**
+ * A member's share of the largest contribution, 0 to 100. Anything unusable reads as no contribution
+ * rather than as a broken style attribute.
+ *
+ * @param {number} total this member's contribution
+ * @param {number} largest the largest contribution in the set
+ * @returns {number}
+ */
+export function contributionPercent(total, largest) {
+  // Both sides are guarded, not just the divisor. A split is validated as strictly positive and has
+  // no update endpoint, so a negative total cannot reach here today, but a function whose whole
+  // reason to exist is distrusting its input should not have one edge it happens to trust.
+  if (!Number.isFinite(total) || !Number.isFinite(largest) || total <= 0 || largest <= 0) {
+    return 0
+  }
+
+  return Math.round((total / largest) * 100)
+}

--- a/assets/js/utils/contributionBar.test.js
+++ b/assets/js/utils/contributionBar.test.js
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { contributionPercent, largestContribution } from './contributionBar.js'
+
+/**
+ * The bug these exist for: the sidebar read `amount` off a payload whose field is `total`, so every
+ * bar was `width: NaN%` and rendered at zero next to a correct amount. The assertions below pin both
+ * halves, the field the API actually sends and the refusal to emit NaN whatever it is handed.
+ *
+ * Run with `npm test`.
+ */
+
+const CONTRIBUTIONS = [
+  { member_id: 'a', name: 'Marie', total: 12000 },
+  { member_id: 'b', name: 'Julien', total: 30000 },
+  { member_id: 'c', name: 'Sam', total: 6000 }
+]
+
+describe('largestContribution', () => {
+  it('finds the biggest contribution of the set', () => {
+    assert.equal(largestContribution(CONTRIBUTIONS), 30000)
+  })
+
+  it('reads total, which is the field the API sends', () => {
+    // The whole bug in one case: an `amount` key is not a contribution, so it counts for nothing
+    // rather than poisoning the maximum with undefined.
+    assert.equal(largestContribution([{ member_id: 'a', amount: 12000 }]), 0)
+  })
+
+  it('has no contribution to compare against when the list is empty or absent', () => {
+    assert.equal(largestContribution([]), 0)
+    assert.equal(largestContribution(undefined), 0)
+    assert.equal(largestContribution(null), 0)
+  })
+
+  it('ignores entries carrying an unusable total', () => {
+    assert.equal(
+      largestContribution([
+        { total: undefined },
+        { total: null },
+        { total: 'beaucoup' },
+        { total: 900 }
+      ]),
+      900
+    )
+    assert.equal(largestContribution([{ total: Number.NaN }]), 0)
+  })
+})
+
+describe('contributionPercent', () => {
+  it('scales a contribution against the largest one', () => {
+    const largest = largestContribution(CONTRIBUTIONS)
+
+    assert.equal(contributionPercent(30000, largest), 100)
+    assert.equal(contributionPercent(6000, largest), 20)
+    assert.equal(contributionPercent(12000, largest), 40)
+  })
+
+  it('rounds to a whole percent', () => {
+    assert.equal(contributionPercent(1, 3), 33)
+    assert.equal(contributionPercent(2, 3), 67)
+  })
+
+  it('never returns NaN, whatever it is handed', () => {
+    // A NaN width is not a visible failure: the browser drops the declaration and the bar sits at
+    // zero, which is how this shipped unnoticed.
+    for (const [total, largest] of [
+      [undefined, 30000],
+      [30000, undefined],
+      [Number.NaN, Number.NaN],
+      ['12000', 30000],
+      [null, null]
+    ]) {
+      assert.equal(contributionPercent(total, largest), 0)
+    }
+  })
+
+  it('treats a zero or negative maximum as nothing to scale against', () => {
+    assert.equal(contributionPercent(0, 0), 0)
+    assert.equal(contributionPercent(500, 0), 0)
+    assert.equal(contributionPercent(500, -100), 0)
+  })
+
+  it('draws no bar for a contribution of zero or less', () => {
+    // Unreachable while a split is validated as strictly positive and has no update endpoint, but a
+    // negative width is not a width, and the guard should not be asymmetric.
+    assert.equal(contributionPercent(0, 30000), 0)
+    assert.equal(contributionPercent(-500, 30000), 0)
+  })
+})


### PR DESCRIPTION
Closes #827.

## The bug

The member contribution bars in the finance sidebar have rendered at zero width for every band since the feature shipped, sitting next to correct amounts. The panel read as "nobody has contributed" while showing non-zero figures.

`FinanceSidebar.vue` computed its maximum from `m.amount`, but the API field is `total`, which the two adjacent lines already used correctly. That is the whole defect, and the one word is the whole fix.

## Why it went unnoticed, and why this is not a one word diff

The typo alone would have been visible. What hid it is the second half:

- `undefined` arithmetic produced `NaN`
- the guard was `maxContribution === 0`, and `NaN === 0` is false, so every division went ahead
- the result reached the DOM as `width: NaN%`, which browsers do not parse and silently drop

So it failed invisibly, in a component with no test that could have caught it.

The bar-width maths therefore moved into `assets/js/utils/contributionBar.js` with a `node --test` suite, matching the four existing precedents for logic that cannot be component tested here (`filePagination.js`, `agendaRange.js`, `taskOrdering.js`, `debouncedSaver.js`). There is no component test harness in this project, so a percentage is only testable once it stops being a closure inside a `.vue` file.

The tests were checked against the defect rather than only against the fix: **7 of the 8 fail on the original logic, all 8 pass with it.**

## Fixed during review

`contributionPercent` guarded its divisor but not its numerator, so a negative total would have returned a negative percentage: an asymmetry in a function whose stated reason to exist is distrusting its input. Unreachable today (a split is `#[Assert\Positive]`, there is no split update endpoint, and the contributions query inner joins so a member with no splits is absent rather than zero), but tightened while nothing depends on the old behaviour.

## Also checked

Every other finance component reading `.amount` reads it off a resource that genuinely has that field (`FinanceEntrySplitResource`, `FinanceEntry`, `FinanceRecurrence`). No sibling instance of this mistake.

## Tests

140 JS tests, Biome and build clean. No backend change.
