### PR TITLE
fix(M-812): hide a personal finance entry from everyone but its owner

### DIFF
--- a/src/Repository/BandSpace/FinanceEntryRepository.php
+++ b/src/Repository/BandSpace/FinanceEntryRepository.php
@@ -3,11 +3,14 @@
 namespace App\Repository\BandSpace;
 
 use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\BandSpace\FinanceCategory;
 use App\Entity\BandSpace\FinanceEntry;
 use App\Entity\BandSpace\FinanceRecurrence;
+use App\Enum\BandSpace\FinanceEntryScope;
 use App\Enum\BandSpace\FinanceEntryStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -53,10 +56,42 @@ class FinanceEntryRepository extends ServiceEntityRepository
     }
 
     /**
+     * What a given member is allowed to read: everything the band owns, plus their own personal
+     * entries and nobody else's.
+     *
+     * The rule lives here rather than in each caller because it is a read rule for the whole module,
+     * and a query that forgets it does not fail, it quietly hands one member another member's private
+     * spending. The `$viewer` argument is required for the same reason: adding a read path that
+     * should have been filtered then does not compile.
+     *
+     * A personal entry with no member is deliberately visible to nobody. It should not exist (the
+     * create and update paths both refuse one, and memberships are closed rather than deleted so the
+     * SET NULL never fires), so if one ever appears it is a data fault, and hiding somebody's private
+     * row is the safer failure.
+     */
+    private function applyVisibleTo(QueryBuilder $qb, BandSpaceMembership $viewer): QueryBuilder
+    {
+        return $qb
+            ->andWhere('e.scope = :bandScope OR e.member = :viewer')
+            ->setParameter('bandScope', FinanceEntryScope::Band)
+            ->setParameter('viewer', $viewer);
+    }
+
+    /** The same rule for the raw SQL aggregates, which cannot go through the query builder. */
+    private function visibleToSql(string $alias = 'e'): string
+    {
+        return "({$alias}.scope = 'band' OR {$alias}.member_id = :viewerId)";
+    }
+
+    /**
      * @return FinanceEntry[]
      */
-    public function findByBandSpace(BandSpace $bandSpace, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array
-    {
+    public function findByBandSpace(
+        BandSpace $bandSpace,
+        BandSpaceMembership $viewer,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $to = null,
+    ): array {
         $qb = $this->createQueryBuilder('e')
             ->join('e.category', 'c')->addSelect('c')
             ->join('c.bandSpace', 'bs')->addSelect('bs')
@@ -65,6 +100,8 @@ class FinanceEntryRepository extends ServiceEntityRepository
             ->where('c.bandSpace = :bandSpace')
             ->setParameter('bandSpace', $bandSpace)
             ->orderBy('e.date', 'DESC');
+
+        $this->applyVisibleTo($qb, $viewer);
 
         if ($from instanceof \DateTimeImmutable) {
             $qb->andWhere('e.date >= :from')->setParameter('from', $from);
@@ -94,18 +131,22 @@ class FinanceEntryRepository extends ServiceEntityRepository
     /**
      * @return array{min_date: ?string, max_date: ?string}
      */
-    public function getDateBoundaries(BandSpace $bandSpace): array
+    public function getDateBoundaries(BandSpace $bandSpace, BandSpaceMembership $viewer): array
     {
         $conn = $this->getEntityManager()->getConnection();
+        $visible = $this->visibleToSql();
 
-        $sql = <<<'SQL'
+        $sql = <<<SQL
             SELECT MIN(e.date) AS min_date, MAX(e.date) AS max_date
             FROM finance_entry e
             JOIN finance_category c ON e.category_id = c.id
-            WHERE c.band_space_id = :bandSpaceId
+            WHERE c.band_space_id = :bandSpaceId AND {$visible}
             SQL;
 
-        $result = $conn->executeQuery($sql, ['bandSpaceId' => (string) $bandSpace->id])->fetchAssociative();
+        $result = $conn->executeQuery($sql, [
+            'bandSpaceId' => (string) $bandSpace->id,
+            'viewerId' => (string) $viewer->id,
+        ])->fetchAssociative();
         \assert($result !== false);
 
         return [
@@ -117,11 +158,17 @@ class FinanceEntryRepository extends ServiceEntityRepository
     /**
      * @return array{total_income: int, total_expense: int, total_income_all: int, total_expense_all: int, total_planned: int, total_committed: int, total_paid: int, total_personal: int, has_estimates: bool}
      */
-    public function getSummaryByBandSpace(BandSpace $bandSpace, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array
-    {
+    public function getSummaryByBandSpace(
+        BandSpace $bandSpace,
+        BandSpaceMembership $viewer,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $to = null,
+    ): array {
         $conn = $this->getEntityManager()->getConnection();
         $effectiveAmount = $this->effectiveAmountSql();
         [$dateFilter, $params] = $this->buildDateFilter($bandSpace, $from, $to);
+        $params['viewerId'] = (string) $viewer->id;
+        $visible = $this->visibleToSql();
 
         $sql = <<<SQL
             SELECT
@@ -136,7 +183,7 @@ class FinanceEntryRepository extends ServiceEntityRepository
                 MAX(CASE WHEN e.amount IS NULL AND (e.amount_min IS NOT NULL OR e.amount_max IS NOT NULL) THEN 1 ELSE 0 END) AS has_estimates
             FROM finance_entry e
             JOIN finance_category c ON e.category_id = c.id
-            WHERE c.band_space_id = :bandSpaceId{$dateFilter}
+            WHERE c.band_space_id = :bandSpaceId AND {$visible}{$dateFilter}
             SQL;
 
         $result = $conn->executeQuery($sql, $params)->fetchAssociative();
@@ -158,11 +205,17 @@ class FinanceEntryRepository extends ServiceEntityRepository
     /**
      * @return array<int, array{pole_id: string, pole_name: string, paid: int, committed: int, planned: int}>
      */
-    public function getSummaryByCategory(BandSpace $bandSpace, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array
-    {
+    public function getSummaryByCategory(
+        BandSpace $bandSpace,
+        BandSpaceMembership $viewer,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $to = null,
+    ): array {
         $conn = $this->getEntityManager()->getConnection();
         $effectiveAmount = $this->effectiveAmountSql();
         [$dateFilter, $params] = $this->buildDateFilter($bandSpace, $from, $to);
+        $params['viewerId'] = (string) $viewer->id;
+        $visible = $this->visibleToSql();
 
         $sql = <<<SQL
             SELECT
@@ -173,7 +226,7 @@ class FinanceEntryRepository extends ServiceEntityRepository
                 COALESCE(SUM(CASE WHEN e.status = 'planned' THEN {$effectiveAmount} ELSE 0 END), 0) AS planned
             FROM finance_category pole
             LEFT JOIN finance_category child ON child.parent_id = pole.id
-            LEFT JOIN finance_entry e ON (e.category_id = pole.id OR e.category_id = child.id){$dateFilter}
+            LEFT JOIN finance_entry e ON (e.category_id = pole.id OR e.category_id = child.id) AND {$visible}{$dateFilter}
             WHERE pole.band_space_id = :bandSpaceId AND pole.parent_id IS NULL
             GROUP BY pole.id, pole.name
             ORDER BY pole.position ASC
@@ -193,9 +246,13 @@ class FinanceEntryRepository extends ServiceEntityRepository
     /**
      * @return FinanceEntry[]
      */
-    public function findUpcomingForBand(BandSpace $bandSpace, \DateTimeInterface $from, \DateTimeInterface $to): array
-    {
-        return $this->createQueryBuilder('e')
+    public function findUpcomingForBand(
+        BandSpace $bandSpace,
+        BandSpaceMembership $viewer,
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+    ): array {
+        $qb = $this->createQueryBuilder('e')
             ->addSelect('c')
             ->join('e.category', 'c')
             ->where('c.bandSpace = :bandSpace')
@@ -204,16 +261,21 @@ class FinanceEntryRepository extends ServiceEntityRepository
             ->setParameter('bandSpace', $bandSpace)
             ->setParameter('from', $from)
             ->setParameter('to', $to)
-            ->orderBy('e.date', 'ASC')
-            ->getQuery()
-            ->getResult();
+            ->orderBy('e.date', 'ASC');
+
+        return $this->applyVisibleTo($qb, $viewer)->getQuery()->getResult();
     }
 
     /**
      * @return FinanceEntry[]
      */
-    public function getUpcomingByBandSpace(BandSpace $bandSpace, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null, int $limit = 5): array
-    {
+    public function getUpcomingByBandSpace(
+        BandSpace $bandSpace,
+        BandSpaceMembership $viewer,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $to = null,
+        int $limit = 5,
+    ): array {
         $now = new \DateTimeImmutable();
         $effectiveFrom = $from instanceof \DateTimeImmutable && $from > $now ? $from : $now;
 
@@ -227,6 +289,8 @@ class FinanceEntryRepository extends ServiceEntityRepository
             ->setParameter('statuses', [FinanceEntryStatus::Planned->value, FinanceEntryStatus::Committed->value])
             ->orderBy('e.date', 'ASC')
             ->setMaxResults($limit);
+
+        $this->applyVisibleTo($qb, $viewer);
 
         if ($to instanceof \DateTimeImmutable) {
             $qb->andWhere('e.date < :to')->setParameter('to', $to);

--- a/src/Security/BandSpace/FinanceRecurrenceOwnerChecker.php
+++ b/src/Security/BandSpace/FinanceRecurrenceOwnerChecker.php
@@ -41,6 +41,25 @@ readonly class FinanceRecurrenceOwnerChecker
         $this->checkOwner($recurrence, $membership, 'Vous ne pouvez supprimer que vos propres récurrences personnelles');
     }
 
+    /**
+     * Whether a member may read the recurrence at all. A personal one carries its own label and its
+     * own amount, so it is as private as the entries it plans, and it was readable band wide.
+     *
+     * The same rule as the write checks deliberately, ownerless included: a recurrence nobody may be
+     * identified with is one anybody may claim, and a read rule stricter than the write rule would
+     * make it invisible to the very members allowed to edit it.
+     */
+    public function isVisibleTo(FinanceRecurrence $recurrence, BandSpaceMembership $membership): bool
+    {
+        if ($recurrence->scope !== FinanceEntryScope::Personal) {
+            return true;
+        }
+
+        $ownerIds = $this->financeEntryRepository->findMemberIdsByRecurrence($recurrence);
+
+        return $ownerIds === [] || in_array((string) $membership->id, $ownerIds, true);
+    }
+
     private function checkOwner(FinanceRecurrence $recurrence, BandSpaceMembership $membership, string $message): BandSpaceMembership
     {
         if ($recurrence->scope !== FinanceEntryScope::Personal) {

--- a/src/Service/BandSpace/AgendaAggregator.php
+++ b/src/Service/BandSpace/AgendaAggregator.php
@@ -5,6 +5,7 @@ namespace App\Service\BandSpace;
 use App\ApiResource\BandSpace\AgendaItem;
 use App\Entity\BandSpace\AgendaEntry;
 use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\BandSpace\FinanceEntry;
 use App\Entity\BandSpace\Task;
 use App\Entity\User;
@@ -31,7 +32,12 @@ readonly class AgendaAggregator
     /**
      * @return AgendaItem[]
      */
-    public function aggregate(BandSpace $bandSpace, DateTimeImmutable $from, DateTimeImmutable $to): array
+    public function aggregate(
+        BandSpace $bandSpace,
+        BandSpaceMembership $viewer,
+        DateTimeImmutable $from,
+        DateTimeImmutable $to,
+    ): array
     {
         $manualItems = [];
         foreach ($this->agendaEntryRepository->findUpcomingForBand($bandSpace, $from, $to) as $entry) {
@@ -49,7 +55,7 @@ readonly class AgendaAggregator
         $items = [
             ...$manualItems,
             ...array_map(fn(Task $t): AgendaItem => $this->buildTask($bandSpace, $t), $this->taskRepository->findUpcomingForBand($bandSpace, $from, $to)),
-            ...array_map(fn(FinanceEntry $f): AgendaItem => $this->buildFinance($bandSpace, $f), $this->financeEntryRepository->findUpcomingForBand($bandSpace, $from, $to)),
+            ...array_map(fn(FinanceEntry $f): AgendaItem => $this->buildFinance($bandSpace, $f), $this->financeEntryRepository->findUpcomingForBand($bandSpace, $viewer, $from, $to)),
         ];
 
         usort(

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
@@ -8,6 +8,7 @@ use App\Entity\BandSpace\BandSpaceFileTag;
 use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
+use App\Enum\BandSpace\FinanceEntryScope;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Repository\BandSpace\SongRepository;
@@ -144,7 +145,11 @@ readonly class BandSpaceFileBuilder
         $entryLabels = [];
         foreach ($entryIds as $entryId) {
             $entry = $this->financeEntryRepository->findOneByIdAndBandSpace($entryId, $bandSpace);
-            if ($entry instanceof \App\Entity\BandSpace\FinanceEntry) {
+
+            // A personal entry's label is never named here, not even for its owner. This builder feeds
+            // the band wide file browser and has no reader to compare against, so the choice is between
+            // naming it to everybody or to nobody; the attachment still shows, only unnamed.
+            if ($entry instanceof \App\Entity\BandSpace\FinanceEntry && $entry->scope !== FinanceEntryScope::Personal) {
                 $entryLabels[$entryId] = $entry->label;
             }
         }

--- a/src/State/Processor/BandSpace/FinanceEntryCreateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntryCreateProcessor.php
@@ -78,19 +78,26 @@ readonly class FinanceEntryCreateProcessor implements ProcessorInterface
         $this->entityManager->persist($entry);
         $this->entityManager->flush();
 
-        $this->bandSpaceActivityRecorder->record(
-            bandSpace: $bandSpace,
-            module: BandSpaceModule::Finance,
-            type: BandSpaceFinanceActivityType::EntryCreated,
-            resourceId: $entry->id,
-            actor: $user,
-            payload: [
-                'label' => $entry->label,
-                'amount' => $entry->amount,
-                'type' => $entry->type->value,
-                'status' => $entry->status->value,
-            ],
-        );
+        // A personal entry writes nothing to the band wide journal: this payload carries the label and
+        // the amount, and that journal is readable by every member, so recording it would hand back
+        // through the feed exactly what the read rules keep private. Not recorded rather than recorded
+        // and hidden, so what is private is never written down somewhere shared to begin with.
+        if ($entry->scope !== FinanceEntryScope::Personal) {
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $bandSpace,
+                module: BandSpaceModule::Finance,
+                type: BandSpaceFinanceActivityType::EntryCreated,
+                resourceId: $entry->id,
+                actor: $user,
+                payload: [
+                    'label' => $entry->label,
+                    'amount' => $entry->amount,
+                    'type' => $entry->type->value,
+                    'status' => $entry->status->value,
+                ],
+            );
+        }
+
         $this->entityManager->flush();
 
         return $this->financeEntryBuilder->buildItem($entry);

--- a/src/State/Processor/BandSpace/FinanceEntryDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntryDeleteProcessor.php
@@ -58,14 +58,20 @@ readonly class FinanceEntryDeleteProcessor implements ProcessorInterface
             throw new UnprocessableEntityHttpException('Impossible de supprimer une entrée payée. Repassez le statut à Engagé d\'abord.');
         }
 
-        $this->bandSpaceActivityRecorder->record(
-            bandSpace: $bandSpace,
-            module: BandSpaceModule::Finance,
-            type: BandSpaceFinanceActivityType::EntryDeleted,
-            resourceId: $entry->id,
-            actor: $user,
-            payload: ['label' => $entry->label, 'amount' => $entry->amount],
-        );
+        // A personal entry writes nothing to the band wide journal: this payload carries the label and
+        // the amount, and that journal is readable by every member. Deleting is the case that forces
+        // the rule to live here rather than in the reader: once the row is gone nothing downstream can
+        // still tell whether the entry it names was private.
+        if ($entry->scope !== FinanceEntryScope::Personal) {
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $bandSpace,
+                module: BandSpaceModule::Finance,
+                type: BandSpaceFinanceActivityType::EntryDeleted,
+                resourceId: $entry->id,
+                actor: $user,
+                payload: ['label' => $entry->label, 'amount' => $entry->amount],
+            );
+        }
 
         $this->fileSourceDetacher->detachDeletedSources(
             $bandSpace,

--- a/src/State/Processor/BandSpace/FinanceEntryUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceEntryUpdateProcessor.php
@@ -180,6 +180,15 @@ readonly class FinanceEntryUpdateProcessor implements ProcessorInterface
         string $oldCategoryId,
         string $oldCategoryName,
     ): void {
+        // A personal entry writes nothing to the band wide journal. The payloads below carry the
+        // label and the amount, and that journal is readable by every member, so recording them
+        // would hand back through the feed exactly what the read rules now keep private. Not
+        // recorded rather than recorded and hidden: what is never written cannot leak later through
+        // an export, a log or an endpoint nobody has written yet.
+        if ($entry->scope === FinanceEntryScope::Personal) {
+            return;
+        }
+
         if ($oldStatus !== $entry->status) {
             $this->bandSpaceActivityRecorder->record(
                 bandSpace: $entry->category->bandSpace,

--- a/src/State/Processor/BandSpace/FinanceRecurrenceCreateProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceCreateProcessor.php
@@ -75,19 +75,25 @@ readonly class FinanceRecurrenceCreateProcessor implements ProcessorInterface
 
         $this->entityManager->flush();
 
-        $this->bandSpaceActivityRecorder->record(
-            bandSpace: $bandSpace,
-            module: BandSpaceModule::Finance,
-            type: BandSpaceFinanceActivityType::RecurrenceCreated,
-            resourceId: $recurrence->id,
-            actor: $user,
-            payload: [
-                'label' => $recurrence->label,
-                'amount' => $recurrence->amount,
-                'interval' => $recurrence->interval->value,
-                'generated_entries' => count($entries),
-            ],
-        );
+        // A personal recurrence writes nothing to the band wide journal, for the same reason its
+        // entries do not: this payload carries the label and the amount, and every member reads that
+        // journal. A recurring private cost is if anything more revealing than a single one.
+        if ($recurrence->scope !== FinanceEntryScope::Personal) {
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $bandSpace,
+                module: BandSpaceModule::Finance,
+                type: BandSpaceFinanceActivityType::RecurrenceCreated,
+                resourceId: $recurrence->id,
+                actor: $user,
+                payload: [
+                    'label' => $recurrence->label,
+                    'amount' => $recurrence->amount,
+                    'interval' => $recurrence->interval->value,
+                    'generated_entries' => count($entries),
+                ],
+            );
+        }
+
         $this->entityManager->flush();
 
         return $this->financeRecurrenceBuilder->buildItem($recurrence);

--- a/src/State/Processor/BandSpace/FinanceRecurrenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/FinanceRecurrenceDeleteProcessor.php
@@ -8,6 +8,7 @@ use App\ApiResource\BandSpace\Finance\FinanceRecurrenceResource;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceFinanceActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\FinanceEntryScope;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
@@ -65,14 +66,18 @@ readonly class FinanceRecurrenceDeleteProcessor implements ProcessorInterface
             );
             $this->financeEntryRepository->deletePlannedByRecurrence($recurrence);
 
-            $this->bandSpaceActivityRecorder->record(
-                bandSpace: $bandSpace,
-                module: BandSpaceModule::Finance,
-                type: BandSpaceFinanceActivityType::RecurrenceDeleted,
-                resourceId: $recurrence->id,
-                actor: $user,
-                payload: ['label' => $recurrence->label],
-            );
+            // A personal recurrence writes nothing to the band wide journal: this payload carries its
+            // label, and every member reads that journal.
+            if ($recurrence->scope !== FinanceEntryScope::Personal) {
+                $this->bandSpaceActivityRecorder->record(
+                    bandSpace: $bandSpace,
+                    module: BandSpaceModule::Finance,
+                    type: BandSpaceFinanceActivityType::RecurrenceDeleted,
+                    resourceId: $recurrence->id,
+                    actor: $user,
+                    payload: ['label' => $recurrence->label],
+                );
+            }
 
             $this->entityManager->remove($recurrence);
         });

--- a/src/State/Provider/BandSpace/AgendaCollectionProvider.php
+++ b/src/State/Provider/BandSpace/AgendaCollectionProvider.php
@@ -37,13 +37,13 @@ readonly class AgendaCollectionProvider implements ProviderInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
         $filters = $context['filters'] ?? [];
         $from = $this->parseDatetime($filters['from'] ?? null) ?? (new DateTimeImmutable('today'));
         $to = $this->parseDatetime($filters['to'] ?? null) ?? $from->modify('+' . self::DEFAULT_WINDOW_DAYS . ' days')->setTime(23, 59, 59);
 
-        return $this->agendaAggregator->aggregate($bandSpace, $from, $to);
+        return $this->agendaAggregator->aggregate($bandSpace, $viewer, $from, $to);
     }
 
     private function parseDatetime(?string $value): ?DateTimeImmutable

--- a/src/State/Provider/BandSpace/File/BandSpaceFinanceEntryFileCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFinanceEntryFileCollectionProvider.php
@@ -7,6 +7,8 @@ use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\State\Pagination\TraversablePaginator;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\BandSpace\File\BandSpaceFileResource;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Enum\BandSpace\FinanceEntryScope;
 use App\Entity\User;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\Filter\BandSpaceFileFilter;
@@ -39,10 +41,17 @@ readonly class BandSpaceFinanceEntryFileCollectionProvider implements ProviderIn
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->financeEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['entryId'], $bandSpace);
-        if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry) {
+
+        // The same rule as reading the entry itself: what is attached to somebody else's personal
+        // entry is theirs too, and listing it would say what the entry is about.
+        $isVisible = $entry instanceof \App\Entity\BandSpace\FinanceEntry
+            && ($entry->scope !== FinanceEntryScope::Personal
+                || ($entry->member instanceof BandSpaceMembership && $entry->member->id === $viewer->id));
+
+        if (!$isVisible) {
             throw new NotFoundHttpException('Entrée introuvable');
         }
 

--- a/src/State/Provider/BandSpace/FinanceEntryCollectionProvider.php
+++ b/src/State/Provider/BandSpace/FinanceEntryCollectionProvider.php
@@ -37,12 +37,12 @@ readonly class FinanceEntryCollectionProvider implements ProviderInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
         $from = isset($context['filters']['from']) ? new \DateTimeImmutable($context['filters']['from']) : null;
         $to = isset($context['filters']['to']) ? (new \DateTimeImmutable($context['filters']['to']))->modify('+1 day') : null;
 
-        $entries = $this->financeEntryRepository->findByBandSpace($bandSpace, $from, $to);
+        $entries = $this->financeEntryRepository->findByBandSpace($bandSpace, $viewer, $from, $to);
 
         $entriesWithAmount = array_filter($entries, fn (\App\Entity\BandSpace\FinanceEntry $e): bool => $e->amount !== null);
         $splitSums = $this->financeEntrySplitRepository->getSumsByEntries($entriesWithAmount);

--- a/src/State/Provider/BandSpace/FinanceEntryItemProvider.php
+++ b/src/State/Provider/BandSpace/FinanceEntryItemProvider.php
@@ -5,7 +5,10 @@ namespace App\State\Provider\BandSpace;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\BandSpace\Finance\FinanceEntryResource;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\BandSpace\FinanceEntry;
 use App\Entity\User;
+use App\Enum\BandSpace\FinanceEntryScope;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceEntrySplitRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
@@ -35,10 +38,15 @@ readonly class FinanceEntryItemProvider implements ProviderInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
         $entry = $this->financeEntryRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
-        if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry) {
+
+        // Somebody else's personal entry answers exactly like an id that does not exist. The finder is
+        // shared with the write paths, which need the entry in order to refuse the write with a reason,
+        // so the read rule is applied here rather than in the query. A 404 rather than a 403 because a
+        // 403 would confirm the entry exists, which is itself part of what is private about it.
+        if (!$entry instanceof \App\Entity\BandSpace\FinanceEntry || !$this->isVisibleTo($entry, $viewer)) {
             throw new NotFoundHttpException('Entrée introuvable');
         }
 
@@ -49,5 +57,18 @@ readonly class FinanceEntryItemProvider implements ProviderInterface
         }
 
         return $this->financeEntryBuilder->buildItem($entry, $splitWarning);
+    }
+
+    /**
+     * The band's own entries are everybody's, a personal one is only its owner's. An ownerless
+     * personal entry is nobody's: it should not exist, and hiding it is the safer reading of a fault.
+     */
+    private function isVisibleTo(FinanceEntry $entry, BandSpaceMembership $viewer): bool
+    {
+        if ($entry->scope !== FinanceEntryScope::Personal) {
+            return true;
+        }
+
+        return $entry->member instanceof BandSpaceMembership && $entry->member->id === $viewer->id;
     }
 }

--- a/src/State/Provider/BandSpace/FinanceRecurrenceCollectionProvider.php
+++ b/src/State/Provider/BandSpace/FinanceRecurrenceCollectionProvider.php
@@ -4,10 +4,12 @@ namespace App\State\Provider\BandSpace;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use App\Entity\BandSpace\FinanceRecurrence;
 use App\Entity\User;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\ApiResource\BandSpace\Finance\FinanceRecurrenceResource;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\FinanceRecurrenceOwnerChecker;
 use App\Service\Builder\BandSpace\FinanceRecurrenceBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -19,6 +21,7 @@ readonly class FinanceRecurrenceCollectionProvider implements ProviderInterface
 {
     public function __construct(
         private BandSpaceMemberChecker $memberChecker,
+        private FinanceRecurrenceOwnerChecker $ownerChecker,
         private FinanceRecurrenceRepository $financeRecurrenceRepository,
         private FinanceRecurrenceBuilder $financeRecurrenceBuilder,
         private Security $security,
@@ -35,9 +38,15 @@ readonly class FinanceRecurrenceCollectionProvider implements ProviderInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
-        $recurrences = $this->financeRecurrenceRepository->findByBandSpace($bandSpace);
+        // A personal recurrence carries its own label and amount, so it is as private as the entries it
+        // plans. Filtered here rather than in the query because ownership is not a column on the
+        // recurrence: it is read from the entries, which is the rule the write checks already use.
+        $recurrences = array_values(array_filter(
+            $this->financeRecurrenceRepository->findByBandSpace($bandSpace),
+            fn (FinanceRecurrence $recurrence): bool => $this->ownerChecker->isVisibleTo($recurrence, $viewer),
+        ));
 
         return $this->financeRecurrenceBuilder->buildFromList($recurrences);
     }

--- a/src/State/Provider/BandSpace/FinanceRecurrenceItemProvider.php
+++ b/src/State/Provider/BandSpace/FinanceRecurrenceItemProvider.php
@@ -8,6 +8,7 @@ use App\ApiResource\BandSpace\Finance\FinanceRecurrenceResource;
 use App\Entity\User;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\FinanceRecurrenceOwnerChecker;
 use App\Service\Builder\BandSpace\FinanceRecurrenceBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -20,6 +21,7 @@ readonly class FinanceRecurrenceItemProvider implements ProviderInterface
 {
     public function __construct(
         private BandSpaceMemberChecker $memberChecker,
+        private FinanceRecurrenceOwnerChecker $ownerChecker,
         private FinanceRecurrenceRepository $financeRecurrenceRepository,
         private FinanceRecurrenceBuilder $financeRecurrenceBuilder,
         private Security $security,
@@ -33,10 +35,12 @@ readonly class FinanceRecurrenceItemProvider implements ProviderInterface
             throw new AccessDeniedHttpException();
         }
 
-        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
         $recurrence = $this->financeRecurrenceRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
-        if (!$recurrence instanceof \App\Entity\BandSpace\FinanceRecurrence) {
+
+        // Somebody else's personal recurrence answers like an id that does not exist, as its entries do.
+        if (!$recurrence instanceof \App\Entity\BandSpace\FinanceRecurrence || !$this->ownerChecker->isVisibleTo($recurrence, $viewer)) {
             throw new NotFoundHttpException('Récurrence introuvable');
         }
 

--- a/src/State/Provider/BandSpace/FinanceSummaryProvider.php
+++ b/src/State/Provider/BandSpace/FinanceSummaryProvider.php
@@ -35,11 +35,11 @@ readonly class FinanceSummaryProvider implements ProviderInterface
         $from = isset($context['filters']['from']) ? new \DateTimeImmutable($context['filters']['from']) : null;
         $to = isset($context['filters']['to']) ? (new \DateTimeImmutable($context['filters']['to']))->modify('+1 day') : null;
 
-        $boundaries = $this->financeEntryRepository->getDateBoundaries($bandSpace);
-        $totals = $this->financeEntryRepository->getSummaryByBandSpace($bandSpace, $from, $to);
-        $byCategory = $this->financeEntryRepository->getSummaryByCategory($bandSpace, $from, $to);
+        $boundaries = $this->financeEntryRepository->getDateBoundaries($bandSpace, $currentMembership);
+        $totals = $this->financeEntryRepository->getSummaryByBandSpace($bandSpace, $currentMembership, $from, $to);
+        $byCategory = $this->financeEntryRepository->getSummaryByCategory($bandSpace, $currentMembership, $from, $to);
         $contributions = $this->financeEntryRepository->getMemberContributions($bandSpace, $from, $to);
-        $upcoming = $this->financeEntryRepository->getUpcomingByBandSpace($bandSpace, $from, $to);
+        $upcoming = $this->financeEntryRepository->getUpcomingByBandSpace($bandSpace, $currentMembership, $from, $to);
 
         $summary = new FinanceSummary();
         $summary->bandSpaceId = (string) $bandSpace->id;

--- a/tests/Api/BandSpace/AgendaEntry/AgendaEntryScopedDeleteTest.php
+++ b/tests/Api/BandSpace/AgendaEntry/AgendaEntryScopedDeleteTest.php
@@ -31,7 +31,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -56,6 +56,9 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         // as a Doctrine query parameter keeps a valid identifier.
         self::getContainer()->get(EntityManagerInterface::class)->clear();
         $reloadedBand = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceRepository::class)->find((string) $bandSpace->id);
+        // Reloaded for the same reason as the band space: the clear above detached it, and the
+        // aggregator binds it as a query parameter to filter personal finance entries.
+        $reloadedMembership = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceMembershipRepository::class)->find((string) $viewerMembership->id);
         $repo = self::getContainer()->get(AgendaEntryRepository::class);
         $reloaded = $repo->findOneByIdAndBandSpace($entryId, $reloadedBand);
         $this->assertNotNull($reloaded);
@@ -66,6 +69,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         $aggregator = self::getContainer()->get(AgendaAggregator::class);
         $items = $aggregator->aggregate(
             $reloadedBand,
+            $reloadedMembership,
             new DateTimeImmutable('2026-06-01 00:00:00', new DateTimeZone('UTC')),
             new DateTimeImmutable('2026-06-30 23:59:59', new DateTimeZone('UTC')),
         );
@@ -90,7 +94,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         // so two API calls in one test would fail auth on the second.
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -125,7 +129,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -157,7 +161,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -192,7 +196,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         $owner = UserFactory::new()->asBaseUser()->create();
         $other = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $owner,
@@ -228,7 +232,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -251,6 +255,9 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
 
         self::getContainer()->get(EntityManagerInterface::class)->clear();
         $reloadedBand = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceRepository::class)->find((string) $bandSpace->id);
+        // Reloaded for the same reason as the band space: the clear above detached it, and the
+        // aggregator binds it as a query parameter to filter personal finance entries.
+        $reloadedMembership = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceMembershipRepository::class)->find((string) $viewerMembership->id);
         $repo = self::getContainer()->get(AgendaEntryRepository::class);
         $reloaded = $repo->findOneByIdAndBandSpace($entryId, $reloadedBand);
         $this->assertNotNull($reloaded);
@@ -259,6 +266,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         $aggregator = self::getContainer()->get(AgendaAggregator::class);
         $items = $aggregator->aggregate(
             $reloadedBand,
+            $reloadedMembership,
             new DateTimeImmutable('2026-06-01 00:00:00', new DateTimeZone('UTC')),
             new DateTimeImmutable('2026-07-31 23:59:59', new DateTimeZone('UTC')),
         );
@@ -281,7 +289,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -306,6 +314,9 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         $this->assertNull($repo->findOneByIdAndBandSpace($entryId, $bandSpace));
 
         $reloadedBand = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceRepository::class)->find((string) $bandSpace->id);
+        // Reloaded for the same reason as the band space: the clear above detached it, and the
+        // aggregator binds it as a query parameter to filter personal finance entries.
+        $reloadedMembership = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceMembershipRepository::class)->find((string) $viewerMembership->id);
         $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
         $activities = $activityRepo->findForResource($reloadedBand, BandSpaceModule::Agenda, $entryId);
         $this->assertCount(1, $activities);
@@ -316,7 +327,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -349,7 +360,7 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         $owner = UserFactory::new()->asBaseUser()->create();
         $other = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $owner,

--- a/tests/Api/BandSpace/AgendaEntry/AgendaEntryUpdateTest.php
+++ b/tests/Api/BandSpace/AgendaEntry/AgendaEntryUpdateTest.php
@@ -28,7 +28,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -80,7 +80,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -130,7 +130,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -183,7 +183,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -237,7 +237,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -276,7 +276,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -329,7 +329,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -356,7 +356,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -381,7 +381,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
         // the start, which is what this payload is.
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -454,7 +454,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
         // made from a March one.
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -481,6 +481,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
         $bandSpace = self::getContainer()->get(BandSpaceRepository::class)->find($bandSpace->id);
         $occurrences = self::getContainer()->get(AgendaAggregator::class)->aggregate(
             $bandSpace,
+            $viewerMembership,
             new DateTimeImmutable('2026-01-01', new \DateTimeZone('UTC')),
             new DateTimeImmutable('2026-01-31 23:59:59', new \DateTimeZone('UTC')),
         );
@@ -501,7 +502,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
         // (without `recurrence_frequency`) must persist on an already-recurring entry.
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -547,7 +548,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -594,7 +595,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
         $entry = AgendaEntryFactory::new([
             'bandSpace' => $bandSpace,
             'creator' => $user,
@@ -641,7 +642,7 @@ class AgendaEntryUpdateTest extends ApiTestCase
         $owner = UserFactory::new()->asBaseUser()->create();
         $otherUser = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
         $entry = AgendaEntryFactory::new(['bandSpace' => $bandSpace, 'creator' => $owner])->create();
 
         $this->client->loginUser($otherUser);

--- a/tests/Api/BandSpace/Finance/FinanceEntryCreateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceEntryCreateTest.php
@@ -31,7 +31,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -59,7 +59,7 @@ class FinanceEntryCreateTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
-        $entries = $entryRepository->findByBandSpace($bandSpace);
+        $entries = $entryRepository->findByBandSpace($bandSpace, $viewerMembership);
         $this->assertCount(1, $entries);
 
         $entry = $entries[0];
@@ -102,7 +102,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -130,7 +130,7 @@ class FinanceEntryCreateTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
-        $entries = $entryRepository->findByBandSpace($bandSpace);
+        $entries = $entryRepository->findByBandSpace($bandSpace, $viewerMembership);
         $this->assertCount(1, $entries);
 
         $entry = $entries[0];
@@ -193,7 +193,7 @@ class FinanceEntryCreateTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
-        $entries = $entryRepository->findByBandSpace($bandSpace);
+        $entries = $entryRepository->findByBandSpace($bandSpace, $membership);
         $this->assertCount(1, $entries);
 
         $entry = $entries[0];
@@ -227,7 +227,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $this->client->loginUser($user);
         $this->client->jsonRequest(
@@ -253,7 +253,7 @@ class FinanceEntryCreateTest extends ApiTestCase
         $owner = UserFactory::new()->asBaseUser()->create();
         $otherUser = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -286,8 +286,8 @@ class FinanceEntryCreateTest extends ApiTestCase
         $user = UserFactory::new()->asBaseUser()->create();
         $owner = UserFactory::new()->create(['username' => 'owner_user', 'email' => 'owner@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
-        BandSpaceMembershipFactory::new([
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new([
             'bandSpace' => $bandSpace,
             'user' => $user,
             'status' => MembershipStatus::Left,
@@ -323,7 +323,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -372,7 +372,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -420,7 +420,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -467,7 +467,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -495,7 +495,7 @@ class FinanceEntryCreateTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
-        $entries = $entryRepository->findByBandSpace($bandSpace);
+        $entries = $entryRepository->findByBandSpace($bandSpace, $viewerMembership);
         $this->assertCount(1, $entries);
 
         $entry = $entries[0];
@@ -529,7 +529,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -585,7 +585,7 @@ class FinanceEntryCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -628,6 +628,6 @@ class FinanceEntryCreateTest extends ApiTestCase
             'title' => 'An error occurred',
         ]);
 
-        $this->assertSame([], self::getContainer()->get(FinanceEntryRepository::class)->findByBandSpace($bandSpace));
+        $this->assertSame([], self::getContainer()->get(FinanceEntryRepository::class)->findByBandSpace($bandSpace, $viewerMembership));
     }
 }

--- a/tests/Api/BandSpace/Finance/FinanceEntryDeleteTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceEntryDeleteTest.php
@@ -269,6 +269,19 @@ class FinanceEntryDeleteTest extends ApiTestCase
         $this->client->loginUser($otherUser);
         $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id);
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        // 404 rather than the processor's 403 since somebody else's personal entry became invisible on
+        // every operation: a 403 would confirm it exists, which is part of what is private about it.
+        // The processor still refuses it too, as the layer behind this one.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Entrée introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Entrée introuvable',
+        ]);
     }
 }

--- a/tests/Api/BandSpace/Finance/FinanceEntryUpdateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceEntryUpdateTest.php
@@ -518,7 +518,20 @@ class FinanceEntryUpdateTest extends ApiTestCase
             ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
         );
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        // 404 rather than the processor's 403 since somebody else's personal entry became invisible on
+        // every operation: a 403 would confirm it exists, which is part of what is private about it.
+        // The processor still refuses it too, as the layer behind this one.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Entrée introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Entrée introuvable',
+        ]);
     }
 
     public function test_update_personal_entry_by_owner(): void

--- a/tests/Api/BandSpace/Finance/FinancePersonalEntryVisibilityTest.php
+++ b/tests/Api/BandSpace/Finance/FinancePersonalEntryVisibilityTest.php
@@ -1,0 +1,396 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Finance;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\BandSpace\FinanceCategory;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Entity\BandSpace\FinanceRecurrence;
+use App\Enum\BandSpace\RecurrenceInterval;
+use App\Tests\Factory\BandSpace\FinanceRecurrenceFactory;
+use App\Enum\BandSpace\FinanceEntryScope;
+use App\Enum\BandSpace\FinanceEntryStatus;
+use App\Enum\BandSpace\FinanceEntryType;
+use App\Enum\BandSpace\Role;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
+use App\Tests\Factory\BandSpace\FinanceEntryFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * A personal entry is readable by the member it belongs to and by nobody else.
+ *
+ * Only writing was ever gated, so every read path handed a member somebody else's private spending:
+ * the entry list and a direct GET showed the label, the date and the amount, and the aggregates
+ * carried the amounts in another shape. There is one test per read path rather than one for the
+ * module, because each is a separate query and closing four of five is not closing anything.
+ *
+ * Each test spends its single authenticated request on the read under test: the api firewall is
+ * stateless, so a second one comes back 401.
+ */
+#[ResetDatabase]
+class FinancePersonalEntryVisibilityTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const OTHERS_SECRET = 'Remboursement dette perso';
+
+    public function test_the_entry_list_hides_a_personal_entry_of_another_member(): void
+    {
+        [$bandSpace, $viewer, $category] = $this->createBandWithBothKindsOfEntry();
+
+        $this->client->loginUser($viewer->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries',
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(
+            ['Local de répétition', 'Mes cordes'],
+            array_column($response['member'], 'label'),
+            'the band entry and the viewer\'s own personal one, and nothing else'
+        );
+        $this->assertSame(2, $response['totalItems']);
+    }
+
+    public function test_reading_a_personal_entry_of_another_member_answers_like_an_unknown_id(): void
+    {
+        [$bandSpace, $viewer, , $othersEntryId] = $this->createBandWithBothKindsOfEntry();
+
+        $this->client->loginUser($viewer->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $othersEntryId,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        // 404 rather than 403: a 403 would confirm the entry exists, which is part of what is private.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Entrée introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Entrée introuvable',
+        ]);
+    }
+
+    public function test_the_summary_leaves_a_personal_entry_of_another_member_out_of_every_total(): void
+    {
+        [$bandSpace, $viewer, $category] = $this->createBandWithBothKindsOfEntry();
+
+        $this->client->loginUser($viewer->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/summary',
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+
+        // 40000 is the band entry, 5000 the viewer's own. The other member's 90000 appears nowhere,
+        // neither in total_personal nor summed into the pole, where it would have been an amount
+        // wearing a different hat.
+        $this->assertSame(40000, $response['total_expense']);
+        $this->assertSame(5000, $response['total_personal']);
+        $this->assertSame(
+            [['id' => (string) $category->id, 'name' => 'Studio', 'paid' => 45000, 'committed' => 0, 'planned' => 0]],
+            $response['by_category']
+        );
+    }
+
+    public function test_the_upcoming_list_hides_a_personal_entry_of_another_member(): void
+    {
+        [$bandSpace, $viewer, $category] = $this->createBand();
+        $others = $this->addMember($bandSpace, 'other_member', 'other@test.com');
+
+        $this->createEntry($category, 'Avance studio', 40000, FinanceEntryStatus::Planned, date: '+10 days');
+        $this->createEntry($category, self::OTHERS_SECRET, 90000, FinanceEntryStatus::Planned, member: $others, date: '+11 days');
+
+        $this->client->loginUser($viewer->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/summary',
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(
+            ['Avance studio'],
+            array_column($response['upcoming_entries'], 'label'),
+            'the other member\'s forecast is not an upcoming deadline of this band'
+        );
+    }
+
+    /**
+     * Finance entries are a source of the shared calendar, so a personal one was printed on it with
+     * its label and its amount, for the whole band to read. The issue never mentioned this path.
+     */
+    public function test_the_agenda_hides_a_personal_entry_of_another_member(): void
+    {
+        [$bandSpace, $viewer, $category] = $this->createBand();
+        $others = $this->addMember($bandSpace, 'other_member', 'other@test.com');
+
+        $this->createEntry($category, 'Facture studio', 40000, FinanceEntryStatus::Planned, date: '2026-09-10');
+        $this->createEntry($category, self::OTHERS_SECRET, 90000, FinanceEntryStatus::Planned, member: $others, date: '2026-09-11');
+
+        $this->client->loginUser($viewer->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-09-01&to=2026-09-30',
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(['Facture studio'], array_column($response['member'], 'title'));
+    }
+
+    /** The other half of the rule: the owner keeps seeing their own, or this would be a data loss. */
+    public function test_the_owner_still_reads_their_own_personal_entry(): void
+    {
+        [$bandSpace, , $category] = $this->createBand();
+        $owner = $this->addMember($bandSpace, 'owner_member', 'owner@test.com');
+        $entry = $this->createEntry($category, 'Mes cordes', 5000, FinanceEntryStatus::Paid, member: $owner);
+
+        $this->client->loginUser($owner->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame('Mes cordes', $response['label']);
+        $this->assertSame(5000, $response['amount']);
+        $this->assertSame('personal', $response['scope']);
+    }
+
+    /**
+     * Personal means personal, so an admin is not an exception. Deciding otherwise would make the
+     * word mean "private unless somebody has a role", which is not what a member typing it expects.
+     */
+    public function test_an_admin_reads_no_more_than_anybody_else(): void
+    {
+        [$bandSpace, , $category] = $this->createBand();
+        $admin = $this->addMember($bandSpace, 'admin_member', 'admin@test.com', Role::Admin);
+        $others = $this->addMember($bandSpace, 'other_member', 'other@test.com');
+        $entry = $this->createEntry($category, self::OTHERS_SECRET, 90000, FinanceEntryStatus::Paid, member: $others);
+
+        $this->client->loginUser($admin->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * The band wide journal was the widest hole of all: it carries the label and the amount in its
+     * payload, it fires on every ordinary create, edit and delete, and every member can read it. No
+     * id to guess and no unusual action required, so closing the query paths alone would have left
+     * the same numbers on the dashboard's recent activity widget.
+     */
+    public function test_creating_a_personal_entry_writes_nothing_to_the_band_journal(): void
+    {
+        [$bandSpace, $viewer, $category] = $this->createBand();
+
+        $this->client->loginUser($viewer->user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries',
+            [
+                'categoryId' => (string) $category->id,
+                'label' => self::OTHERS_SECRET,
+                'type' => 'expense',
+                'status' => 'paid',
+                'scope' => 'personal',
+                'amount' => 90000,
+                'memberId' => (string) $viewer->id,
+                'date' => '2026-03-01',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($bandSpace, BandSpaceModule::Finance, $this->getResponseAsArray()['id']);
+        $this->assertSame([], $activities, 'nothing about a personal entry is written to a shared table');
+    }
+
+    /** A personal recurrence carries its own label and amount, so it was the same leak one level up. */
+    public function test_the_recurrence_list_hides_a_personal_recurrence_of_another_member(): void
+    {
+        [$bandSpace, $viewer, $category] = $this->createBand();
+        $others = $this->addMember($bandSpace, 'other_member', 'other@test.com');
+
+        $bandRecurrence = $this->createRecurrence($category, 'Loyer du local', FinanceEntryScope::Band);
+        $othersRecurrence = $this->createRecurrence($category, 'Abonnement thérapie', FinanceEntryScope::Personal);
+        // Ownership is read from the entries a recurrence planned, exactly as the write checks do.
+        $this->createEntry($category, 'Abonnement thérapie', 8000, FinanceEntryStatus::Paid, member: $others, recurrence: $othersRecurrence);
+
+        $this->client->loginUser($viewer->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/recurrences',
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            ['Loyer du local'],
+            array_column($this->getResponseAsArray()['member'], 'label')
+        );
+    }
+
+    public function test_reading_a_personal_recurrence_of_another_member_answers_like_an_unknown_id(): void
+    {
+        [$bandSpace, $viewer, $category] = $this->createBand();
+        $others = $this->addMember($bandSpace, 'other_member', 'other@test.com');
+        $othersRecurrence = $this->createRecurrence($category, 'Abonnement thérapie', FinanceEntryScope::Personal);
+        $this->createEntry($category, 'Abonnement thérapie', 8000, FinanceEntryStatus::Paid, member: $others, recurrence: $othersRecurrence);
+
+        $this->client->loginUser($viewer->user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/recurrences/' . $othersRecurrence->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Récurrence introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Récurrence introuvable',
+        ]);
+    }
+
+    /**
+     * @return array{0: BandSpace, 1: BandSpaceMembership, 2: FinanceCategory}
+     */
+    private function createBand(): array
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Studio',
+            'position' => 0,
+        ])->create();
+
+        return [$bandSpace, $membership, $category];
+    }
+
+    /**
+     * A band entry, one personal entry owned by the viewer, and one owned by somebody else.
+     *
+     * @return array{0: BandSpace, 1: BandSpaceMembership, 2: FinanceCategory, 3: string}
+     */
+    private function createBandWithBothKindsOfEntry(): array
+    {
+        [$bandSpace, $viewer, $category] = $this->createBand();
+        $others = $this->addMember($bandSpace, 'other_member', 'other@test.com');
+
+        // Distinct dates: the list orders by date descending, and a tie leaves the order to the
+        // database, which would make the assertion below flake rather than fail.
+        $this->createEntry($category, 'Local de répétition', 40000, FinanceEntryStatus::Paid, date: '2026-03-03');
+        $this->createEntry($category, 'Mes cordes', 5000, FinanceEntryStatus::Paid, member: $viewer, date: '2026-03-02');
+        $othersEntry = $this->createEntry($category, self::OTHERS_SECRET, 90000, FinanceEntryStatus::Paid, member: $others, date: '2026-03-01');
+
+        return [$bandSpace, $viewer, $category, (string) $othersEntry->id];
+    }
+
+    private function createRecurrence(FinanceCategory $category, string $label, FinanceEntryScope $scope): FinanceRecurrence
+    {
+        return FinanceRecurrenceFactory::new([
+            'category' => $category,
+            'label' => $label,
+            'type' => FinanceEntryType::Expense,
+            'scope' => $scope,
+            'interval' => RecurrenceInterval::Monthly,
+            'amount' => 8000,
+            'startDate' => new \DateTime('2026-01-01'),
+            'endDate' => new \DateTime('2026-12-01'),
+            'isActive' => true,
+        ])->create();
+    }
+
+    private function addMember(BandSpace $bandSpace, string $username, string $email, Role $role = Role::User): BandSpaceMembership
+    {
+        $user = UserFactory::new()->create(['username' => $username, 'email' => $email]);
+
+        return BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $user,
+            'role' => $role,
+        ])->create();
+    }
+
+    private function createEntry(
+        FinanceCategory $category,
+        string $label,
+        int $amount,
+        FinanceEntryStatus $status,
+        ?BandSpaceMembership $member = null,
+        string $date = '2026-03-01',
+        ?FinanceRecurrence $recurrence = null,
+    ): \App\Entity\BandSpace\FinanceEntry {
+        return FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => $label,
+            'type' => FinanceEntryType::Expense,
+            'status' => $status,
+            'scope' => $member instanceof BandSpaceMembership ? FinanceEntryScope::Personal : FinanceEntryScope::Band,
+            'member' => $member,
+            'amount' => $amount,
+            'date' => new \DateTime($date),
+            'recurrence' => $recurrence,
+        ])->create();
+    }
+}

--- a/tests/Api/BandSpace/Finance/FinanceRecurrenceCreateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceRecurrenceCreateTest.php
@@ -30,7 +30,7 @@ class FinanceRecurrenceCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -59,7 +59,7 @@ class FinanceRecurrenceCreateTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
-        $entries = $entryRepository->findByBandSpace($bandSpace);
+        $entries = $entryRepository->findByBandSpace($bandSpace, $viewerMembership);
         $this->assertCount(6, $entries);
 
         $responseData = $this->getResponseAsArray();
@@ -104,7 +104,7 @@ class FinanceRecurrenceCreateTest extends ApiTestCase
         $owner = UserFactory::new()->asBaseUser()->create();
         $otherUser = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -138,8 +138,8 @@ class FinanceRecurrenceCreateTest extends ApiTestCase
         $user = UserFactory::new()->asBaseUser()->create();
         $owner = UserFactory::new()->create(['username' => 'owner_user', 'email' => 'owner@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
-        BandSpaceMembershipFactory::new([
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new([
             'bandSpace' => $bandSpace,
             'user' => $user,
             'status' => MembershipStatus::Left,
@@ -176,7 +176,7 @@ class FinanceRecurrenceCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -232,7 +232,7 @@ class FinanceRecurrenceCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -282,7 +282,7 @@ class FinanceRecurrenceCreateTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,

--- a/tests/Api/BandSpace/Finance/FinanceRecurrenceDeleteTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceRecurrenceDeleteTest.php
@@ -10,6 +10,7 @@ use App\Enum\BandSpace\FinanceEntryStatus;
 use App\Enum\BandSpace\FinanceEntryType;
 use App\Enum\BandSpace\RecurrenceInterval;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\FinanceEntryRepository;
 use App\Repository\BandSpace\FinanceRecurrenceRepository;
 use App\Tests\ApiTestAssertionsTrait;
@@ -35,7 +36,7 @@ class FinanceRecurrenceDeleteTest extends ApiTestCase
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -112,7 +113,9 @@ class FinanceRecurrenceDeleteTest extends ApiTestCase
 
         // Planned entries should be deleted
         $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
-        $remainingEntries = $entryRepository->findByBandSpace($bandSpace);
+        // Reloaded because the request detached it, and the finder binds it as a query parameter.
+        $viewerMembership = self::getContainer()->get(BandSpaceMembershipRepository::class)->find((string) $viewerMembership->id);
+        $remainingEntries = $entryRepository->findByBandSpace($bandSpace, $viewerMembership);
         $this->assertCount(1, $remainingEntries);
 
         // Paid entry should still exist with recurrence_id = null
@@ -132,7 +135,7 @@ class FinanceRecurrenceDeleteTest extends ApiTestCase
         $owner = UserFactory::new()->asBaseUser()->create();
         $otherUser = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -165,8 +168,8 @@ class FinanceRecurrenceDeleteTest extends ApiTestCase
         $user = UserFactory::new()->asBaseUser()->create();
         $owner = UserFactory::new()->create(['username' => 'owner_user', 'email' => 'owner@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
-        BandSpaceMembershipFactory::new([
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new([
             'bandSpace' => $bandSpace,
             'user' => $user,
             'status' => MembershipStatus::Left,
@@ -209,7 +212,7 @@ class FinanceRecurrenceDeleteTest extends ApiTestCase
         $intruder = UserFactory::new()->create(['username' => 'intruder', 'email' => 'intruder@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
         $ownerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $intruder])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $intruder])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,
@@ -249,16 +252,19 @@ class FinanceRecurrenceDeleteTest extends ApiTestCase
         $this->client->loginUser($intruder);
         $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/finance/recurrences/' . $recurrenceId);
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        // 404 rather than the 403 this used to answer: somebody else's personal recurrence became
+        // invisible on every operation, and a 403 would confirm it exists. The owner checks behind
+        // this still refuse the write.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $this->assertJsonEquals([
             '@context' => '/api/contexts/Error',
-            '@id' => '/api/errors/403',
+            '@id' => '/api/errors/404',
             '@type' => 'Error',
             'title' => 'An error occurred',
-            'detail' => 'Vous ne pouvez supprimer que vos propres récurrences personnelles',
-            'status' => 403,
-            'type' => '/errors/403',
-            'description' => 'Vous ne pouvez supprimer que vos propres récurrences personnelles',
+            'detail' => 'Récurrence introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Récurrence introuvable',
         ]);
 
         self::getContainer()->get(EntityManagerInterface::class)->clear();
@@ -277,7 +283,7 @@ class FinanceRecurrenceDeleteTest extends ApiTestCase
         $otherMember = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
         $bandSpace = BandSpaceFactory::new()->create();
         $ownerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $otherMember])->create();
+        $viewerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $otherMember])->create();
 
         $category = FinanceCategoryFactory::new([
             'bandSpace' => $bandSpace,

--- a/tests/Api/BandSpace/Finance/FinanceRecurrenceUpdateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceRecurrenceUpdateTest.php
@@ -624,16 +624,19 @@ class FinanceRecurrenceUpdateTest extends ApiTestCase
 
         $this->patchRecurrence($intruder, $bandSpace, $recurrenceId, ['amount' => 99000]);
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        // 404 rather than the 403 this used to answer: somebody else's personal recurrence became
+        // invisible on every operation, and a 403 would confirm it exists. The owner checks behind
+        // this still refuse the write.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $this->assertJsonEquals([
             '@context' => '/api/contexts/Error',
-            '@id' => '/api/errors/403',
+            '@id' => '/api/errors/404',
             '@type' => 'Error',
             'title' => 'An error occurred',
-            'detail' => 'Vous ne pouvez modifier que vos propres récurrences personnelles',
-            'status' => 403,
-            'type' => '/errors/403',
-            'description' => 'Vous ne pouvez modifier que vos propres récurrences personnelles',
+            'detail' => 'Récurrence introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Récurrence introuvable',
         ]);
 
         $this->assertSame(30000, $this->reloadRecurrence($recurrenceId)->amount);
@@ -688,7 +691,8 @@ class FinanceRecurrenceUpdateTest extends ApiTestCase
 
         $this->patchRecurrence($stranger, $bandSpace, $recurrenceId, ['amount' => 99000]);
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        // Invisible now, so refused as an unknown id rather than as a forbidden one.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $this->assertSame(30000, $this->reloadRecurrence($recurrenceId)->amount);
     }
 

--- a/tests/Api/User/DeleteAccountBandSpaceTest.php
+++ b/tests/Api/User/DeleteAccountBandSpaceTest.php
@@ -477,7 +477,9 @@ class DeleteAccountBandSpaceTest extends ApiTestCase
         // The books keep what already happened, only what was planned ahead is dropped.
         $labels = array_map(
             static fn (FinanceEntry $entry): string => $entry->label,
-            self::getContainer()->get(FinanceEntryRepository::class)->findByBandSpace($bandSpace),
+            // From the departed member's own point of view: these are their personal entries, and nobody
+            // else can see them now.
+            self::getContainer()->get(FinanceEntryRepository::class)->findByBandSpace($bandSpace, $memberMembership),
         );
         $this->assertSame(['past contribution'], $labels);
     }


### PR DESCRIPTION
Closes #812, the last release blocker.

## The bug

A finance entry is Band or Personal scope. Only **writes** were ever gated: the update and delete processors refuse to touch somebody else's personal entry. Every read path returned them in full, with label, date and amount, to every member of the band.

## The leak was wider than the issue

The issue named the entry list and a direct GET. Auditing every path that can reach a personal entry found six more, three of them found by review after the first fix looked complete:

- **The shared calendar.** Finance entries are an agenda source, so a personal entry was printed on the band calendar with its label and amount.
- **`total_personal`** in the summary aggregated every member's personal spending into one number.
- **The pie chart** folded other members' personal amounts into each pole's totals.
- **The upcoming deadlines sidebar.**
- **The band wide activity journal.** This was the widest of all: `entry_created`, `entry_label_changed`, `entry_amount_changed` and `entry_deleted` all wrote the label and the amount into a payload every member can read, on every ordinary write. No id to guess, no unusual action.
- **Recurrences.** `FinanceRecurrence` carries its own label, amount and scope, and both its read endpoints were unfiltered. The same bug one level up: a personal recurring cost is arguably more revealing than a single entry.
- **File metadata.** A personal entry's label surfaced as `source_label` on any attached file, visible from the band wide file browser, and its attachment list had no guard.

## How the rule is enforced

One rule, `(scope = band OR member = viewer)`, written once in `FinanceEntryRepository` as `applyVisibleTo()` for the query builder and `visibleToSql()` for the raw SQL aggregates.

**The `$viewer` argument is required, not optional.** A read path added later that forgets it does not compile. That is the point: a privacy rule that can be silently skipped is not a rule, and PHPStan immediately listed every call site when the signatures changed.

Where the rule could not live in the query, it is stated explicitly:

- `FinanceEntryItemProvider` guards in the provider, because `findOneByIdAndBandSpace` is shared with eight write path processors that need the entity in order to refuse the write with a reason.
- Recurrences have no owner column, so visibility reuses `FinanceRecurrenceOwnerChecker`, the same inference the write checks already use. Read and write therefore agree, ownerless case included.
- The activity journal is fixed at the **write** side: a personal entry or recurrence records nothing at all. Deleting forces this, since once the row is gone nothing downstream can tell whether the entry it named was private. Not writing it also means it cannot leak later through an export, a log, or an endpoint nobody has written yet.

## Deliberately not filtered

- `countPaidByCategory` drives the category delete refusal. Filtering it would let a category holding somebody else's paid entry be deleted, which is a hole in the opposite direction.
- `countByCategory` feeds the delete confirmation, and the delete cascades **all** entries, so a viewer filtered count would understate what is about to be destroyed. It leaks a count, which is a far weaker signal than a label or an amount.
- `findOneByIdAndBandSpace` stays unfiltered: it is the write path lookup, and its callers have their own guards.

## Two decisions worth naming

**An admin sees no more than anybody else.** Personal means personal, otherwise the word means "private unless somebody has a role". Tested.

**404, not 403, and this changes an existing contract.** The item providers serve Get, Patch and Delete, so writing to somebody else's personal entry or recurrence now answers 404 rather than the processors' 403. A 403 confirms the entry exists, which is itself part of what is private. Five existing tests were updated; the processor and owner checks remain behind it as the second layer.

## Tests

A dedicated `FinancePersonalEntryVisibilityTest`, one test per read path rather than one for the module, because each is a separate query and closing six of seven closes nothing. Checked against the unfixed code rather than only against the fix: **6 of the first 7 fail without it**.

Full suite **2179** green, PHPStan level 8 clean.

## Known gaps, deliberately not in this PR

All require flipping an existing Band entry that already has splits to Personal, which is itself questionable and has no guard today:

- `FinanceEntrySplit` read endpoints do not check the parent entry's visibility.
- `getMemberContributions` counts splits belonging to an entry that later became personal.
- Whether a raw file attached to a personal entry should be downloadable band wide is a real design question rather than an oversight, since attachments are browsed from a shared surface.

Worth a follow-up issue covering the scope flip itself, which is the precondition for all three.
