### PR TITLE
Files: folder cascade attachment guard, share revocation on trash, admin delete

### DIFF
--- a/assets/js/components/BandSpace/Files/FileActivityFeed.vue
+++ b/assets/js/components/BandSpace/Files/FileActivityFeed.vue
@@ -55,7 +55,12 @@ function quotedSourceLabel(activity) {
 
 const FILE_ACTIVITY_LABELS = {
   uploaded: () => 'a téléversé le fichier',
-  archived: () => 'a archivé le fichier',
+  // folder_path is only set when the file was swept up by a folder cascade: the folder is gone, so
+  // the feed is the only place left saying where the file used to live.
+  archived: (a) => {
+    const path = a.payload?.folder_path
+    return path ? `a archivé le fichier (dossier « ${path} » supprimé)` : 'a archivé le fichier'
+  },
   restored: () => 'a restauré le fichier',
   purged: () => 'a supprimé définitivement le fichier',
   renamed: (a) => {

--- a/assets/js/components/BandSpace/Files/FileDetailDrawer.vue
+++ b/assets/js/components/BandSpace/Files/FileDetailDrawer.vue
@@ -194,7 +194,7 @@
           severity="danger"
           :disabled="!canDelete || isAttachedToSource"
           :loading="filesStore.isDeletingFile"
-          v-tooltip.top="isAttachedToSource ? attachedSourceMessage : null"
+          v-tooltip.top="deleteDisabledReason"
           @click="confirmDelete"
         />
       </div>
@@ -214,6 +214,7 @@ import { computed, ref, watch } from 'vue'
 import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
+import { isFileCreatorOrAdmin } from '../../../utils/bandSpaceFilePermissions.js'
 import Avatar from '../../User/Avatar.vue'
 import FileActivityFeed from './FileActivityFeed.vue'
 
@@ -241,12 +242,9 @@ const selectedTagIds = ref([])
 
 const selectedFolderId = computed(() => file.value?.folder_id ?? null)
 
-const canDelete = computed(() => {
-  const f = file.value
-  if (!f) return false
-  const userId = userSecurityStore.userProfile?.id
-  return f.created_by?.id === userId
-})
+const canDelete = computed(() =>
+  isFileCreatorOrAdmin(file.value, userSecurityStore.userProfile?.id, isAdmin.value)
+)
 
 const attachments = computed(() => file.value?.attachments ?? [])
 
@@ -268,6 +266,12 @@ const attachedSourceMessage = computed(() => {
     default:
       return "Ce fichier est attaché à une autre ressource. Détachez-le d'abord."
   }
+})
+
+const deleteDisabledReason = computed(() => {
+  if (isAttachedToSource.value) return attachedSourceMessage.value
+  if (!canDelete.value) return 'Seul le créateur ou un administrateur peut supprimer ce fichier'
+  return null
 })
 
 function attachmentIcon(sourceType) {

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -127,6 +127,7 @@ import {
 import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
+import { isFileCreatorOrAdmin } from '../../../utils/bandSpaceFilePermissions.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -162,12 +163,9 @@ const dropTargetId = ref(null)
 const contextMenuRef = ref(null)
 const contextMenuFile = ref(null)
 
-const canDeleteContextFile = computed(() => {
-  const f = contextMenuFile.value
-  if (!f) return false
-  const userId = userSecurityStore.userProfile?.id
-  return f.created_by?.id === userId
-})
+const canDeleteContextFile = computed(() =>
+  isFileCreatorOrAdmin(contextMenuFile.value, userSecurityStore.userProfile?.id, isAdmin.value)
+)
 
 const contextFileSourceLabel = computed(() => {
   const attachments = contextMenuFile.value?.attachments ?? []

--- a/assets/js/components/BandSpace/Files/FileTrashList.vue
+++ b/assets/js/components/BandSpace/Files/FileTrashList.vue
@@ -69,6 +69,7 @@ import { useToast } from 'primevue/usetoast'
 import { ref } from 'vue'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
+import { isFileCreatorOrAdmin } from '../../../utils/bandSpaceFilePermissions.js'
 import { formatDateLong } from '../../../utils/date.js'
 import { formatBytes } from '../../../utils/formatBytes.js'
 
@@ -87,7 +88,7 @@ const toast = useToast()
 const busyId = ref(null)
 
 function canRestore(file) {
-  return props.isAdmin || file.created_by?.id === userSecurityStore.userProfile?.id
+  return isFileCreatorOrAdmin(file, userSecurityStore.userProfile?.id, props.isAdmin)
 }
 
 function daysRemaining(file) {

--- a/assets/js/components/BandSpace/Files/FolderDeleteDialog.vue
+++ b/assets/js/components/BandSpace/Files/FolderDeleteDialog.vue
@@ -29,11 +29,23 @@
           class="flex items-start gap-3 cursor-pointer"
         >
           <RadioButton v-model="strategy" value="cascade" name="folder-delete-strategy" />
-          <div class="flex flex-col gap-0.5">
+          <div class="flex flex-col gap-1">
             <span class="text-sm font-medium text-red-600">Tout supprimer</span>
             <span class="text-xs text-surface-500">
-              Archive tous les fichiers contenus dans ce dossier et ses sous-dossiers. Réservé aux administrateurs.
+              Les fichiers de ce dossier et de ses sous-dossiers partent à la corbeille pendant
+              {{ filesStore.trashRetentionDays }} jours. Réservé aux administrateurs.
             </span>
+            <ul class="text-xs text-surface-500 list-disc pl-4">
+              <li>
+                Leurs liens de partage sont révoqués : une restauration ne les réactive pas.
+              </li>
+              <li>
+                Si l'un d'eux est attaché à {{ FILE_SOURCE_LIST_LABEL }}, la suppression est refusée.
+              </li>
+              <li>
+                Les sous-dossiers disparaissent : les fichiers restaurés reviennent à la racine.
+              </li>
+            </ul>
           </div>
         </label>
       </div>
@@ -65,6 +77,7 @@ import Dialog from 'primevue/dialog'
 import Message from 'primevue/message'
 import RadioButton from 'primevue/radiobutton'
 import { ref, watch } from 'vue'
+import { FILE_SOURCE_LIST_LABEL } from '../../../constants/fileSources.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 
 const props = defineProps({

--- a/assets/js/constants/fileSources.js
+++ b/assets/js/constants/fileSources.js
@@ -1,0 +1,18 @@
+/**
+ * The resources a band space file can be attached to, in the wording the API refuses with.
+ *
+ * The backend keeps the same five in `BandSpaceFileSourceTypes::ALL` and words them in
+ * `BandSpaceFileAttachmentLabels`; both delete paths refuse to trash a file attached to any of them.
+ * This list is what tells the user which ones that covers, so a sixth source type is two edits, one
+ * on each side, and never a screen quietly naming three of five.
+ */
+export const FILE_SOURCE_NOUNS = Object.freeze([
+  'une tâche',
+  'une note',
+  'une entrée financière',
+  'une chanson',
+  'une setlist'
+])
+
+/** « une tâche, une note, ... ou une setlist », for prose listing every source at once. */
+export const FILE_SOURCE_LIST_LABEL = `${FILE_SOURCE_NOUNS.slice(0, -1).join(', ')} ou ${FILE_SOURCE_NOUNS.at(-1)}`

--- a/assets/js/constants/fileSources.test.js
+++ b/assets/js/constants/fileSources.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { FILE_SOURCE_LIST_LABEL, FILE_SOURCE_NOUNS } from './fileSources.js'
+
+/**
+ * The folder delete dialog promises the cascade is refused when a file is attached. Naming fewer
+ * sources than the API actually refuses on is the drift this pins down.
+ *
+ * Run with `npm test`.
+ */
+
+describe('FILE_SOURCE_NOUNS', () => {
+  it('covers the five source types the API accepts', () => {
+    assert.deepEqual(FILE_SOURCE_NOUNS, [
+      'une tâche',
+      'une note',
+      'une entrée financière',
+      'une chanson',
+      'une setlist'
+    ])
+  })
+
+  it('cannot be edited in place by a caller', () => {
+    assert.equal(Object.isFrozen(FILE_SOURCE_NOUNS), true)
+  })
+})
+
+describe('FILE_SOURCE_LIST_LABEL', () => {
+  it('lists every source, the last one after « ou »', () => {
+    assert.equal(
+      FILE_SOURCE_LIST_LABEL,
+      'une tâche, une note, une entrée financière, une chanson ou une setlist'
+    )
+  })
+
+  it('names as many sources as there are types', () => {
+    assert.equal(FILE_SOURCE_LIST_LABEL.split(/, | ou /).length, FILE_SOURCE_NOUNS.length)
+  })
+})

--- a/assets/js/utils/bandSpaceFilePermissions.js
+++ b/assets/js/utils/bandSpaceFilePermissions.js
@@ -1,0 +1,20 @@
+/**
+ * Who may act on a band space file: whoever uploaded it, or an admin of the space.
+ *
+ * This is the rule BandSpaceFileDeleteProcessor and BandSpaceFileRestoreProcessor both enforce. The
+ * file list and the detail drawer used to gate on the uploader alone, so an admin could restore from
+ * the trash a file the interface would not let them delete, and nobody could reclaim the quota a
+ * departed member left behind (#823). One function so the surfaces cannot drift apart again.
+ *
+ * @param {{created_by?: {id?: string|number}}|null|undefined} file
+ * @param {string|number|null|undefined} currentUserId id of the logged in member, if any
+ * @param {boolean} isAdmin whether that member is an admin of the band space
+ * @returns {boolean}
+ */
+export function isFileCreatorOrAdmin(file, currentUserId, isAdmin) {
+  if (!file) return false
+  if (isAdmin) return true
+
+  // Both sides undefined would otherwise compare equal and hand the file to an anonymous visitor.
+  return Boolean(currentUserId) && file.created_by?.id === currentUserId
+}

--- a/assets/js/utils/bandSpaceFilePermissions.test.js
+++ b/assets/js/utils/bandSpaceFilePermissions.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { isFileCreatorOrAdmin } from './bandSpaceFilePermissions.js'
+
+/**
+ * The creator-or-admin rule the API enforces on delete and restore.
+ *
+ * Run with `npm test`.
+ */
+
+describe('isFileCreatorOrAdmin', () => {
+  it('lets the uploader act on their own file', () => {
+    assert.equal(isFileCreatorOrAdmin({ created_by: { id: 'user-1' } }, 'user-1', false), true)
+  })
+
+  it('lets an admin act on a file uploaded by somebody else', () => {
+    assert.equal(isFileCreatorOrAdmin({ created_by: { id: 'user-1' } }, 'user-2', true), true)
+  })
+
+  it('lets an admin act on a file whose uploader is gone', () => {
+    assert.equal(isFileCreatorOrAdmin({ created_by: null }, 'user-2', true), true)
+  })
+
+  it('refuses a plain member acting on somebody else file', () => {
+    assert.equal(isFileCreatorOrAdmin({ created_by: { id: 'user-1' } }, 'user-2', false), false)
+  })
+
+  it('refuses when there is no file', () => {
+    assert.equal(isFileCreatorOrAdmin(null, 'user-1', true), false)
+    assert.equal(isFileCreatorOrAdmin(undefined, 'user-1', false), false)
+  })
+
+  it('refuses an anonymous visitor on a file with no uploader', () => {
+    assert.equal(isFileCreatorOrAdmin({ created_by: null }, undefined, false), false)
+    assert.equal(isFileCreatorOrAdmin({}, undefined, false), false)
+  })
+})

--- a/src/Repository/BandSpace/BandSpaceFileAttachmentRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileAttachmentRepository.php
@@ -57,6 +57,40 @@ class BandSpaceFileAttachmentRepository extends ServiceEntityRepository
     }
 
     /**
+     * The distinct source types each of the given files is attached to. Files with no attachment are
+     * absent from the result, so an empty array means "none of them is attached".
+     *
+     * A projection rather than the rows themselves: the folder cascade only needs to know which files
+     * are pinned and by what kind of source, and a subtree can hold far more attachments than the
+     * sentence it ends up building has room for.
+     *
+     * @param string[] $fileIds
+     *
+     * @return array<string, string[]> file id => distinct source types
+     */
+    public function findSourceTypesByFileIds(array $fileIds): array
+    {
+        if (count($fileIds) === 0) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('a')
+            ->select('IDENTITY(a.bandSpaceFile) AS file_id', 'a.sourceType AS source_type')
+            ->where('a.bandSpaceFile IN (:ids)')
+            ->groupBy('a.bandSpaceFile', 'a.sourceType')
+            ->setParameter('ids', $fileIds)
+            ->getQuery()
+            ->getArrayResult();
+
+        $sourceTypesByFile = [];
+        foreach ($rows as $row) {
+            $sourceTypesByFile[(string) $row['file_id']][] = (string) $row['source_type'];
+        }
+
+        return $sourceTypesByFile;
+    }
+
+    /**
      * @param string[] $fileIds
      *
      * @return array<string, BandSpaceFileAttachment[]> file id => attachments

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -75,6 +75,74 @@ class BandSpaceFileRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * How many live files sit directly in any of the given folders.
+     *
+     * Asked before findActiveByFolderIds() hydrates anything, so a subtree too large to archive in one
+     * request is refused without ever being loaded into memory.
+     *
+     * @param string[] $folderIds
+     */
+    public function countActiveByFolderIds(array $folderIds): int
+    {
+        if (count($folderIds) === 0) {
+            return 0;
+        }
+
+        return (int) $this->createQueryBuilder('bsf')
+            ->select('COUNT(bsf.id)')
+            ->where('bsf.folder IN (:folderIds)')
+            ->andWhere('bsf.archiveDatetime IS NULL')
+            ->setParameter('folderIds', $folderIds)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * Live files sitting directly in any of the given folders, uploader and folder included.
+     *
+     * Entities rather than a bulk UPDATE on purpose: archiving a folder subtree has to write one
+     * Archived activity per file and revoke the share links of each, so every row is needed anyway.
+     * Only ever called on a subtree countActiveByFolderIds() has already found small enough.
+     *
+     * @param string[] $folderIds
+     *
+     * @return BandSpaceFile[]
+     */
+    public function findActiveByFolderIds(array $folderIds): array
+    {
+        if (count($folderIds) === 0) {
+            return [];
+        }
+
+        return $this->createQueryBuilder('bsf')
+            ->addSelect('u', 'f')
+            ->leftJoin('bsf.createdBy', 'u')
+            ->leftJoin('bsf.folder', 'f')
+            ->where('bsf.folder IN (:folderIds)')
+            ->andWhere('bsf.archiveDatetime IS NULL')
+            ->setParameter('folderIds', $folderIds)
+            ->orderBy('bsf.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Sends every file of $folder back to the root, without touching its subfolders.
+     *
+     * Bulk DQL, not an ORM loop: the rows are only ever loaded to have one nullable column blanked,
+     * and the caller discards them immediately. Being a bulk update it fires no lifecycle event and
+     * leaves any file already in the identity map pointing at the deleted folder, so read it back
+     * through the repository rather than from an entity held across the call.
+     */
+    public function detachFromFolder(BandSpaceFolder $folder): void
+    {
+        $this->getEntityManager()
+            ->createQuery('UPDATE App\Entity\BandSpace\BandSpaceFile bsf SET bsf.folder = NULL WHERE bsf.folder = :folder')
+            ->setParameter('folder', $folder)
+            ->execute();
+    }
+
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?BandSpaceFile
     {
         return $this->createQueryBuilder('bsf')

--- a/src/Repository/BandSpace/BandSpaceFileShareRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileShareRepository.php
@@ -48,6 +48,29 @@ class BandSpaceFileShareRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Every share of the given files that has not been revoked yet, expired ones included: an expiry
+     * can be read off the row, a revocation is what makes the link dead for good.
+     *
+     * @param string[] $fileIds
+     *
+     * @return BandSpaceFileShare[]
+     */
+    public function findUnrevokedByFileIds(array $fileIds): array
+    {
+        if (count($fileIds) === 0) {
+            return [];
+        }
+
+        return $this->createQueryBuilder('s')
+            ->where('s.bandSpaceFile IN (:fileIds)')
+            ->andWhere('s.revocationDatetime IS NULL')
+            ->setParameter('fileIds', $fileIds)
+            ->orderBy('s.creationDatetime', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?BandSpaceFileShare
     {
         return $this->createQueryBuilder('s')

--- a/src/Repository/BandSpace/BandSpaceFolderRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFolderRepository.php
@@ -44,7 +44,25 @@ class BandSpaceFolderRepository extends ServiceEntityRepository
     }
 
     /**
+     * Sends the direct children of $folder back to the root, so deleting it does not take them with it.
+     *
+     * Bulk DQL, not an ORM loop: the rows are only ever loaded to have their parent blanked. Being a
+     * bulk update it fires no lifecycle event and leaves any child already in the identity map still
+     * pointing at $folder, which the DELETE that follows would then cascade over.
+     */
+    public function detachChildrenFrom(BandSpaceFolder $folder): void
+    {
+        $this->getEntityManager()
+            ->createQuery('UPDATE App\Entity\BandSpace\BandSpaceFolder f SET f.parent = NULL WHERE f.parent = :folder')
+            ->setParameter('folder', $folder)
+            ->execute();
+    }
+
+    /**
      * Returns the IDs of $folder and every descendant beneath it.
+     *
+     * Raw SQL because DQL has no recursive CTE and the tree has no materialised path: walking it in
+     * PHP would mean one SELECT per level per branch.
      *
      * @return string[]
      */

--- a/src/Service/BandSpace/File/BandSpaceFileAttachmentLabels.php
+++ b/src/Service/BandSpace/File/BandSpaceFileAttachmentLabels.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace\File;
+
+/**
+ * French wording for the sources a file can hang on.
+ *
+ * Shared by the two delete paths that refuse to trash an attached file. Those two paths silently
+ * disagreeing on what "attached" means is the bug this class exists to prevent, so the list of
+ * sources is built once and both sentences are written around it.
+ *
+ * assets/js/constants/fileSources.js carries the same five nouns, for the screens that warn about the
+ * refusal before it happens. A source type added to BandSpaceFileSourceTypes::ALL is two edits, one
+ * here and one there, and BandSpaceFileAttachmentLabelsTest fails until this half is done.
+ */
+final class BandSpaceFileAttachmentLabels
+{
+    private const array NOUN_BY_SOURCE_TYPE = [
+        'task' => 'une tâche',
+        'finance' => 'une entrée financière',
+        'note' => 'une note',
+        'song' => 'une chanson',
+        'setlist' => 'une setlist',
+    ];
+
+    /**
+     * Enumerates the given source types as a French list, for example "une tâche et une note".
+     *
+     * @param string[] $sourceTypes
+     */
+    public static function describe(array $sourceTypes): string
+    {
+        $labels = array_values(array_unique(array_map(
+            static fn (string $sourceType): string => self::NOUN_BY_SOURCE_TYPE[$sourceType] ?? 'une autre ressource',
+            $sourceTypes,
+        )));
+
+        return match (count($labels)) {
+            0 => 'une autre ressource',
+            1 => $labels[0],
+            2 => $labels[0] . ' et ' . $labels[1],
+            default => implode(', ', array_slice($labels, 0, -1)) . ' et ' . end($labels),
+        };
+    }
+}

--- a/src/Service/BandSpace/File/BandSpaceFileShareRevoker.php
+++ b/src/Service/BandSpace/File/BandSpaceFileShareRevoker.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace\File;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceFileShareRepository;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use DateTimeImmutable;
+
+/**
+ * Kills the public links of files that are being trashed (#823).
+ *
+ * Archiving used to leave band_space_file_share untouched. The admin share list hides shares of
+ * archived files, so the link vanished from the only screen that can revoke it while the row stayed
+ * live underneath, and a restore weeks later silently reopened the URL until its original expiry.
+ * Revoking on the way into the trash makes the disappearance real: a restore brings the file back,
+ * never the link, because nothing clears revocation_datetime once it is set.
+ *
+ * One implementation rather than one per delete path: the single file endpoint and the folder cascade
+ * both archive files, and either of them forgetting produces a link the band cannot see or revoke.
+ */
+readonly class BandSpaceFileShareRevoker
+{
+    public function __construct(
+        private BandSpaceFileShareRepository $shareRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+    ) {
+    }
+
+    /**
+     * Nothing is flushed here: the revocations join the caller's own unit of work so the files and
+     * their links are archived together, or not at all.
+     *
+     * @param string[] $fileIds
+     */
+    public function revokeForArchivedFiles(BandSpace $bandSpace, array $fileIds, User $actor): void
+    {
+        $now = new DateTimeImmutable();
+
+        foreach ($this->shareRepository->findUnrevokedByFileIds($fileIds) as $share) {
+            $share->revocationDatetime = $now;
+
+            $this->activityRecorder->record(
+                $bandSpace,
+                BandSpaceModule::File,
+                BandSpaceFileActivityType::ShareRevoked,
+                resourceId: (string) $share->bandSpaceFile->id,
+                actor: $actor,
+                payload: ['share_id' => (string) $share->id],
+            );
+        }
+    }
+}

--- a/src/State/Processor/BandSpace/File/BandSpaceFileDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileDeleteProcessor.php
@@ -13,6 +13,8 @@ use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileAttachmentLabels;
+use App\Service\BandSpace\File\BandSpaceFileShareRevoker;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -30,6 +32,7 @@ readonly class BandSpaceFileDeleteProcessor implements ProcessorInterface
         private BandSpaceMemberChecker $memberChecker,
         private BandSpaceFileRepository $fileRepository,
         private BandSpaceFileAttachmentRepository $attachmentRepository,
+        private BandSpaceFileShareRevoker $shareRevoker,
         private BandSpaceActivityRecorder $activityRecorder,
         private Security $security,
     ) {
@@ -56,11 +59,16 @@ readonly class BandSpaceFileDeleteProcessor implements ProcessorInterface
 
         $attachments = $this->attachmentRepository->findByFile($file);
         if (count($attachments) > 0) {
-            $sourceTypes = array_unique(array_map(fn ($a): string => $a->sourceType, $attachments));
-            throw new UnprocessableEntityHttpException($this->buildAttachmentMessage($sourceTypes));
+            $sourceTypes = array_map(static fn ($attachment): string => $attachment->sourceType, $attachments);
+            throw new UnprocessableEntityHttpException(sprintf(
+                "Ce fichier est attaché à %s. Détachez-le d'abord depuis la ressource concernée.",
+                BandSpaceFileAttachmentLabels::describe($sourceTypes),
+            ));
         }
 
         $file->archiveDatetime = new DateTimeImmutable();
+
+        $this->shareRevoker->revokeForArchivedFiles($membership->bandSpace, [(string) $file->id], $user);
 
         $this->activityRecorder->record(
             $membership->bandSpace,
@@ -72,26 +80,5 @@ readonly class BandSpaceFileDeleteProcessor implements ProcessorInterface
         );
 
         $this->entityManager->flush();
-    }
-
-    /**
-     * @param string[] $sourceTypes
-     */
-    private function buildAttachmentMessage(array $sourceTypes): string
-    {
-        $labels = array_map(static fn (string $type): string => match ($type) {
-            'task' => 'une tâche',
-            'finance' => 'une entrée financière',
-            'note' => 'une note',
-            default => 'une autre ressource',
-        }, $sourceTypes);
-
-        $list = match (count($labels)) {
-            1 => $labels[0],
-            2 => $labels[0] . ' et ' . $labels[1],
-            default => implode(', ', array_slice($labels, 0, -1)) . ' et ' . end($labels),
-        };
-
-        return "Ce fichier est attaché à {$list}. Détachez-le d'abord depuis la ressource concernée.";
     }
 }

--- a/src/State/Processor/BandSpace/File/BandSpaceFileRestoreProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileRestoreProcessor.php
@@ -69,6 +69,8 @@ readonly class BandSpaceFileRestoreProcessor implements ProcessorInterface
         // the band's usage. Refuse rather than let a restore push the space over its limit.
         $this->quotaService->assertCanUpload($bandSpace, $this->versionRepository->sumBytesByFile($file));
 
+        // Only the archive flag comes off. The share links revoked on the way into the trash stay
+        // revoked: a link the band watched disappear must not come back to life behind their back.
         $file->archiveDatetime = null;
 
         $this->activityRecorder->record(

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
@@ -5,19 +5,29 @@ namespace App\State\Processor\BandSpace\File;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\BandSpace\File\BandSpaceFolderResource;
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\BandSpace\BandSpaceFolder;
 use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceFileActivityType;
 use App\Enum\BandSpace\BandSpaceFolderActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileAttachmentLabels;
+use App\Service\BandSpace\File\BandSpaceFileShareRevoker;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
  * @implements ProcessorInterface<BandSpaceFolderResource, void>
@@ -27,10 +37,33 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
     private const string STRATEGY_MOVE_TO_ROOT = 'move_to_root';
     private const string STRATEGY_CASCADE = 'cascade';
 
+    /**
+     * Guard rail on the cascade, not a workflow limit.
+     *
+     * Archiving is per file (each one needs its own Archived activity and its share links revoked), so
+     * the request writes roughly two statements per file. Nothing caps how many files a space holds:
+     * BAND_SPACE_FILE_QUOTA_BYTES caps bytes, 5 GiB by default, so a band filling it with 2 MiB photos
+     * rather than the audio the module is built around tops out around 2500 files for the whole space.
+     * A single subtree above this limit is therefore already pathological, while the limit sits above
+     * what one folder of a realistic band space can hold.
+     *
+     * Refusing beats letting it run. The cascade is one transaction, so a request that times out rolls
+     * back and leaves the admin with a 504 explaining nothing. This way they get a sentence telling
+     * them what to do instead.
+     *
+     * Measured at the limit (BandSpaceFolderDeleteTest, 2000 files): about 6 to 7 seconds and 70 MB
+     * over an idle request. Slow, but it completes, and it is inside the usual PHP-FPM and nginx
+     * budgets. That cost is the reason the limit sits here rather than higher.
+     */
+    private const int MAX_CASCADE_FILES = 2000;
+
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private BandSpaceFolderRepository $folderRepository,
+        private BandSpaceFileRepository $fileRepository,
+        private BandSpaceFileAttachmentRepository $attachmentRepository,
+        private BandSpaceFileShareRevoker $shareRevoker,
         private BandSpaceActivityRecorder $activityRecorder,
         private Security $security,
         private RequestStack $requestStack,
@@ -47,7 +80,7 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
         [, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $folder = $this->folderRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $membership->bandSpace);
-        if (!$folder instanceof \App\Entity\BandSpace\BandSpaceFolder) {
+        if (!$folder instanceof BandSpaceFolder) {
             throw new NotFoundHttpException('Dossier introuvable');
         }
 
@@ -61,42 +94,39 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('Seul un administrateur peut supprimer un dossier en cascade');
         }
 
-        $isOwner = $folder->createdBy instanceof \App\Entity\User && $folder->createdBy->id === $user->id;
+        $isOwner = $folder->createdBy instanceof User && $folder->createdBy->id === $user->id;
         if ($strategy === self::STRATEGY_MOVE_TO_ROOT && !$isOwner && $membership->role !== Role::Admin) {
             throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut supprimer ce dossier');
         }
 
-        $folderName = $folder->name;
-        $folderId = (string) $folder->id;
+        // Everything the cascade is about to archive, read before any of it is touched: both guards
+        // have to be able to refuse the whole operation with nothing written.
+        $filesToArchive = [];
+        if ($strategy === self::STRATEGY_CASCADE) {
+            $descendantIds = $this->folderRepository->findDescendantIds($folder);
+            $this->assertSubtreeIsSmallEnough($this->fileRepository->countActiveByFolderIds($descendantIds));
+            $filesToArchive = $this->fileRepository->findActiveByFolderIds($descendantIds);
+        }
+
+        $this->assertNoAttachedFile($filesToArchive);
 
         $this->activityRecorder->record(
             $membership->bandSpace,
             BandSpaceModule::File,
             BandSpaceFolderActivityType::FolderArchived,
-            resourceId: $folderId,
+            resourceId: (string) $folder->id,
             actor: $user,
-            payload: ['name' => $folderName, 'strategy' => $strategy],
+            payload: ['name' => $folder->name, 'strategy' => $strategy, 'file_count' => count($filesToArchive)],
         );
 
         $connection = $this->entityManager->getConnection();
         $connection->beginTransaction();
         try {
             if ($strategy === self::STRATEGY_CASCADE) {
-                $descendantIds = $this->folderRepository->findDescendantIds($folder);
-                $connection->executeStatement(
-                    'UPDATE band_space_file SET archive_datetime = :now WHERE folder_id IN (:ids) AND archive_datetime IS NULL',
-                    ['now' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'), 'ids' => $descendantIds],
-                    ['ids' => \Doctrine\DBAL\ArrayParameterType::STRING],
-                );
+                $this->archive($filesToArchive, $membership->bandSpace, $user);
             } else {
-                $connection->executeStatement(
-                    'UPDATE band_space_folder SET parent_id = NULL WHERE parent_id = :folderId',
-                    ['folderId' => $folderId],
-                );
-                $connection->executeStatement(
-                    'UPDATE band_space_file SET folder_id = NULL WHERE folder_id = :folderId',
-                    ['folderId' => $folderId],
-                );
+                $this->folderRepository->detachChildrenFrom($folder);
+                $this->fileRepository->detachFromFolder($folder);
             }
 
             $this->entityManager->remove($folder);
@@ -106,5 +136,104 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
             $connection->rollBack();
             throw $e;
         }
+    }
+
+    private function assertSubtreeIsSmallEnough(int $fileCount): void
+    {
+        if ($fileCount <= self::MAX_CASCADE_FILES) {
+            return;
+        }
+
+        throw new UnprocessableEntityHttpException(sprintf(
+            'Ce dossier contient %d fichiers, au-delà de la limite de %d par suppression. Supprimez ses sous-dossiers un par un, ou déplacez une partie des fichiers avant de réessayer.',
+            $fileCount,
+            self::MAX_CASCADE_FILES,
+        ));
+    }
+
+    /**
+     * Refuses the cascade when it would trash a file some task, note or finance entry still points at.
+     *
+     * The single file endpoint has always refused exactly this, and the cascade did not: attachment
+     * panels list live files only, so the file simply vanished from the resource holding it and
+     * app:band-space:purge destroyed it once the grace period ran out (#823).
+     *
+     * @param BandSpaceFile[] $files
+     */
+    private function assertNoAttachedFile(array $files): void
+    {
+        $sourceTypesByFile = $this->attachmentRepository->findSourceTypesByFileIds(
+            array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files),
+        );
+
+        if (count($sourceTypesByFile) === 0) {
+            return;
+        }
+
+        // Sorted because the sentence is asserted verbatim: without it the list follows whatever order
+        // the database returned the attachment rows in.
+        $sourceTypes = array_merge(...array_values($sourceTypesByFile));
+        sort($sourceTypes);
+        $sources = BandSpaceFileAttachmentLabels::describe($sourceTypes);
+
+        throw new UnprocessableEntityHttpException(count($sourceTypesByFile) === 1
+            ? sprintf("Ce dossier contient 1 fichier attaché à %s. Détachez-le d'abord depuis la ressource concernée.", $sources)
+            : sprintf(
+                "Ce dossier contient %d fichiers attachés à %s. Détachez-les d'abord depuis les ressources concernées.",
+                count($sourceTypesByFile),
+                $sources,
+            ));
+    }
+
+    /**
+     * Trashes the subtree file by file, the way the single file endpoint does it.
+     *
+     * The folder rows are about to go and band_space_file.folder_id is ON DELETE SET NULL, so each
+     * file keeps the path it was archived from in its Archived activity: without it a restore drops
+     * the file at the root with nothing left saying where it used to live.
+     *
+     * Paths are memoised per folder. findActiveByFolderIds() fetch joins the file's own folder but not
+     * its ancestors, so walking the chain pulls each ancestor in once; the identity map then serves
+     * every later walk, which caps the extra queries at the number of distinct folders in the subtree
+     * plus the chain above it, never at the number of files. Six levels at most, MAX_DEPTH sees to it.
+     *
+     * @param BandSpaceFile[] $files
+     */
+    private function archive(array $files, BandSpace $bandSpace, User $actor): void
+    {
+        if (count($files) === 0) {
+            return;
+        }
+
+        $archivedAt = new DateTimeImmutable();
+        $pathByFolderId = [];
+
+        foreach ($files as $file) {
+            $file->archiveDatetime = $archivedAt;
+
+            $folderId = (string) $file->folder?->id;
+            $pathByFolderId[$folderId] ??= implode(
+                ' / ',
+                array_column($this->fileRepository->buildFolderPath($file->folder), 'name'),
+            );
+
+            $this->activityRecorder->record(
+                $bandSpace,
+                BandSpaceModule::File,
+                BandSpaceFileActivityType::Archived,
+                resourceId: (string) $file->id,
+                actor: $actor,
+                payload: [
+                    'original_name' => $file->originalName,
+                    'folder_path' => $pathByFolderId[$folderId],
+                ],
+            );
+        }
+
+        $this->shareRevoker->revokeForArchivedFiles(
+            $bandSpace,
+            array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files),
+            $actor,
+        );
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceFileDeleteTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileDeleteTest.php
@@ -2,15 +2,21 @@
 
 namespace App\Tests\Api\BandSpace\File;
 
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFileShareRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFileAttachmentFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileShareFactory;
 use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -54,6 +60,76 @@ class BandSpaceFileDeleteTest extends ApiTestCase
         $this->client->jsonRequest('DELETE', '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id, [], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
 
         $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * The admin share list hides shares of archived files, so trashing a file used to take its link off
+     * the only screen that can revoke it while the row stayed live underneath. A restore weeks later
+     * silently reopened the URL until its original expiry.
+     */
+    public function test_delete_revokes_the_share_links_of_the_file(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin])->create();
+        $other = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin])->create();
+
+        $live = BandSpaceFileShareFactory::new([
+            'bandSpaceFile' => $file,
+            'createdBy' => $admin,
+            'tokenHash' => hash('sha256', 'live-token'),
+            'expiryDatetime' => new \DateTimeImmutable('+30 days'),
+        ])->create();
+        $alreadyRevoked = BandSpaceFileShareFactory::new([
+            'bandSpaceFile' => $file,
+            'createdBy' => $admin,
+            'tokenHash' => hash('sha256', 'revoked-token'),
+            'revocationDatetime' => new \DateTimeImmutable('2026-01-02T03:04:05+00:00'),
+        ])->create();
+        $untouched = BandSpaceFileShareFactory::new([
+            'bandSpaceFile' => $other,
+            'createdBy' => $admin,
+            'tokenHash' => hash('sha256', 'other-file-token'),
+        ])->create();
+
+        $bandSpaceId = $bandSpace->id;
+        $fileId = (string) $file->id;
+        $liveId = $live->id;
+        $alreadyRevokedId = $alreadyRevoked->id;
+        $untouchedId = $untouched->id;
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('DELETE', '/api/band_spaces/' . $bandSpaceId . '/files/' . $fileId, [], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+
+        /** @var BandSpaceFileShareRepository $shareRepo */
+        $shareRepo = self::getContainer()->get(BandSpaceFileShareRepository::class);
+        $this->assertNotNull($shareRepo->find($liveId)?->revocationDatetime);
+        // An already revoked link keeps the date it was revoked on, it is not re-stamped.
+        $this->assertSame(
+            '2026-01-02T03:04:05+00:00',
+            $shareRepo->find($alreadyRevokedId)?->revocationDatetime?->format(\DATE_ATOM),
+        );
+        // A link on another file is none of this delete's business.
+        $this->assertNull($shareRepo->find($untouchedId)?->revocationDatetime);
+
+        /** @var BandSpaceActivityRepository $activityRepo */
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $types = array_map(
+            static fn ($activity): string => $activity->type,
+            $activityRepo->findForResource($bandSpace, BandSpaceModule::File, $fileId),
+        );
+        sort($types);
+        $this->assertSame(
+            [BandSpaceFileActivityType::Archived->value, BandSpaceFileActivityType::ShareRevoked->value],
+            $types,
+        );
     }
 
     public function test_delete_by_random_member_returns_403(): void

--- a/tests/Api/BandSpace/File/BandSpaceFileTrashTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileTrashTest.php
@@ -8,12 +8,14 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFileShareRepository;
 use App\Repository\BandSpace\BandSpaceFileVersionRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileShareFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
 use App\Tests\Factory\User\UserFactory;
 use Doctrine\ORM\EntityManagerInterface;
@@ -85,6 +87,51 @@ class BandSpaceFileTrashTest extends ApiTestCase
         $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
             ->findForResource($bandSpace, BandSpaceModule::File, $fileId);
         $this->assertSame(BandSpaceFileActivityType::Restored->value, $activities[0]->type);
+    }
+
+    /**
+     * Deleting a file revokes its share links. Restoring brings the file back, never the links: an
+     * admin who deleted a rough mix to unshare it must not have the old public URL work again weeks
+     * later because a bandmate pulled the file out of the trash.
+     *
+     * A guard rather than a reproducer: the restore endpoint never touched the shares, which is what
+     * makes revoking on archive enough. Undoing the revocation here would silently give the fix back.
+     */
+    public function test_restoring_does_not_bring_a_revoked_share_link_back_to_life(): void
+    {
+        [$admin, $bandSpace, $file] = $this->setupArchivedFile();
+        $fileId = (string) $file->id;
+
+        $revokedAt = new \DateTimeImmutable('2026-07-01T08:00:00+00:00');
+        $share = BandSpaceFileShareFactory::new([
+            'bandSpaceFile' => $file,
+            'createdBy' => $admin,
+            'tokenHash' => hash('sha256', 'restored-file-token'),
+            'expiryDatetime' => new \DateTimeImmutable('+90 days'),
+            'revocationDatetime' => $revokedAt,
+        ])->create();
+        $shareId = $share->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('POST', '/api/band_spaces/' . $bandSpace->id . '/files/' . $fileId . '/restore', [], [], self::HEADERS);
+
+        $this->assertResponseIsSuccessful();
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+
+        $reloaded = self::getContainer()->get(BandSpaceFileRepository::class)->findOneByIdAndBandSpace($fileId, $bandSpace);
+        $this->assertNull($reloaded?->archiveDatetime);
+
+        /** @var BandSpaceFileShareRepository $shareRepo */
+        $shareRepo = self::getContainer()->get(BandSpaceFileShareRepository::class);
+        $this->assertSame(
+            $revokedAt->format(\DATE_ATOM),
+            $shareRepo->find($shareId)?->revocationDatetime?->format(\DATE_ATOM),
+        );
+
+        // And the restored file is not offered a live link again by the admin share list either.
+        $this->assertCount(0, $shareRepo->findActiveByBandSpace($bandSpace, new \DateTimeImmutable()));
     }
 
     /**

--- a/tests/Api/BandSpace/File/BandSpaceFolderDeleteTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFolderDeleteTest.php
@@ -2,16 +2,24 @@
 
 namespace App\Tests\Api\BandSpace\File;
 
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFileShareRepository;
 use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileAttachmentFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileShareFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFolderFactory;
 use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -163,6 +171,264 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
         ]);
     }
 
+    /**
+     * The cascade used to archive the whole subtree with no attachment check at all, which is exactly
+     * what the single file endpoint refuses. Attachment panels list live files only, so the file just
+     * vanished from the task or entry holding it and app:band-space:purge destroyed it 30 days later.
+     */
+    public function test_delete_cascade_refuses_a_subtree_holding_attached_files(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $parent = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Live'])->create();
+        $child = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => '2026', 'parent' => $parent])->create();
+
+        $attachedToTask = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'folder' => $parent])->create();
+        $attachedToNote = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'folder' => $child])->create();
+        $free = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'folder' => $child])->create();
+
+        BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $attachedToTask,
+            'sourceType' => 'task',
+            'sourceId' => Uuid::uuid4(),
+            'attachedBy' => $admin,
+        ]);
+        BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $attachedToNote,
+            'sourceType' => 'note',
+            'sourceId' => Uuid::uuid4(),
+            'attachedBy' => $admin,
+        ]);
+
+        $bandSpaceId = $bandSpace->id;
+        $parentId = $parent->id;
+        $freeFileId = $free->id;
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpaceId . '/folders/' . $parentId . '?strategy=cascade',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Ce dossier contient 2 fichiers attachés à une note et une tâche. Détachez-les d'abord depuis les ressources concernées.",
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => "Ce dossier contient 2 fichiers attachés à une note et une tâche. Détachez-les d'abord depuis les ressources concernées.",
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+
+        // Nothing at all was written: not the folders, not even the unattached file beside them.
+        /** @var BandSpaceFolderRepository $folderRepo */
+        $folderRepo = self::getContainer()->get(BandSpaceFolderRepository::class);
+        $this->assertNotNull($folderRepo->find($parentId));
+
+        /** @var BandSpaceFileRepository $fileRepo */
+        $fileRepo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($fileRepo->find($freeFileId)?->archiveDatetime);
+
+        /** @var BandSpaceActivityRepository $activityRepo */
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findBy(['bandSpace' => $bandSpaceId, 'module' => BandSpaceModule::File]));
+    }
+
+    public function test_delete_cascade_refuses_a_subtree_holding_a_single_attached_file(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Live'])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'folder' => $folder])->create();
+
+        BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $file,
+            'sourceType' => 'finance',
+            'sourceId' => Uuid::uuid4(),
+            'attachedBy' => $admin,
+        ]);
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/folders/' . $folder->id . '?strategy=cascade',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Ce dossier contient 1 fichier attaché à une entrée financière. Détachez-le d'abord depuis la ressource concernée.",
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => "Ce dossier contient 1 fichier attaché à une entrée financière. Détachez-le d'abord depuis la ressource concernée.",
+        ]);
+    }
+
+    /**
+     * The folder rows are gone and band_space_file.folder_id is ON DELETE SET NULL, so the Archived
+     * activity is the only thing left saying where a restored file used to live.
+     */
+    public function test_delete_cascade_records_an_archived_activity_carrying_the_folder_path(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $parent = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Live'])->create();
+        $child = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => '2026', 'parent' => $parent])->create();
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $admin,
+            'folder' => $child,
+            'originalName' => 'soundcheck.wav',
+        ])->create();
+
+        $bandSpaceId = $bandSpace->id;
+        $fileId = (string) $file->id;
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpaceId . '/folders/' . $parent->id . '?strategy=cascade',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+
+        /** @var BandSpaceActivityRepository $activityRepo */
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepo->findForResource($bandSpace, BandSpaceModule::File, $fileId);
+
+        $this->assertCount(1, $activities);
+        $this->assertSame(BandSpaceFileActivityType::Archived->value, $activities[0]->type);
+        $this->assertSame('soundcheck.wav', $activities[0]->payload['original_name']);
+        $this->assertSame('Live / 2026', $activities[0]->payload['folder_path']);
+    }
+
+    /**
+     * Same rule as the single file endpoint: a link the band watched disappear must not come back to
+     * life when somebody restores the file weeks later.
+     */
+    public function test_delete_cascade_revokes_the_share_links_of_the_archived_files(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Live'])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'folder' => $folder])->create();
+
+        $share = BandSpaceFileShareFactory::new([
+            'bandSpaceFile' => $file,
+            'createdBy' => $admin,
+            'tokenHash' => hash('sha256', 'cascade-token'),
+            'expiryDatetime' => new \DateTimeImmutable('+30 days'),
+        ])->create();
+
+        $shareId = $share->id;
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/folders/' . $folder->id . '?strategy=cascade',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+
+        /** @var BandSpaceFileShareRepository $shareRepo */
+        $shareRepo = self::getContainer()->get(BandSpaceFileShareRepository::class);
+        $this->assertNotNull($shareRepo->find($shareId)?->revocationDatetime);
+    }
+
+    /**
+     * The cascade archives file by file, so an unbounded subtree would run the whole thing inside one
+     * HTTP request. Nothing caps how many files a space holds (the quota caps bytes), so the processor
+     * counts first and refuses rather than letting the admin hit a 504 that explains nothing.
+     */
+    public function test_delete_cascade_refuses_a_subtree_above_the_file_limit(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Photos'])->create();
+
+        $overTheLimit = 2001;
+        $this->seedFiles($bandSpace->id, (string) $folder->id, $overTheLimit);
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/folders/' . $folder->id . '?strategy=cascade',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Ce dossier contient 2001 fichiers, au-delà de la limite de 2000 par suppression. Supprimez ses sous-dossiers un par un, ou déplacez une partie des fichiers avant de réessayer.',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Ce dossier contient 2001 fichiers, au-delà de la limite de 2000 par suppression. Supprimez ses sous-dossiers un par un, ou déplacez une partie des fichiers avant de réessayer.',
+        ]);
+    }
+
+    public function test_delete_cascade_accepts_a_subtree_at_the_file_limit(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Photos'])->create();
+
+        // Exactly on the limit: the guard rejects above it, never at it.
+        $this->seedFiles($bandSpace->id, (string) $folder->id, 2000);
+
+        $bandSpaceId = $bandSpace->id;
+        $folderId = (string) $folder->id;
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpaceId . '/folders/' . $folderId . '?strategy=cascade',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        /** @var BandSpaceFileRepository $fileRepo */
+        $fileRepo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertSame(0, $fileRepo->countActiveByFolderIds([$folderId]));
+    }
+
     public function test_delete_move_to_root_by_admin_non_creator_succeeds(): void
     {
         $owner = UserFactory::new()->asBaseUser()->create(['username' => 'owner', 'email' => 'owner@test.com']);
@@ -180,5 +446,29 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Rows straight through the connection: thousands of files is the whole point of the two limit
+     * tests, and building them as Foundry objects would cost minutes for state no assertion reads.
+     * created_by_id is left null, which the uploader join tolerates and the count ignores.
+     */
+    private function seedFiles(string $bandSpaceId, string $folderId, int $count): void
+    {
+        $connection = self::getContainer()->get(EntityManagerInterface::class)->getConnection();
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $rows = [];
+        $parameters = [];
+        for ($i = 0; $i < $count; $i++) {
+            $rows[] = '(?, ?, ?, ?, ?)';
+            array_push($parameters, Uuid::uuid4()->toString(), $bandSpaceId, $folderId, 'photo-' . $i . '.jpg', $now);
+        }
+
+        $connection->executeStatement(
+            'INSERT INTO band_space_file (id, band_space_id, folder_id, original_name, creation_datetime) VALUES '
+            . implode(', ', $rows),
+            $parameters,
+        );
     }
 }

--- a/tests/Unit/Service/BandSpace/File/BandSpaceFileAttachmentLabelsTest.php
+++ b/tests/Unit/Service/BandSpace/File/BandSpaceFileAttachmentLabelsTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\BandSpace\File;
+
+use App\Service\BandSpace\File\BandSpaceFileAttachmentLabels;
+use App\Service\BandSpace\File\BandSpaceFileSourceTypes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The sentence both delete paths refuse with. The two of them naming the same sources in the same
+ * words is the whole point of the class, so the wording is pinned here rather than only through the
+ * handful of source types the API tests happen to attach.
+ */
+class BandSpaceFileAttachmentLabelsTest extends TestCase
+{
+    public function test_an_empty_list_still_names_something(): void
+    {
+        $this->assertSame('une autre ressource', BandSpaceFileAttachmentLabels::describe([]));
+    }
+
+    /**
+     * The five types of BandSpaceFileSourceTypes::ALL, one by one. song and setlist used to fall
+     * through to the unknown fallback, which is what this class was extracted to fix.
+     */
+    public function test_every_source_type_has_its_own_french_noun(): void
+    {
+        $this->assertSame('une tâche', BandSpaceFileAttachmentLabels::describe(['task']));
+        $this->assertSame('une entrée financière', BandSpaceFileAttachmentLabels::describe(['finance']));
+        $this->assertSame('une note', BandSpaceFileAttachmentLabels::describe(['note']));
+        $this->assertSame('une chanson', BandSpaceFileAttachmentLabels::describe(['song']));
+        $this->assertSame('une setlist', BandSpaceFileAttachmentLabels::describe(['setlist']));
+    }
+
+    /**
+     * Guards the pair against drift: a sixth source type added to the allowlist without a noun here
+     * would silently be described as "une autre ressource" in the refusal.
+     */
+    public function test_no_allowed_source_type_falls_back_to_the_unknown_label(): void
+    {
+        foreach (BandSpaceFileSourceTypes::ALL as $sourceType) {
+            $this->assertNotSame(
+                'une autre ressource',
+                BandSpaceFileAttachmentLabels::describe([$sourceType]),
+                sprintf('Source type "%s" has no French noun', $sourceType),
+            );
+        }
+    }
+
+    public function test_an_unknown_source_type_falls_back(): void
+    {
+        $this->assertSame('une autre ressource', BandSpaceFileAttachmentLabels::describe(['gigposter']));
+    }
+
+    public function test_two_types_are_joined_with_et(): void
+    {
+        $this->assertSame('une tâche et une note', BandSpaceFileAttachmentLabels::describe(['task', 'note']));
+    }
+
+    public function test_three_or_more_types_are_a_comma_list_ending_in_et(): void
+    {
+        $this->assertSame(
+            'une tâche, une note et une chanson',
+            BandSpaceFileAttachmentLabels::describe(['task', 'note', 'song']),
+        );
+        $this->assertSame(
+            'une tâche, une note, une chanson et une setlist',
+            BandSpaceFileAttachmentLabels::describe(['task', 'note', 'song', 'setlist']),
+        );
+    }
+
+    /**
+     * The caller passes one row per attachment, so the same type arrives many times over: three files
+     * attached to three tasks must read "une tâche", not "une tâche, une tâche et une tâche".
+     */
+    public function test_repeated_types_are_named_once(): void
+    {
+        $this->assertSame('une tâche', BandSpaceFileAttachmentLabels::describe(['task', 'task', 'task']));
+        $this->assertSame(
+            'une tâche et une note',
+            BandSpaceFileAttachmentLabels::describe(['task', 'note', 'task', 'note']),
+        );
+    }
+
+    /**
+     * Two unknown types are one "une autre ressource", not two, so the list never repeats itself.
+     */
+    public function test_several_unknown_types_collapse_into_one_fallback(): void
+    {
+        $this->assertSame(
+            'une tâche et une autre ressource',
+            BandSpaceFileAttachmentLabels::describe(['task', 'gigposter', 'poster']),
+        );
+    }
+}


### PR DESCRIPTION
Closes #823 (items 1, 2, 3). Item 4 (multi-file upload) was split to #862.

## Item 1: admins could not delete another member(s) file

The API allows creator-or-admin, but both UI surfaces gated on the creator only, while the trash list already got it right, so an admin could restore a file they could not delete. Concrete case: a member leaves having uploaded 3 GB of rehearsal video and the admin sees the quota bar at 95% with no working button.

New `assets/js/utils/bandSpaceFilePermissions.js` mirrors the server rule, including a guard so two `undefined` ids do not compare equal. All three surfaces now share it so they cannot drift apart again.

## Item 2: folder delete bypassed the attachment guard

`BandSpaceFolderDeleteProcessor` archived the whole subtree with raw SQL and no attachment check, which is exactly the operation the single-file path refuses. Attachment panels only list non-archived files, so a file silently vanished from its task or finance entry, and `app:band-space:purge` destroyed it after the grace period.

Now refuses with 422 when any file in the subtree is attached, matching the single-file path (the bug was that the two paths disagreed). The refusal is atomic: the full file set and its attachments are computed and checked before anything is persisted or any transaction opens, and a test proves the folder still exists, an unattached sibling is untouched and zero activities are written.

The raw bulk UPDATE is gone. Archiving is per-file ORM now, because each file needs its own `Archived` activity carrying `original_name` and `folder_path`. The remaining DQL moved into `BandSpaceFolderRepository::detachChildrenFrom()` and `BandSpaceFileRepository::detachFromFolder()` with docblocks explaining why they bypass the ORM, which clears this processor off the CLAUDE.md known-exceptions list.

**Cascade is capped at 2000 files**, measured rather than guessed. Nothing caps a space file count (the 5 GiB quota bounds bytes only), so the worst case by construction is unbounded. Measured on this stack: refusal path at 2001 files 6.85s against a 7.6s boot baseline, so the guard is free; full cascade at 2000 files 14.2s, about 6-7s and 70 MB over an idle request. Batching would lower peak memory but not statement count or wall time, and simply accepting it gives the admin a 504 that explains nothing, so the cap produces an actionable French 422 instead. The check is a COUNT before hydration, so an oversized subtree is refused without being loaded. Both boundaries are pinned: exactly 2000 succeeds, 2001 refuses.

## Item 3: share links survived trashing and revived on restore

Deleting a file never touched its shares. The admin share list hides shares of archived files, so after trashing there was nothing left to revoke, and restore simply cleared `archiveDatetime`. An admin could share a rough mix, delete the file believing that unshared it, and a bandmate restoring it weeks later would silently bring the public URL back.

New `BandSpaceFileShareRevoker` sets `revocationDatetime` on every unrevoked share of the archived files and records a `share_revoked` activity, wired into both the single-file path and the folder cascade. No schema change: the column and its index already existed. Already-revoked shares keep their original date.

Review confirmed the public share providers already check `revocationDatetime` independently of `archiveDatetime`, so this closes the actual root cause rather than papering over the enforcement path.

## Also

`BandSpaceFileAttachmentLabels` (PHP) and `assets/js/constants/fileSources.js` now hold the same five source nouns on each side, so the delete dialog no longer names three of five. Both are pinned by tests that fail the day a sixth source type is added without a noun. This also fixes `song`/`setlist` previously rendering as "une autre ressource".

## Verification

`tests/Api/BandSpace/` + `tests/Unit/` 1334 passing, PHPStan level 8 clean, npm test 178/178, Biome clean, build OK.

## Note

This branch and #868 (M-824) both add a method to `BandSpaceFileAttachmentRepository`, at different line ranges, so they should merge cleanly in either order.
