### PR TITLE
fix(M-820): stop the finance module losing splits and paid entries

### DIFF
--- a/assets/js/api/utils/apiErrorDetail.js
+++ b/assets/js/api/utils/apiErrorDetail.js
@@ -1,0 +1,17 @@
+/**
+ * The sentence to show the user for a failed request.
+ *
+ * A 4xx from this API carries a message written for the band ("Cette catégorie contient une entrée
+ * payée..."), and dropping it for a generic "Impossible de supprimer" throws away the only part that
+ * says what to do next. A 5xx or a network failure carries a technical string in English, which the
+ * caller's own wording replaces.
+ *
+ * @param {{status?: number, message?: string}|null|undefined} error a normalized error from handleApiError
+ * @param {string} fallback wording to use when the error has nothing worth showing
+ * @returns {string}
+ */
+export function apiErrorDetail(error, fallback) {
+  const status = error?.status ?? 0
+
+  return status >= 400 && status < 500 && error?.message ? error.message : fallback
+}

--- a/assets/js/api/utils/apiErrorDetail.test.js
+++ b/assets/js/api/utils/apiErrorDetail.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { apiErrorDetail } from './apiErrorDetail.js'
+
+describe('apiErrorDetail', () => {
+  it('shows the message a 4xx wrote for the user', () => {
+    assert.equal(
+      apiErrorDetail(
+        { status: 422, message: 'Cette catégorie contient une entrée payée.' },
+        'fallback'
+      ),
+      'Cette catégorie contient une entrée payée.'
+    )
+  })
+
+  it('shows the message of a 403, which is the ownership refusal', () => {
+    assert.equal(
+      apiErrorDetail(
+        {
+          status: 403,
+          message: 'Vous ne pouvez supprimer que vos propres récurrences personnelles'
+        },
+        'fallback'
+      ),
+      'Vous ne pouvez supprimer que vos propres récurrences personnelles'
+    )
+  })
+
+  it('hides the technical message of a 5xx', () => {
+    assert.equal(
+      apiErrorDetail({ status: 500, message: 'Internal Server Error' }, 'fallback'),
+      'fallback'
+    )
+  })
+
+  it('hides a network failure, which carries no status at all', () => {
+    assert.equal(apiErrorDetail({ message: 'Network Error' }, 'fallback'), 'fallback')
+  })
+
+  it('falls back on a 4xx with no message', () => {
+    assert.equal(apiErrorDetail({ status: 404 }, 'fallback'), 'fallback')
+  })
+
+  it('falls back when there is no error object at all', () => {
+    assert.equal(apiErrorDetail(null, 'fallback'), 'fallback')
+    assert.equal(apiErrorDetail(undefined, 'fallback'), 'fallback')
+  })
+})

--- a/assets/js/components/BandSpace/Finance/FinanceDrawer.vue
+++ b/assets/js/components/BandSpace/Finance/FinanceDrawer.vue
@@ -155,6 +155,7 @@
         :bandSpaceId="props.bandSpaceId"
         :entryId="isEditMode ? props.entry.id : null"
         :amountEuros="effectiveAmountEuros"
+        :exactAmountEuros="form.amountMode === 'exact' ? form.amountEuros : null"
         :visible="props.visible"
         :disabled="isLocked"
       />
@@ -210,7 +211,6 @@ import Message from 'primevue/message'
 import Select from 'primevue/select'
 import SelectButton from 'primevue/selectbutton'
 import { useConfirm } from 'primevue/useconfirm'
-import { useToast } from 'primevue/usetoast'
 import { computed, nextTick, reactive, ref, watch } from 'vue'
 import { useBandSpaceFinanceStore } from '../../../store/bandSpace/bandSpaceFinance.js'
 import { attachedFilesNotice } from '../../../utils/attachedFilesNotice.js'
@@ -228,7 +228,6 @@ const props = defineProps({
 
 const emit = defineEmits(['update:visible', 'saved', 'deleted'])
 const confirm = useConfirm()
-const toast = useToast()
 const financeStore = useBandSpaceFinanceStore()
 const splitManagerRef = ref(null)
 const formError = ref(null)
@@ -443,6 +442,17 @@ async function handleSave() {
     formError.value = 'Veuillez sélectionner une catégorie'
     return
   }
+
+  const splitManager = splitManagerRef.value
+
+  // Asked before the entry is written, because raising one member's share means deleting their split
+  // and creating it again: a repartition the API would refuse used to cost that member their share.
+  const splitError = splitManager?.validateSplits()
+  if (splitError) {
+    formError.value = splitError
+    return
+  }
+
   try {
     const data = buildPayload()
     let entryId
@@ -455,21 +465,16 @@ async function handleSave() {
       entryId = created?.id
     }
 
-    const splitManager = splitManagerRef.value
     if (entryId && splitManager) {
       try {
-        if (splitManager.activeSplitsCount > 0) {
-          await splitManager.syncSplits(entryId)
-        } else if (splitManager.existingSplits.length > 0) {
-          await splitManager.syncSplits(entryId)
-        }
-      } catch {
-        toast.add({
-          severity: 'warn',
-          summary: 'Attention',
-          detail: 'L\u2019entrée a été enregistrée mais la répartition a échoué',
-          life: 5000
-        })
+        await splitManager.syncSplits(entryId)
+      } catch (error) {
+        // The entry itself is saved, so this is not a failed save, but the repartition on screen is no
+        // longer what the entry carries. The drawer stays open on the reloaded splits instead of
+        // closing on a success message, which is how a lost share used to go unnoticed.
+        await splitManager.loadExistingSplits(entryId)
+        formError.value = `L\u2019entrée a été enregistrée mais la répartition a échoué : ${error.message || 'erreur inconnue'}`
+        return
       }
     }
 

--- a/assets/js/components/BandSpace/Finance/RecurrenceDrawer.vue
+++ b/assets/js/components/BandSpace/Finance/RecurrenceDrawer.vue
@@ -136,8 +136,10 @@ import Select from 'primevue/select'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, reactive, watch } from 'vue'
+import { apiErrorDetail } from '../../../api/utils/apiErrorDetail.js'
 import { useBandSpaceFinanceStore } from '../../../store/bandSpace/bandSpaceFinance.js'
 import { centsToCurrency, currencyToCents } from '../../../utils/currency.js'
+import { RECURRENCE_DELETE_MESSAGE } from '../../../utils/financeConfirmations.js'
 
 const props = defineProps({
   visible: { type: Boolean, default: false },
@@ -161,13 +163,6 @@ const isEditMode = computed(() => props.recurrence !== null)
 // The generated entries all sit on the grid drawn by the start date and the interval, so the API refuses
 // to re-anchor it once entries exist. Say it here rather than let the user hit a 422.
 const frozenScheduleHint = 'Non modifiable : terminez cette récurrence et créez-en une nouvelle.'
-
-// A 4xx carries a message written for the user, anything else carries a technical one in English.
-function apiErrorDetail(error, fallback) {
-  const status = error?.status ?? 0
-
-  return status >= 400 && status < 500 && error?.message ? error.message : fallback
-}
 
 const typeOptions = [
   { label: 'Dépense', value: 'expense' },
@@ -272,7 +267,7 @@ async function handleSave() {
 
 function handleDelete() {
   confirm.require({
-    message: 'Es-tu sûr de vouloir supprimer cette récurrence ?',
+    message: RECURRENCE_DELETE_MESSAGE,
     header: 'Confirmer la suppression',
     icon: 'pi pi-exclamation-triangle',
     rejectLabel: 'Annuler',
@@ -282,11 +277,12 @@ function handleDelete() {
       try {
         await financeStore.deleteRecurrence(props.bandSpaceId, props.recurrence.id)
         emit('deleted')
-      } catch {
+      } catch (error) {
+        // A personal recurrence answers only to its owner, and that 403 says so.
         toast.add({
           severity: 'error',
           summary: 'Erreur',
-          detail: 'Impossible de supprimer la récurrence',
+          detail: apiErrorDetail(error, 'Impossible de supprimer la récurrence'),
           life: 5000
         })
       }

--- a/assets/js/components/BandSpace/Finance/SplitManager.vue
+++ b/assets/js/components/BandSpace/Finance/SplitManager.vue
@@ -77,11 +77,17 @@ import { computed, reactive, ref, watch } from 'vue'
 import bandSpaceFinanceApi from '../../../api/bandSpace/band-space-finance.js'
 import bandSpaceSettingsApi from '../../../api/bandSpace/band-space-settings.js'
 import { centsToCurrency, currencyToCents, formatAmount } from '../../../utils/currency.js'
+import { planSplitSync } from '../../../utils/splitReconciliation.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
   entryId: { type: String, default: null },
+  // What the total line is measured against: the middle of the fourchette when the entry has one.
   amountEuros: { type: Number, default: null },
+  // What the API caps the split total at, which is the entry's exact amount and nothing else: an entry
+  // storing a fourchette has amount NULL and is capped at nothing. Only ever the exact one, so the
+  // guard below refuses exactly what the API would refuse, no more.
+  exactAmountEuros: { type: Number, default: null },
   visible: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false }
 })
@@ -177,24 +183,43 @@ function buildSplitsPayload() {
   return splits
 }
 
+function buildPlan() {
+  const capCents = props.exactAmountEuros != null ? currencyToCents(props.exactAmountEuros) : null
+
+  return planSplitSync(existingSplits.value, buildSplitsPayload(), capCents)
+}
+
+/**
+ * Why the repartition cannot be saved as typed, or null when it can. The drawer asks before it writes
+ * anything at all, so a repartition the API would refuse never costs an existing split.
+ */
+function validateSplits() {
+  return buildPlan().error
+}
+
 async function syncSplits(entryId) {
-  const desired = buildSplitsPayload()
-  const desiredByMember = new Map(desired.map((s) => [s.member_id, s.amount]))
+  const { error, operations } = buildPlan()
+  if (error) {
+    throw new Error(error)
+  }
+  if (operations.length === 0) {
+    return
+  }
 
-  for (const existing of existingSplits.value) {
-    const newAmount = desiredByMember.get(existing.member_id)
-    if (newAmount == null || newAmount !== existing.amount) {
-      await bandSpaceFinanceApi.deleteSplit(props.bandSpaceId, entryId, existing.id)
+  for (const operation of operations) {
+    if (operation.type === 'delete') {
+      await bandSpaceFinanceApi.deleteSplit(props.bandSpaceId, entryId, operation.splitId)
+    } else {
+      await bandSpaceFinanceApi.createSplit(props.bandSpaceId, entryId, {
+        member_id: operation.memberId,
+        amount: operation.amount
+      })
     }
   }
 
-  const existingByMember = new Map(existingSplits.value.map((s) => [s.member_id, s.amount]))
-  for (const split of desired) {
-    const oldAmount = existingByMember.get(split.member_id)
-    if (oldAmount == null || oldAmount !== split.amount) {
-      await bandSpaceFinanceApi.createSplit(props.bandSpaceId, entryId, split)
-    }
-  }
+  // The plan was built against the splits loaded when the drawer opened. Saving twice without
+  // re-reading them would plan the second save against split ids that no longer exist.
+  await loadExistingSplits(entryId)
 }
 
 async function reset(entryId) {
@@ -218,9 +243,9 @@ watch(expanded, (isExpanded) => {
 })
 
 defineExpose({
+  validateSplits,
   syncSplits,
-  activeSplitsCount,
-  existingSplits,
+  loadExistingSplits,
   reset
 })
 </script>

--- a/assets/js/utils/financeConfirmations.js
+++ b/assets/js/utils/financeConfirmations.js
@@ -1,0 +1,41 @@
+/**
+ * What the finance delete confirmations say, kept here because both used to describe something other
+ * than what the API does.
+ *
+ * The category one claimed "Les entrées et récurrences associées seront également supprimées" without
+ * ever saying how many, on a dialog whose only other content is the word Supprimer. The recurrence one
+ * never mentioned entries at all, while deleting one drops every forecast it had planned.
+ */
+
+/**
+ * A category holding sub-categories is refused outright, so that is named first and instead of the
+ * rest: a dialog that promises a deletion the server is about to refuse, for a reason it never
+ * mentioned, is worse than the vague copy this replaced. Such a category can hold no entries at all
+ * and still not be deletable, so the entry count alone cannot be trusted to describe the outcome.
+ *
+ * @param {number|null|undefined} entryCount entries filed directly under the category
+ * @param {boolean} hasChildren whether it holds sub-categories
+ * @returns {string}
+ */
+export function categoryDeleteMessage(entryCount, hasChildren = false) {
+  if (hasChildren) {
+    return 'Cette catégorie contient des sous-catégories et ne peut pas être supprimée. Supprimez ou déplacez ses sous-catégories d’abord.'
+  }
+
+  if (!entryCount || entryCount < 1) {
+    return 'Es-tu sûr de vouloir supprimer cette catégorie ? Elle ne contient aucune entrée.'
+  }
+
+  if (entryCount === 1) {
+    return 'Es-tu sûr de vouloir supprimer cette catégorie ? L’entrée qu’elle contient et ses récurrences seront également supprimées.'
+  }
+
+  return `Es-tu sûr de vouloir supprimer cette catégorie ? Les ${entryCount} entrées qu’elle contient et ses récurrences seront également supprimées.`
+}
+
+/**
+ * Deleting a recurrence drops the entries it planned, but only those still Prévu: an occurrence that
+ * was engaged or paid has stopped belonging to the series and stays in the accounts.
+ */
+export const RECURRENCE_DELETE_MESSAGE =
+  'Es-tu sûr de vouloir supprimer cette récurrence ? Les entrées prévues qu’elle a générées seront également supprimées, les entrées engagées ou payées seront conservées.'

--- a/assets/js/utils/financeConfirmations.test.js
+++ b/assets/js/utils/financeConfirmations.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { categoryDeleteMessage, RECURRENCE_DELETE_MESSAGE } from './financeConfirmations.js'
+
+describe('categoryDeleteMessage', () => {
+  it('says an empty category takes nothing with it', () => {
+    assert.equal(
+      categoryDeleteMessage(0),
+      'Es-tu sûr de vouloir supprimer cette catégorie ? Elle ne contient aucune entrée.'
+    )
+  })
+
+  it('treats a missing count as an empty category rather than printing undefined', () => {
+    assert.equal(categoryDeleteMessage(undefined), categoryDeleteMessage(0))
+    assert.equal(categoryDeleteMessage(null), categoryDeleteMessage(0))
+  })
+
+  it('agrees in the singular', () => {
+    assert.equal(
+      categoryDeleteMessage(1),
+      'Es-tu sûr de vouloir supprimer cette catégorie ? L’entrée qu’elle contient et ses récurrences seront également supprimées.'
+    )
+  })
+
+  it('names the number of entries the delete destroys', () => {
+    assert.equal(
+      categoryDeleteMessage(12),
+      'Es-tu sûr de vouloir supprimer cette catégorie ? Les 12 entrées qu’elle contient et ses récurrences seront également supprimées.'
+    )
+  })
+
+  it('says a category holding sub-categories cannot be deleted at all', () => {
+    // The server refuses this outright, and a category with children can hold no entries of its own,
+    // so the old copy promised a deletion and then failed for a reason it had never raised.
+    const refused =
+      'Cette catégorie contient des sous-catégories et ne peut pas être supprimée. Supprimez ou déplacez ses sous-catégories d’abord.'
+
+    assert.equal(categoryDeleteMessage(0, true), refused)
+    assert.equal(categoryDeleteMessage(12, true), refused)
+  })
+
+  it('describes the entries again once there are no sub-categories', () => {
+    assert.equal(categoryDeleteMessage(12, false), categoryDeleteMessage(12))
+  })
+})
+
+describe('RECURRENCE_DELETE_MESSAGE', () => {
+  it('says the forecasts go and the committed or paid occurrences stay', () => {
+    assert.match(RECURRENCE_DELETE_MESSAGE, /entrées prévues/)
+    assert.match(RECURRENCE_DELETE_MESSAGE, /engagées ou payées seront conservées/)
+  })
+})

--- a/assets/js/utils/splitReconciliation.js
+++ b/assets/js/utils/splitReconciliation.js
@@ -1,0 +1,78 @@
+import { formatAmount } from './currency.js'
+
+/**
+ * Turns the split amounts typed in the drawer into the sequence of API calls that gets the entry from
+ * the splits it has to the splits it should have, or refuses the whole thing before anything is touched.
+ *
+ * The refusal is the point. There is no endpoint that edits a split: changing one member's share means
+ * deleting the split and creating it again, and the create is rejected when the running total would pass
+ * the entry amount. So an entry of 100 with A=50 and B=50, saved with A bumped to 70, used to delete A,
+ * be refused the re-create at 50 + 70 > 100, and leave A's 50 gone for good. Nothing checked the target
+ * set first, and the drawer closed on a success message.
+ *
+ * Deleting before creating is not a choice: two splits for the same member on the same entry are a
+ * conflict, so a share can only be replaced after the old one is gone. What makes that safe is checking
+ * the total up front. Once the desired total fits, every intermediate total does too, because the
+ * untouched splits are already counted and each create only adds a positive amount on the way to a sum
+ * that fits. The window where a share is missing still exists, which is why the caller has to treat a
+ * failure as an error worth showing rather than a warning worth swallowing.
+ */
+
+/**
+ * @typedef {{id: string, member_id: string, amount: number}} ExistingSplit
+ * @typedef {{member_id: string, amount: number}} DesiredSplit
+ * @typedef {{type: 'delete', splitId: string, memberId: string}
+ *          |{type: 'create', memberId: string, amount: number}} SplitOperation
+ */
+
+/**
+ * @param {DesiredSplit[]|ExistingSplit[]} splits
+ * @returns {number} total in cents
+ */
+export function totalOfSplits(splits) {
+  return splits.reduce((total, split) => total + split.amount, 0)
+}
+
+/**
+ * @param {ExistingSplit[]} existingSplits splits the entry currently carries
+ * @param {DesiredSplit[]} desiredSplits splits it should carry, already filtered to positive amounts
+ * @param {number|null} capCents the entry's exact amount, which the API caps the split total at; null
+ *                               when the entry carries a fourchette or no amount, where there is no cap
+ * @returns {{error: string|null, operations: SplitOperation[]}} operations to run in order, and an
+ *          error that means run none of them
+ */
+export function planSplitSync(existingSplits, desiredSplits, capCents = null) {
+  const desiredByMember = new Map(desiredSplits.map((split) => [split.member_id, split.amount]))
+  const existingByMember = new Map(existingSplits.map((split) => [split.member_id, split.amount]))
+
+  const operations = []
+
+  for (const existing of existingSplits) {
+    if (desiredByMember.get(existing.member_id) !== existing.amount) {
+      operations.push({ type: 'delete', splitId: existing.id, memberId: existing.member_id })
+    }
+  }
+
+  for (const desired of desiredSplits) {
+    if (existingByMember.get(desired.member_id) !== desired.amount) {
+      operations.push({ type: 'create', memberId: desired.member_id, amount: desired.amount })
+    }
+  }
+
+  // Nothing to write means nothing to lose. Lowering an entry's amount under a repartition nobody
+  // touched keeps the mismatch the total line already shows in orange, rather than making an ordinary
+  // amount edit impossible until the shares are redone.
+  if (operations.length === 0) {
+    return { error: null, operations }
+  }
+
+  const desiredTotal = totalOfSplits(desiredSplits)
+  if (capCents != null && desiredTotal > capCents) {
+    return {
+      error: `Le total des répartitions (${formatAmount(desiredTotal)}) dépasse le montant de l’entrée (${formatAmount(capCents)}).`,
+      operations: []
+    }
+  }
+
+  return { error: null, operations }
+}

--- a/assets/js/utils/splitReconciliation.test.js
+++ b/assets/js/utils/splitReconciliation.test.js
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { planSplitSync, totalOfSplits } from './splitReconciliation.js'
+
+/**
+ * These pin the split editor's save, which used to destroy money during an ordinary edit: raising one
+ * member's share deleted their split, the re-create was refused for busting the entry total, and the
+ * drawer closed on a green "Entrée enregistrée" with the old share gone.
+ *
+ * Run with `npm test`. The Vue wiring around this has no coverage, which is why the whole decision
+ * lives here rather than inside the component.
+ */
+
+/** A split as the collection returns it. */
+function existing(id, memberId, amount) {
+  return { id, member_id: memberId, amount }
+}
+
+/** A split as the drawer's inputs describe it. */
+function desired(memberId, amount) {
+  return { member_id: memberId, amount }
+}
+
+describe('totalOfSplits', () => {
+  it('adds nothing up to zero', () => {
+    assert.equal(totalOfSplits([]), 0)
+  })
+
+  it('adds the shares in cents', () => {
+    assert.equal(totalOfSplits([desired('a', 5000), desired('b', 2550)]), 7550)
+  })
+})
+
+describe('planSplitSync', () => {
+  it('does nothing when the splits already match', () => {
+    const splits = [existing('s1', 'a', 5000), existing('s2', 'b', 5000)]
+
+    assert.deepEqual(planSplitSync(splits, [desired('a', 5000), desired('b', 5000)], 10000), {
+      error: null,
+      operations: []
+    })
+  })
+
+  it('creates the splits of an entry that had none', () => {
+    assert.deepEqual(planSplitSync([], [desired('a', 4000)], 10000), {
+      error: null,
+      operations: [{ type: 'create', memberId: 'a', amount: 4000 }]
+    })
+  })
+
+  it('deletes the split of a member dropped from the repartition', () => {
+    assert.deepEqual(planSplitSync([existing('s1', 'a', 5000)], [], 10000), {
+      error: null,
+      operations: [{ type: 'delete', splitId: 's1', memberId: 'a' }]
+    })
+  })
+
+  it('replaces a changed share, deleting before creating because the API refuses a second split for one member', () => {
+    assert.deepEqual(planSplitSync([existing('s1', 'a', 5000)], [desired('a', 7000)], 10000), {
+      error: null,
+      operations: [
+        { type: 'delete', splitId: 's1', memberId: 'a' },
+        { type: 'create', memberId: 'a', amount: 7000 }
+      ]
+    })
+  })
+
+  it('leaves an untouched member alone while another one changes', () => {
+    const splits = [existing('s1', 'a', 5000), existing('s2', 'b', 5000)]
+    const { operations } = planSplitSync(splits, [desired('a', 3000), desired('b', 5000)], 10000)
+
+    assert.deepEqual(operations, [
+      { type: 'delete', splitId: 's1', memberId: 'a' },
+      { type: 'create', memberId: 'a', amount: 3000 }
+    ])
+  })
+
+  it('runs every delete before any create, so no create is ever refused by a share about to go', () => {
+    const splits = [existing('s1', 'a', 6000), existing('s2', 'b', 4000)]
+    const { operations } = planSplitSync(splits, [desired('a', 4000), desired('b', 6000)], 10000)
+
+    const lastDelete = operations.findLastIndex((operation) => operation.type === 'delete')
+    const firstCreate = operations.findIndex((operation) => operation.type === 'create')
+
+    assert.equal(operations.length, 4)
+    assert.ok(lastDelete < firstCreate)
+  })
+
+  // The bug this module exists for: entry 100, A=50 and B=50, A bumped to 70 and saved.
+  it('refuses a repartition above the entry amount instead of deleting a share it cannot re-create', () => {
+    const splits = [existing('s1', 'a', 5000), existing('s2', 'b', 5000)]
+    const plan = planSplitSync(splits, [desired('a', 7000), desired('b', 5000)], 10000)
+
+    assert.deepEqual(plan.operations, [])
+    assert.equal(
+      plan.error,
+      'Le total des répartitions (120,00 €) dépasse le montant de l’entrée (100,00 €).'
+    )
+  })
+
+  /**
+   * Lowering the amount of an entry whose shares nobody touched: there is nothing to write, so there
+   * is nothing to refuse. The entry keeps the mismatch it already shows, which is what happened before
+   * and is not what this module is here to stop.
+   */
+  it('lets an unchanged repartition stand even once it exceeds the entry amount', () => {
+    const splits = [existing('s1', 'a', 5000), existing('s2', 'b', 5000)]
+    const plan = planSplitSync(splits, [desired('a', 5000), desired('b', 5000)], 8000)
+
+    assert.equal(plan.error, null)
+    assert.deepEqual(plan.operations, [])
+  })
+
+  it('still refuses as soon as one share moves under a lowered amount', () => {
+    const splits = [existing('s1', 'a', 5000), existing('s2', 'b', 5000)]
+    const plan = planSplitSync(splits, [desired('a', 6000), desired('b', 5000)], 8000)
+
+    assert.deepEqual(plan.operations, [])
+    assert.equal(
+      plan.error,
+      'Le total des répartitions (110,00 €) dépasse le montant de l’entrée (80,00 €).'
+    )
+  })
+
+  it('accepts a repartition landing exactly on the entry amount', () => {
+    const plan = planSplitSync([], [desired('a', 6000), desired('b', 4000)], 10000)
+
+    assert.equal(plan.error, null)
+    assert.equal(plan.operations.length, 2)
+  })
+
+  it('accepts a partial repartition, which is a normal way to use the feature', () => {
+    const plan = planSplitSync([], [desired('a', 3000)], 10000)
+
+    assert.equal(plan.error, null)
+    assert.deepEqual(plan.operations, [{ type: 'create', memberId: 'a', amount: 3000 }])
+  })
+
+  // A fourchette or an empty amount stores NULL, and the API caps nothing against NULL.
+  it('caps nothing when the entry carries no exact amount', () => {
+    const plan = planSplitSync([], [desired('a', 900000)], null)
+
+    assert.equal(plan.error, null)
+    assert.equal(plan.operations.length, 1)
+  })
+
+  /**
+   * The property that makes deleting first safe: replay the plan against the API's own rule, which
+   * refuses a create whose amount would push the total held past the entry amount.
+   */
+  it('never trips the running total the API checks each create against', () => {
+    const capCents = 10000
+    const splits = [existing('s1', 'a', 2000), existing('s2', 'b', 3000), existing('s3', 'c', 1000)]
+    const target = [desired('a', 5000), desired('b', 3000), desired('d', 2000)]
+
+    const { error, operations } = planSplitSync(splits, target, capCents)
+    assert.equal(error, null)
+
+    const held = new Map(splits.map((split) => [split.id, split.amount]))
+    for (const operation of operations) {
+      if (operation.type === 'delete') {
+        held.delete(operation.splitId)
+        continue
+      }
+      const total = [...held.values()].reduce((sum, amount) => sum + amount, 0)
+      assert.ok(
+        total + operation.amount <= capCents,
+        `create of ${operation.amount} on a held total of ${total} would be refused`
+      )
+      held.set(`created-${operation.memberId}`, operation.amount)
+    }
+
+    assert.equal(
+      [...held.values()].reduce((sum, amount) => sum + amount, 0),
+      10000
+    )
+  })
+})

--- a/assets/js/views/BandSpace/Finance.vue
+++ b/assets/js/views/BandSpace/Finance.vue
@@ -180,6 +180,7 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { apiErrorDetail } from '../../api/utils/apiErrorDetail.js'
 import DateRangePicker from '../../components/Admin/DateRangePicker.vue'
 import CreateCategoryDialog from '../../components/BandSpace/Finance/CreateCategoryDialog.vue'
 import FinanceBootstrap from '../../components/BandSpace/Finance/FinanceBootstrap.vue'
@@ -192,6 +193,7 @@ import FinanceTimeline from '../../components/BandSpace/Finance/FinanceTimeline.
 import RecurrenceDrawer from '../../components/BandSpace/Finance/RecurrenceDrawer.vue'
 import RecurrenceList from '../../components/BandSpace/Finance/RecurrenceList.vue'
 import { useBandSpaceFinanceStore } from '../../store/bandSpace/bandSpaceFinance.js'
+import { categoryDeleteMessage } from '../../utils/financeConfirmations.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -447,9 +449,10 @@ async function handleCategoryCreated({ name, parentId }) {
 }
 
 function handleDeleteCategory(categoryId) {
+  const category = financeStore.categories.find((item) => item.id === categoryId)
+
   confirm.require({
-    message:
-      'Es-tu sûr de vouloir supprimer cette catégorie ? Les entrées et récurrences associées seront également supprimées.',
+    message: categoryDeleteMessage(category?.entry_count, category?.has_children === true),
     header: 'Confirmer la suppression',
     icon: 'pi pi-exclamation-triangle',
     rejectLabel: 'Annuler',
@@ -460,11 +463,13 @@ function handleDeleteCategory(categoryId) {
         await financeStore.deleteCategory(bandSpaceId, categoryId)
         trackUmamiEvent('finance-category-delete')
         toast.add({ severity: 'success', summary: 'Catégorie supprimée', life: 3000 })
-      } catch {
+      } catch (error) {
+        // The API refuses a category holding paid entries or sub-categories, and its message is the
+        // only thing that says which of the two it was and what to do about it.
         toast.add({
           severity: 'error',
           summary: 'Erreur',
-          detail: 'Impossible de supprimer la catégorie',
+          detail: apiErrorDetail(error, 'Impossible de supprimer la catégorie'),
           life: 5000
         })
       }

--- a/src/ApiResource/BandSpace/Finance/FinanceCategoryResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceCategoryResource.php
@@ -86,6 +86,13 @@ class FinanceCategoryResource
     public int $position;
 
     public bool $hasChildren = false;
+
+    /**
+     * Entries filed directly under this category, whatever their status. Exactly what a delete would
+     * take with it, which is why the confirmation dialog can finally name a number.
+     */
+    public int $entryCount = 0;
+
     public \DateTimeInterface $creationDatetime;
     public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/ApiResource/BandSpace/Finance/FinanceEntryResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceEntryResource.php
@@ -11,12 +11,22 @@ use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
-use Symfony\Component\Validator\Constraints\Date;
 use App\State\Processor\BandSpace\FinanceEntryDeleteProcessor;
 use App\State\Processor\BandSpace\FinanceEntryUpdateProcessor;
 use App\State\Provider\BandSpace\FinanceEntryCollectionProvider;
 use App\State\Provider\BandSpace\FinanceEntryItemProvider;
+use App\Validator\BandSpace\FinanceAmountRange;
+use Symfony\Component\Validator\Constraints as Assert;
 
+/**
+ * The PATCH is validated on this class, not on a dedicated input: API Platform merges the request into
+ * the resource the provider returned, so the constraints below see the entry as it will be once the
+ * write lands. That is the point. The old shape carried no constraint at all, and every rule the create
+ * endpoint enforces was reachable in reverse through an edit: a negative amount, a minimum above its
+ * maximum, an exact amount next to a fourchette, a blank libellé, and a date string that only ever
+ * failed inside new DateTime().
+ */
+#[FinanceAmountRange]
 #[ApiResource(
     shortName: 'FinanceEntry',
     operations: [
@@ -31,8 +41,8 @@ use App\State\Provider\BandSpace\FinanceEntryItemProvider;
             name: 'api_band_space_finance_entries_get_collection',
             provider: FinanceEntryCollectionProvider::class,
             parameters: [
-                'from' => new QueryParameter(key: 'from', constraints: [new Date()]),
-                'to' => new QueryParameter(key: 'to', constraints: [new Date()]),
+                'from' => new QueryParameter(key: 'from', constraints: [new Assert\Date()]),
+                'to' => new QueryParameter(key: 'to', constraints: [new Assert\Date()]),
             ],
         ),
         new Get(
@@ -81,17 +91,41 @@ class FinanceEntryResource
     #[ApiProperty(identifier: true)]
     public string $bandSpaceId;
 
+    #[Assert\NotBlank(message: 'Veuillez spécifier une catégorie')]
+    #[Assert\Uuid(message: 'Identifiant de catégorie invalide')]
     public string $categoryId;
+
     public string $categoryName;
+
+    #[Assert\NotBlank(message: 'Veuillez spécifier un libellé')]
+    #[Assert\Length(max: 255, maxMessage: 'Le libellé ne peut pas dépasser {{ limit }} caractères')]
     public string $label;
+
+    #[Assert\Choice(choices: ['expense', 'income'], message: 'Type invalide')]
     public string $type;
+
+    #[Assert\Choice(choices: ['planned', 'committed', 'paid'], message: 'Statut invalide')]
     public string $status;
+
+    #[Assert\PositiveOrZero(message: 'Le montant doit être positif ou zéro')]
     public ?int $amount = null;
+
+    #[Assert\PositiveOrZero(message: 'Le montant minimum doit être positif ou zéro')]
     public ?int $amountMin = null;
+
+    #[Assert\PositiveOrZero(message: 'Le montant maximum doit être positif ou zéro')]
     public ?int $amountMax = null;
+
+    #[Assert\NotBlank(message: 'Veuillez spécifier une date')]
+    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
     public string $date;
+
+    #[Assert\Choice(choices: ['band', 'personal'], message: 'Périmètre invalide')]
     public string $scope;
+
+    #[Assert\Uuid(message: 'Identifiant de membre invalide')]
     public ?string $memberId = null;
+
     public ?string $memberName = null;
     public bool $isFormerMember = false;
     public ?string $recurrenceId = null;

--- a/src/ApiResource/BandSpace/Finance/FinanceRecurrenceResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceRecurrenceResource.php
@@ -85,10 +85,22 @@ class FinanceRecurrenceResource
     #[Assert\Length(max: 255, maxMessage: 'Le libellé ne peut pas dépasser {{ limit }} caractères')]
     public string $label;
 
+    // The PATCH reads type, scope and interval straight back into an enum, so without a Choice an
+    // unknown value reached ::from() and came out as a 500 instead of a violation. The dates carry no
+    // Assert\Date because the provider hands them back in ATOM while the interface sends AAAA-MM-JJ;
+    // RecurrenceEndDate parses both and reports an unparsable one itself.
+    #[Assert\Choice(choices: ['expense', 'income'], message: 'Type invalide')]
     public string $type;
+
+    #[Assert\Positive(message: 'Le montant doit être positif')]
     public int $amount;
+
+    #[Assert\Choice(choices: ['band', 'personal'], message: 'Périmètre invalide')]
     public string $scope;
+
+    #[Assert\Choice(choices: ['weekly', 'monthly', 'quarterly', 'yearly'], message: 'Intervalle de récurrence invalide')]
     public string $interval;
+
     public string $startDate;
     public string $endDate;
     public bool $isActive;

--- a/src/Repository/BandSpace/FinanceEntryRepository.php
+++ b/src/Repository/BandSpace/FinanceEntryRepository.php
@@ -20,9 +20,17 @@ class FinanceEntryRepository extends ServiceEntityRepository
         parent::__construct($registry, FinanceEntry::class);
     }
 
+    /**
+     * What an entry contributes to a total: its exact amount, else the middle of its estimate.
+     *
+     * The two lone bounds are the safety net for rows written before a fourchette had to carry both of
+     * them. `amount_min + amount_max` is NULL as soon as one side is, so those rows used to fall all the
+     * way through to 0 and vanish from every total. Falling back to the bound that is actually there is
+     * wrong by at most half a bracket, where 0 was wrong by the whole entry.
+     */
     private function effectiveAmountSql(string $alias = 'e'): string
     {
-        return "COALESCE({$alias}.amount, ROUND(({$alias}.amount_min + {$alias}.amount_max) / 2), 0)";
+        return "COALESCE({$alias}.amount, ROUND(({$alias}.amount_min + {$alias}.amount_max) / 2), {$alias}.amount_min, {$alias}.amount_max, 0)";
     }
 
     /**
@@ -125,7 +133,7 @@ class FinanceEntryRepository extends ServiceEntityRepository
                 COALESCE(SUM(CASE WHEN e.scope = 'band' AND e.status = 'committed' THEN {$effectiveAmount} ELSE 0 END), 0) AS total_committed,
                 COALESCE(SUM(CASE WHEN e.scope = 'band' AND e.status = 'paid' THEN {$effectiveAmount} ELSE 0 END), 0) AS total_paid,
                 COALESCE(SUM(CASE WHEN e.scope = 'personal' THEN {$effectiveAmount} ELSE 0 END), 0) AS total_personal,
-                MAX(CASE WHEN e.amount IS NULL AND e.amount_min IS NOT NULL THEN 1 ELSE 0 END) AS has_estimates
+                MAX(CASE WHEN e.amount IS NULL AND (e.amount_min IS NOT NULL OR e.amount_max IS NOT NULL) THEN 1 ELSE 0 END) AS has_estimates
             FROM finance_entry e
             JOIN finance_category c ON e.category_id = c.id
             WHERE c.band_space_id = :bandSpaceId{$dateFilter}
@@ -315,6 +323,93 @@ class FinanceEntryRepository extends ServiceEntityRepository
         }
 
         return $labels;
+    }
+
+    /**
+     * How many entries each of these categories holds, keyed by category id. A category with none is
+     * absent from the map rather than present at zero, so callers default it themselves.
+     *
+     * One query for the whole tree: the interface names the number in the delete confirmation of every
+     * category it draws, and that must not cost one round trip per pole.
+     *
+     * @param FinanceCategory[] $categories
+     * @return array<string, int>
+     */
+    public function countByCategories(array $categories): array
+    {
+        if ($categories === []) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('e')
+            ->select('IDENTITY(e.category) AS category_id, COUNT(e.id) AS cnt')
+            ->where('e.category IN (:categories)')
+            ->setParameter('categories', $categories)
+            ->groupBy('e.category')
+            ->getQuery()
+            ->getArrayResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(string) $row['category_id']] = (int) $row['cnt'];
+        }
+
+        return $counts;
+    }
+
+    public function countByCategory(FinanceCategory $category): int
+    {
+        return (int) $this->createQueryBuilder('e')
+            ->select('COUNT(e.id)')
+            ->where('e.category = :category')
+            ->setParameter('category', $category)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * How many Paid entries a category holds. Deleting the category cascades them in the database, which
+     * is the one route around FinanceEntryDeleteProcessor's refusal to delete a paid entry, so the
+     * delete asks this first.
+     */
+    public function countPaidByCategory(FinanceCategory $category): int
+    {
+        return (int) $this->createQueryBuilder('e')
+            ->select('COUNT(e.id)')
+            ->where('e.category = :category')
+            ->andWhere('e.status = :status')
+            ->setParameter('category', $category)
+            ->setParameter('status', FinanceEntryStatus::Paid)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * The memberships the entries of a recurrence were generated for, as plain ids.
+     *
+     * A FinanceRecurrence carries no owner column: a personal one is owned by whoever it planned its
+     * entries for, and that is only readable from those entries. Ids rather than entities because the
+     * only caller compares them, and because ORM 3 refuses to select a joined alias on its own.
+     *
+     * @return string[]
+     */
+    public function findMemberIdsByRecurrence(FinanceRecurrence $recurrence): array
+    {
+        $rows = $this->createQueryBuilder('e')
+            ->select('IDENTITY(e.member) AS member_id')
+            ->where('e.recurrence = :recurrence')
+            ->andWhere('e.member IS NOT NULL')
+            ->setParameter('recurrence', $recurrence)
+            ->groupBy('e.member')
+            ->getQuery()
+            ->getArrayResult();
+
+        $memberIds = [];
+        foreach ($rows as $row) {
+            $memberIds[] = (string) $row['member_id'];
+        }
+
+        return $memberIds;
     }
 
     /**

--- a/src/Security/BandSpace/FinanceRecurrenceOwnerChecker.php
+++ b/src/Security/BandSpace/FinanceRecurrenceOwnerChecker.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\BandSpace\FinanceRecurrence;
+use App\Enum\BandSpace\FinanceEntryScope;
+use App\Repository\BandSpace\FinanceEntryRepository;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * A personal finance recurrence belongs to one member, and only that member may edit or delete it.
+ *
+ * The entry endpoints have always enforced this on the entries themselves. The recurrence endpoints did
+ * not, so any member could delete somebody else's personal recurrence and take its planned entries with
+ * it, which is precisely the operation the entry endpoints protect their owner from. Extending one was
+ * as bad in a quieter way: the occurrences it generated were filed under whoever pressed Enregistrer,
+ * splitting one series across two owners.
+ *
+ * FinanceRecurrence carries no owner column, so the owner is read from the entries the recurrence
+ * planned, which RecurrenceEntryGenerator files under the creator's membership.
+ */
+readonly class FinanceRecurrenceOwnerChecker
+{
+    public function __construct(
+        private FinanceEntryRepository $financeEntryRepository,
+    ) {
+    }
+
+    /**
+     * @return BandSpaceMembership the membership the recurrence plans its entries for, which is the
+     *                             caller's own whenever the recurrence has an owner at all
+     */
+    public function checkCanUpdate(FinanceRecurrence $recurrence, BandSpaceMembership $membership): BandSpaceMembership
+    {
+        return $this->checkOwner($recurrence, $membership, 'Vous ne pouvez modifier que vos propres récurrences personnelles');
+    }
+
+    public function checkCanDelete(FinanceRecurrence $recurrence, BandSpaceMembership $membership): void
+    {
+        $this->checkOwner($recurrence, $membership, 'Vous ne pouvez supprimer que vos propres récurrences personnelles');
+    }
+
+    private function checkOwner(FinanceRecurrence $recurrence, BandSpaceMembership $membership, string $message): BandSpaceMembership
+    {
+        if ($recurrence->scope !== FinanceEntryScope::Personal) {
+            return $membership;
+        }
+
+        $ownerIds = $this->financeEntryRepository->findMemberIdsByRecurrence($recurrence);
+
+        // A personal recurrence that planned nothing, or whose entries were all deleted, has nobody to
+        // protect: the caller becomes its owner for whatever it materialises next.
+        if ($ownerIds === [] || in_array((string) $membership->id, $ownerIds, true)) {
+            return $membership;
+        }
+
+        throw new AccessDeniedHttpException($message);
+    }
+}

--- a/src/Service/Builder/BandSpace/FinanceCategoryBuilder.php
+++ b/src/Service/Builder/BandSpace/FinanceCategoryBuilder.php
@@ -9,17 +9,21 @@ readonly class FinanceCategoryBuilder
 {
     /**
      * @param FinanceCategory[] $entities
+     * @param array<string, int> $entryCounts entry count keyed by category id, absent meaning none
      * @return FinanceCategoryResource[]
      */
-    public function buildFromList(array $entities): array
+    public function buildFromList(array $entities, array $entryCounts = []): array
     {
         return array_map(
-            fn (FinanceCategory $entity): FinanceCategoryResource => $this->buildItem($entity),
+            fn (FinanceCategory $entity): FinanceCategoryResource => $this->buildItem(
+                $entity,
+                $entryCounts[(string) $entity->id] ?? 0
+            ),
             $entities
         );
     }
 
-    public function buildItem(FinanceCategory $entity): FinanceCategoryResource
+    public function buildItem(FinanceCategory $entity, int $entryCount = 0): FinanceCategoryResource
     {
         $dto = new FinanceCategoryResource();
         $dto->id = (string) $entity->id;
@@ -28,6 +32,7 @@ readonly class FinanceCategoryBuilder
         $dto->parentId = $entity->parent instanceof \App\Entity\BandSpace\FinanceCategory ? (string) $entity->parent->id : null;
         $dto->position = $entity->position;
         $dto->hasChildren = !$entity->children->isEmpty();
+        $dto->entryCount = $entryCount;
         $dto->creationDatetime = $entity->creationDatetime;
         $dto->updateDatetime = $entity->updateDatetime;
 

--- a/src/State/Processor/BandSpace/FinanceBootstrapProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceBootstrapProcessor.php
@@ -11,6 +11,7 @@ use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceFinanceActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\FinanceCategoryRepository;
+use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\FinanceCategoryBuilder;
@@ -37,6 +38,7 @@ readonly class FinanceBootstrapProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private FinanceCategoryRepository $financeCategoryRepository,
+        private FinanceEntryRepository $financeEntryRepository,
         private FinanceCategoryBuilder $financeCategoryBuilder,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
@@ -57,7 +59,10 @@ readonly class FinanceBootstrapProcessor implements ProcessorInterface
         if ($this->financeCategoryRepository->existsByBandSpace($bandSpace)) {
             $categories = $this->financeCategoryRepository->findByBandSpace($bandSpace);
 
-            return $this->financeCategoryBuilder->buildFromList($categories);
+            return $this->financeCategoryBuilder->buildFromList(
+                $categories,
+                $this->financeEntryRepository->countByCategories($categories),
+            );
         }
 
         $categories = [];

--- a/src/State/Processor/BandSpace/FinanceCategoryDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceCategoryDeleteProcessor.php
@@ -16,8 +16,19 @@ use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
+ * Deleting a category cascades its entries in the database, which used to make this the one route that
+ * destroyed a Paid entry: FinanceEntryDeleteProcessor refuses one outright, and going through its
+ * category took it out anyway, silently, along with the whole pole. So the delete now refuses while
+ * anything it would take with it is accounting history.
+ *
+ * Sub-categories are refused for the same reason one step down. `finance_category.parent_id` is
+ * `SET NULL`, so they were never deleted with their parent: they resurfaced as top-level poles, which
+ * both contradicted the confirmation the interface showed and put their own Paid entries out of reach
+ * of the check above. Emptying the subtree first is one click more and no surprises.
+ *
  * @implements ProcessorInterface<FinanceCategoryResource, void>
  */
 readonly class FinanceCategoryDeleteProcessor implements ProcessorInterface
@@ -46,6 +57,26 @@ readonly class FinanceCategoryDeleteProcessor implements ProcessorInterface
         $category = $this->financeCategoryRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$category instanceof \App\Entity\BandSpace\FinanceCategory) {
             throw new NotFoundHttpException('Catégorie introuvable');
+        }
+
+        $childCount = $category->children->count();
+        if ($childCount > 1) {
+            throw new UnprocessableEntityHttpException(
+                sprintf('Cette catégorie contient %d sous-catégories. Supprimez-les d\'abord.', $childCount)
+            );
+        }
+        if ($childCount === 1) {
+            throw new UnprocessableEntityHttpException('Cette catégorie contient une sous-catégorie. Supprimez-la d\'abord.');
+        }
+
+        $paidEntryCount = $this->financeEntryRepository->countPaidByCategory($category);
+        if ($paidEntryCount > 1) {
+            throw new UnprocessableEntityHttpException(
+                sprintf('Cette catégorie contient %d entrées payées. Repassez leur statut à Engagé ou déplacez-les d\'abord.', $paidEntryCount)
+            );
+        }
+        if ($paidEntryCount === 1) {
+            throw new UnprocessableEntityHttpException('Cette catégorie contient une entrée payée. Repassez son statut à Engagé ou déplacez-la d\'abord.');
         }
 
         $this->bandSpaceActivityRecorder->record(

--- a/src/State/Processor/BandSpace/FinanceCategoryUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceCategoryUpdateProcessor.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceFinanceActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\FinanceCategoryRepository;
+use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\FinanceCategoryBuilder;
@@ -28,6 +29,7 @@ readonly class FinanceCategoryUpdateProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private FinanceCategoryRepository $financeCategoryRepository,
+        private FinanceEntryRepository $financeEntryRepository,
         private FinanceCategoryBuilder $financeCategoryBuilder,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
@@ -95,6 +97,9 @@ readonly class FinanceCategoryUpdateProcessor implements ProcessorInterface
 
         $this->entityManager->flush();
 
-        return $this->financeCategoryBuilder->buildItem($category);
+        return $this->financeCategoryBuilder->buildItem(
+            $category,
+            $this->financeEntryRepository->countByCategory($category),
+        );
     }
 }

--- a/src/State/Processor/BandSpace/FinanceRecurrenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceDeleteProcessor.php
@@ -11,6 +11,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\FinanceRecurrenceOwnerChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,6 +26,7 @@ readonly class FinanceRecurrenceDeleteProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private FinanceRecurrenceOwnerChecker $recurrenceOwnerChecker,
         private FinanceRecurrenceRepository $financeRecurrenceRepository,
         private FinanceEntryRepository $financeEntryRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
@@ -41,12 +43,14 @@ readonly class FinanceRecurrenceDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $currentMembership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $recurrence = $this->financeRecurrenceRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$recurrence instanceof \App\Entity\BandSpace\FinanceRecurrence) {
             throw new NotFoundHttpException('Récurrence introuvable');
         }
+
+        $this->recurrenceOwnerChecker->checkCanDelete($recurrence, $currentMembership);
 
         // One transaction, because the entries go out through a bulk DQL delete that reaches the
         // database immediately while the detached attachments wait for the flush. Unwrapped, a flush

--- a/src/State/Processor/BandSpace/FinanceRecurrenceUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceUpdateProcessor.php
@@ -18,6 +18,7 @@ use App\Enum\BandSpace\RecurrenceInterval;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\FinanceRecurrenceOwnerChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use App\Service\BandSpace\RecurrenceEntryGenerator;
@@ -41,6 +42,9 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
  * - The start date and the interval define the grid every materialised entry sits on, frozen entries
  *   included, so changing either is refused rather than half applied.
  *
+ * Who may run the edit at all is FinanceRecurrenceOwnerChecker's business: a personal recurrence answers
+ * only to the member its forecasts belong to.
+ *
  * @implements ProcessorInterface<FinanceRecurrenceResource, FinanceRecurrenceResource>
  */
 readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
@@ -48,6 +52,7 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private FinanceRecurrenceOwnerChecker $recurrenceOwnerChecker,
         private FinanceRecurrenceRepository $financeRecurrenceRepository,
         private FinanceEntryRepository $financeEntryRepository,
         private FinanceRecurrenceBuilder $financeRecurrenceBuilder,
@@ -73,6 +78,11 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
         if (!$recurrence instanceof FinanceRecurrence) {
             throw new NotFoundHttpException('Récurrence introuvable');
         }
+
+        // The owner of a personal recurrence, and the caller's own membership for a band one. Everything
+        // this processor materialises is filed under it rather than under whoever is calling, so an edit
+        // can never split one series between two members.
+        $ownerMembership = $this->recurrenceOwnerChecker->checkCanUpdate($recurrence, $currentMembership);
 
         $requestPayload = $this->requestStack->getCurrentRequest()?->toArray() ?? [];
 
@@ -116,7 +126,7 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
                 $requestPayload,
                 $bandSpace,
                 $user,
-                $currentMembership,
+                $ownerMembership,
                 $now,
                 $oldLabel,
                 $oldType,
@@ -160,7 +170,7 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
                 // stopped recurrence must not refill the budget just because its end date moved.
                 $materialiseFrom = $this->earlierOf($extendedFrom, $reactivated ? $now : null);
                 if ($recurrence->isActive && $materialiseFrom instanceof DateTimeInterface) {
-                    $createdEntries = $this->materialiseAfter($recurrence, $currentMembership, $materialiseFrom);
+                    $createdEntries = $this->materialiseAfter($recurrence, $ownerMembership, $materialiseFrom);
                 }
 
                 foreach ($createdEntries as $entry) {
@@ -177,7 +187,7 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
                     || $oldAmount !== $recurrence->amount
                     || $oldScope !== $recurrence->scope;
                 $updatedEntryCount = $propagatingFieldChanged
-                    ? $this->syncFutureForecasts($recurrence, $currentMembership, $now)
+                    ? $this->syncFutureForecasts($recurrence, $ownerMembership, $now)
                     : 0;
 
                 $recurrence->updateDatetime = new DateTime();
@@ -284,7 +294,7 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
     /**
      * @return FinanceEntry[]
      */
-    private function materialiseAfter(FinanceRecurrence $recurrence, BandSpaceMembership $currentMembership, DateTimeInterface $after): array
+    private function materialiseAfter(FinanceRecurrence $recurrence, BandSpaceMembership $ownerMembership, DateTimeInterface $after): array
     {
         $takenDates = array_map(
             static fn (FinanceEntry $entry): string => $entry->date->format('Y-m-d'),
@@ -293,7 +303,7 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
 
         return $this->recurrenceEntryGenerator->generateMissingEntriesAfter(
             $recurrence,
-            $recurrence->scope === FinanceEntryScope::Personal ? $currentMembership : null,
+            $recurrence->scope === FinanceEntryScope::Personal ? $ownerMembership : null,
             $after,
             $takenDates,
         );
@@ -306,13 +316,13 @@ readonly class FinanceRecurrenceUpdateProcessor implements ProcessorInterface
      * An entry is left exactly as it is when it already matches, which is what makes an edit that changes
      * nothing on the recurrence change nothing on the entries.
      */
-    private function syncFutureForecasts(FinanceRecurrence $recurrence, BandSpaceMembership $currentMembership, DateTimeInterface $now): int
+    private function syncFutureForecasts(FinanceRecurrence $recurrence, BandSpaceMembership $ownerMembership, DateTimeInterface $now): int
     {
         $updatedEntryCount = 0;
 
         foreach ($this->financeEntryRepository->findPlannedByRecurrenceAfter($recurrence, $now) as $entry) {
             $member = $recurrence->scope === FinanceEntryScope::Personal
-                ? $entry->member ?? $currentMembership
+                ? $entry->member ?? $ownerMembership
                 : null;
 
             if (

--- a/src/State/Provider/BandSpace/FinanceCategoryCollectionProvider.php
+++ b/src/State/Provider/BandSpace/FinanceCategoryCollectionProvider.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Entity\User;
 use App\Repository\BandSpace\FinanceCategoryRepository;
+use App\Repository\BandSpace\FinanceEntryRepository;
 use App\ApiResource\BandSpace\Finance\FinanceCategoryResource;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\Builder\BandSpace\FinanceCategoryBuilder;
@@ -20,6 +21,7 @@ readonly class FinanceCategoryCollectionProvider implements ProviderInterface
     public function __construct(
         private BandSpaceMemberChecker $memberChecker,
         private FinanceCategoryRepository $financeCategoryRepository,
+        private FinanceEntryRepository $financeEntryRepository,
         private FinanceCategoryBuilder $financeCategoryBuilder,
         private Security $security,
     ) {
@@ -39,6 +41,9 @@ readonly class FinanceCategoryCollectionProvider implements ProviderInterface
 
         $categories = $this->financeCategoryRepository->findByBandSpace($bandSpace);
 
-        return $this->financeCategoryBuilder->buildFromList($categories);
+        return $this->financeCategoryBuilder->buildFromList(
+            $categories,
+            $this->financeEntryRepository->countByCategories($categories),
+        );
     }
 }

--- a/src/State/Provider/BandSpace/FinanceCategoryItemProvider.php
+++ b/src/State/Provider/BandSpace/FinanceCategoryItemProvider.php
@@ -7,6 +7,7 @@ use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\BandSpace\Finance\FinanceCategoryResource;
 use App\Entity\User;
 use App\Repository\BandSpace\FinanceCategoryRepository;
+use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\Builder\BandSpace\FinanceCategoryBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -21,6 +22,7 @@ readonly class FinanceCategoryItemProvider implements ProviderInterface
     public function __construct(
         private BandSpaceMemberChecker $memberChecker,
         private FinanceCategoryRepository $financeCategoryRepository,
+        private FinanceEntryRepository $financeEntryRepository,
         private FinanceCategoryBuilder $financeCategoryBuilder,
         private Security $security,
     ) {
@@ -40,6 +42,9 @@ readonly class FinanceCategoryItemProvider implements ProviderInterface
             throw new NotFoundHttpException('Catégorie introuvable');
         }
 
-        return $this->financeCategoryBuilder->buildItem($category);
+        return $this->financeCategoryBuilder->buildItem(
+            $category,
+            $this->financeEntryRepository->countByCategory($category),
+        );
     }
 }

--- a/src/Validator/BandSpace/FinanceAmountRange.php
+++ b/src/Validator/BandSpace/FinanceAmountRange.php
@@ -9,6 +9,7 @@ class FinanceAmountRange extends Constraint
 {
     public string $message = 'Le montant minimum doit être inférieur ou égal au montant maximum';
     public string $exclusiveMessage = 'Vous ne pouvez pas définir un montant exact et une fourchette en même temps';
+    public string $incompleteMessage = 'Une fourchette doit avoir un montant minimum et un montant maximum';
 
     public function getTargets(): string
     {

--- a/src/Validator/BandSpace/FinanceAmountRangeValidator.php
+++ b/src/Validator/BandSpace/FinanceAmountRangeValidator.php
@@ -10,6 +10,8 @@ class FinanceAmountRangeValidator extends ConstraintValidator
 {
     public const string ERROR_CODE_EXCLUSIVE = 'music_all_434bf45e-e038-4c98-be5d-d48d96d6e2c3';
     public const string ERROR_CODE_MIN_MAX = 'music_all_340f2feb-4d58-4e44-bd3c-e0ddda45a31a';
+    public const string ERROR_CODE_INCOMPLETE = 'music_all_6b1c0a5f-8f1e-4a1e-9a2c-2c9e1f7a4d80';
+
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof FinanceAmountRange) {
@@ -32,7 +34,17 @@ class FinanceAmountRangeValidator extends ConstraintValidator
             return;
         }
 
+        // One bound on its own is the shape that silently costs the band money: every total reads the
+        // entry through COALESCE(amount, ROUND((min + max) / 2), ...) and an addition with a NULL side
+        // is NULL, so a half filled estimate used to count as zero everywhere without a single warning.
         if ($value->amountMin === null || $value->amountMax === null) {
+            if ($hasRange) {
+                $this->context->buildViolation($constraint->incompleteMessage)
+                    ->atPath($value->amountMin === null ? 'amountMin' : 'amountMax')
+                    ->setCode(self::ERROR_CODE_INCOMPLETE)
+                    ->addViolation();
+            }
+
             return;
         }
 

--- a/tests/Api/BandSpace/Finance/FinanceCategoryCreateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceCategoryCreateTest.php
@@ -54,6 +54,7 @@ class FinanceCategoryCreateTest extends ApiTestCase
             'parent_id' => null,
             'position' => 0,
             'has_children' => false,
+            'entry_count' => 0,
             'creation_datetime' => $category->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => null,
         ]);
@@ -109,6 +110,7 @@ class FinanceCategoryCreateTest extends ApiTestCase
             'parent_id' => $parentCategory->id,
             'position' => 0,
             'has_children' => false,
+            'entry_count' => 0,
             'creation_datetime' => $child->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => null,
         ]);

--- a/tests/Api/BandSpace/Finance/FinanceCategoryDeleteTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceCategoryDeleteTest.php
@@ -13,6 +13,7 @@ use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\FinanceCategoryRepository;
+use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
@@ -76,11 +77,13 @@ class FinanceCategoryDeleteTest extends ApiTestCase
         BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
 
         $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio'])->create();
+        // Planned, not Paid: a paid entry now blocks the delete outright, so the cascade this test is
+        // about would never run.
         $entry = FinanceEntryFactory::new([
             'category' => $category,
             'label' => 'Mixage',
             'type' => FinanceEntryType::Expense,
-            'status' => FinanceEntryStatus::Paid,
+            'status' => FinanceEntryStatus::Planned,
             'scope' => FinanceEntryScope::Band,
             'amount' => 12000,
             'date' => new \DateTime('2026-03-01'),
@@ -94,6 +97,7 @@ class FinanceCategoryDeleteTest extends ApiTestCase
         ]);
 
         $categoryId = (string) $category->id;
+        $entryId = (string) $entry->id;
         $fileId = (string) $file->id;
         $attachmentId = (string) $attachment->id;
 
@@ -103,6 +107,8 @@ class FinanceCategoryDeleteTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
 
         self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $this->assertNull(self::getContainer()->get(FinanceEntryRepository::class)->find($entryId));
+
         $attachmentRepository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
         $this->assertNull($attachmentRepository->find($attachmentId));
 
@@ -189,5 +195,131 @@ class FinanceCategoryDeleteTest extends ApiTestCase
         $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/categories/' . $category->id);
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * FinanceEntryDeleteProcessor refuses to delete a paid entry, and `finance_entry.category_id` is
+     * ON DELETE CASCADE, so deleting the category took the paid entry out anyway. That made this the
+     * one route in the module that destroyed accounting history, silently and in bulk.
+     */
+    public function test_delete_category_holding_a_paid_entry_is_refused(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio'])->create();
+        $paidEntry = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Mastering',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Paid,
+            'scope' => FinanceEntryScope::Band,
+            'amount' => 42000,
+            'date' => new \DateTime('2026-03-01'),
+        ])->create();
+        $categoryId = (string) $category->id;
+        $paidEntryId = (string) $paidEntry->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/categories/' . $categoryId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cette catégorie contient une entrée payée. Repassez son statut à Engagé ou déplacez-la d\'abord.',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Cette catégorie contient une entrée payée. Repassez son statut à Engagé ou déplacez-la d\'abord.',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $this->assertNotNull(self::getContainer()->get(FinanceCategoryRepository::class)->find($categoryId));
+        $this->assertNotNull(self::getContainer()->get(FinanceEntryRepository::class)->find($paidEntryId));
+
+        // The clear above detached it, and a detached entity cannot be bound as a query parameter.
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findForResource($bandSpace, BandSpaceModule::Finance, $categoryId));
+    }
+
+    public function test_delete_category_holding_several_paid_entries_names_the_count(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio'])->create();
+        foreach (['Mastering', 'Mixage'] as $index => $label) {
+            FinanceEntryFactory::new([
+                'category' => $category,
+                'label' => $label,
+                'type' => FinanceEntryType::Expense,
+                'status' => FinanceEntryStatus::Paid,
+                'scope' => FinanceEntryScope::Band,
+                'amount' => 42000,
+                'date' => new \DateTime('2026-03-0' . ($index + 1)),
+            ])->create();
+        }
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/categories/' . $category->id);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cette catégorie contient 2 entrées payées. Repassez leur statut à Engagé ou déplacez-les d\'abord.',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Cette catégorie contient 2 entrées payées. Repassez leur statut à Engagé ou déplacez-les d\'abord.',
+        ]);
+    }
+
+    /**
+     * `finance_category.parent_id` is SET NULL, so a sub-category was never deleted with its parent: it
+     * resurfaced as a top-level pole, which contradicted the confirmation the interface showed and put
+     * its own paid entries out of reach of the check above. Emptying the subtree first is explicit.
+     */
+    public function test_delete_category_with_a_sub_category_is_refused(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $pole = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $child = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Mixage',
+            'position' => 0,
+            'parent' => $pole,
+        ])->create();
+        $poleId = (string) $pole->id;
+        $childId = (string) $child->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/categories/' . $poleId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cette catégorie contient une sous-catégorie. Supprimez-la d\'abord.',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Cette catégorie contient une sous-catégorie. Supprimez-la d\'abord.',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $categoryRepository = self::getContainer()->get(FinanceCategoryRepository::class);
+        $this->assertNotNull($categoryRepository->find($poleId));
+        $this->assertNotNull($categoryRepository->find($childId));
     }
 }

--- a/tests/Api/BandSpace/Finance/FinanceCategoryGetCollectionTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceCategoryGetCollectionTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Api\BandSpace\Finance;
 
+use App\Enum\BandSpace\FinanceEntryScope;
+use App\Enum\BandSpace\FinanceEntryStatus;
+use App\Enum\BandSpace\FinanceEntryType;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
+use App\Tests\Factory\BandSpace\FinanceEntryFactory;
 use App\Tests\Factory\User\UserFactory;
 use App\Enum\BandSpace\MembershipStatus;
 use Symfony\Component\HttpFoundation\Response;
@@ -57,6 +61,7 @@ class FinanceCategoryGetCollectionTest extends ApiTestCase
                     'parent_id' => null,
                     'position' => 0,
                     'has_children' => false,
+                    'entry_count' => 0,
                     'creation_datetime' => '2024-01-01T10:00:00+00:00',
                     'update_datetime' => null,
                 ],
@@ -69,12 +74,64 @@ class FinanceCategoryGetCollectionTest extends ApiTestCase
                     'parent_id' => null,
                     'position' => 1,
                     'has_children' => false,
+                    'entry_count' => 0,
                     'creation_datetime' => '2024-01-02T10:00:00+00:00',
                     'update_datetime' => null,
                 ],
             ],
             'totalItems' => 2,
         ]);
+    }
+
+    /**
+     * The count the delete confirmation names, so a wrong one tells a member their category is empty
+     * on the dialog that decides whether they delete it. Counted per category rather than in total,
+     * and only from entries filed directly under it.
+     */
+    public function test_get_categories_counts_the_entries_filed_under_each_one(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $withEntries = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Studio',
+            'position' => 0,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+        $empty = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Transport',
+            'position' => 1,
+            'creationDatetime' => new \DateTime('2024-01-02 10:00:00'),
+        ])->create();
+
+        foreach ([FinanceEntryStatus::Paid, FinanceEntryStatus::Planned, FinanceEntryStatus::Committed] as $index => $status) {
+            FinanceEntryFactory::new([
+                'category' => $withEntries,
+                'label' => 'Séance ' . $index,
+                'type' => FinanceEntryType::Expense,
+                'status' => $status,
+                'scope' => FinanceEntryScope::Band,
+                'amount' => 10000,
+                'date' => new \DateTime('2026-03-0' . ($index + 1)),
+            ])->create();
+        }
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/finance/categories');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(
+            ['Studio' => 3, 'Transport' => 0],
+            array_combine(
+                array_column($response['member'], 'name'),
+                array_column($response['member'], 'entry_count'),
+            ),
+        );
+        $this->assertSame((string) $empty->id, $response['member'][1]['id']);
     }
 
     public function test_get_categories_not_member(): void

--- a/tests/Api/BandSpace/Finance/FinanceCategoryGetItemTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceCategoryGetItemTest.php
@@ -47,6 +47,7 @@ class FinanceCategoryGetItemTest extends ApiTestCase
             'parent_id' => null,
             'position' => 0,
             'has_children' => false,
+            'entry_count' => 0,
             'creation_datetime' => '2024-01-01T10:00:00+00:00',
             'update_datetime' => null,
         ]);

--- a/tests/Api/BandSpace/Finance/FinanceCategoryUpdateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceCategoryUpdateTest.php
@@ -52,6 +52,7 @@ class FinanceCategoryUpdateTest extends ApiTestCase
             'parent_id' => null,
             'position' => 0,
             'has_children' => false,
+            'entry_count' => 0,
             'creation_datetime' => '2024-01-01T10:00:00+00:00',
             'update_datetime' => $category->updateDatetime->format(\DateTimeInterface::ATOM),
         ]);
@@ -94,6 +95,7 @@ class FinanceCategoryUpdateTest extends ApiTestCase
             'parent_id' => null,
             'position' => 5,
             'has_children' => false,
+            'entry_count' => 0,
             'creation_datetime' => $category->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $category->updateDatetime->format(\DateTimeInterface::ATOM),
         ]);

--- a/tests/Api/BandSpace/Finance/FinanceEntryCreateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceEntryCreateTest.php
@@ -574,4 +574,60 @@ class FinanceEntryCreateTest extends ApiTestCase
             'title' => 'An error occurred',
         ]);
     }
+
+    /**
+     * A fourchette with one side missing used to be accepted, and then counted as zero everywhere: the
+     * totals read the entry through ROUND((amount_min + amount_max) / 2) and an addition with a NULL
+     * side is NULL. Nothing warned about it either, because the estimate flag only looked at the
+     * minimum.
+     */
+    public function test_create_entry_with_only_a_minimum_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $category = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Studio',
+            'position' => 0,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries',
+            [
+                'categoryId' => (string) $category->id,
+                'label' => 'Mastering (devis partiel)',
+                'type' => 'expense',
+                'status' => 'planned',
+                'scope' => 'band',
+                'amountMin' => 40000,
+                'date' => '2024-01-15',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'amount_max',
+                    'message' => 'Une fourchette doit avoir un montant minimum et un montant maximum',
+                    'code' => FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+                ],
+            ],
+            'detail' => 'amount_max: Une fourchette doit avoir un montant minimum et un montant maximum',
+            'description' => 'amount_max: Une fourchette doit avoir un montant minimum et un montant maximum',
+            'type' => '/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+            'title' => 'An error occurred',
+        ]);
+
+        $this->assertSame([], self::getContainer()->get(FinanceEntryRepository::class)->findByBandSpace($bandSpace));
+    }
 }

--- a/tests/Api/BandSpace/Finance/FinanceEntryUpdateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceEntryUpdateTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Api\BandSpace\Finance;
 
+use App\Entity\BandSpace\FinanceCategory;
+use App\Entity\BandSpace\FinanceEntry;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\FinanceEntryScope;
 use App\Enum\BandSpace\FinanceEntryStatus;
@@ -17,8 +19,13 @@ use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
 use App\Tests\Factory\BandSpace\FinanceEntryFactory;
 use App\Tests\Factory\User\UserFactory;
+use App\Validator\BandSpace\FinanceAmountRangeValidator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\Date;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
 
@@ -235,21 +242,28 @@ class FinanceEntryUpdateTest extends ApiTestCase
     }
 
     /**
-     * @return iterable<string, array{0: string, 1: int|string|null}>
+     * Every payload here is one a non paid entry would accept, so what the test catches is the paid
+     * lock rather than a constraint tripped on the way in. Which is why the fourchette arrives whole
+     * and clears the exact amount: half a fourchette, or one sitting beside an amount, is now refused
+     * by FinanceAmountRange before the processor ever looks at the status.
+     *
+     * @return iterable<string, array{0: array<string, mixed>}>
      */
     public static function paidEntryProtectedFieldProvider(): iterable
     {
-        yield 'label' => ['label', 'Nouveau libellé'];
-        yield 'amount' => ['amount', 99999];
-        yield 'amount_min' => ['amount_min', 1000];
-        yield 'amount_max' => ['amount_max', 2000];
-        yield 'type' => ['type', 'income'];
-        yield 'date' => ['date', '2024-12-31'];
-        yield 'scope' => ['scope', 'personal'];
+        yield 'label' => [['label' => 'Nouveau libellé']];
+        yield 'amount' => [['amount' => 99999]];
+        yield 'amount range' => [['amount' => null, 'amount_min' => 1000, 'amount_max' => 2000]];
+        yield 'type' => [['type' => 'income']];
+        yield 'date' => [['date' => '2024-12-31']];
+        yield 'scope' => [['scope' => 'personal']];
     }
 
+    /**
+     * @param array<string, mixed> $payload
+     */
     #[DataProvider('paidEntryProtectedFieldProvider')]
-    public function test_update_paid_entry_each_protected_field_rejected(string $field, mixed $value): void
+    public function test_update_paid_entry_each_protected_field_rejected(array $payload): void
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
@@ -275,7 +289,7 @@ class FinanceEntryUpdateTest extends ApiTestCase
         $this->client->jsonRequest(
             'PATCH',
             '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
-            [$field => $value],
+            $payload,
             ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
         );
 
@@ -636,5 +650,342 @@ class FinanceEntryUpdateTest extends ApiTestCase
         );
 
         $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * A planned band entry of 500 EUR, the subject of the validation tests below. The PATCH endpoint
+     * carried no constraint at all, so each of them was accepted, and the unparsable date reached
+     * new DateTime() and came back as a 500.
+     */
+    private function createPlannedEntry(FinanceCategory $category): FinanceEntry
+    {
+        return FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Mixage',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Band,
+            'amount' => 50000,
+            'date' => new \DateTime('2024-01-15'),
+            'creationDatetime' => new \DateTime('2024-02-01 10:00:00'),
+        ])->create();
+    }
+
+    public function test_update_entry_with_a_negative_amount_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['amount' => -100],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . GreaterThanOrEqual::TOO_LOW_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'amount',
+                    'message' => 'Le montant doit être positif ou zéro',
+                    'code' => GreaterThanOrEqual::TOO_LOW_ERROR,
+                ],
+            ],
+            'detail' => 'amount: Le montant doit être positif ou zéro',
+            'description' => 'amount: Le montant doit être positif ou zéro',
+            'type' => '/validation_errors/' . GreaterThanOrEqual::TOO_LOW_ERROR,
+            'title' => 'An error occurred',
+        ]);
+    }
+
+    public function test_update_entry_with_a_minimum_above_its_maximum_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['amount' => null, 'amount_min' => 60000, 'amount_max' => 40000],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_MIN_MAX,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'amount_min',
+                    'message' => 'Le montant minimum doit être inférieur ou égal au montant maximum',
+                    'code' => FinanceAmountRangeValidator::ERROR_CODE_MIN_MAX,
+                ],
+            ],
+            'detail' => 'amount_min: Le montant minimum doit être inférieur ou égal au montant maximum',
+            'description' => 'amount_min: Le montant minimum doit être inférieur ou égal au montant maximum',
+            'type' => '/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_MIN_MAX,
+            'title' => 'An error occurred',
+        ]);
+    }
+
+    /**
+     * The merge-patch is validated on the entry as it would be after the write, so a fourchette sent
+     * onto an entry that already carries an exact amount is caught even though the request never
+     * mentions the amount.
+     */
+    public function test_update_entry_adding_a_range_next_to_its_exact_amount_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['amount_min' => 40000, 'amount_max' => 60000],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_EXCLUSIVE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'amount',
+                    'message' => 'Vous ne pouvez pas définir un montant exact et une fourchette en même temps',
+                    'code' => FinanceAmountRangeValidator::ERROR_CODE_EXCLUSIVE,
+                ],
+            ],
+            'detail' => 'amount: Vous ne pouvez pas définir un montant exact et une fourchette en même temps',
+            'description' => 'amount: Vous ne pouvez pas définir un montant exact et une fourchette en même temps',
+            'type' => '/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_EXCLUSIVE,
+            'title' => 'An error occurred',
+        ]);
+    }
+
+    /**
+     * Half a fourchette is the shape that silently counted as zero: amount_min + amount_max is NULL as
+     * soon as one side is, so the entry disappeared from every total without a warning anywhere.
+     */
+    public function test_update_entry_with_only_a_maximum_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['amount' => null, 'amount_max' => 60000],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'amount_min',
+                    'message' => 'Une fourchette doit avoir un montant minimum et un montant maximum',
+                    'code' => FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+                ],
+            ],
+            'detail' => 'amount_min: Une fourchette doit avoir un montant minimum et un montant maximum',
+            'description' => 'amount_min: Une fourchette doit avoir un montant minimum et un montant maximum',
+            'type' => '/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+            'title' => 'An error occurred',
+        ]);
+    }
+
+    /**
+     * The deliberate cost of the new rule, pinned so it is a decision rather than a surprise. Rows
+     * written before it could carry a single bound, and merge-patch validates the whole merged
+     * object, so an untouched half fourchette now refuses even a PATCH that has nothing to do with
+     * the amount. Its totals were wrong until the missing bound is filled in, so refusing is the
+     * intended outcome, and the violation names the bound to fill.
+     */
+    public function test_update_a_legacy_entry_carrying_half_an_estimate_is_refused_until_it_is_completed(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+
+        // Written straight to the database, the way a row predating the rule looks.
+        $legacy = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Cachet estimé',
+            'type' => FinanceEntryType::Income,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Band,
+            'amount' => null,
+            'amountMin' => 30000,
+            'amountMax' => null,
+            'date' => new \DateTime('2026-05-01'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $legacy->id,
+            ['status' => 'committed'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'amount_max',
+                    'message' => 'Une fourchette doit avoir un montant minimum et un montant maximum',
+                    'code' => FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+                ],
+            ],
+            'detail' => 'amount_max: Une fourchette doit avoir un montant minimum et un montant maximum',
+            'description' => 'amount_max: Une fourchette doit avoir un montant minimum et un montant maximum',
+            'type' => '/validation_errors/' . FinanceAmountRangeValidator::ERROR_CODE_INCOMPLETE,
+            'title' => 'An error occurred',
+        ]);
+    }
+
+    public function test_update_entry_with_a_blank_label_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['label' => ''],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . NotBlank::IS_BLANK_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'label',
+                    'message' => 'Veuillez spécifier un libellé',
+                    'code' => NotBlank::IS_BLANK_ERROR,
+                ],
+            ],
+            'detail' => 'label: Veuillez spécifier un libellé',
+            'description' => 'label: Veuillez spécifier un libellé',
+            'type' => '/validation_errors/' . NotBlank::IS_BLANK_ERROR,
+            'title' => 'An error occurred',
+        ]);
+    }
+
+    /** This one used to be a 500: the string went straight into new DateTime(). */
+    public function test_update_entry_with_an_unparsable_date_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['date' => 'la semaine prochaine'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . Date::INVALID_FORMAT_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'date',
+                    'message' => 'Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+                    'code' => Date::INVALID_FORMAT_ERROR,
+                ],
+            ],
+            'detail' => 'date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+            'description' => 'date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+            'type' => '/validation_errors/' . Date::INVALID_FORMAT_ERROR,
+            'title' => 'An error occurred',
+        ]);
+    }
+
+    /** Also a 500 before: FinanceEntryStatus::from() on an unknown case. */
+    public function test_update_entry_with_an_unknown_status_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['status' => 'annule'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . Choice::NO_SUCH_CHOICE_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'status',
+                    'message' => 'Statut invalide',
+                    'code' => Choice::NO_SUCH_CHOICE_ERROR,
+                ],
+            ],
+            'detail' => 'status: Statut invalide',
+            'description' => 'status: Statut invalide',
+            'type' => '/validation_errors/' . Choice::NO_SUCH_CHOICE_ERROR,
+            'title' => 'An error occurred',
+        ]);
     }
 }

--- a/tests/Api/BandSpace/Finance/FinanceRecurrenceDeleteTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceRecurrenceDeleteTest.php
@@ -197,4 +197,130 @@ class FinanceRecurrenceDeleteTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
+
+    /**
+     * Deleting a recurrence hard-deletes every forecast it planned. A personal one belongs to the
+     * member those forecasts are filed under, so this used to let any member destroy planned entries
+     * they are explicitly forbidden from deleting one by one.
+     */
+    public function test_delete_personal_recurrence_of_another_member_is_refused(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $intruder = UserFactory::new()->create(['username' => 'intruder', 'email' => 'intruder@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $ownerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $intruder])->create();
+
+        $category = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Studio',
+            'position' => 0,
+        ])->create();
+
+        $recurrence = FinanceRecurrenceFactory::new([
+            'category' => $category,
+            'label' => 'Cordes',
+            'type' => FinanceEntryType::Expense,
+            'scope' => FinanceEntryScope::Personal,
+            'interval' => RecurrenceInterval::Monthly,
+            'amount' => 3000,
+            'startDate' => new \DateTime('2024-01-01'),
+            'endDate' => new \DateTime('2024-06-30'),
+            'isActive' => true,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $forecast = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Cordes',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Personal,
+            'member' => $ownerMembership,
+            'amount' => 3000,
+            'date' => new \DateTime('2024-02-01'),
+            'recurrence' => $recurrence,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $recurrenceId = (string) $recurrence->id;
+        $forecastId = (string) $forecast->id;
+
+        $this->client->loginUser($intruder);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/recurrences/' . $recurrenceId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous ne pouvez supprimer que vos propres récurrences personnelles',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous ne pouvez supprimer que vos propres récurrences personnelles',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $this->assertNotNull(self::getContainer()->get(FinanceRecurrenceRepository::class)->find($recurrenceId));
+        $this->assertNotNull(self::getContainer()->get(FinanceEntryRepository::class)->find($forecastId));
+
+        // The clear above detached it, and a detached entity cannot be bound as a query parameter.
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findForResource($bandSpace, BandSpaceModule::Finance, $recurrenceId));
+    }
+
+    public function test_delete_own_personal_recurrence(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $otherMember = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $ownerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $otherMember])->create();
+
+        $category = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Studio',
+            'position' => 0,
+        ])->create();
+
+        $recurrence = FinanceRecurrenceFactory::new([
+            'category' => $category,
+            'label' => 'Cordes',
+            'type' => FinanceEntryType::Expense,
+            'scope' => FinanceEntryScope::Personal,
+            'interval' => RecurrenceInterval::Monthly,
+            'amount' => 3000,
+            'startDate' => new \DateTime('2024-01-01'),
+            'endDate' => new \DateTime('2024-06-30'),
+            'isActive' => true,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $forecast = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Cordes',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Personal,
+            'member' => $ownerMembership,
+            'amount' => 3000,
+            'date' => new \DateTime('2024-02-01'),
+            'recurrence' => $recurrence,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $recurrenceId = (string) $recurrence->id;
+        $forecastId = (string) $forecast->id;
+
+        $this->client->loginUser($owner);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/recurrences/' . $recurrenceId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $this->assertNull(self::getContainer()->get(FinanceRecurrenceRepository::class)->find($recurrenceId));
+        $this->assertNull(self::getContainer()->get(FinanceEntryRepository::class)->find($forecastId));
+    }
 }

--- a/tests/Api/BandSpace/Finance/FinanceRecurrenceUpdateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceRecurrenceUpdateTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Api\BandSpace\Finance;
 
 use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\BandSpace\FinanceCategory;
 use App\Entity\BandSpace\FinanceEntry;
 use App\Entity\BandSpace\FinanceRecurrence;
@@ -28,6 +29,8 @@ use App\Tests\Factory\User\UserFactory;
 use App\Validator\BandSpace\RecurrenceEndDateValidator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\GreaterThan;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
 /**
@@ -601,6 +604,217 @@ class FinanceRecurrenceUpdateTest extends ApiTestCase
     }
 
     /**
+     * A personal recurrence answers only to the member its forecasts belong to. The entry endpoints
+     * have always said so; the recurrence endpoints did not, so anybody in the band could reprice, or
+     * shorten, somebody else's personal series.
+     */
+    public function test_updating_a_personal_recurrence_of_another_member_is_refused(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $intruder = UserFactory::new()->create(['username' => 'intruder', 'email' => 'intruder@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $ownerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $intruder])->create();
+
+        $category = $this->createCategory($bandSpace);
+        $recurrence = $this->createRecurrence($category, self::monthStart(-1), self::monthStart(3), FinanceEntryScope::Personal);
+        $forecast = $this->createEntry($category, $recurrence, self::monthStart(1), FinanceEntryStatus::Planned, $ownerMembership);
+        $recurrenceId = (string) $recurrence->id;
+        $forecastId = (string) $forecast->id;
+
+        $this->patchRecurrence($intruder, $bandSpace, $recurrenceId, ['amount' => 99000]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous ne pouvez modifier que vos propres récurrences personnelles',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous ne pouvez modifier que vos propres récurrences personnelles',
+        ]);
+
+        $this->assertSame(30000, $this->reloadRecurrence($recurrenceId)->amount);
+        $this->assertSame(30000, self::getContainer()->get(FinanceEntryRepository::class)->find($forecastId)->amount);
+    }
+
+    /**
+     * The documented hole in inferring ownership from the entries: a personal recurrence that never
+     * planned anything, or whose entries were all deleted, records nobody, so there is nobody to
+     * protect and the next caller becomes its owner. Reachable, because a member may delete every
+     * Prévu and Engagé entry of their own series. Pinned so the behaviour is a decision rather than
+     * something discovered later: closing it properly needs an owner column on the recurrence.
+     */
+    public function test_updating_a_personal_recurrence_that_records_no_owner_is_allowed(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $stranger])->create();
+
+        $category = $this->createCategory($bandSpace);
+        // Personal, but it has planned nothing, so no entry carries a member to read ownership from.
+        $recurrence = $this->createRecurrence($category, self::monthStart(-1), self::monthStart(3), FinanceEntryScope::Personal);
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->patchRecurrence($stranger, $bandSpace, $recurrenceId, ['amount' => 42000]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(42000, $this->reloadRecurrence($recurrenceId)->amount);
+    }
+
+    /**
+     * Entries can carry two different members, because a member may reassign their own personal entry
+     * to somebody else. Ownership then reads as "either of them", so whichever acts next passes while
+     * an unrelated member is still refused. Pinned because it is the ambiguity the inference cannot
+     * resolve, and because the refusal is the half that must not regress.
+     */
+    public function test_a_personal_recurrence_recording_two_members_admits_both_and_refuses_a_third(): void
+    {
+        $first = UserFactory::new()->asBaseUser()->create();
+        $second = UserFactory::new()->create(['username' => 'second_owner', 'email' => 'second@test.com']);
+        $stranger = UserFactory::new()->create(['username' => 'stranger', 'email' => 'stranger@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $firstMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $first])->create();
+        $secondMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $second])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $stranger])->create();
+
+        $category = $this->createCategory($bandSpace);
+        $recurrence = $this->createRecurrence($category, self::monthStart(-2), self::monthStart(3), FinanceEntryScope::Personal);
+        $this->createEntry($category, $recurrence, self::monthStart(-1), FinanceEntryStatus::Paid, $firstMembership);
+        $this->createEntry($category, $recurrence, self::monthStart(1), FinanceEntryStatus::Planned, $secondMembership);
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->patchRecurrence($stranger, $bandSpace, $recurrenceId, ['amount' => 99000]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertSame(30000, $this->reloadRecurrence($recurrenceId)->amount);
+    }
+
+    /** A band recurrence belongs to nobody in particular, so any member still edits it. */
+    public function test_updating_a_band_recurrence_of_another_member_is_allowed(): void
+    {
+        $creator = UserFactory::new()->asBaseUser()->create();
+        $otherMember = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $creatorMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $creator])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $otherMember])->create();
+
+        $category = $this->createCategory($bandSpace);
+        $recurrence = $this->createRecurrence($category, self::monthStart(-1), self::monthStart(3));
+        // Its forecast carries a member, which on its own must not be read as ownership: only the
+        // recurrence's own scope decides whether anybody owns the series.
+        $this->createEntry($category, $recurrence, self::monthStart(1), FinanceEntryStatus::Planned, $creatorMembership);
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->patchRecurrence($otherMember, $bandSpace, $recurrenceId, ['amount' => 35000]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(35000, $this->reloadRecurrence($recurrenceId)->amount);
+    }
+
+    /**
+     * Extending used to file the new occurrences under whoever pressed save, which split one personal
+     * series across two owners and put half of it out of its owner's reach. The owner is now read from
+     * the series itself.
+     */
+    public function test_extending_a_personal_recurrence_files_the_new_forecasts_under_its_owner(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $ownerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+
+        $category = $this->createCategory($bandSpace);
+        $recurrence = $this->createRecurrence($category, self::monthStart(-1), self::monthStart(1), FinanceEntryScope::Personal);
+        foreach (range(-1, 1) as $offset) {
+            $this->createEntry($category, $recurrence, self::monthStart($offset), FinanceEntryStatus::Planned, $ownerMembership);
+        }
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->patchRecurrence($owner, $bandSpace, $recurrenceId, [
+            'end_date' => self::monthStart(3)->format('Y-m-d'),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $responseData = $this->getResponseAsArray();
+        $this->assertSame(2, $responseData['created_entry_count']);
+        $this->assertSame($this->gridDates(-1, 3), $this->remainingEntryDates($recurrenceId));
+
+        $ownerMembershipId = (string) $ownerMembership->id;
+        foreach ($this->remainingEntries($recurrenceId) as $entry) {
+            $this->assertSame(FinanceEntryScope::Personal, $entry->scope);
+            $this->assertSame($ownerMembershipId, (string) $entry->member->id, $entry->date->format('Y-m-d'));
+        }
+    }
+
+    /** The PATCH carried no constraint on the amount, so a recurrence could be repriced to a debt. */
+    public function test_update_recurrence_with_a_negative_amount_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = $this->createCategory($bandSpace);
+        $recurrence = $this->createRecurrence($category, self::monthStart(-1), self::monthStart(3));
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->patchRecurrence($user, $bandSpace, $recurrenceId, ['amount' => -35000]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . GreaterThan::TOO_LOW_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'amount',
+                    'message' => 'Le montant doit être positif',
+                    'code' => GreaterThan::TOO_LOW_ERROR,
+                ],
+            ],
+            'detail' => 'amount: Le montant doit être positif',
+            'description' => 'amount: Le montant doit être positif',
+            'type' => '/validation_errors/' . GreaterThan::TOO_LOW_ERROR,
+            'title' => 'An error occurred',
+        ]);
+
+        $this->assertSame(30000, $this->reloadRecurrence($recurrenceId)->amount);
+    }
+
+    /** This one used to be a 500: the value went straight into FinanceEntryType::from(). */
+    public function test_update_recurrence_with_an_unknown_type_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = $this->createCategory($bandSpace);
+        $recurrence = $this->createRecurrence($category, self::monthStart(-1), self::monthStart(3));
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->patchRecurrence($user, $bandSpace, $recurrenceId, ['type' => 'subvention']);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . Choice::NO_SUCH_CHOICE_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'type',
+                    'message' => 'Type invalide',
+                    'code' => Choice::NO_SUCH_CHOICE_ERROR,
+                ],
+            ],
+            'detail' => 'type: Type invalide',
+            'description' => 'type: Type invalide',
+            'type' => '/validation_errors/' . Choice::NO_SUCH_CHOICE_ERROR,
+            'title' => 'An error occurred',
+        ]);
+    }
+
+    /**
      * The first of a month relative to today, so an occurrence never lands on the boundary between
      * "already due" and "still to come".
      */
@@ -656,13 +870,17 @@ class FinanceRecurrenceUpdateTest extends ApiTestCase
         ])->create();
     }
 
-    private function createRecurrence(FinanceCategory $category, \DateTime $startDate, \DateTime $endDate): FinanceRecurrence
-    {
+    private function createRecurrence(
+        FinanceCategory $category,
+        \DateTime $startDate,
+        \DateTime $endDate,
+        FinanceEntryScope $scope = FinanceEntryScope::Band,
+    ): FinanceRecurrence {
         return FinanceRecurrenceFactory::new([
             'category' => $category,
             'label' => self::LABEL,
             'type' => FinanceEntryType::Expense,
-            'scope' => FinanceEntryScope::Band,
+            'scope' => $scope,
             'interval' => RecurrenceInterval::Monthly,
             'amount' => 30000,
             'startDate' => $startDate,
@@ -672,18 +890,21 @@ class FinanceRecurrenceUpdateTest extends ApiTestCase
         ])->create();
     }
 
+    /** An entry with a member on it is a personal one: that member is what makes it personal. */
     private function createEntry(
         FinanceCategory $category,
         FinanceRecurrence $recurrence,
         \DateTime $date,
         FinanceEntryStatus $status,
+        ?BandSpaceMembership $member = null,
     ): FinanceEntry {
         return FinanceEntryFactory::new([
             'category' => $category,
             'label' => self::LABEL,
             'type' => FinanceEntryType::Expense,
             'status' => $status,
-            'scope' => FinanceEntryScope::Band,
+            'scope' => $member instanceof BandSpaceMembership ? FinanceEntryScope::Personal : FinanceEntryScope::Band,
+            'member' => $member,
             'amount' => 30000,
             'date' => $date,
             'recurrence' => $recurrence,

--- a/tests/Api/BandSpace/Finance/FinanceSummaryTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceSummaryTest.php
@@ -251,4 +251,87 @@ class FinanceSummaryTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
+
+    /**
+     * A fourchette with one bound missing can no longer be written through the API, but rows created
+     * before that rule exist. They used to disappear from every total, because ROUND((min + max) / 2)
+     * is NULL as soon as one side is and the COALESCE fell straight through to 0, and they raised no
+     * estimate warning either since the flag only looked at the minimum. Both now hold.
+     */
+    public function test_get_summary_counts_a_half_filled_estimate_by_the_bound_it_has(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $category = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Studio',
+            'position' => 0,
+        ])->create();
+
+        FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Mastering (borne haute inconnue)',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Band,
+            'amount' => null,
+            'amountMin' => 40000,
+            'amountMax' => null,
+            'date' => new \DateTime('2024-09-01'),
+        ])->create();
+
+        FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Pressage (borne basse inconnue)',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Band,
+            'amount' => null,
+            'amountMin' => null,
+            'amountMax' => 25000,
+            'date' => new \DateTime('2024-09-02'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/summary',
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/FinanceSummary',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/finance/summary',
+            '@type' => 'FinanceSummary',
+            'band_space_id' => $bandSpace->id,
+            'current_membership_id' => $membership->id,
+            'total_income' => 0,
+            'total_expense' => 0,
+            'total_income_all' => 0,
+            'total_expense_all' => 65000,
+            'total_planned' => 65000,
+            'total_committed' => 0,
+            'total_paid' => 0,
+            'total_personal' => 0,
+            'has_estimates' => true,
+            'min_date' => '2024-09-01T00:00:00+00:00',
+            'max_date' => '2024-09-02T00:00:00+00:00',
+            'by_category' => [
+                [
+                    'id' => $category->id,
+                    'name' => 'Studio',
+                    'paid' => 0,
+                    'committed' => 0,
+                    'planned' => 65000,
+                ],
+            ],
+            'member_contributions' => [],
+            'upcoming_entries' => [],
+        ]);
+    }
 }


### PR DESCRIPTION
Closes #820, the finance should-fix batch from the release audit.

## Deploy notes

**1. Clear the API Platform metadata pools.** `entry_count` is a new property on the already-shipped `FinanceCategory` DTO, and that metadata is cached in Valkey, which survives a deploy. `cache:clear` does not touch named pools. This is the third occurrence of the same trap in this series and it was reproduced locally on #849.

```
bin/console cache:pool:clear api_platform.cache.metadata.resource api_platform.cache.metadata.property api_platform.cache.metadata.resource_collection api_platform.cache.metadata.operation cache.serializer cache.property_info
```

**2. Check for half-filled estimates before shipping.** Item 3 makes a lone bound invalid, and merge-patch validates the whole merged object, so a pre-existing row with only one bound will refuse every PATCH until it is completed:

```sql
SELECT COUNT(*) FROM finance_entry WHERE (amount_min IS NULL) != (amount_max IS NULL);
```

Zero means nothing to do. Otherwise those rows need their missing bound filled, and their totals were wrong until now.

No migration.

## 1. The split editor could destroy a split

There is no update endpoint for a split, so changing a share is delete then create, and the create is refused when the running total would pass the entry amount. Lower one share and raise another and the old one was deleted, the replacement refused, and the drawer closed on a green "Entrée enregistrée" with the share gone.

The actual bug was the failure path: the catch fell through to `emit('saved')` after a warning toast. It now reloads the real splits, shows the error and does not emit, so the drawer stays open on what actually happened.

The repartition is also checked before anything is written, in a pure `planSplitSync`. Delete-before-create is kept, because two splits for one member is a 409 so a share can only be replaced once the old one is gone. That is safe because the up-front check compares the *desired* total against the cap: untouched splits are already counted and every create adds a positive amount, so if the final total fits, every intermediate total fits. A test replays the plan against the API's own rule to pin that.

An unchanged repartition is never refused, so lowering an entry's amount under shares nobody touched still saves and keeps the existing `split_warning`.

Known limit, disclosed rather than hidden: a concurrent write between the plan and its execution can still fail mid-plan. Closing it properly needs a bulk replace endpoint (`PUT .../splits`).

## 2. PATCH had no validation at all

`FinanceEntryResource` carried zero constraints while its create twin had 16. Two of the gaps were **500s**, not just missing rules: `new DateTime()` on an unparseable date, and `enum::from()` on an unknown `status`, `type` or `scope`. The recurrence Patch resource could 500 the same way on `type` and `scope`.

Both resources now mirror the create constraints. Deliberately no `Assert\Date` on the recurrence dates: the provider echoes them back in ATOM while the form sends `AAAA-MM-JJ`, and `RecurrenceEndDate` already parses both.

## 3. A half-filled estimate counted as zero

`COALESCE(amount, ROUND((amount_min + amount_max)/2), 0)` is NULL when one bound is missing, so the entry contributed 0 to every total, and the estimate warning only ever looked at the minimum.

Now: a bound requires its partner, the effective-amount SQL falls back to whichever single bound a legacy row has, and `has_estimates` detects either. An entry with no amount at all stays legal on purpose, because 0 is its truthful contribution and requiring one would lock every amount-less row out of an unrelated PATCH.

## 4. Deleting a category destroyed Paid entries

`finance_entry.category_id` is `ON DELETE CASCADE` and nothing checked, so this was the one route around the explicit refusal to delete a paid entry. Sub-categories were a second way through: `parent_id` is `SET NULL`, so children were never deleted, they resurfaced as top-level poles, taking their own paid entries out of reach of any check on the parent.

Both are now refused with a 422 and a count. Refusing rather than cascading the subtree, because it is a restriction rather than a new destructive path, it makes the confirmation true by construction, and a one-click delete across a hierarchy is exactly where people misjudge. Non-paid entries still cascade, and the file detach from #852 still runs.

## 5. Recurrence update and delete skipped the ownership check

Any member could edit or delete another member's personal recurrence, hard-deleting their planned entries: exactly what the entry endpoints refuse.

`FinanceRecurrence` has no owner column, so ownership is inferred from `finance_entry.member` through a new `FinanceRecurrenceOwnerChecker` following the `src/Security/` convention. The update processor now materialises against the resolved owner rather than the caller, so a series cannot split across two owners.

Two limits of inferring rather than storing, both now pinned by tests: a recurrence that planned nothing records no owner, so the next caller becomes one; and if entries carry two different members, either passes while a third party is still refused. Closing those properly needs an owner column.

## Fixed during review

- **The delete confirmation lied about sub-categories.** It named only the entry count, so a category with children and no entries said "Elle ne contient aucune entrée" and then 422'd for a reason the dialog never raised. It now says plainly that such a category cannot be deleted.
- `entry_count` had no test with a non-zero value anywhere, despite being the number the confirmation names. Added.
- The legacy half-estimate consequence had no test. Added, so it reads as a decision rather than a surprise.
- The two ownership edge cases above had no tests. Added.

## Tests

140 finance tests, full suite **2169** green, PHPStan level 8 clean, 157 JS tests, Biome and build clean. Every test spends exactly one authenticated request, since the `api` firewall is stateless.
