### PR TITLE
Band Space core: mask invitee emails, revoked invitations, membership reactivation

### DIFF
--- a/assets/js/components/Notification/NotificationItem.vue
+++ b/assets/js/components/Notification/NotificationItem.vue
@@ -288,6 +288,9 @@ const resolvedLabel = computed(() => {
   if (invitationStatus.value === 'declined') {
     return 'Invitation déclinée'
   }
+  if (invitationStatus.value === 'revoked') {
+    return 'Invitation annulée'
+  }
   return 'Invitation expirée'
 })
 

--- a/src/Enum/BandSpace/InvitationStatus.php
+++ b/src/Enum/BandSpace/InvitationStatus.php
@@ -8,4 +8,6 @@ enum InvitationStatus: string
     case Accepted = 'accepted';
     case Declined = 'declined';
     case Expired = 'expired';
+    /** Cancelled by an admin, as opposed to Expired which is the clock running out on its own. */
+    case Revoked = 'revoked';
 }

--- a/src/Privacy/ActivityPayloadMask.php
+++ b/src/Privacy/ActivityPayloadMask.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace App\Privacy;
+
+/**
+ * The one door a stored band space activity payload goes through on its way into a response DTO.
+ *
+ * Invitation activities record the invitee's address, and the activity feed is readable by every
+ * member while the pending-invitation list is admin only, so that address never leaves the server in
+ * full. Masking on the way out rather than at the recording sites also repairs the rows written in
+ * plaintext during the beta, with no migration.
+ *
+ * Every builder that renders a BandSpaceActivity calls this, including the ones whose module cannot
+ * carry an address today. Which modules those are is decided by a filter inside a provider, far from
+ * here, and a privacy guarantee that depends on remembering that filter is not a guarantee.
+ * BandSpaceActivityPayloadMaskCoverageTest is what keeps a new builder from skipping the door.
+ */
+final class ActivityPayloadMask
+{
+    private const string EMAIL_KEY = 'email';
+
+    /**
+     * @param array<string, mixed>|null $payload
+     * @return array<string, mixed>|null
+     */
+    public static function mask(?array $payload): ?array
+    {
+        if ($payload === null || !isset($payload[self::EMAIL_KEY]) || !is_string($payload[self::EMAIL_KEY])) {
+            return $payload;
+        }
+
+        $payload[self::EMAIL_KEY] = EmailMask::mask($payload[self::EMAIL_KEY]);
+
+        return $payload;
+    }
+}

--- a/src/Privacy/EmailMask.php
+++ b/src/Privacy/EmailMask.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace App\Privacy;
+
+/**
+ * Turns an email address into something recognisable by the person who typed it and useless to
+ * everybody else: "john.doe@gmail.com" becomes "j***@gmail.com".
+ *
+ * The asterisks are a fixed run rather than one per hidden character, so the mask does not even
+ * leak how long the local part was. Anything that is not a plain "local@domain" pair is replaced
+ * whole, because a value we cannot parse is a value we cannot safely show a fragment of.
+ */
+final class EmailMask
+{
+    private const string MASK = '***';
+
+    public static function mask(string $email): string
+    {
+        // Last "@" wins: it is the one separating the domain, so a local part that itself contains
+        // an "@" stays entirely hidden instead of spilling into the visible half.
+        $separatorPosition = mb_strrpos($email, '@');
+        if ($separatorPosition === false) {
+            return self::MASK;
+        }
+
+        $localPart = mb_substr($email, 0, $separatorPosition);
+        $domain = mb_substr($email, $separatorPosition + 1);
+
+        if ($localPart === '' || $domain === '') {
+            return self::MASK;
+        }
+
+        return mb_substr($localPart, 0, 1) . self::MASK . '@' . $domain;
+    }
+}

--- a/src/Service/Builder/BandSpace/BandSpaceActivityBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceActivityBuilder.php
@@ -4,6 +4,7 @@ namespace App\Service\Builder\BandSpace;
 
 use App\ApiResource\BandSpace\BandSpaceActivityResource;
 use App\Entity\BandSpace\BandSpaceActivity;
+use App\Privacy\ActivityPayloadMask;
 use App\Service\Builder\User\UserProfilePictureUrlBuilder;
 
 readonly class BandSpaceActivityBuilder
@@ -30,7 +31,7 @@ readonly class BandSpaceActivityBuilder
         $dto->module = $entity->module->value;
         $dto->resourceId = $entity->resourceId?->toString();
         $dto->type = $entity->type;
-        $dto->payload = $entity->payload;
+        $dto->payload = ActivityPayloadMask::mask($entity->payload);
         $dto->actor = $entity->actor instanceof \App\Entity\User ? [
             'id' => (string) $entity->actor->id,
             'username' => $entity->actor->username,

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileActivityBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileActivityBuilder.php
@@ -5,6 +5,7 @@ namespace App\Service\Builder\BandSpace\File;
 use App\ApiResource\BandSpace\File\BandSpaceFileActivityResource;
 use App\Entity\BandSpace\BandSpaceActivity;
 use App\Entity\BandSpace\BandSpaceFile;
+use App\Privacy\ActivityPayloadMask;
 use App\Service\Builder\User\UserProfilePictureUrlBuilder;
 
 readonly class BandSpaceFileActivityBuilder
@@ -45,7 +46,7 @@ readonly class BandSpaceFileActivityBuilder
         $dto->actorUsername = $entity->actor->username;
         $dto->actorProfilePictureUrl = $this->profilePictureUrlBuilder->build($entity->actor);
         $dto->type = $entity->type;
-        $dto->payload = $entity->payload;
+        $dto->payload = ActivityPayloadMask::mask($entity->payload);
         $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;

--- a/src/Service/Builder/BandSpace/TaskActivityBuilder.php
+++ b/src/Service/Builder/BandSpace/TaskActivityBuilder.php
@@ -5,6 +5,7 @@ namespace App\Service\Builder\BandSpace;
 use App\ApiResource\BandSpace\Task\TaskActivityResource;
 use App\Entity\BandSpace\BandSpaceActivity;
 use App\Entity\BandSpace\Task;
+use App\Privacy\ActivityPayloadMask;
 use App\Service\Builder\User\UserProfilePictureUrlBuilder;
 
 readonly class TaskActivityBuilder
@@ -46,7 +47,7 @@ readonly class TaskActivityBuilder
         $dto->actorUsername = $entity->actor->username;
         $dto->actorProfilePictureUrl = $this->profilePictureUrlBuilder->build($entity->actor);
         $dto->type = $entity->type;
-        $dto->payload = $entity->payload;
+        $dto->payload = ActivityPayloadMask::mask($entity->payload);
         $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;

--- a/src/State/Processor/BandSpace/BandSpaceInvitationDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceInvitationDeleteProcessor.php
@@ -38,7 +38,10 @@ readonly class BandSpaceInvitationDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['bandSpaceId'], $user);
+        // Deliberately the read-only checker: revoking is the one write worth keeping open while a
+        // deletion is pending. It only ever takes an invitation away, accepting one is refused for the
+        // whole grace period anyway, and an admin tidying up before the space goes should not be stopped.
+        [$bandSpace] = $this->adminChecker->checkAdmin((string) $uriVariables['bandSpaceId'], $user);
 
         $invitation = $this->bandSpaceInvitationRepository->findOneByIdAndBandSpace(
             (string) $uriVariables['id'],
@@ -49,7 +52,7 @@ readonly class BandSpaceInvitationDeleteProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Invitation introuvable');
         }
 
-        $invitation->status = InvitationStatus::Expired;
+        $invitation->status = InvitationStatus::Revoked;
 
         $this->bandSpaceActivityRecorder->record(
             bandSpace: $bandSpace,

--- a/src/State/Processor/BandSpace/BandSpaceMemberUpdateRoleProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceMemberUpdateRoleProcessor.php
@@ -8,7 +8,6 @@ use App\ApiResource\BandSpace\BandSpaceMember;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceSettingsActivityType;
-use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\BandSpace\Role;
 use App\Event\BandSpaceMemberRoleChangedEvent;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
@@ -63,6 +62,15 @@ readonly class BandSpaceMemberUpdateRoleProcessor implements ProcessorInterface
 
         $requestPayload = $this->requestStack->getCurrentRequest()?->toArray() ?? [];
 
+        // Reopening a closed membership is the invitation flow's job, and only that flow applies the
+        // rules joining deserves: the invitee's own consent, a space that is not pending deletion, and a
+        // return as a plain member rather than with the powers they were excluded with. This endpoint
+        // used to flip the status back to active with none of that, so it now says no and points there.
+        // Sending the status the member already has stays a no-op, so a full-object PATCH still works.
+        if (array_key_exists('status', $requestPayload) && $data->status !== $membership->status->value) {
+            throw new ConflictHttpException("Le statut d'un membre ne se modifie pas ici. Un membre exclu ou parti revient en acceptant une nouvelle invitation.");
+        }
+
         $oldRole = $membership->role;
 
         if (array_key_exists('role', $requestPayload)) {
@@ -77,11 +85,6 @@ readonly class BandSpaceMemberUpdateRoleProcessor implements ProcessorInterface
             }
 
             $membership->role = $newRole;
-        }
-
-        if (array_key_exists('status', $requestPayload) && ($data->status === 'active' && $membership->status !== MembershipStatus::Active)) {
-            $membership->status = MembershipStatus::Active;
-            $membership->leftDatetime = null;
         }
 
         $roleChanged = $oldRole !== $membership->role;

--- a/tests/Api/BandSpace/BandSpaceActivityCollectionTest.php
+++ b/tests/Api/BandSpace/BandSpaceActivityCollectionTest.php
@@ -220,6 +220,70 @@ class BandSpaceActivityCollectionTest extends ApiTestCase
         $this->assertSame('status_changed', $data['member'][0]['type']);
     }
 
+    /**
+     * The pending-invitation list is admin only, this feed is open to every member, and both carry the
+     * invitee's address. Masking happens when the stored row is turned into the response, so the rows
+     * written in plaintext before the fix are covered too and the raw address never reaches the wire.
+     */
+    public function test_an_invitee_email_is_masked_for_a_plain_member_reading_the_feed(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $activity = BandSpaceActivityFactory::new([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Settings,
+            'type' => 'invitation_sent',
+            'actor' => $admin,
+            'payload' => ['email' => 'john.doe@gmail.com', 'invited_user_id' => null, 'invited_username' => null],
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($member);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/activities',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceActivity',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/activities',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/activities/' . $activity->id,
+                    '@type' => 'BandSpaceActivity',
+                    'id' => $activity->id,
+                    'band_space_id' => $bandSpace->id,
+                    'module' => 'settings',
+                    'resource_id' => null,
+                    'type' => 'invitation_sent',
+                    'payload' => [
+                        'email' => 'j***@gmail.com',
+                        'invited_user_id' => null,
+                        'invited_username' => null,
+                    ],
+                    'actor' => [
+                        'id' => $admin->id,
+                        'username' => $admin->username,
+                        'profile_picture_url' => null,
+                    ],
+                    'creation_datetime' => '2026-04-01T10:00:00+00:00',
+                ],
+            ],
+        ]);
+        // Belt and braces: the address must be absent from the whole body, not just from the field we
+        // happened to look at. Masking in the frontend would still have shipped it here.
+        $this->assertStringNotContainsString('john.doe@gmail.com', (string) $this->client->getResponse()->getContent());
+    }
+
     public function test_non_member_forbidden(): void
     {
         $stranger = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/BandSpaceInvitationDeleteTest.php
+++ b/tests/Api/BandSpace/BandSpaceInvitationDeleteTest.php
@@ -45,7 +45,9 @@ class BandSpaceInvitationDeleteTest extends ApiTestCase
 
         $invitationRepo = self::getContainer()->get(BandSpaceInvitationRepository::class);
         $updated = $invitationRepo->find($invitation->id);
-        $this->assertSame(InvitationStatus::Expired, $updated->status);
+        // Revoked, not Expired: the clock did not run out, an admin cancelled it, and the two must stay
+        // distinguishable in the database.
+        $this->assertSame(InvitationStatus::Revoked, $updated->status);
 
         $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
         $activities = $activityRepo->findForResource($bandSpace, BandSpaceModule::Settings, $invitation->id);
@@ -53,6 +55,38 @@ class BandSpaceInvitationDeleteTest extends ApiTestCase
         $this->assertSame('invitation_revoked', $activities[0]->type);
         $this->assertSame(['email' => 'invited@example.com'], $activities[0]->payload);
         $this->assertSame($admin->id, $activities[0]->actor?->id);
+    }
+
+    /**
+     * The grace period makes a space read only, but revoking only ever takes an invitation away, and
+     * accepting one is refused for the whole period anyway. Blocking it left an admin unable to tidy up.
+     */
+    public function test_cancel_invitation_on_a_space_pending_deletion(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create([
+            'name' => 'Groupe condamné',
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+30 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $invitation = BandSpaceInvitationFactory::new([
+            'bandSpace' => $bandSpace,
+            'invitedBy' => $admin,
+            'email' => 'invited@example.com',
+            'expirationDatetime' => (new \DateTime())->modify('+7 days'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/invitations/' . $invitation->id
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $invitationRepo = self::getContainer()->get(BandSpaceInvitationRepository::class);
+        $this->assertSame(InvitationStatus::Revoked, $invitationRepo->find($invitation->id)->status);
     }
 
     public function test_non_admin_cannot_cancel_invitation(): void

--- a/tests/Api/BandSpace/BandSpaceMemberUpdateRoleTest.php
+++ b/tests/Api/BandSpace/BandSpaceMemberUpdateRoleTest.php
@@ -6,6 +6,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\Notification\NotificationRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
@@ -184,6 +185,132 @@ class BandSpaceMemberUpdateRoleTest extends ApiTestCase
             'status' => 409,
             'type' => '/errors/409',
             'description' => 'Vous ne pouvez pas vous rétrograder car vous êtes le seul administrateur',
+        ]);
+    }
+
+    /**
+     * Reactivation used to be a second, silent door into the space: no consent from the person, no
+     * refusal on a space pending deletion, and an excluded admin walked back in with their powers.
+     * Joining is the invitation flow's job, and that flow is where those rules live.
+     */
+    public function test_a_kicked_membership_cannot_be_reactivated_through_the_status(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $kicked = UserFactory::new()->create(['username' => 'kicked_user', 'email' => 'kicked@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $kickedMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $kicked,
+            'role' => Role::Admin,
+            'status' => MembershipStatus::Kicked,
+            'leftDatetime' => new \DateTime('2024-06-01 10:00:00'),
+            'creationDatetime' => new \DateTime('2024-01-02 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/members/' . $kickedMembership->id,
+            ['status' => 'active'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Le statut d'un membre ne se modifie pas ici. Un membre exclu ou parti revient en acceptant une nouvelle invitation.",
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => "Le statut d'un membre ne se modifie pas ici. Un membre exclu ou parti revient en acceptant une nouvelle invitation.",
+        ]);
+
+        $membershipRepository = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $this->assertSame(MembershipStatus::Kicked, $membershipRepository->find($kickedMembership->id)->status);
+    }
+
+    public function test_a_member_who_left_cannot_be_dragged_back_in_through_the_status(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $gone = UserFactory::new()->create(['username' => 'gone_user', 'email' => 'gone@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $goneMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $gone,
+            'role' => Role::User,
+            'status' => MembershipStatus::Left,
+            'leftDatetime' => new \DateTime('2024-06-01 10:00:00'),
+            'creationDatetime' => new \DateTime('2024-01-02 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/members/' . $goneMembership->id,
+            ['status' => 'active'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Le statut d'un membre ne se modifie pas ici. Un membre exclu ou parti revient en acceptant une nouvelle invitation.",
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => "Le statut d'un membre ne se modifie pas ici. Un membre exclu ou parti revient en acceptant une nouvelle invitation.",
+        ]);
+
+        $membershipRepository = self::getContainer()->get(BandSpaceMembershipRepository::class);
+        $this->assertSame(MembershipStatus::Left, $membershipRepository->find($goneMembership->id)->status);
+    }
+
+    /**
+     * Sending back the status the member already has is not an attempt to change anything, so a client
+     * that PATCHes the whole object it just read still gets its role change through.
+     */
+    public function test_resending_the_current_status_alongside_a_role_is_not_refused(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin, 'creationDatetime' => new \DateTime('2024-01-01 10:00:00')])->create();
+        $memberMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User, 'creationDatetime' => new \DateTime('2024-01-02 10:00:00')])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/members/' . $memberMembership->id,
+            ['role' => 'admin', 'status' => 'active'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceMember',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/members/' . $memberMembership->id,
+            '@type' => 'BandSpaceMember',
+            'id' => $memberMembership->id,
+            'band_space_id' => $bandSpace->id,
+            'user_id' => $member->id,
+            'username' => 'member_user',
+            'role' => 'admin',
+            'stage_name' => null,
+            'display_name' => 'member_user',
+            'instruments' => [],
+            'profile_picture_url' => null,
+            'creation_datetime' => '2024-01-02T10:00:00+00:00',
+            'status' => 'active',
+            'left_datetime' => null,
         ]);
     }
 

--- a/tests/Api/BandSpace/BandSpacePendingDeletionWriteBlockTest.php
+++ b/tests/Api/BandSpace/BandSpacePendingDeletionWriteBlockTest.php
@@ -65,7 +65,7 @@ class BandSpacePendingDeletionWriteBlockTest extends ApiTestCase
     }
 
     /**
-     * Representative of the 8 processors on checkAdminForWrite().
+     * Representative of the 7 processors on checkAdminForWrite().
      */
     public function test_an_admin_cannot_invite_anyone(): void
     {

--- a/tests/Integration/Service/Builder/BandSpace/ActivityPayloadMaskingTest.php
+++ b/tests/Integration/Service/Builder/BandSpace/ActivityPayloadMaskingTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Integration\Service\Builder\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceActivity;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\BandSpace\Task;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Service\Builder\BandSpace\BandSpaceActivityBuilder;
+use App\Service\Builder\BandSpace\File\BandSpaceFileActivityBuilder;
+use App\Service\Builder\BandSpace\TaskActivityBuilder;
+use App\Service\Builder\User\UserProfilePictureUrlBuilder;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Three builders turn a stored BandSpaceActivity into a response DTO, and only one of them serves the
+ * module invitation activities are recorded under. That makes the other two safe by coincidence: what
+ * keeps an address away from them is a module filter in a provider, which a future cross-module feed
+ * would drop without anything failing. So the row here carries an address under the Task module, and
+ * every builder is asked to render it.
+ */
+class ActivityPayloadMaskingTest extends KernelTestCase
+{
+    private const string RAW_EMAIL = 'john.doe@gmail.com';
+
+    /** @var array<string, string> */
+    private const array MASKED_PAYLOAD = ['email' => 'j***@gmail.com', 'label' => 'Studio'];
+
+    public function test_an_email_in_an_activity_payload_is_masked_whichever_builder_renders_it(): void
+    {
+        self::bootKernel();
+        // Built by hand rather than fetched: each of the three has a single consumer, so the container
+        // is free to inline it. The masking guarantee belongs to the classes, not to the wiring.
+        $profilePictureUrlBuilder = self::getContainer()->get(UserProfilePictureUrlBuilder::class);
+
+        $bandSpace = new BandSpace();
+        $bandSpace->name = 'The Rockers';
+
+        $actor = new User();
+        $actor->id = '3f8b4a1e-0000-4000-8000-000000000001';
+        $actor->username = 'admin_user';
+
+        $activity = new BandSpaceActivity();
+        $activity->bandSpace = $bandSpace;
+        $activity->module = BandSpaceModule::Task;
+        $activity->type = 'invitation_sent';
+        $activity->actor = $actor;
+        $activity->payload = ['email' => self::RAW_EMAIL, 'label' => 'Studio'];
+
+        $task = new Task();
+        $task->bandSpace = $bandSpace;
+        $task->title = 'Répéter le nouveau morceau';
+
+        $file = new BandSpaceFile();
+        $file->bandSpace = $bandSpace;
+
+        self::assertSame(
+            self::MASKED_PAYLOAD,
+            (new BandSpaceActivityBuilder($profilePictureUrlBuilder))->buildItem($activity)->payload,
+        );
+        self::assertSame(
+            self::MASKED_PAYLOAD,
+            (new TaskActivityBuilder($profilePictureUrlBuilder))->buildItem($task, $activity)->payload,
+        );
+        self::assertSame(
+            self::MASKED_PAYLOAD,
+            (new BandSpaceFileActivityBuilder($profilePictureUrlBuilder))->buildItem($file, $activity)->payload,
+        );
+    }
+}

--- a/tests/Unit/Privacy/ActivityPayloadMaskTest.php
+++ b/tests/Unit/Privacy/ActivityPayloadMaskTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Privacy;
+
+use App\Privacy\ActivityPayloadMask;
+use PHPUnit\Framework\TestCase;
+
+class ActivityPayloadMaskTest extends TestCase
+{
+    public function test_it_masks_the_email_and_leaves_the_rest_alone(): void
+    {
+        self::assertSame(
+            ['email' => 'j***@gmail.com', 'invited_username' => 'johnny', 'invited_user_id' => null],
+            ActivityPayloadMask::mask([
+                'email' => 'john.doe@gmail.com',
+                'invited_username' => 'johnny',
+                'invited_user_id' => null,
+            ]),
+        );
+    }
+
+    public function test_a_payload_without_an_email_passes_through(): void
+    {
+        self::assertSame(['label' => 'Studio'], ActivityPayloadMask::mask(['label' => 'Studio']));
+    }
+
+    public function test_a_null_payload_stays_null(): void
+    {
+        self::assertNull(ActivityPayloadMask::mask(null));
+    }
+
+    /**
+     * The column is JSON, so nothing stops a caller storing something other than a string under the key.
+     * Masking must not turn that into a type error on a read path.
+     */
+    public function test_a_non_string_email_is_left_untouched(): void
+    {
+        self::assertSame(['email' => null], ActivityPayloadMask::mask(['email' => null]));
+        self::assertSame(['email' => ['a@b.com']], ActivityPayloadMask::mask(['email' => ['a@b.com']]));
+    }
+}

--- a/tests/Unit/Privacy/BandSpaceActivityPayloadMaskCoverageTest.php
+++ b/tests/Unit/Privacy/BandSpaceActivityPayloadMaskCoverageTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Privacy;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Invitation activities carry the invitee's address, and every builder that renders a BandSpaceActivity
+ * must mask it. Three do so today, but only one of them serves a module that can carry an address, so a
+ * fourth builder, or a provider widened to feed an existing one across modules, would reopen the leak
+ * with every behaviour test still green.
+ *
+ * This asserts the wiring instead: builder number four is the point. Same shape as
+ * BandSpaceWriteGuardCoverageTest, for the same reason.
+ */
+class BandSpaceActivityPayloadMaskCoverageTest extends TestCase
+{
+    private const string BUILDER_DIR = 'src/Service/Builder';
+
+    private const string MASK_MARKER = 'ActivityPayloadMask::mask(';
+
+    public function test_every_builder_rendering_an_activity_payload_goes_through_the_mask(): void
+    {
+        $unmasked = [];
+        foreach ($this->activityPayloadBuilders() as $relativePath => $source) {
+            if (!str_contains($source, self::MASK_MARKER)) {
+                $unmasked[] = $relativePath;
+            }
+        }
+
+        self::assertSame(
+            [],
+            $unmasked,
+            "These builders put a stored activity payload on the wire without masking it.\n"
+            . "Assign App\\Privacy\\ActivityPayloadMask::mask(\$entity->payload) instead of the raw payload.\n",
+        );
+    }
+
+    /**
+     * Guards against the scan silently matching nothing, which would make the test above pass vacuously.
+     */
+    public function test_the_scan_finds_the_known_activity_builders(): void
+    {
+        self::assertSame(
+            [
+                'src/Service/Builder/BandSpace/BandSpaceActivityBuilder.php',
+                'src/Service/Builder/BandSpace/File/BandSpaceFileActivityBuilder.php',
+                'src/Service/Builder/BandSpace/TaskActivityBuilder.php',
+            ],
+            array_keys($this->activityPayloadBuilders()),
+        );
+    }
+
+    /**
+     * Every builder that both knows the BandSpaceActivity entity and writes a payload onto a DTO.
+     *
+     * @return array<string, string> relative path => file contents
+     */
+    private function activityPayloadBuilders(): array
+    {
+        // tests/Unit/Privacy -> project root
+        $directory = \dirname(__DIR__, 3) . '/' . self::BUILDER_DIR;
+        self::assertDirectoryExists($directory);
+
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory));
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $source = file_get_contents($file->getPathname());
+            self::assertIsString($source);
+
+            if (!str_contains($source, 'BandSpaceActivity') || !str_contains($source, '->payload = ')) {
+                continue;
+            }
+
+            $files[self::BUILDER_DIR . '/' . $iterator->getSubPathname()] = $source;
+        }
+
+        ksort($files);
+
+        return $files;
+    }
+}

--- a/tests/Unit/Privacy/EmailMaskTest.php
+++ b/tests/Unit/Privacy/EmailMaskTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Privacy;
+
+use App\Privacy\EmailMask;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class EmailMaskTest extends TestCase
+{
+    #[DataProvider('provideAddresses')]
+    public function test_it_masks(string $email, string $expected): void
+    {
+        self::assertSame($expected, EmailMask::mask($email));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideAddresses(): iterable
+    {
+        yield 'keeps the initial and the domain' => ['john.doe@gmail.com', 'j***@gmail.com'];
+        yield 'a one letter local part is indistinguishable from a long one' => ['j@gmail.com', 'j***@gmail.com'];
+        yield 'accented initial survives' => ['élodie@musicall.fr', 'é***@musicall.fr'];
+        yield 'case is left alone, masking is not normalising' => ['John@Example.COM', 'J***@Example.COM'];
+        yield 'a plus tag is hidden with the rest' => ['john+bands@gmail.com', 'j***@gmail.com'];
+        yield 'only the last at separates, the rest stays hidden' => ['a@b@example.com', 'a***@example.com'];
+        yield 'no at, nothing shown' => ['notanemail', '***'];
+        yield 'empty local part, nothing shown' => ['@gmail.com', '***'];
+        yield 'empty domain, nothing shown' => ['john@', '***'];
+        yield 'empty string' => ['', '***'];
+        yield 'a lone at' => ['@', '***'];
+    }
+
+    public function test_the_mask_length_does_not_follow_the_local_part_length(): void
+    {
+        self::assertSame(
+            EmailMask::mask('j@musicall.fr'),
+            EmailMask::mask('jeremy.tonneau@musicall.fr'),
+        );
+    }
+}

--- a/tests/Unit/Security/BandSpace/BandSpaceWriteGuardCoverageTest.php
+++ b/tests/Unit/Security/BandSpace/BandSpaceWriteGuardCoverageTest.php
@@ -39,6 +39,9 @@ class BandSpaceWriteGuardCoverageTest extends TestCase
         'BandSpaceRestoreProcessor.php' => 'Cancels the deletion. Guarding it would make the deletion unrecoverable.',
         'BandSpaceLeaveProcessor.php' => 'A member must be able to walk away from a condemned space.',
         'BandSpaceInvitationDeclineProcessor.php' => 'Declining is the invitee cleaning up their own state.',
+        'BandSpaceInvitationDeleteProcessor.php' => 'Revoking only ever takes an invitation away, and accepting one '
+            . 'is refused for the whole grace period anyway, so blocking it bought nothing and left an admin unable '
+            . 'to tidy up the pending invitations of a condemned space.',
         'BandSpaceMemberUpdateRoleProcessor.php' => 'Leaving requires promoting a successor first, so guarding '
             . 'this would trap the sole admin of a condemned space. Letting them leave without a successor is '
             . 'not the alternative: it would strand the space with nobody able to restore it.',


### PR DESCRIPTION
Closes #822 (items 1, 3, 4). Item 2 was split to #861 and ships separately.

## Item 1: invitee emails leaked to every member (the release blocker)

The pending-invitation list is admin only, but the activity feed is member readable and shipped the payload verbatim, so every member saw `a invité john.doe@gmail.com` permanently, including members who joined later. That is personal data belonging to somebody who is not even a user yet.

**Masked on the way out, not on the way in.** New `App\Privacy\EmailMask` (`john.doe@gmail.com` becomes `j***@gmail.com`, fixed-length so it does not leak the local part length, splitting on the last `@`). Applied through a single `App\Privacy\ActivityPayloadMask` that all three activity builders call. Masking at read time repairs the rows already written during the beta, which a write-time mask could not, and no migration is needed.

Review found that the first version masked in only one of three builders. The other two were safe only because their providers happen to filter by module, so the guarantee rested on coincidence. Two tests now pin it: a behavioural one that records an email under `BandSpaceModule::Task` (deliberately not Settings) and asserts all three builders mask it, and a structural one that scans `src/Service/Builder` for any file assigning an activity payload without going through the mask, which is what catches builder number four.

The API test asserts the full JSON-LD body **and** separately asserts the raw address appears nowhere in the response string, which is the assertion that would catch a frontend-only fix.

## Item 3: no change needed

Already fixed on master by `cfd9de06` (M-815) before this branch existed. Verified independently rather than assumed: the invite form and the promote/demote/kick controls are gated on `isAdmin`, and `loadInvitations` is skipped for non-admins inside a try/catch.

## Item 4a: revoked is now distinguishable from expired

Cancelling an invitation recorded status `Expired` while logging a `Revoked` activity, so a deliberate revocation could not be told from one that lapsed. Added `InvitationStatus::Revoked`. No migration: the column is `VARCHAR(32)` with a PHP-side `enumType` and no CHECK constraint. Every invitation query filters on `Pending`, so re-invite and the expiry cron are unaffected. `checkAdminForWrite` relaxed to `checkAdmin` so an admin can still tidy up pending invitations on a space pending deletion.

## Item 4b: membership reactivation removed rather than hardened

A `PATCH {"status":"active"}` could revive a `Kicked` or `Left` membership with no activity, no notification, the old Admin role retained, and it worked on a space pending deletion, which both invitation paths refuse.

Removed instead of hardened. No client sends `status` (the whole frontend only ever PATCHes `{role}`), the invitation-accept path already revives a closed membership correctly, and hardening would have meant a second copy of four join rules behind a door nobody opens. There is also a consent argument: flipping someone back to active by admin fiat re-adds a person who chose to leave. One of the new tests shows the old code doing exactly that to a member who had **left**, not just been kicked.

A PATCH whose `status` differs from the stored one now returns 409 pointing at the invitation flow; sending the unchanged status stays a no-op so a full-object PATCH still works.

## Verification

Full suite 2203 passing, PHPStan level 8 clean, Biome clean, build OK. Reverting the two sibling builders fails exactly the two new masking tests while the original settings-feed test still passes.

Independently reviewed. The reviewer confirmed no second leak channel: invitation **notification** payloads carry no email field at all.