### PR TITLE
Setlists: archived rows read only, live position, duplicate keeps attachments

### DIFF
--- a/assets/js/components/BandSpace/Setlist/SetlistEditor.vue
+++ b/assets/js/components/BandSpace/Setlist/SetlistEditor.vue
@@ -10,6 +10,11 @@
     </div>
 
     <div v-else class="flex flex-col gap-4">
+      <Message v-if="isArchived" severity="warn" :closable="false" icon="pi pi-archive">
+        Cette setlist est archivée, elle est en lecture seule. Dupliquez-la pour repartir de son
+        contenu.
+      </Message>
+
       <div class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700">
         <div class="flex flex-wrap items-center gap-3 mb-3">
           <div class="flex-1 min-w-0">
@@ -24,8 +29,9 @@
             />
             <h2
               v-else
-              class="font-semibold text-xl truncate cursor-text hover:text-primary"
-              v-tooltip.top="'Cliquez pour renommer'"
+              class="font-semibold text-xl truncate"
+              :class="isArchived ? '' : 'cursor-text hover:text-primary'"
+              v-tooltip.top="isArchived ? null : 'Cliquez pour renommer'"
               @click="startRename"
             >
               {{ setlist.name }}
@@ -48,7 +54,7 @@
               v-tooltip.top="setlist.items.length === 0 ? 'Ajoutez au moins un titre' : null"
               @click="openLiveMode"
             />
-            <Button label="Archiver" icon="pi pi-archive" severity="danger" outlined size="small" @click="confirmArchive" />
+            <Button v-if="!isArchived" label="Archiver" icon="pi pi-archive" severity="danger" outlined size="small" @click="confirmArchive" />
           </div>
         </div>
       </div>
@@ -56,7 +62,7 @@
       <div class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700">
         <div class="flex items-center justify-between mb-3">
           <h3 class="font-semibold">Programme</h3>
-          <Button label="Ajouter un titre" icon="pi pi-plus" size="small" @click="addDialogOpen = true" />
+          <Button v-if="!isArchived" label="Ajouter un titre" icon="pi pi-plus" size="small" @click="addDialogOpen = true" />
         </div>
 
         <div v-if="setlist.items.length === 0" class="text-center py-8 text-surface-500">
@@ -68,6 +74,7 @@
           v-else
           v-model="localItems"
           :animation="200"
+          :disabled="isArchived"
           ghost-class="opacity-30"
           handle=".cursor-pointer"
           class="flex flex-col gap-2"
@@ -77,6 +84,7 @@
             v-for="item in localItems"
             :key="item.id"
             :item="item"
+            :readonly="isArchived"
             @edit="openItemEdit"
             @open-menu="openItemMenu"
           />
@@ -111,6 +119,7 @@
       v-model:visible="filesDrawerOpen"
       :band-space-id="bandSpaceId"
       :setlist-id="setlistId"
+      :readonly="isArchived"
     />
   </div>
 </template>
@@ -119,6 +128,7 @@
 import Button from 'primevue/button'
 import InputText from 'primevue/inputtext'
 import Menu from 'primevue/menu'
+import Message from 'primevue/message'
 import Skeleton from 'primevue/skeleton'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
@@ -152,6 +162,11 @@ function openLiveMode() {
 }
 
 const setlist = computed(() => setlistsStore.activeSetlist)
+
+// An archived setlist stays reachable through ?setlist=<id> and through a tab left open, and the
+// API now refuses every write on it. Showing the state and dropping the editing affordances is the
+// visible half of that: without it the buttons are there, they just fail.
+const isArchived = computed(() => Boolean(setlist.value?.archive_datetime))
 
 const localItems = ref([])
 
@@ -193,6 +208,7 @@ const editingName = ref(false)
 const nameDraft = ref('')
 
 function startRename() {
+  if (isArchived.value) return
   nameDraft.value = setlist.value?.name ?? ''
   editingName.value = true
 }
@@ -233,11 +249,13 @@ const itemMenu = ref(null)
 const menuTargetItem = ref(null)
 
 function openItemEdit(item) {
+  if (isArchived.value) return
   editingItem.value = item
   editDrawerOpen.value = true
 }
 
 function openItemMenu(event, item) {
+  if (isArchived.value) return
   menuTargetItem.value = item
   itemMenu.value?.toggle(event)
 }

--- a/assets/js/components/BandSpace/Setlist/SetlistFileDrawer.vue
+++ b/assets/js/components/BandSpace/Setlist/SetlistFileDrawer.vue
@@ -43,14 +43,18 @@
 
       <p v-else class="text-xs text-surface-400 italic">Aucun fichier pour le moment.</p>
 
-      <input ref="fileInput" type="file" class="hidden" @change="handleFileSelected" />
-      <Button
-        label="Importer un fichier"
-        icon="pi pi-cloud-upload"
-        severity="secondary"
-        :loading="isUploading"
-        @click="fileInput?.click()"
-      />
+      <!-- Import only: detaching stays available on an archived setlist, the same way the API keeps
+           it open, because it frees a file rather than adding to a list nobody can see. -->
+      <template v-if="!readonly">
+        <input ref="fileInput" type="file" class="hidden" @change="handleFileSelected" />
+        <Button
+          label="Importer un fichier"
+          icon="pi pi-cloud-upload"
+          severity="secondary"
+          :loading="isUploading"
+          @click="fileInput?.click()"
+        />
+      </template>
     </div>
   </Drawer>
 </template>
@@ -66,7 +70,9 @@ import bandSpaceSetlistsApi from '../../../api/bandSpace/band-space-setlists.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
-  setlistId: { type: String, required: true }
+  setlistId: { type: String, required: true },
+  /** An archived setlist accepts no new attachment, so the import button goes away. */
+  readonly: { type: Boolean, default: false }
 })
 
 const visible = defineModel('visible', { type: Boolean, default: false })

--- a/assets/js/components/BandSpace/Setlist/SetlistItemCard.vue
+++ b/assets/js/components/BandSpace/Setlist/SetlistItemCard.vue
@@ -1,8 +1,9 @@
 <template>
   <div
-    class="bg-surface-0 dark:bg-surface-900 border border-surface-200 dark:border-surface-700 rounded-xl p-3 flex items-center gap-3 cursor-pointer hover:border-primary"
+    class="bg-surface-0 dark:bg-surface-900 border border-surface-200 dark:border-surface-700 rounded-xl p-3 flex items-center gap-3"
+    :class="readonly ? 'cursor-default' : 'cursor-pointer hover:border-primary'"
     :data-item-id="item.id"
-    @click="emit('edit', item)"
+    @click="handleClick"
   >
     <div class="text-surface-400 text-sm font-semibold tabular-nums w-8 text-center">
       {{ item.position + 1 }}
@@ -39,6 +40,7 @@
     </div>
 
     <Button
+      v-if="!readonly"
       icon="pi pi-ellipsis-v"
       severity="secondary"
       text
@@ -56,10 +58,17 @@ import Button from 'primevue/button'
 import { computed } from 'vue'
 
 const props = defineProps({
-  item: { type: Object, required: true }
+  item: { type: Object, required: true },
+  /** An archived setlist is read only: the card still renders, it just stops offering to edit. */
+  readonly: { type: Boolean, default: false }
 })
 
 const emit = defineEmits(['edit', 'open-menu'])
+
+function handleClick() {
+  if (props.readonly) return
+  emit('edit', props.item)
+}
 
 const isSong = computed(() => props.item.type === 'song')
 

--- a/assets/js/utils/setlistLivePosition.js
+++ b/assets/js/utils/setlistLivePosition.js
@@ -1,0 +1,66 @@
+/**
+ * Where the singer had got to in the set, kept across a reload.
+ *
+ * Live mode holds its position in a single ref, and a phone drops a backgrounded tab whenever it
+ * feels like it. Coming back to track 1 of a 25 song set, on stage, is the failure this prevents.
+ * sessionStorage is the right lifetime: the position belongs to that tab and that show, and dies
+ * with them.
+ *
+ * The key carries the setlist id so two lists do not share a position, and every read is checked
+ * against the current item count: a stored index is only as good as the setlist it was written
+ * for, and that setlist may have lost items since. Anything unusable reads as 0, never as a crash.
+ *
+ * Pure on purpose, with the storage passed in, so the rules are tested without a browser. See
+ * setlistLivePosition.test.js.
+ */
+
+const STORAGE_KEY_PREFIX = 'setlist-live-position:'
+
+export function livePositionStorageKey(setlistId) {
+  return `${STORAGE_KEY_PREFIX}${setlistId}`
+}
+
+/**
+ * sessionStorage is not merely absent outside a browser: reading the property itself throws when
+ * the browser blocks storage (Safari with cookies refused). Resolved once, and null from then on.
+ */
+export function openLivePositionStorage() {
+  try {
+    return globalThis.sessionStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The stored position, or 0 whenever it cannot be trusted: no storage, nothing stored, not a whole
+ * number, negative, or past the end of the setlist as it stands now.
+ */
+export function readLivePosition(storage, setlistId, itemCount) {
+  if (!storage || !setlistId || itemCount <= 0) return 0
+
+  let stored = null
+  try {
+    stored = storage.getItem(livePositionStorageKey(setlistId))
+  } catch {
+    return 0
+  }
+
+  if (stored === null || stored === '') return 0
+
+  const index = Number(stored)
+  if (!Number.isInteger(index) || index < 0 || index >= itemCount) return 0
+
+  return index
+}
+
+/** Writes the position, silently doing nothing when storage is unavailable or full. */
+export function writeLivePosition(storage, setlistId, index) {
+  if (!storage || !setlistId || !Number.isInteger(index) || index < 0) return
+
+  try {
+    storage.setItem(livePositionStorageKey(setlistId), String(index))
+  } catch {
+    // Storage full or blocked: the position is a convenience, never a reason to break the show.
+  }
+}

--- a/assets/js/utils/setlistLivePosition.test.js
+++ b/assets/js/utils/setlistLivePosition.test.js
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  livePositionStorageKey,
+  openLivePositionStorage,
+  readLivePosition,
+  writeLivePosition
+} from './setlistLivePosition.js'
+
+/**
+ * These pin the rule that keeps a singer on the right track after a reload. Live mode is used on a
+ * phone on stage, where a backgrounded tab gets evicted without warning, so a position that comes
+ * back wrong is worse than no position at all: every read has to be checked against the setlist as
+ * it stands now, and fall back to the first item rather than throw or land past the end.
+ *
+ * Run with `npm test`.
+ */
+
+const SETLIST_ID = '7f3c9b1e-0000-4000-8000-000000000001'
+const OTHER_SETLIST_ID = '7f3c9b1e-0000-4000-8000-000000000002'
+
+/** Minimal Storage stand in: the two methods the helpers use, over a plain object. */
+function fakeStorage(initial = {}) {
+  const values = { ...initial }
+
+  return {
+    values,
+    getItem: (key) => (key in values ? values[key] : null),
+    setItem: (key, value) => {
+      values[key] = value
+    }
+  }
+}
+
+/** A Storage that refuses every operation, the way a browser with storage blocked does. */
+function throwingStorage() {
+  return {
+    getItem: () => {
+      throw new Error('storage blocked')
+    },
+    setItem: () => {
+      throw new Error('storage blocked')
+    }
+  }
+}
+
+describe('readLivePosition', () => {
+  it('reads back the position written for that setlist', () => {
+    const storage = fakeStorage()
+    writeLivePosition(storage, SETLIST_ID, 11)
+
+    assert.equal(readLivePosition(storage, SETLIST_ID, 25), 11)
+  })
+
+  it('keeps two setlists on separate positions', () => {
+    const storage = fakeStorage()
+    writeLivePosition(storage, SETLIST_ID, 11)
+    writeLivePosition(storage, OTHER_SETLIST_ID, 3)
+
+    assert.equal(readLivePosition(storage, SETLIST_ID, 25), 11)
+    assert.equal(readLivePosition(storage, OTHER_SETLIST_ID, 25), 3)
+  })
+
+  it('starts at the first item when nothing was stored', () => {
+    assert.equal(readLivePosition(fakeStorage(), SETLIST_ID, 25), 0)
+  })
+
+  // The setlist can lose items between the write and the read, and the last index of a 25 song set
+  // is off the end of a 4 song one. Restoring it would render an empty screen.
+  it('falls back to the first item when the stored index is past the end', () => {
+    const storage = fakeStorage()
+    writeLivePosition(storage, SETLIST_ID, 24)
+
+    assert.equal(readLivePosition(storage, SETLIST_ID, 4), 0)
+  })
+
+  it('accepts the last item of the setlist', () => {
+    const storage = fakeStorage()
+    writeLivePosition(storage, SETLIST_ID, 3)
+
+    assert.equal(readLivePosition(storage, SETLIST_ID, 4), 3)
+  })
+
+  it('falls back to the first item on an empty setlist', () => {
+    const storage = fakeStorage()
+    writeLivePosition(storage, SETLIST_ID, 2)
+
+    assert.equal(readLivePosition(storage, SETLIST_ID, 0), 0)
+  })
+
+  it('refuses anything that is not a whole positive index', () => {
+    const key = livePositionStorageKey(SETLIST_ID)
+
+    for (const stored of ['', 'deux', '-1', '1.5', 'NaN', 'null']) {
+      const storage = fakeStorage({ [key]: stored })
+      assert.equal(readLivePosition(storage, SETLIST_ID, 25), 0, `stored: ${stored}`)
+    }
+  })
+
+  it('falls back to the first item when there is no storage at all', () => {
+    assert.equal(readLivePosition(null, SETLIST_ID, 25), 0)
+  })
+
+  it('falls back to the first item when the browser blocks storage', () => {
+    assert.equal(readLivePosition(throwingStorage(), SETLIST_ID, 25), 0)
+  })
+
+  it('falls back to the first item when the setlist id is missing', () => {
+    assert.equal(readLivePosition(fakeStorage(), null, 25), 0)
+  })
+})
+
+describe('writeLivePosition', () => {
+  it('stores the index under a key carrying the setlist id', () => {
+    const storage = fakeStorage()
+    writeLivePosition(storage, SETLIST_ID, 7)
+
+    assert.equal(storage.values[livePositionStorageKey(SETLIST_ID)], '7')
+  })
+
+  it('does nothing when the browser blocks storage', () => {
+    assert.doesNotThrow(() => writeLivePosition(throwingStorage(), SETLIST_ID, 7))
+  })
+
+  it('does nothing without a storage or a setlist id', () => {
+    assert.doesNotThrow(() => writeLivePosition(null, SETLIST_ID, 7))
+
+    const storage = fakeStorage()
+    writeLivePosition(storage, null, 7)
+    assert.deepEqual(storage.values, {})
+  })
+
+  it('refuses to store a nonsense index', () => {
+    const storage = fakeStorage()
+    writeLivePosition(storage, SETLIST_ID, -1)
+    writeLivePosition(storage, SETLIST_ID, 1.5)
+    writeLivePosition(storage, SETLIST_ID, Number.NaN)
+
+    assert.deepEqual(storage.values, {})
+  })
+})
+
+describe('openLivePositionStorage', () => {
+  // No sessionStorage under the test runner, which is the same shape as a browser refusing it.
+  it('returns null when there is no session storage', () => {
+    assert.equal(openLivePositionStorage(), null)
+  })
+})

--- a/assets/js/views/BandSpace/SetlistLive.vue
+++ b/assets/js/views/BandSpace/SetlistLive.vue
@@ -133,6 +133,11 @@ import Drawer from 'primevue/drawer'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useBandSetlistsStore } from '../../store/bandSpace/bandSpaceSetlists.js'
+import {
+  openLivePositionStorage,
+  readLivePosition,
+  writeLivePosition
+} from '../../utils/setlistLivePosition.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -141,6 +146,7 @@ const setlistsStore = useBandSetlistsStore()
 const rootEl = ref(null)
 const currentIndex = ref(0)
 const overviewOpen = ref(false)
+const positionStorage = openLivePositionStorage()
 
 const bandSpaceId = computed(() => route.params.bandSpaceId)
 const setlistId = computed(() => route.params.setlistId)
@@ -296,11 +302,27 @@ function handleVisibilityChange() {
   }
 }
 
-// Reset currentIndex if the setlist changes (e.g. items reload).
+// The position outlives the page, because a phone evicts a backgrounded tab whenever it wants and
+// an accidental refresh mid-show must not send the singer back to the first track.
+let hasRestoredPosition = false
+
 watch(items, (next, prev) => {
+  // First load of the setlist: pick the stored position back up, clamped to what is on screen now.
+  if (!hasRestoredPosition && next.length > 0) {
+    hasRestoredPosition = true
+    currentIndex.value = readLivePosition(positionStorage, setlistId.value, next.length)
+
+    return
+  }
+
+  // Reset currentIndex if the setlist changes (e.g. items reload).
   if (prev && next.length !== prev.length) {
     currentIndex.value = Math.min(currentIndex.value, Math.max(0, next.length - 1))
   }
+})
+
+watch(currentIndex, (index) => {
+  writeLivePosition(positionStorage, setlistId.value, index)
 })
 
 onMounted(() => {

--- a/src/ApiResource/BandSpace/Setlist/SetlistItemResource.php
+++ b/src/ApiResource/BandSpace/Setlist/SetlistItemResource.php
@@ -13,6 +13,7 @@ use App\Enum\BandSpace\SetlistItemType;
 use App\State\Processor\BandSpace\Setlist\SetlistItemDeleteProcessor;
 use App\State\Processor\BandSpace\Setlist\SetlistItemUpdateProcessor;
 use App\State\Provider\BandSpace\Setlist\SetlistItemReadProvider;
+use App\Validator\BandSpace\Setlist\ValidSetlistItemPayload;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
@@ -59,6 +60,10 @@ use Symfony\Component\Validator\Constraints as Assert;
     ],
     normalizationContext: ['skip_null_values' => false],
 )]
+// Same rule as on SetlistItemCreate, on the way back in: a PATCH that empties the label of a pause
+// or an MC slot would leave a row nothing can identify. Only reached on PATCH, since API Platform
+// does not validate a DELETE and the provider hydrates `type` before the payload is applied.
+#[ValidSetlistItemPayload]
 class SetlistItemResource
 {
     #[ApiProperty(identifier: true)]

--- a/src/Repository/BandSpace/BandSpaceFileAttachmentRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileAttachmentRepository.php
@@ -143,6 +143,30 @@ class BandSpaceFileAttachmentRepository extends ServiceEntityRepository
     }
 
     /**
+     * Attachments hanging on a single source, archived files left out.
+     *
+     * Used when a source is copied: the copy should carry the documents the band still sees, and an
+     * attachment pointing at a file in the trash is invisible everywhere the copy is rendered, so
+     * cloning it would only add a row nobody can act on.
+     *
+     * @return BandSpaceFileAttachment[]
+     */
+    public function findActiveBySource(string $sourceType, string $sourceId): array
+    {
+        return $this->createQueryBuilder('a')
+            ->addSelect('bsf')
+            ->innerJoin('a.bandSpaceFile', 'bsf')
+            ->where('a.sourceType = :sourceType')
+            ->andWhere('a.sourceId = :sourceId')
+            ->andWhere('bsf.archiveDatetime IS NULL')
+            ->setParameter('sourceType', $sourceType)
+            ->setParameter('sourceId', $sourceId)
+            ->orderBy('a.attachedDatetime', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Attachments pointing at a source row that no longer exists.
      *
      * source_id carries no foreign key, so nothing at database level can tell these apart from live

--- a/src/Repository/BandSpace/SetlistRepository.php
+++ b/src/Repository/BandSpace/SetlistRepository.php
@@ -37,6 +37,9 @@ class SetlistRepository extends ServiceEntityRepository
     /**
      * Direct id lookup does NOT filter archived setlists - clients need
      * archived setlists to render in activity logs / restore flows.
+     *
+     * So this is a READ finder, and a write path cannot treat what it returns as writable: every
+     * processor that mutates the setlist has to run SetlistWriteGuard on the result.
      */
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?Setlist
     {

--- a/src/Repository/BandSpace/SongRepository.php
+++ b/src/Repository/BandSpace/SongRepository.php
@@ -37,6 +37,9 @@ class SongRepository extends ServiceEntityRepository
     /**
      * Direct id lookup does NOT filter archived songs - clients need the
      * archived song to render in setlist items / file detail drawers.
+     *
+     * So this is a READ finder, and a write path cannot treat what it returns as writable: every
+     * processor that mutates the song has to run SongWriteGuard on the result.
      */
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?Song
     {

--- a/src/Security/BandSpace/SetlistWriteGuard.php
+++ b/src/Security/BandSpace/SetlistWriteGuard.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\BandSpace;
+
+use App\Entity\BandSpace\Setlist;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+/**
+ * Refuses writes to an archived setlist.
+ *
+ * SetlistRepository::findOneByIdAndBandSpace() returns archived rows on purpose, because reads
+ * legitimately need them: the PDF of last year's gig, the activity log, the file drawer. That makes
+ * the finder unable to carry the rule, so every write path states it here instead. Without it a
+ * stale tab or a bookmarked ?setlist=<id> renames the list, adds songs and reorders them, each
+ * answered with a 200, into a row nobody can see and nothing can restore (no restore until #761).
+ *
+ * Deliberately not guarded: archiving, which is how a setlist gets here, and duplicating, which
+ * reads the archived list without touching it and is the only way back out of the archive today.
+ *
+ * Same shape as BandSpaceWriteGuard and TechRiderWriteGuard.
+ */
+readonly class SetlistWriteGuard
+{
+    public function assertWritable(Setlist $setlist): void
+    {
+        if ($setlist->archiveDatetime !== null) {
+            throw new ConflictHttpException('Cette setlist est archivée, les modifications sont désactivées');
+        }
+    }
+}

--- a/src/Security/BandSpace/SongWriteGuard.php
+++ b/src/Security/BandSpace/SongWriteGuard.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\BandSpace;
+
+use App\Entity\BandSpace\Song;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+/**
+ * Refuses writes to an archived song.
+ *
+ * SongRepository::findOneByIdAndBandSpace() returns archived rows on purpose, because a setlist
+ * item still has to render the song it was built with. The write side therefore states the rule
+ * here, exactly as SetlistWriteGuard does one level up.
+ *
+ * Archiving is deliberately not guarded: it is how a song gets here, and the processor already
+ * treats a second call as a no-op.
+ */
+readonly class SongWriteGuard
+{
+    public function assertWritable(Song $song): void
+    {
+        if ($song->archiveDatetime !== null) {
+            throw new ConflictHttpException('Cette chanson est archivée, les modifications sont désactivées');
+        }
+    }
+}

--- a/src/State/Processor/BandSpace/File/BandSpaceFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileAttachProcessor.php
@@ -20,6 +20,8 @@ use App\Repository\BandSpace\SetlistRepository;
 use App\Repository\BandSpace\SongRepository;
 use App\Repository\BandSpace\TaskRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SetlistWriteGuard;
+use App\Security\BandSpace\SongWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\File\BandSpaceFileBuilder;
 use Doctrine\ORM\EntityManagerInterface;
@@ -37,6 +39,8 @@ readonly class BandSpaceFileAttachProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SetlistWriteGuard $setlistWriteGuard,
+        private SongWriteGuard $songWriteGuard,
         private BandSpaceFileRepository $fileRepository,
         private BandSpaceFileAttachmentRepository $attachmentRepository,
         private TaskRepository $taskRepository,
@@ -155,6 +159,8 @@ readonly class BandSpaceFileAttachProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Chanson introuvable');
         }
 
+        $this->songWriteGuard->assertWritable($song);
+
         return $song->title;
     }
 
@@ -164,6 +170,8 @@ readonly class BandSpaceFileAttachProcessor implements ProcessorInterface
         if (!$setlist instanceof \App\Entity\BandSpace\Setlist) {
             throw new NotFoundHttpException('Setlist introuvable');
         }
+
+        $this->setlistWriteGuard->assertWritable($setlist);
 
         return $setlist->name;
     }

--- a/src/State/Processor/BandSpace/File/BandSpaceSetlistFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceSetlistFileAttachProcessor.php
@@ -18,6 +18,7 @@ use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Repository\BandSpace\BandSpaceFileTagRepository;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SetlistWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\File\BandSpaceFileMimeAllowlist;
 use App\Service\BandSpace\File\BandSpaceFileQuotaService;
@@ -40,6 +41,7 @@ readonly class BandSpaceSetlistFileAttachProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SetlistWriteGuard $setlistWriteGuard,
         private SetlistRepository $setlistRepository,
         private BandSpaceFolderRepository $folderRepository,
         private BandSpaceFileTagRepository $tagRepository,
@@ -65,6 +67,8 @@ readonly class BandSpaceSetlistFileAttachProcessor implements ProcessorInterface
         if (!$setlist instanceof \App\Entity\BandSpace\Setlist) {
             throw new NotFoundHttpException('Setlist introuvable');
         }
+
+        $this->setlistWriteGuard->assertWritable($setlist);
 
         $upload = $data->uploadedFile;
         if ($upload === null) {

--- a/src/State/Processor/BandSpace/File/BandSpaceSongFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceSongFileAttachProcessor.php
@@ -18,6 +18,7 @@ use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Repository\BandSpace\BandSpaceFileTagRepository;
 use App\Repository\BandSpace\SongRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SongWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\File\BandSpaceFileMimeAllowlist;
 use App\Service\BandSpace\File\BandSpaceFileQuotaService;
@@ -40,6 +41,7 @@ readonly class BandSpaceSongFileAttachProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SongWriteGuard $songWriteGuard,
         private SongRepository $songRepository,
         private BandSpaceFolderRepository $folderRepository,
         private BandSpaceFileTagRepository $tagRepository,
@@ -65,6 +67,8 @@ readonly class BandSpaceSongFileAttachProcessor implements ProcessorInterface
         if (!$song instanceof \App\Entity\BandSpace\Song) {
             throw new NotFoundHttpException('Chanson introuvable');
         }
+
+        $this->songWriteGuard->assertWritable($song);
 
         $upload = $data->uploadedFile;
         if ($upload === null) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistDuplicateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistDuplicateProcessor.php
@@ -5,16 +5,19 @@ namespace App\State\Processor\BandSpace\Setlist;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\BandSpace\Setlist\SetlistResource;
+use App\Entity\BandSpace\BandSpaceFileAttachment;
 use App\Entity\BandSpace\Setlist;
 use App\Entity\BandSpace\SetlistItem;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceSetlistActivityType;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\SetlistBuilder;
 use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -24,10 +27,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 readonly class SetlistDuplicateProcessor implements ProcessorInterface
 {
+    private const string ATTACHMENT_SOURCE_TYPE = 'setlist';
+
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private SetlistRepository $setlistRepository,
+        private BandSpaceFileAttachmentRepository $attachmentRepository,
         private BandSpaceActivityRecorder $activityRecorder,
         private SetlistBuilder $setlistBuilder,
         private Security $security,
@@ -43,6 +49,9 @@ readonly class SetlistDuplicateProcessor implements ProcessorInterface
 
         [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
+        // Deliberately not guarded by SetlistWriteGuard: an archived setlist is a valid source and
+        // duplicating it does not touch it. It is also the only way back out of the archive while
+        // there is no restore (#761), so refusing it here would strand the work for good.
         $source = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$source instanceof Setlist) {
             throw new NotFoundHttpException('Setlist introuvable');
@@ -69,6 +78,8 @@ readonly class SetlistDuplicateProcessor implements ProcessorInterface
             $copy->items->add($itemCopy);
         }
 
+        $this->copyFileAttachments($source, $copy, $user);
+
         $this->activityRecorder->record(
             bandSpace: $bandSpace,
             module: BandSpaceModule::Setlist,
@@ -81,5 +92,37 @@ readonly class SetlistDuplicateProcessor implements ProcessorInterface
         $this->entityManager->flush();
 
         return $this->setlistBuilder->buildItem($copy);
+    }
+
+    /**
+     * Points the copy at the same files as the source.
+     *
+     * An attachment is keyed by (sourceType, sourceId), so nothing follows a copy on its own: the
+     * lyric sheets and backing tracks of the gig would silently vanish from a list duplicated for
+     * the next one, which is the whole reason this endpoint exists. Only the attachment rows are
+     * cloned, never the files themselves, so this costs no storage and no quota.
+     *
+     * Attachments of the items are NOT cloned: an item points at a shared Song row, and song
+     * attachments hang on that song id, so the copy already reaches them through the same song.
+     * Cloning them would mean writing a second (song, same id) row, which the unique index refuses.
+     */
+    private function copyFileAttachments(Setlist $source, Setlist $copy, User $user): void
+    {
+        $sourceAttachments = $this->attachmentRepository->findActiveBySource(
+            self::ATTACHMENT_SOURCE_TYPE,
+            (string) $source->id,
+        );
+
+        foreach ($sourceAttachments as $sourceAttachment) {
+            $attachmentCopy = new BandSpaceFileAttachment();
+            $attachmentCopy->bandSpaceFile = $sourceAttachment->bandSpaceFile;
+            $attachmentCopy->sourceType = self::ATTACHMENT_SOURCE_TYPE;
+            $attachmentCopy->sourceId = Uuid::fromString((string) $copy->id);
+            // The duplicator, not whoever attached the original: this attachment was created now,
+            // and attachedDatetime already says so.
+            $attachmentCopy->attachedBy = $user;
+
+            $this->entityManager->persist($attachmentCopy);
+        }
     }
 }

--- a/src/State/Processor/BandSpace/Setlist/SetlistItemCreateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistItemCreateProcessor.php
@@ -16,6 +16,8 @@ use App\Enum\BandSpace\SetlistItemType;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Repository\BandSpace\SongRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SetlistWriteGuard;
+use App\Security\BandSpace\SongWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\SetlistItemBuilder;
 use Doctrine\ORM\EntityManagerInterface;
@@ -32,6 +34,8 @@ readonly class SetlistItemCreateProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SetlistWriteGuard $setlistWriteGuard,
+        private SongWriteGuard $songWriteGuard,
         private SetlistRepository $setlistRepository,
         private SongRepository $songRepository,
         private BandSpaceActivityRecorder $activityRecorder,
@@ -57,12 +61,20 @@ readonly class SetlistItemCreateProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Setlist introuvable');
         }
 
+        $this->setlistWriteGuard->assertWritable($setlist);
+
         $song = null;
         if ($data->type === SetlistItemType::Song) {
             $song = $this->songRepository->findOneByIdAndBandSpace((string) $data->songId, $bandSpace);
             if (!$song instanceof Song) {
                 throw new UnprocessableEntityHttpException('La chanson référencée n\'appartient pas à ce Band Space');
             }
+
+            // A song retired from the repertoire cannot start a new life as a fresh item. The
+            // picker never offers one, so this only closes the direct call. Items that predate the
+            // archiving keep working: they are read, never recreated, and duplicating a setlist
+            // copies the song reference straight across instead of coming through here.
+            $this->songWriteGuard->assertWritable($song);
         }
 
         // Type is non-null by Assert\NotNull on SetlistItemCreate; narrow for PHPStan.

--- a/src/State/Processor/BandSpace/Setlist/SetlistItemDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistItemDeleteProcessor.php
@@ -13,6 +13,7 @@ use App\Enum\BandSpace\BandSpaceSetlistActivityType;
 use App\Repository\BandSpace\SetlistItemRepository;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SetlistWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -27,6 +28,7 @@ readonly class SetlistItemDeleteProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SetlistWriteGuard $setlistWriteGuard,
         private SetlistRepository $setlistRepository,
         private SetlistItemRepository $setlistItemRepository,
         private BandSpaceActivityRecorder $activityRecorder,
@@ -53,6 +55,8 @@ readonly class SetlistItemDeleteProcessor implements ProcessorInterface
         if (!$setlist instanceof Setlist) {
             throw new NotFoundHttpException('Setlist introuvable');
         }
+
+        $this->setlistWriteGuard->assertWritable($setlist);
 
         $item = $this->setlistItemRepository->findOneByIdAndSetlist((string) $uriVariables['id'], $setlist);
         if (!$item instanceof SetlistItem) {

--- a/src/State/Processor/BandSpace/Setlist/SetlistItemUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistItemUpdateProcessor.php
@@ -13,6 +13,7 @@ use App\Enum\BandSpace\BandSpaceSetlistActivityType;
 use App\Repository\BandSpace\SetlistItemRepository;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SetlistWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\SetlistItemBuilder;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,14 +26,15 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *
  * Update of item-level fields only (label/durationOverride/note/transition).
  * Type and song are immutable post-creation: callers must delete + recreate to
- * change them, which keeps the create-time validator (type/songId/label combo)
- * the single source of consistency truth.
+ * change them. The label still has to match the type, so ValidSetlistItemPayload
+ * sits on SetlistItemResource as well and has already run by the time we get here.
  */
 readonly class SetlistItemUpdateProcessor implements ProcessorInterface
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SetlistWriteGuard $setlistWriteGuard,
         private SetlistRepository $setlistRepository,
         private SetlistItemRepository $setlistItemRepository,
         private BandSpaceActivityRecorder $activityRecorder,
@@ -58,14 +60,15 @@ readonly class SetlistItemUpdateProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Setlist introuvable');
         }
 
+        $this->setlistWriteGuard->assertWritable($setlist);
+
         $item = $this->setlistItemRepository->findOneByIdAndSetlist((string) $uriVariables['id'], $setlist);
         if (!$item instanceof SetlistItem) {
             throw new NotFoundHttpException('Item introuvable');
         }
 
-        // Label is a snapshot/display field on any item type; create-time validator
-        // already gates the song/label exclusivity, so PATCH just stores whatever
-        // the client sends.
+        // ValidSetlistItemPayload has already checked the label against the type, so what
+        // arrives here is either a filled label on a non-song row or nothing on a song row.
         $item->label = $data->label;
         $item->durationOverride = $data->durationOverride;
         $item->note = $data->note;

--- a/src/State/Processor/BandSpace/Setlist/SetlistReorderProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistReorderProcessor.php
@@ -13,6 +13,7 @@ use App\Enum\BandSpace\BandSpaceSetlistActivityType;
 use App\Repository\BandSpace\SetlistItemRepository;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SetlistWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -29,6 +30,7 @@ readonly class SetlistReorderProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SetlistWriteGuard $setlistWriteGuard,
         private SetlistRepository $setlistRepository,
         private SetlistItemRepository $itemRepository,
         private BandSpaceActivityRecorder $activityRecorder,
@@ -52,6 +54,8 @@ readonly class SetlistReorderProcessor implements ProcessorInterface
         if (!$setlist instanceof Setlist) {
             throw new NotFoundHttpException('Setlist introuvable');
         }
+
+        $this->setlistWriteGuard->assertWritable($setlist);
 
         $requestedIds = array_column($data->positions, 'id');
         $foundItems = $this->itemRepository->findByIdsAndSetlist($requestedIds, $setlist);

--- a/src/State/Processor/BandSpace/Setlist/SetlistUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistUpdateProcessor.php
@@ -11,6 +11,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceSetlistActivityType;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SetlistWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\SetlistBuilder;
 use DateTime;
@@ -27,6 +28,7 @@ readonly class SetlistUpdateProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SetlistWriteGuard $setlistWriteGuard,
         private SetlistRepository $setlistRepository,
         private BandSpaceActivityRecorder $activityRecorder,
         private SetlistBuilder $setlistBuilder,
@@ -54,6 +56,8 @@ readonly class SetlistUpdateProcessor implements ProcessorInterface
         if (!$setlist instanceof Setlist) {
             throw new NotFoundHttpException('Setlist introuvable');
         }
+
+        $this->setlistWriteGuard->assertWritable($setlist);
 
         $setlist->name = $data->name;
         $setlist->updateDatetime = new DateTime();

--- a/src/State/Processor/BandSpace/Setlist/Song/SongUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/Song/SongUpdateProcessor.php
@@ -11,6 +11,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceSetlistActivityType;
 use App\Repository\BandSpace\SongRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\SongWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\SongBuilder;
 use DateTime;
@@ -27,6 +28,7 @@ readonly class SongUpdateProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private SongWriteGuard $songWriteGuard,
         private SongRepository $songRepository,
         private BandSpaceActivityRecorder $activityRecorder,
         private SongBuilder $songBuilder,
@@ -50,6 +52,8 @@ readonly class SongUpdateProcessor implements ProcessorInterface
         if (!$song instanceof Song) {
             throw new NotFoundHttpException('Chanson introuvable');
         }
+
+        $this->songWriteGuard->assertWritable($song);
 
         $song->title = $data->title;
         $song->tempo = $data->tempo;

--- a/src/Validator/BandSpace/Setlist/ValidSetlistItemPayloadValidator.php
+++ b/src/Validator/BandSpace/Setlist/ValidSetlistItemPayloadValidator.php
@@ -3,11 +3,21 @@
 namespace App\Validator\BandSpace\Setlist;
 
 use App\ApiResource\BandSpace\Setlist\SetlistItemCreate;
+use App\ApiResource\BandSpace\Setlist\SetlistItemResource;
 use App\Enum\BandSpace\SetlistItemType;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
+/**
+ * Guards the type/song/label combination on both write paths.
+ *
+ * Creation is the richer one, because it is the only place song_id is settable. Update carries no
+ * song_id at all (type and song are immutable once the item exists), so only the label rule can
+ * still be broken there, and it is the one that matters: emptying the label of a pause or an MC
+ * slot leaves a row that renders as a bare dash in the editor, in live mode and on the printed
+ * sheet, with no way back other than delete and recreate.
+ */
 class ValidSetlistItemPayloadValidator extends ConstraintValidator
 {
     public function validate(mixed $value, Constraint $constraint): void
@@ -16,27 +26,29 @@ class ValidSetlistItemPayloadValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, ValidSetlistItemPayload::class);
         }
 
-        if (!$value instanceof SetlistItemCreate) {
-            return;
-        }
-
-        // Type is required by Assert\NotNull on the property - skip combo checks if absent.
-        if ($value->type === null) {
-            return;
-        }
-
-        $isSong = $value->type === SetlistItemType::Song;
-        $labelTrimmed = $value->label !== null ? trim($value->label) : '';
-        $hasLabel = $labelTrimmed !== '';
-        $hasSongId = $value->songId !== null && trim($value->songId) !== '';
-
-        if ($isSong) {
-            if (!$hasSongId) {
-                $this->context->buildViolation($constraint->songIdRequiredMessage)
-                    ->atPath('song_id')
-                    ->setCode(ValidSetlistItemPayload::ERROR_CODE)
-                    ->addViolation();
+        if ($value instanceof SetlistItemCreate) {
+            // Type is required by Assert\NotNull on the property - skip combo checks if absent.
+            if ($value->type === null) {
+                return;
             }
+
+            $this->validateLabel($value->type, $value->label, $constraint);
+            $this->validateSongId($value->type, $value->songId, $constraint);
+
+            return;
+        }
+
+        if ($value instanceof SetlistItemResource) {
+            // Hydrated by the provider before the patch is applied, so the type is always there.
+            $this->validateLabel($value->type, $value->label, $constraint);
+        }
+    }
+
+    private function validateLabel(SetlistItemType $type, ?string $label, ValidSetlistItemPayload $constraint): void
+    {
+        $hasLabel = $this->isFilled($label);
+
+        if ($type === SetlistItemType::Song) {
             if ($hasLabel) {
                 $this->context->buildViolation($constraint->labelForbiddenMessage)
                     ->atPath('label')
@@ -54,11 +66,33 @@ class ValidSetlistItemPayloadValidator extends ConstraintValidator
                 ->setCode(ValidSetlistItemPayload::ERROR_CODE)
                 ->addViolation();
         }
+    }
+
+    private function validateSongId(SetlistItemType $type, ?string $songId, ValidSetlistItemPayload $constraint): void
+    {
+        $hasSongId = $this->isFilled($songId);
+
+        if ($type === SetlistItemType::Song) {
+            if (!$hasSongId) {
+                $this->context->buildViolation($constraint->songIdRequiredMessage)
+                    ->atPath('song_id')
+                    ->setCode(ValidSetlistItemPayload::ERROR_CODE)
+                    ->addViolation();
+            }
+
+            return;
+        }
+
         if ($hasSongId) {
             $this->context->buildViolation($constraint->songIdForbiddenMessage)
                 ->atPath('song_id')
                 ->setCode(ValidSetlistItemPayload::ERROR_CODE)
                 ->addViolation();
         }
+    }
+
+    private function isFilled(?string $value): bool
+    {
+        return $value !== null && trim($value) !== '';
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceSetlistFileAttachTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceSetlistFileAttachTest.php
@@ -239,4 +239,49 @@ class BandSpaceSetlistFileAttachTest extends ApiTestCase
             'description' => "Vous n'êtes pas membre de ce Band Space",
         ]);
     }
+
+    /**
+     * Uploading into an archived setlist would file a document under a list nobody can see, and
+     * the quota would still be spent on it. Detaching stays open: that is how a file gets freed.
+     */
+    public function test_attach_to_an_archived_setlist_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $setlist = SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Concert 12/06',
+            'archiveDatetime' => new \DateTimeImmutable('2026-06-13T09:00:00+00:00'),
+        ])->create();
+
+        $upload = new UploadedFile(__DIR__ . '/fixtures/sample.txt', 'sample.txt', 'text/plain', null, true);
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/files',
+            [],
+            ['uploadedFile' => $upload],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cette setlist est archivée, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cette setlist est archivée, les modifications sont désactivées',
+        ]);
+
+        $this->assertCount(
+            0,
+            self::getContainer()->get(BandSpaceFileRepository::class)->findBy(['bandSpace' => $bandSpace->id]),
+        );
+    }
 }

--- a/tests/Api/BandSpace/File/BandSpaceSongFileAttachTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceSongFileAttachTest.php
@@ -243,4 +243,49 @@ class BandSpaceSongFileAttachTest extends ApiTestCase
             'description' => "Vous n'êtes pas membre de ce Band Space",
         ]);
     }
+
+    /**
+     * Same rule one level down: a song the band has retired takes no new document, while detaching
+     * one already attached stays possible.
+     */
+    public function test_attach_to_an_archived_song_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $song = SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Retirée du répertoire',
+            'archiveDatetime' => new \DateTimeImmutable('2026-06-13T09:00:00+00:00'),
+        ])->create();
+
+        $upload = new UploadedFile(__DIR__ . '/fixtures/sample.txt', 'sample.txt', 'text/plain', null, true);
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/songs/' . $song->id . '/files',
+            [],
+            ['uploadedFile' => $upload],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cette chanson est archivée, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cette chanson est archivée, les modifications sont désactivées',
+        ]);
+
+        $this->assertCount(
+            0,
+            self::getContainer()->get(BandSpaceFileRepository::class)->findBy(['bandSpace' => $bandSpace->id]),
+        );
+    }
 }

--- a/tests/Api/BandSpace/Setlist/SetlistArchivedWriteGuardTest.php
+++ b/tests/Api/BandSpace/Setlist/SetlistArchivedWriteGuardTest.php
@@ -1,0 +1,330 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Setlist;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\Setlist;
+use App\Enum\BandSpace\SetlistItemType;
+use App\Repository\BandSpace\SetlistItemRepository;
+use App\Repository\BandSpace\SetlistRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\SetlistFactory;
+use App\Tests\Factory\BandSpace\SetlistItemFactory;
+use App\Tests\Factory\BandSpace\SongFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * Archiving a setlist used to hide it and nothing more: the finder behind every write returns
+ * archived rows on purpose, so a member who still had the list open, or who came back through a
+ * bookmarked ?setlist=<id>, could rename it and rework its programme, every request answered with
+ * a 200, into a row nobody can see and nothing can restore.
+ *
+ * Reads have to keep working, so each refusal is paired with proof the row is still readable and
+ * still duplicable, which is the only way back out of the archive today.
+ */
+#[ResetDatabase]
+class SetlistArchivedWriteGuardTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+    private const array PATCH_HEADERS = ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    private const string ARCHIVED_DETAIL = 'Cette setlist est archivée, les modifications sont désactivées';
+
+    public function test_renaming_an_archived_setlist_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $setlistId = (string) $setlist->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlistId,
+            ['name' => 'Concert 19/06'],
+            self::PATCH_HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => self::ARCHIVED_DETAIL,
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => self::ARCHIVED_DETAIL,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistRepository::class)->find($setlistId);
+        $this->assertSame('Concert 12/06', $stored?->name);
+    }
+
+    public function test_adding_an_item_to_an_archived_setlist_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $setlistId = (string) $setlist->id;
+        $song = SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Trop tard'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlistId . '/items',
+            ['type' => 'song', 'song_id' => (string) $song->id],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => self::ARCHIVED_DETAIL,
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => self::ARCHIVED_DETAIL,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistRepository::class)->find($setlistId);
+        $this->assertCount(0, $stored->items);
+    }
+
+    public function test_editing_an_item_of_an_archived_setlist_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $item = SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Talk,
+            'label' => 'Présentation du groupe',
+            'position' => 0,
+        ])->create();
+        $itemId = (string) $item->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $itemId,
+            ['label' => 'Modifié malgré tout'],
+            self::PATCH_HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => self::ARCHIVED_DETAIL,
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => self::ARCHIVED_DETAIL,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistItemRepository::class)->find($itemId);
+        $this->assertSame('Présentation du groupe', $stored?->label);
+    }
+
+    public function test_removing_an_item_of_an_archived_setlist_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $item = SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Talk,
+            'label' => 'Présentation du groupe',
+            'position' => 0,
+        ])->create();
+        $itemId = (string) $item->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $itemId,
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => self::ARCHIVED_DETAIL,
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => self::ARCHIVED_DETAIL,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $this->assertNotNull(self::getContainer()->get(SetlistItemRepository::class)->find($itemId));
+    }
+
+    public function test_reordering_an_archived_setlist_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $first = SetlistItemFactory::new(['setlist' => $setlist, 'type' => SetlistItemType::Talk, 'label' => 'Un', 'position' => 0])->create();
+        $second = SetlistItemFactory::new(['setlist' => $setlist, 'type' => SetlistItemType::Talk, 'label' => 'Deux', 'position' => 1])->create();
+        $firstId = (string) $first->id;
+        $secondId = (string) $second->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/reorder',
+            ['positions' => [
+                ['id' => $secondId, 'position' => 0],
+                ['id' => $firstId, 'position' => 1],
+            ]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => self::ARCHIVED_DETAIL,
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => self::ARCHIVED_DETAIL,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $itemRepository = self::getContainer()->get(SetlistItemRepository::class);
+        $this->assertSame(0, $itemRepository->find($firstId)?->position);
+        $this->assertSame(1, $itemRepository->find($secondId)?->position);
+    }
+
+    /**
+     * The finder is shared with every write path, so the guard had to be put on the writes rather
+     * than in the query. This is the half that must NOT change: an archived setlist is still read,
+     * because that is how last year's PDF gets exported.
+     */
+    public function test_an_archived_setlist_is_still_readable(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Concert 12/06',
+            'creationDatetime' => new DateTime('2026-06-01T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-06-13T09:00:00+00:00'),
+        ])->create();
+        $item = SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Break,
+            'label' => 'Pause',
+            'durationOverride' => 300,
+            'position' => 0,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Setlist',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id,
+            '@type' => 'Setlist',
+            'id' => $setlist->id,
+            'band_space_id' => $bandSpace->id,
+            'name' => 'Concert 12/06',
+            'archive_datetime' => $setlist->archiveDatetime->format(\DateTimeInterface::ATOM),
+            'creation_datetime' => $setlist->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => null,
+            'items' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $item->id,
+                    '@type' => 'SetlistItem',
+                    'id' => $item->id,
+                    'band_space_id' => $bandSpace->id,
+                    'setlist_id' => $setlist->id,
+                    'type' => 'break',
+                    'song' => null,
+                    'label' => 'Pause',
+                    'duration_override' => 300,
+                    'note' => null,
+                    'transition' => null,
+                    'position' => 0,
+                ],
+            ],
+            'total_duration_seconds' => 300,
+        ]);
+    }
+
+    /**
+     * Duplicating reads the archived list without touching it, and with no restore yet (#761) it is
+     * the only way to get the work back, so the guard must never catch it.
+     */
+    public function test_an_archived_setlist_can_still_be_duplicated(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Talk,
+            'label' => 'Présentation du groupe',
+            'position' => 0,
+        ])->create();
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/setlists/' . $setlist->id . '/duplicate',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $reloadedBand = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceRepository::class)->find($bandSpaceId);
+        $live = self::getContainer()->get(SetlistRepository::class)->findByBandSpace($reloadedBand);
+        $this->assertCount(1, $live, 'The copy is a live setlist, the archived source stays hidden');
+        $this->assertSame('Concert 12/06 (copie)', $live[0]->name);
+        $this->assertCount(1, $live[0]->items);
+    }
+
+    private function archivedSetlist(BandSpace $bandSpace, string $name): Setlist
+    {
+        return SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => $name,
+            'creationDatetime' => new DateTime('2026-06-01T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-06-13T09:00:00+00:00'),
+        ])->create();
+    }
+}

--- a/tests/Api/BandSpace/Setlist/SetlistDuplicateTest.php
+++ b/tests/Api/BandSpace/Setlist/SetlistDuplicateTest.php
@@ -5,11 +5,13 @@ namespace App\Tests\Api\BandSpace\Setlist;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\SetlistItemType;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\SetlistRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
 use App\Tests\Factory\BandSpace\SetlistFactory;
 use App\Tests\Factory\BandSpace\SetlistItemFactory;
 use App\Tests\Factory\BandSpace\SongFactory;
@@ -91,6 +93,124 @@ class SetlistDuplicateTest extends ApiTestCase
         $activities = $activityRepo->findForResource($reloadedBand, BandSpaceModule::Setlist, (string) $copy->id);
         $this->assertCount(1, $activities);
         $this->assertSame('setlist_duplicated', $activities[0]->type);
+    }
+
+    /**
+     * A duplicate exists to build the next gig from the last one, and the lyric sheets and backing
+     * tracks are half of what makes the list usable. Attachments are keyed by (sourceType,
+     * sourceId), so nothing follows the copy on its own and they used to vanish from it silently.
+     * Only the attachment rows are cloned, the files themselves stay shared.
+     */
+    public function test_duplicate_carries_the_file_attachments_over(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $source = SetlistFactory::new(['bandSpace' => $bandSpace, 'name' => 'Original'])->create();
+        $sourceId = (string) $source->id;
+
+        $lyrics = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'originalName' => 'paroles.pdf'])
+            ->withAttachment(['type' => 'setlist', 'id' => $sourceId])
+            ->create();
+        $backingTrack = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'originalName' => 'playback.mp3'])
+            ->withAttachment(['type' => 'setlist', 'id' => $sourceId])
+            ->create();
+
+        // Attached to another setlist, so it must not follow this copy.
+        $otherSetlist = SetlistFactory::new(['bandSpace' => $bandSpace, 'name' => 'Autre'])->create();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'originalName' => 'ailleurs.pdf'])
+            ->withAttachment(['type' => 'setlist', 'id' => (string) $otherSetlist->id])
+            ->create();
+
+        // Trashed file: the copy has no reason to carry a document nobody can open any more.
+        BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'originalName' => 'corbeille.pdf',
+            'archiveDatetime' => new \DateTimeImmutable('2026-06-01T10:00:00+00:00'),
+        ])
+            ->withAttachment(['type' => 'setlist', 'id' => $sourceId])
+            ->create();
+
+        $lyricsId = (string) $lyrics->id;
+        $backingTrackId = (string) $backingTrack->id;
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/setlists/' . $sourceId . '/duplicate',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $copyId = $this->getResponseAsArray()['id'];
+        $this->assertNotSame($sourceId, $copyId);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $attachmentRepository = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+
+        $copiedFileIds = array_map(
+            static fn ($attachment): string => (string) $attachment->bandSpaceFile->id,
+            $attachmentRepository->findActiveBySource('setlist', $copyId),
+        );
+        sort($copiedFileIds);
+        $expectedFileIds = [$lyricsId, $backingTrackId];
+        sort($expectedFileIds);
+        $this->assertSame($expectedFileIds, $copiedFileIds);
+
+        // The source keeps its own rows: the copy points at the same files, it does not steal them.
+        $this->assertCount(3, $attachmentRepository->findBySource('setlist', [$sourceId]));
+    }
+
+    /**
+     * The other side of refusing an archived song at item creation: a band archives a song, then
+     * duplicates last season's list to build the next one. The copy assigns the song reference
+     * straight across instead of going through the create path, and it has to stay that way, or
+     * archiving one song would quietly cost the band every setlist that still contains it.
+     */
+    public function test_duplicate_keeps_an_item_pointing_at_an_archived_song(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $source = SetlistFactory::new(['bandSpace' => $bandSpace, 'name' => 'Saison passée'])->create();
+        $sourceId = (string) $source->id;
+
+        $archivedSong = SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Retirée du répertoire',
+            'archiveDatetime' => new \DateTimeImmutable('2026-06-13T09:00:00+00:00'),
+        ])->create();
+        $archivedSongId = (string) $archivedSong->id;
+
+        SetlistItemFactory::new([
+            'setlist' => $source,
+            'type' => SetlistItemType::Song,
+            'song' => $archivedSong,
+            'label' => null,
+            'position' => 0,
+        ])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/setlists/' . $sourceId . '/duplicate',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $copyId = $this->getResponseAsArray()['id'];
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $copy = self::getContainer()->get(SetlistRepository::class)->find($copyId);
+        $this->assertCount(1, $copy->items);
+        $this->assertSame($archivedSongId, (string) $copy->items->first()->song->id);
     }
 
     public function test_duplicate_not_member(): void

--- a/tests/Api/BandSpace/Setlist/SetlistItemCreateTest.php
+++ b/tests/Api/BandSpace/Setlist/SetlistItemCreateTest.php
@@ -353,4 +353,48 @@ class SetlistItemCreateTest extends ApiTestCase
             'description' => "Vous n'êtes pas membre de ce Band Space",
         ]);
     }
+    /**
+     * A song archived after a setlist was built keeps rendering in the items that already point at
+     * it, so the finder returns archived rows and the create path saw nothing wrong with a fresh
+     * reference to one. The picker never offers an archived song, so this closes the direct call
+     * only: "retired from the repertoire" now means the same thing to the API and to the interface.
+     */
+    public function test_create_song_item_referencing_an_archived_song_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = SetlistFactory::new(['bandSpace' => $bandSpace])->create();
+        $song = SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Retirée du répertoire',
+            'archiveDatetime' => new \DateTimeImmutable('2026-06-13T09:00:00+00:00'),
+        ])->create();
+        $setlistId = (string) $setlist->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlistId . '/items',
+            ['type' => 'song', 'song_id' => (string) $song->id],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cette chanson est archivée, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cette chanson est archivée, les modifications sont désactivées',
+        ]);
+
+        $this->assertCount(
+            0,
+            self::getContainer()->get(SetlistItemRepository::class)->findBy(['setlist' => $setlistId]),
+        );
+    }
 }

--- a/tests/Api/BandSpace/Setlist/SetlistItemUpdateTest.php
+++ b/tests/Api/BandSpace/Setlist/SetlistItemUpdateTest.php
@@ -12,7 +12,9 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\SetlistFactory;
 use App\Tests\Factory\BandSpace\SetlistItemFactory;
+use App\Tests\Factory\BandSpace\SongFactory;
 use App\Tests\Factory\User\UserFactory;
+use App\Validator\BandSpace\Setlist\ValidSetlistItemPayload;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -144,6 +146,212 @@ class SetlistItemUpdateTest extends ApiTestCase
             'status' => 403,
             'type' => '/errors/403',
             'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    /**
+     * The label is the only thing that names a pause or an MC slot. Emptying it left a row showing
+     * a bare dash in the editor, in live mode and on the printed sheet, and since the type and the
+     * song are immutable the only way back was to delete and recreate, losing the position, the
+     * note and the transition. Creation already refused it, the update now does too.
+     */
+    public function test_clearing_the_label_of_a_break_item_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = SetlistFactory::new(['bandSpace' => $bandSpace])->create();
+
+        $item = SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Break,
+            'label' => 'Pause',
+            'position' => 0,
+        ])->create();
+        $itemId = (string) $item->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $itemId,
+            ['label' => null],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . ValidSetlistItemPayload::ERROR_CODE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'label',
+                    'message' => "Un libellé est requis pour ce type d'item",
+                    'code' => ValidSetlistItemPayload::ERROR_CODE,
+                ],
+            ],
+            'detail' => "label: Un libellé est requis pour ce type d'item",
+            'type' => '/validation_errors/' . ValidSetlistItemPayload::ERROR_CODE,
+            'title' => 'An error occurred',
+            'description' => "label: Un libellé est requis pour ce type d'item",
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistItemRepository::class)->find($itemId);
+        $this->assertSame('Pause', $stored?->label);
+    }
+
+    /** Whitespace is not a label: the row would still print as a blank line. */
+    public function test_blanking_the_label_of_a_talk_item_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = SetlistFactory::new(['bandSpace' => $bandSpace])->create();
+
+        $item = SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Talk,
+            'label' => 'Présentation du groupe',
+            'position' => 0,
+        ])->create();
+        $itemId = (string) $item->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $itemId,
+            ['label' => '   '],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . ValidSetlistItemPayload::ERROR_CODE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'label',
+                    'message' => "Un libellé est requis pour ce type d'item",
+                    'code' => ValidSetlistItemPayload::ERROR_CODE,
+                ],
+            ],
+            'detail' => "label: Un libellé est requis pour ce type d'item",
+            'type' => '/validation_errors/' . ValidSetlistItemPayload::ERROR_CODE,
+            'title' => 'An error occurred',
+            'description' => "label: Un libellé est requis pour ce type d'item",
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistItemRepository::class)->find($itemId);
+        $this->assertSame('Présentation du groupe', $stored?->label);
+    }
+
+    /** The other half of the same rule, mirrored from creation: a song row is named by its song. */
+    public function test_labelling_a_song_item_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = SetlistFactory::new(['bandSpace' => $bandSpace])->create();
+        $song = SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Le titre'])->create();
+
+        $item = SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Song,
+            'song' => $song,
+            'label' => null,
+            'position' => 0,
+        ])->create();
+        $itemId = (string) $item->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $itemId,
+            ['label' => 'Un autre nom'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . ValidSetlistItemPayload::ERROR_CODE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'label',
+                    'message' => "Le champ label n'est pas autorisé pour un item de type 'song'",
+                    'code' => ValidSetlistItemPayload::ERROR_CODE,
+                ],
+            ],
+            'detail' => "label: Le champ label n'est pas autorisé pour un item de type 'song'",
+            'type' => '/validation_errors/' . ValidSetlistItemPayload::ERROR_CODE,
+            'title' => 'An error occurred',
+            'description' => "label: Le champ label n'est pas autorisé pour un item de type 'song'",
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistItemRepository::class)->find($itemId);
+        $this->assertNull($stored?->label);
+    }
+
+    /**
+     * A song row keeps its null label untouched while the other fields change: the new rule must
+     * not turn every partial patch of a song item into a 422.
+     */
+    public function test_updating_a_song_item_without_touching_the_label_still_works(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $setlist = SetlistFactory::new(['bandSpace' => $bandSpace])->create();
+        $song = SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Le titre'])->create();
+
+        $item = SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Song,
+            'song' => $song,
+            'label' => null,
+            'position' => 0,
+        ])->create();
+        $itemId = (string) $item->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $itemId,
+            ['duration_override' => 210, 'note' => 'capo 2'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/SetlistItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $itemId,
+            '@type' => 'SetlistItem',
+            'id' => $itemId,
+            'band_space_id' => (string) $bandSpace->id,
+            'setlist_id' => (string) $setlist->id,
+            'type' => 'song',
+            'song' => [
+                'id' => (string) $song->id,
+                'title' => 'Le titre',
+                'tempo' => null,
+                'tonality' => null,
+                'reference_duration' => null,
+                'archive_datetime' => null,
+                '@type' => 'SetlistItemSongInfo',
+            ],
+            'label' => null,
+            'duration_override' => 210,
+            'note' => 'capo 2',
+            'transition' => null,
+            'position' => 0,
         ]);
     }
 }

--- a/tests/Api/BandSpace/Setlist/Song/SongUpdateTest.php
+++ b/tests/Api/BandSpace/Setlist/Song/SongUpdateTest.php
@@ -186,4 +186,47 @@ class SongUpdateTest extends ApiTestCase
             'description' => "Vous n'êtes pas membre de ce Band Space",
         ]);
     }
+
+    /**
+     * The song finder returns archived rows on purpose, so a setlist item can still render the song
+     * it was built with. That left the edit endpoint open on a song the band has retired, and the
+     * write landed on a row the repertoire no longer lists.
+     */
+    public function test_update_an_archived_song_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $song = SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Retirée du répertoire',
+            'archiveDatetime' => new \DateTimeImmutable('2026-06-13T09:00:00+00:00'),
+        ])->create();
+        $songId = (string) $song->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/songs/' . $songId,
+            ['title' => 'Modifiée malgré tout'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cette chanson est archivée, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cette chanson est archivée, les modifications sont désactivées',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SongRepository::class)->find($songId);
+        $this->assertSame('Retirée du répertoire', $stored?->title);
+    }
 }


### PR DESCRIPTION
Closes #824 (items 1, 2, 4, 5). Item 3 (song notes on stage and in the PDF) was split to #863.

## Item 1: archived setlists and songs stayed fully writable

`SetlistRepository::findOneByIdAndBandSpace()` deliberately ignores `archiveDatetime`, which is right for reads (the PDF of last year gig, the activity log) but every write processor reused the same finder. So if A archived a list while B still had it open or bookmarked, B could rename it, add songs and export a PDF, each answered with a 200, into a row nobody can see and nothing can restore.

New `SetlistWriteGuard` and `SongWriteGuard`, same shape as the existing `BandSpaceWriteGuard` and `TechRiderWriteGuard`. The read finders are untouched and their docblocks now say they are read finders and that write paths must run the guard.

**Status code is 409, not the 422 the issue text asked for.** The two existing guards expressing the identical concept both return 409, and RFC 7231 puts 409 on a conflict with the resource current state while 422 is for an unprocessable payload, which reads oddly on the DELETE and reorder endpoints this guard also protects since they carry no body. All four guards in the codebase now agree. No functional impact: `handleApiError` keys off `violations.length` and neither status carries violations here.

Three paths are deliberately left unguarded, each documented at the call site: duplicate (reads the source without touching it, and with no restore yet it is the only way out of the archive), archive and delete (that is how a row gets there, already idempotent), and detach (frees a file rather than adding to an invisible list).

Review also found that `SetlistItemCreateProcessor` guarded the parent setlist but not the referenced song, so an archived song could still be added to a live list through a direct API call. Now guarded. The reasoning that decided it: with no restore built (#761), an archived song is permanently retired, so a fresh reference to it can never become valid. `SetlistDuplicateProcessor` assigns the song directly rather than routing through the create processor, so "archive a song then duplicate last season list" still works, and that boundary is now pinned by its own test so a future refactor cannot quietly propagate the guard there and cost a band every setlist containing an archived song.

Frontend: archived banner, rename disabled, add and archive hidden, drag disabled, read-only item cards and file drawer. Export, live mode and duplicate stay available.

## Item 2: live mode lost its place on any reload

`currentIndex` was the only position state and was never persisted, so a mobile tab eviction or an accidental refresh dropped the singer to track 1 of a 25-song set mid-show. Now persisted in sessionStorage keyed by setlist id, clamped against the current item count, with anything unusable reading as 0.

## Item 4: duplicating a setlist dropped its file attachments

Duplicate exists for per-gig versioning, so the lyric sheets and backing tracks silently vanished from the copy. Now clones the `sourceType=setlist` attachment rows onto the new id. No file is copied, so no storage or quota cost.

Per-item song attachments are deliberately **not** cloned: the copy items point at the same shared `Song` rows and song attachments hang on the song id, so the copy already reaches them, and a second `(file, song, same id)` row would violate the `uniq_attachment_file_source` index.

## Item 5: pause and MC items could be stripped of their label

The label/type validator existed only on the create DTO while the update processor wrote the label unconditionally, so clearing the label on a Pause row rendered a bare dash in the editor, in live mode and on the printed sheet, with no recovery since type and song are immutable. The existing constraint now covers the update path too.

## Verification

`tests/Api/BandSpace/Setlist/` and `File/` 302 passing, full suite green, PHPStan level 8 clean, npm test, Biome and build all clean.

## Note

This branch and #867 both add a method to `BandSpaceFileAttachmentRepository`, at different line ranges, so they should merge cleanly in either order.