### PR TITLE
Tasks: Terminé column drag, bulk error detail, mentions on edit, archived read only

### DIFF
--- a/assets/js/components/BandSpace/Task/TaskBulkActionBar.vue
+++ b/assets/js/components/BandSpace/Task/TaskBulkActionBar.vue
@@ -10,15 +10,20 @@
 
     <div class="w-px h-6 bg-surface-600"></div>
 
-    <Button
-      label="Archiver"
-      icon="pi pi-box"
-      size="small"
-      severity="secondary"
-      :loading="busy === 'archive'"
-      :disabled="!!busy"
-      @click="handleArchive"
-    />
+    <!-- The tooltip sits on the wrapper, since a disabled button fires no pointer event of its
+         own, and a tooltip carries no accessible name either, hence the sr-only twin. -->
+    <span v-tooltip.top="archiveBlockedReason">
+      <Button
+        label="Archiver"
+        icon="pi pi-box"
+        size="small"
+        severity="secondary"
+        :loading="busy === 'archive'"
+        :disabled="!!busy || archiveBlockers.length > 0"
+        @click="handleArchive"
+      />
+      <span v-if="archiveBlockedReason" class="sr-only">{{ archiveBlockedReason }}</span>
+    </span>
 
     <Button
       label="Catégorie"
@@ -76,15 +81,18 @@
       </div>
     </Popover>
 
-    <Button
-      label="Supprimer"
-      icon="pi pi-trash"
-      size="small"
-      severity="danger"
-      :loading="busy === 'delete'"
-      :disabled="!!busy"
-      @click="confirmDelete"
-    />
+    <span v-tooltip.top="deleteBlockedReason">
+      <Button
+        label="Supprimer"
+        icon="pi pi-trash"
+        size="small"
+        severity="danger"
+        :loading="busy === 'delete'"
+        :disabled="!!busy || deleteBlockers.length > 0"
+        @click="confirmDelete"
+      />
+      <span v-if="deleteBlockedReason" class="sr-only">{{ deleteBlockedReason }}</span>
+    </span>
 
     <div class="w-px h-6 bg-surface-600"></div>
 
@@ -109,8 +117,12 @@ import Select from 'primevue/select'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
+import { apiErrorDetail } from '../../../api/utils/apiErrorDetail.js'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
 import { useBandTasksStore } from '../../../store/bandSpace/bandSpaceTasks.js'
+import { useUserSecurityStore } from '../../../store/user/security.js'
 import { attachedFilesNotice } from '../../../utils/attachedFilesNotice.js'
+import { tasksBlockingArchive, tasksBlockingDelete } from '../../../utils/taskActions.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -119,6 +131,8 @@ const props = defineProps({
 })
 
 const tasksStore = useBandTasksStore()
+const userSecurityStore = useUserSecurityStore()
+const { isAdmin } = useBandSpaceNavigation()
 const toast = useToast()
 const confirm = useConfirm()
 
@@ -133,16 +147,46 @@ const categoryOptions = computed(() => [
   ...props.categories.map((c) => ({ label: c.name, value: c.id }))
 ])
 
+// Selection only happens on the board, so every ticked card is one of the loaded tasks.
+const selectedTasks = computed(() =>
+  tasksStore.tasks.filter((task) => tasksStore.selectedTaskIds.has(task.id))
+)
+
+const archiveBlockers = computed(() => tasksBlockingArchive(selectedTasks.value))
+
+const deleteBlockers = computed(() =>
+  tasksBlockingDelete(selectedTasks.value, userSecurityStore.userProfile?.id ?? null, isAdmin.value)
+)
+
+/**
+ * The batch is one transaction, so a single card in the way takes the whole selection down. Rather
+ * than let somebody run it and read a refusal, the button is greyed out and says which cards it is
+ * waiting on. The names are the point: with eight cards ticked, "une tâche n'est pas terminée" is
+ * not something a member can act on.
+ */
+const archiveBlockedReason = computed(() =>
+  archiveBlockers.value.length === 0
+    ? null
+    : `Seules les tâches terminées peuvent être archivées : ${archiveBlockers.value.join(', ')}`
+)
+
+const deleteBlockedReason = computed(() =>
+  deleteBlockers.value.length === 0
+    ? null
+    : `Seul le créateur ou un administrateur peut supprimer ces tâches : ${deleteBlockers.value.join(', ')}`
+)
+
 async function runBulk(name, fn) {
   busy.value = name
   try {
     await fn()
   } catch (e) {
+    // The refusal names the tasks that blocked the batch, which is the only part worth reading.
     toast.add({
       severity: 'error',
       summary: 'Action en lot impossible',
-      detail: e?.message ?? 'Erreur inconnue',
-      life: 5000
+      detail: apiErrorDetail(e, 'Une erreur est survenue'),
+      life: 8000
     })
   } finally {
     busy.value = null

--- a/assets/js/components/BandSpace/Task/TaskCategoryManager.vue
+++ b/assets/js/components/BandSpace/Task/TaskCategoryManager.vue
@@ -32,13 +32,14 @@
               {{ category.name }}
             </span>
             <Button
+              v-if="isAdmin"
               icon="pi pi-trash"
               text
               rounded
               size="small"
               severity="danger"
-              v-tooltip.left="'Supprimer'"
-              aria-label="Supprimer"
+              v-tooltip.left="`Supprimer la catégorie ${category.name}`"
+              :aria-label="`Supprimer la catégorie ${category.name}`"
               @click="handleDelete(category)"
             />
           </template>
@@ -76,6 +77,7 @@ import InputText from 'primevue/inputtext'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
 import { useBandTasksStore } from '../../../store/bandSpace/bandSpaceTasks.js'
 
 const props = defineProps({
@@ -87,6 +89,9 @@ const emit = defineEmits(['update:visible'])
 const confirm = useConfirm()
 const toast = useToast()
 const tasksStore = useBandTasksStore()
+// Creating and renaming a category is any member's, deleting one is an administrator's, so the
+// trash is the only control of this drawer that comes and goes with the role.
+const { isAdmin } = useBandSpaceNavigation()
 
 const visibleModel = computed({
   get: () => props.visible,

--- a/assets/js/components/BandSpace/Task/TaskColumn.vue
+++ b/assets/js/components/BandSpace/Task/TaskColumn.vue
@@ -1,7 +1,17 @@
 <template>
   <div class="flex-1 min-w-[280px] bg-surface-100 dark:bg-surface-800 rounded-xl p-3">
     <div class="flex items-center justify-between mb-3">
-      <h3 class="font-semibold text-sm text-surface-700 dark:text-surface-200">{{ label }}</h3>
+      <div class="flex items-center gap-1.5 min-w-0">
+        <h3 class="font-semibold text-sm text-surface-700 dark:text-surface-200">{{ label }}</h3>
+        <span
+          v-if="isDoneColumn"
+          class="text-surface-500 dark:text-surface-400"
+          v-tooltip.top="COMPLETION_ORDER_HINT"
+        >
+          <i class="pi pi-sort-amount-down text-xs" aria-hidden="true" />
+          <span class="sr-only">{{ COMPLETION_ORDER_HINT }}</span>
+        </span>
+      </div>
       <span class="text-xs text-surface-400 bg-surface-200 dark:bg-surface-700 rounded-full px-2 py-0.5">
         {{ tasks.length }}
       </span>
@@ -10,6 +20,7 @@
       v-model="localTasks"
       group="tasks"
       :animation="200"
+      :sort="!isDoneColumn"
       :disabled="tasksStore.isSelectionMode || tasksStore.isReorderDisabled"
       ghost-class="opacity-30"
       :data-status="status"
@@ -40,11 +51,15 @@
 import { computed, ref, watch } from 'vue'
 import { VueDraggable } from 'vue-draggable-plus'
 import { useBandTasksStore } from '../../../store/bandSpace/bandSpaceTasks.js'
+import { dropIndexForColumn, isCompletionOrderedColumn } from '../../../utils/taskOrdering.js'
 import TaskCard from './TaskCard.vue'
 
 const tasksStore = useBandTasksStore()
 
 const MAX_DONE_VISIBLE = 5
+
+const COMPLETION_ORDER_HINT =
+  'Classées par date de fin, les plus récentes en premier. Cette colonne ne se réordonne pas.'
 
 const props = defineProps({
   status: { type: String, required: true },
@@ -65,7 +80,7 @@ watch(
   }
 )
 
-const isDoneColumn = computed(() => props.status === 'done')
+const isDoneColumn = computed(() => isCompletionOrderedColumn(props.status))
 
 const visibleTasks = computed(() => {
   if (!isDoneColumn.value) return localTasks.value
@@ -89,6 +104,14 @@ function getCategoryColor(categoryId) {
 }
 
 function handleDragEnd(event) {
+  // v-model splices localTasks at the indices the drag reports, and those address the cards on
+  // screen. Here that is a re-sorted, cut-down view of the model, so a card leaving the column
+  // takes a different one out of it, and both the cards drawn and the "voir tout" button are built
+  // from what is left. The model is rebuilt from the board rather than trusted.
+  if (isDoneColumn.value) {
+    localTasks.value = [...props.tasks]
+  }
+
   const taskId = event.item?.dataset?.taskId
   if (!taskId) return
 
@@ -96,6 +119,11 @@ function handleDragEnd(event) {
   const toStatus = event.to?.dataset?.status
 
   if (fromStatus === toStatus) {
+    // Dragging inside a column drawn by completion date writes a position the column never reads
+    // back, so the gesture is dropped rather than persisted for the whole band. The cards do not
+    // move under the pointer either, since sorting is off there.
+    if (isDoneColumn.value) return
+
     // Same-column reorder: localTasks is already updated by v-model. It holds the column as this
     // member sees it, which a filter can cut down, so the store replays the drag against the
     // whole column before writing any position.
@@ -103,8 +131,9 @@ function handleDragEnd(event) {
     emit('reorder', props.status, visibleOrderedIds, taskId)
   } else {
     // Cross-column move: @end fires on the source column, so only the drop index is known here.
-    // The store resolves it against the whole destination column, hidden tasks included.
-    emit('status-change', taskId, toStatus, event.newIndex)
+    // The store resolves it against the whole destination column, hidden tasks included, unless
+    // the destination is the one whose drop points address nothing.
+    emit('status-change', taskId, toStatus, dropIndexForColumn(toStatus, event.newIndex))
   }
 }
 </script>

--- a/assets/js/components/BandSpace/Task/TaskCommentList.vue
+++ b/assets/js/components/BandSpace/Task/TaskCommentList.vue
@@ -92,7 +92,9 @@ import Avatar from '../../User/Avatar.vue'
 
 const props = defineProps({
   comments: { type: Array, default: () => [] },
-  members: { type: Array, default: () => [] }
+  members: { type: Array, default: () => [] },
+  // The thread of an archived task is history: it is still read, never written.
+  readOnly: { type: Boolean, default: false }
 })
 
 const emit = defineEmits(['edit', 'delete'])
@@ -114,10 +116,12 @@ const currentMember = computed(() => {
 const isBandSpaceAdmin = computed(() => currentMember.value?.role === 'admin')
 
 function canEdit(comment) {
+  if (props.readOnly) return false
   return currentUserId.value !== null && comment.author_id === currentUserId.value
 }
 
 function canDelete(comment) {
+  if (props.readOnly) return false
   return canEdit(comment) || isBandSpaceAdmin.value
 }
 

--- a/assets/js/components/BandSpace/Task/TaskDetail.vue
+++ b/assets/js/components/BandSpace/Task/TaskDetail.vue
@@ -24,11 +24,17 @@
     </div>
 
     <div v-else-if="task" class="flex flex-col gap-5">
+      <Message v-if="isArchived" severity="info" :closable="false">
+        Cette tâche est archivée, elle est en lecture seule. Désarchivez-la pour la modifier.
+      </Message>
+
       <!-- Title (inline edit, save on Enter or via Save button) -->
       <div>
         <input
           v-model="editTitle"
-          class="w-full text-lg font-semibold bg-transparent border-none outline-none text-surface-800 dark:text-surface-100 focus:ring-1 focus:ring-primary rounded px-1 -mx-1"
+          :readonly="isArchived"
+          aria-label="Titre de la tâche"
+          class="w-full text-lg font-semibold bg-transparent border-none outline-none text-surface-800 dark:text-surface-100 focus:ring-1 focus:ring-primary rounded px-1 -mx-1 read-only:text-surface-500 dark:read-only:text-surface-400"
           @keydown.enter.prevent="saveTextFields"
         />
       </div>
@@ -44,6 +50,7 @@
             optionValue="value"
             size="small"
             aria-label="Statut"
+            :disabled="isArchived"
             @change="saveField('status', editStatus)"
           />
         </div>
@@ -56,6 +63,7 @@
             optionValue="value"
             size="small"
             aria-label="Priorité"
+            :disabled="isArchived"
             @change="saveField('priority', editPriority)"
           />
         </div>
@@ -70,6 +78,7 @@
             showClear
             size="small"
             aria-label="Catégorie"
+            :disabled="isArchived"
             @change="saveField('category_id', editCategoryId)"
           />
         </div>
@@ -82,6 +91,7 @@
             showButtonBar
             size="small"
             aria-label="Échéance"
+            :disabled="isArchived"
             @date-select="saveDueDate"
             @clear-click="saveDueDate"
           />
@@ -100,6 +110,7 @@
           display="chip"
           size="small"
           aria-label="Assignés"
+          :disabled="isArchived"
           @change="saveAssignees"
         />
       </div>
@@ -119,11 +130,12 @@
           v-model="editDescription"
           rows="4"
           autoResize
-          placeholder="Ajouter une description..."
+          :placeholder="isArchived ? 'Aucune description' : 'Ajouter une description...'"
           class="text-sm"
           aria-label="Description"
+          :disabled="isArchived"
         />
-        <div class="flex justify-end gap-2">
+        <div v-if="!isArchived" class="flex justify-end gap-2">
           <Button
             v-if="hasTextChanges"
             label="Annuler"
@@ -152,6 +164,7 @@
         :band-space-id="bandSpaceId"
         source-type="task"
         :source-id="task.id"
+        :can-attach="!isArchived"
         @attached="tasksStore.bumpFileCount(task.id, 1)"
         @detached="tasksStore.bumpFileCount(task.id, -1)"
       />
@@ -161,13 +174,21 @@
 
       <!-- Comments -->
       <TaskCommentForm
+        v-if="!isArchived"
         :members="members"
         :is-submitting="isSubmittingComment"
         @submit="handleCommentSubmit"
       />
+      <h4
+        v-else
+        class="text-sm font-semibold text-surface-700 dark:text-surface-200"
+      >
+        Commentaires
+      </h4>
       <TaskCommentList
         :comments="comments"
         :members="members"
+        :read-only="isArchived"
         @edit="handleCommentEdit"
         @delete="handleCommentDelete"
       />
@@ -176,9 +197,12 @@
       <TaskActivityFeed :activities="activities" />
 
       <!-- Archive / Unarchive / Delete -->
-      <div class="border-t border-surface-200 dark:border-surface-700 pt-4 flex flex-col gap-2">
+      <div
+        v-if="canArchive || isArchived || canDelete"
+        class="border-t border-surface-200 dark:border-surface-700 pt-4 flex flex-col gap-2"
+      >
         <Button
-          v-if="task.status === 'done' && !task.archive_datetime"
+          v-if="canArchive"
           label="Archiver"
           severity="secondary"
           text
@@ -187,7 +211,7 @@
           @click="handleArchive"
         />
         <Button
-          v-if="task.archive_datetime"
+          v-if="isArchived"
           label="Désarchiver"
           severity="secondary"
           text
@@ -196,6 +220,7 @@
           @click="handleUnarchive"
         />
         <Button
+          v-if="canDelete"
           label="Supprimer la tâche"
           severity="danger"
           text
@@ -223,8 +248,11 @@ import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref, watch } from 'vue'
 import bandSpaceTasksApi from '../../../api/bandSpace/band-space-tasks.js'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
 import { useBandTasksStore } from '../../../store/bandSpace/bandSpaceTasks.js'
+import { useUserSecurityStore } from '../../../store/user/security.js'
 import { attachedFilesNotice } from '../../../utils/attachedFilesNotice.js'
+import { canDeleteTask } from '../../../utils/taskActions.js'
 import AttachedFilesSection from '../Files/AttachedFilesSection.vue'
 import TaskActivityFeed from './TaskActivityFeed.vue'
 import TaskCommentForm from './TaskCommentForm.vue'
@@ -240,6 +268,8 @@ const emit = defineEmits(['update:visible', 'deleted'])
 const confirm = useConfirm()
 const toast = useToast()
 const tasksStore = useBandTasksStore()
+const userSecurityStore = useUserSecurityStore()
+const { isAdmin } = useBandSpaceNavigation()
 
 const visibleModel = computed({
   get: () => props.visible,
@@ -249,6 +279,21 @@ const visibleModel = computed({
 const task = computed(() => tasksStore.activeTask)
 const categories = computed(() => tasksStore.categories)
 const members = computed(() => tasksStore.members)
+
+/**
+ * An archived task is a closed record and the API refuses every write to it, so the drawer opens
+ * read-only rather than offering fields that come back with a refusal. Unarchiving and deleting
+ * stay: neither edits the record, and taking the task back out is how it becomes editable again.
+ */
+const isArchived = computed(() => Boolean(task.value?.archive_datetime))
+
+const canArchive = computed(() => task.value?.status === 'done' && !isArchived.value)
+
+// Only the creator and an administrator get past TaskDeleteProcessor, so only they are offered the
+// button. Everyone else used to confirm a destructive dialog and read the refusal afterwards.
+const canDelete = computed(() =>
+  canDeleteTask(task.value, userSecurityStore.userProfile?.id ?? null, isAdmin.value)
+)
 
 const comments = ref([])
 const activities = ref([])

--- a/assets/js/store/bandSpace/bandSpaceTasks.js
+++ b/assets/js/store/bandSpace/bandSpaceTasks.js
@@ -212,7 +212,10 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
     isSaving.value = true
     try {
       const updated = await bandSpaceTasksApi.updateTask(bandSpaceId, taskId, data)
+      // Both lists, since the drawer reads whichever holds the task: an archived one written back
+      // only to `tasks` left the drawer showing what was there before the save it just confirmed.
       tasks.value = tasks.value.map((t) => (t.id === taskId ? updated : t))
+      archivedTasks.value = archivedTasks.value.map((t) => (t.id === taskId ? updated : t))
       return updated
     } finally {
       isSaving.value = false
@@ -283,6 +286,7 @@ export const useBandTasksStore = defineStore('bandTasks', () => {
     try {
       await bandSpaceTasksApi.deleteTask(bandSpaceId, taskId)
       tasks.value = tasks.value.filter((t) => t.id !== taskId)
+      archivedTasks.value = archivedTasks.value.filter((t) => t.id !== taskId)
     } finally {
       isDeleting.value = false
     }

--- a/assets/js/utils/taskActions.js
+++ b/assets/js/utils/taskActions.js
@@ -1,0 +1,60 @@
+/**
+ * Which task actions the API will accept, decided on the board's own data.
+ *
+ * Deleting a task is the creator's or an administrator's, and only a finished task can be
+ * archived. A bulk write is one transaction, so a single card in the way takes the whole selection
+ * with it: a member who ticked eight cards then reads a refusal that names none of them. Working
+ * it out here lets the board grey out what would be refused and say which cards are responsible,
+ * instead of letting somebody confirm a destructive dialog to find out. The server still has the
+ * last word; this only spares the round trip and the surprise.
+ */
+
+/** The only status the archive endpoint accepts. */
+const DONE_STATUS = 'done'
+
+/**
+ * Mirrors TaskDeleteProcessor: the task's creator, or an administrator of the band space.
+ *
+ * @param {{created_by_id?: string}} task
+ * @param {string|null} currentUserId
+ * @param {boolean} isAdmin Whether the current member administrates the band space.
+ * @returns {boolean}
+ */
+export function canDeleteTask(task, currentUserId, isAdmin) {
+  if (isAdmin) {
+    return true
+  }
+
+  return (
+    currentUserId !== null && currentUserId !== undefined && task?.created_by_id === currentUserId
+  )
+}
+
+/**
+ * The titles of the selected tasks a bulk delete would be refused over.
+ *
+ * @param {{title: string, created_by_id?: string}[]} tasks
+ * @param {string|null} currentUserId
+ * @param {boolean} isAdmin
+ * @returns {string[]}
+ */
+export function tasksBlockingDelete(tasks, currentUserId, isAdmin) {
+  return tasks
+    .filter((task) => !canDeleteTask(task, currentUserId, isAdmin))
+    .map((task) => task.title)
+}
+
+/**
+ * The titles of the selected tasks a bulk archive would be refused over.
+ *
+ * Mirrors TaskBulkPatchProcedure, down to leaving out a task that is already archived: archiving
+ * it again is a no-op there, never a refusal.
+ *
+ * @param {{title: string, status: string, archive_datetime?: string|null}[]} tasks
+ * @returns {string[]}
+ */
+export function tasksBlockingArchive(tasks) {
+  return tasks
+    .filter((task) => task.status !== DONE_STATUS && !task.archive_datetime)
+    .map((task) => task.title)
+}

--- a/assets/js/utils/taskActions.test.js
+++ b/assets/js/utils/taskActions.test.js
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { canDeleteTask, tasksBlockingArchive, tasksBlockingDelete } from './taskActions.js'
+
+/**
+ * These pin the rules the board reads off a task before offering a destructive button, so they
+ * cannot drift from the endpoints they mirror without a failing test.
+ *
+ * Run with `npm test`.
+ */
+
+const ALICE = 'user-alice'
+const BOB = 'user-bob'
+
+function task(overrides = {}) {
+  return {
+    id: 'task-1',
+    title: 'Mix final',
+    status: 'todo',
+    created_by_id: ALICE,
+    archive_datetime: null,
+    ...overrides
+  }
+}
+
+describe('canDeleteTask', () => {
+  it('lets the creator delete their own task', () => {
+    assert.equal(canDeleteTask(task({ created_by_id: ALICE }), ALICE, false), true)
+  })
+
+  it('refuses a member the task they did not create', () => {
+    assert.equal(canDeleteTask(task({ created_by_id: ALICE }), BOB, false), false)
+  })
+
+  it('lets an administrator delete anybody’s task', () => {
+    assert.equal(canDeleteTask(task({ created_by_id: ALICE }), BOB, true), true)
+  })
+
+  // The profile arrives with the session rather than with the board, so it can still be missing
+  // when the drawer first paints. Nobody is the creator until it lands.
+  it('refuses when the current user is not known yet', () => {
+    assert.equal(canDeleteTask(task({ created_by_id: ALICE }), null, false), false)
+    assert.equal(canDeleteTask(task({ created_by_id: undefined }), null, false), false)
+  })
+})
+
+describe('tasksBlockingDelete', () => {
+  it('names every task of the selection the member did not create', () => {
+    const selection = [
+      task({ title: 'Ma tâche', created_by_id: BOB }),
+      task({ title: 'Mix final', created_by_id: ALICE }),
+      task({ title: 'Réserver le studio', created_by_id: ALICE })
+    ]
+
+    assert.deepEqual(tasksBlockingDelete(selection, BOB, false), [
+      'Mix final',
+      'Réserver le studio'
+    ])
+  })
+
+  it('blocks nothing for an administrator', () => {
+    const selection = [task({ created_by_id: ALICE }), task({ created_by_id: BOB })]
+
+    assert.deepEqual(tasksBlockingDelete(selection, BOB, true), [])
+  })
+
+  it('blocks nothing when the whole selection is the member’s own', () => {
+    assert.deepEqual(tasksBlockingDelete([task({ created_by_id: BOB })], BOB, false), [])
+  })
+
+  it('blocks nothing on an empty selection', () => {
+    assert.deepEqual(tasksBlockingDelete([], BOB, false), [])
+  })
+})
+
+describe('tasksBlockingArchive', () => {
+  it('names every task of the selection that is not finished', () => {
+    const selection = [
+      task({ title: 'Mix final', status: 'done' }),
+      task({ title: 'Réserver le studio', status: 'todo' }),
+      task({ title: 'Écrire le pont', status: 'in_progress' })
+    ]
+
+    assert.deepEqual(tasksBlockingArchive(selection), ['Réserver le studio', 'Écrire le pont'])
+  })
+
+  // The server leaves an already archived task out of the blocking set, because archiving it a
+  // second time is a no-op there rather than a refusal.
+  it('leaves out a task that is already archived, whatever its status', () => {
+    const selection = [
+      task({
+        title: 'Master cassette',
+        status: 'todo',
+        archive_datetime: '2026-04-01T10:00:00+00:00'
+      })
+    ]
+
+    assert.deepEqual(tasksBlockingArchive(selection), [])
+  })
+
+  it('blocks nothing when the whole selection is finished', () => {
+    assert.deepEqual(tasksBlockingArchive([task({ status: 'done' })]), [])
+  })
+
+  it('blocks nothing on an empty selection', () => {
+    assert.deepEqual(tasksBlockingArchive([]), [])
+  })
+})

--- a/assets/js/utils/taskOrdering.js
+++ b/assets/js/utils/taskOrdering.js
@@ -75,3 +75,42 @@ export function orderColumnAfterDrag(fullOrderedIds, visibleOrderedIds, movedId)
 export function toPositions(orderedIds) {
   return orderedIds.map((id, index) => ({ id, position: index }))
 }
+
+/** The one column the board draws by completion date rather than by position. */
+const COMPLETION_ORDERED_STATUS = 'done'
+
+/**
+ * Whether the board draws this column in an order its stored positions do not carry.
+ *
+ * "Terminé" is drawn most recently finished first and cut to the few that fit, because the column
+ * has no pagination yet (#568). Its cards therefore sit in an order that owes nothing to their
+ * positions: a drag inside it reports indices into the list on screen while the write renumbers
+ * the list behind it, so a card nobody touched gets a new position for the whole band, and the
+ * re-sort that follows hides it. There is also no ordering worth saving there, since the column
+ * re-sorts whatever it is given, so it simply does not reorder.
+ *
+ * @param {string} status
+ * @returns {boolean}
+ */
+export function isCompletionOrderedColumn(status) {
+  return status === COMPLETION_ORDERED_STATUS
+}
+
+/**
+ * The index a card dropped into `status` should take, or null to append it to the column.
+ *
+ * A drop point inside a completion-ordered column says nothing about where the card belongs: it
+ * has just been finished, so it comes back at the top of that column whatever position it holds.
+ * Appending is the one placement that is honest about it.
+ *
+ * @param {string} status The destination column.
+ * @param {number|null|undefined} visibleIndex Where the card landed among the cards on screen.
+ * @returns {number|null}
+ */
+export function dropIndexForColumn(status, visibleIndex) {
+  if (isCompletionOrderedColumn(status)) {
+    return null
+  }
+
+  return visibleIndex ?? null
+}

--- a/assets/js/utils/taskOrdering.test.js
+++ b/assets/js/utils/taskOrdering.test.js
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { orderColumnAfterDrag, toPositions } from './taskOrdering.js'
+import {
+  dropIndexForColumn,
+  isCompletionOrderedColumn,
+  orderColumnAfterDrag,
+  toPositions
+} from './taskOrdering.js'
 
 /**
  * These pin the fix for the reorder corruption: a drag made inside a filtered column used to be
@@ -124,5 +129,41 @@ describe('toPositions', () => {
 
   it('returns an empty payload for an empty column', () => {
     assert.deepEqual(toPositions([]), [])
+  })
+})
+
+/**
+ * These pin the second reorder corruption, the one the filter fix above did not reach: the
+ * "Terminé" column renders its model re-sorted by completion date and cut to the most recent few,
+ * so the indices a drag reports there address a list the stored positions do not describe.
+ */
+describe('isCompletionOrderedColumn', () => {
+  it('reports the Terminé column, which is drawn by completion date', () => {
+    assert.equal(isCompletionOrderedColumn('done'), true)
+  })
+
+  it('reports the other columns, which are drawn by position', () => {
+    assert.equal(isCompletionOrderedColumn('todo'), false)
+    assert.equal(isCompletionOrderedColumn('in_progress'), false)
+  })
+})
+
+describe('dropIndexForColumn', () => {
+  it('drops the index of a card landing in Terminé, so the card is appended', () => {
+    assert.equal(dropIndexForColumn('done', 3), null)
+  })
+
+  it('drops the index even when the card lands first, which the top five cannot address either', () => {
+    assert.equal(dropIndexForColumn('done', 0), null)
+  })
+
+  it('keeps the index of a card landing in a column drawn by position', () => {
+    assert.equal(dropIndexForColumn('todo', 3), 3)
+    assert.equal(dropIndexForColumn('in_progress', 0), 0)
+  })
+
+  it('appends when the drag reported no index at all', () => {
+    assert.equal(dropIndexForColumn('todo', undefined), null)
+    assert.equal(dropIndexForColumn('todo', null), null)
   })
 })

--- a/assets/js/views/BandSpace/Tasks.vue
+++ b/assets/js/views/BandSpace/Tasks.vue
@@ -37,17 +37,28 @@
       <!-- Archived list view -->
       <div v-if="tasksStore.filters.showArchived">
         <div class="flex flex-col gap-2">
+          <!-- The row opens the drawer read-only: the description, the comments, the activity and
+               the attachments of an archived task were otherwise unreachable without taking it out
+               of the archive first. A button rather than a clickable div, so it is operable from
+               the keyboard without borrowing a role from the one sitting next to it. -->
           <div
             v-for="task in tasksStore.archivedTasks"
             :key="task.id"
             class="flex items-center justify-between p-3 rounded-lg bg-surface-0 dark:bg-surface-900 border border-surface-200 dark:border-surface-700"
           >
-            <div class="flex-1 min-w-0">
-              <p class="text-sm font-medium text-surface-800 dark:text-surface-100 truncate">{{ task.title }}</p>
-              <span class="text-xs text-surface-400">
+            <button
+              type="button"
+              class="flex-1 min-w-0 text-left rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+              :aria-label="`Ouvrir la tâche archivée ${task.title}`"
+              @click="handleOpenTask(task.id)"
+            >
+              <span class="block text-sm font-medium text-surface-800 dark:text-surface-100 truncate">
+                {{ task.title }}
+              </span>
+              <span class="block text-xs text-surface-400">
                 Archivée le {{ formatDate(task.archive_datetime) }}
               </span>
-            </div>
+            </button>
             <Button
               label="Désarchiver"
               icon="pi pi-replay"

--- a/src/Procedure/BandSpace/TaskBulkDeleteProcedure.php
+++ b/src/Procedure/BandSpace/TaskBulkDeleteProcedure.php
@@ -4,6 +4,7 @@ namespace App\Procedure\BandSpace;
 
 use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\BandSpace\Task;
 use App\Entity\User;
 use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\TaskRepository;
@@ -31,18 +32,14 @@ readonly class TaskBulkDeleteProcedure
         }
 
         $tasks = $this->taskRepository->findByIdsAndBandSpace($taskIds, $bandSpace);
-        $foundIds = array_map(fn(\App\Entity\BandSpace\Task $task): string => (string) $task->id, $tasks);
+        $foundIds = array_map(fn(Task $task): string => (string) $task->id, $tasks);
         $missing = array_diff($taskIds, $foundIds);
         if (count($missing) > 0) {
             throw new BadRequestHttpException(sprintf('Tâche %s introuvable dans ce Band Space', reset($missing)));
         }
 
-        $isAdmin = $membership->role === Role::Admin;
-        foreach ($tasks as $task) {
-            $isCreator = $task->createdBy !== null && $task->createdBy->id === $user->id;
-            if (!$isAdmin && !$isCreator) {
-                throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut supprimer ces tâches');
-            }
+        if ($membership->role !== Role::Admin) {
+            $this->assertEveryTaskIsOwnedBy($tasks, $user);
         }
 
         $titlesByTaskId = [];
@@ -57,5 +54,31 @@ readonly class TaskBulkDeleteProcedure
                 $this->entityManager->remove($task);
             }
         });
+    }
+
+    /**
+     * The batch is one transaction, so a single task somebody else created takes the whole selection
+     * down with it. Someone who ticked eight cards cannot act on that unless the answer says which
+     * ones are not theirs, hence the up-front pass: it names them instead of failing on whichever the
+     * loop reached first.
+     *
+     * @param Task[] $tasks
+     */
+    private function assertEveryTaskIsOwnedBy(array $tasks, User $user): void
+    {
+        $userId = (string) $user->id;
+        $foreign = array_filter(
+            $tasks,
+            static fn(Task $task): bool => !$task->createdBy instanceof User || (string) $task->createdBy->id !== $userId,
+        );
+
+        if ($foreign === []) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException(sprintf(
+            'Seul le créateur ou un administrateur peut supprimer ces tâches : %s',
+            implode(', ', array_map(static fn(Task $task): string => $task->title, $foreign)),
+        ));
     }
 }

--- a/src/Procedure/BandSpace/TaskBulkPatchProcedure.php
+++ b/src/Procedure/BandSpace/TaskBulkPatchProcedure.php
@@ -3,11 +3,15 @@
 namespace App\Procedure\BandSpace;
 
 use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\Task;
 use App\Entity\User;
+use App\Enum\BandSpace\TaskStatus;
 use App\Repository\BandSpace\TaskRepository;
 use App\Service\Builder\BandSpace\TaskBuilder;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 readonly class TaskBulkPatchProcedure
 {
@@ -30,10 +34,14 @@ readonly class TaskBulkPatchProcedure
         }
 
         $tasks = $this->taskRepository->findByIdsAndBandSpace($taskIds, $bandSpace);
-        $foundIds = array_map(fn(\App\Entity\BandSpace\Task $task): string => (string) $task->id, $tasks);
+        $foundIds = array_map(fn(Task $task): string => (string) $task->id, $tasks);
         $missing = array_diff($taskIds, $foundIds);
         if (count($missing) > 0) {
             throw new BadRequestHttpException(sprintf('Tâche %s introuvable dans ce Band Space', reset($missing)));
+        }
+
+        if (array_key_exists('archived', $patchPayload) && (bool) $patchPayload['archived']) {
+            $this->assertEveryTaskIsDone($tasks);
         }
 
         $this->entityManager->wrapInTransaction(function () use ($tasks, $patchPayload, $bandSpace, $user): void {
@@ -46,5 +54,32 @@ readonly class TaskBulkPatchProcedure
                 $this->taskUpdateProcedure->update($task, $patchPayload, $resource, $bandSpace, $user);
             }
         });
+    }
+
+    /**
+     * The batch is one transaction, so a single task that is not done takes the whole selection down
+     * with it. Somebody who ticked eight cards cannot act on that unless the answer says which ones
+     * are in the way, hence the up-front pass: it names them instead of failing on whichever the
+     * loop reached first.
+     *
+     * @param Task[] $tasks
+     */
+    private function assertEveryTaskIsDone(array $tasks): void
+    {
+        // An already archived task is left out: archiving it again is a no-op, never a refusal.
+        $blocking = array_filter(
+            $tasks,
+            static fn(Task $task): bool => $task->status !== TaskStatus::Done
+                && !$task->archiveDatetime instanceof DateTimeImmutable,
+        );
+
+        if ($blocking === []) {
+            return;
+        }
+
+        throw new UnprocessableEntityHttpException(sprintf(
+            'Seules les tâches terminées peuvent être archivées : %s',
+            implode(', ', array_map(static fn(Task $task): string => $task->title, $blocking)),
+        ));
     }
 }

--- a/src/Procedure/BandSpace/TaskUpdateProcedure.php
+++ b/src/Procedure/BandSpace/TaskUpdateProcedure.php
@@ -45,6 +45,8 @@ readonly class TaskUpdateProcedure
         BandSpace $bandSpace,
         User $user,
     ): Task {
+        $this->assertArchivedTaskIsReadOnly($task, $payload);
+
         if (array_key_exists('title', $payload)) {
             $task->title = $data->title;
         }
@@ -90,6 +92,28 @@ readonly class TaskUpdateProcedure
         }
 
         return $task;
+    }
+
+    /**
+     * An archived task is a closed record: archiving demands a task be done, so anything that could
+     * reopen it, its status first of all, would leave the archive holding something it would never
+     * have accepted. The board gives no way in, but a deep link to the drawer does, so the refusal
+     * belongs here rather than in the interface. Taking the task back out of the archive is the one
+     * write left, and everything is editable again once it is out.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private function assertArchivedTaskIsReadOnly(Task $task, array $payload): void
+    {
+        if (!$task->archiveDatetime instanceof DateTimeImmutable) {
+            return;
+        }
+
+        if (array_diff(array_keys($payload), ['archived']) === []) {
+            return;
+        }
+
+        throw new HttpException(422, 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier');
     }
 
     private function applyStatusChange(Task $task, string $newStatus, User $user): void

--- a/src/Repository/BandSpace/TaskRepository.php
+++ b/src/Repository/BandSpace/TaskRepository.php
@@ -159,6 +159,10 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
+     * The tasks come back in the order the ids were given. A bulk write applies them one by one and
+     * can refuse the whole batch over any of them, so the caller's own order is what makes a batch
+     * behave the same way twice and lets an answer name the tasks in the way they were selected.
+     *
      * @param string[] $ids
      * @return Task[]
      */
@@ -168,13 +172,19 @@ class TaskRepository extends ServiceEntityRepository
             return [];
         }
 
-        return $this->createQueryBuilder('t')
+        $tasks = $this->createQueryBuilder('t')
             ->where('t.id IN (:ids)')
             ->andWhere('t.bandSpace = :bandSpace')
             ->setParameter('ids', $ids)
             ->setParameter('bandSpace', $bandSpace)
             ->getQuery()
             ->getResult();
+
+        $rank = array_flip(array_values($ids));
+        usort($tasks, static fn(Task $a, Task $b): int
+            => ($rank[(string) $a->id] ?? PHP_INT_MAX) <=> ($rank[(string) $b->id] ?? PHP_INT_MAX));
+
+        return $tasks;
     }
 
     /**

--- a/src/Service/BandSpace/TaskCommentMentionRecorder.php
+++ b/src/Service/BandSpace/TaskCommentMentionRecorder.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+use App\Entity\BandSpace\Task;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceTaskActivityType;
+use App\Repository\UserRepository;
+
+/**
+ * Records the @-mentions a comment write adds, and hands back the members it named for the first
+ * time so the caller can notify them once its own flush has committed.
+ *
+ * Writing a comment and editing one mention people the same way, so both paths come through here.
+ * Only what the text did not already carry counts: the members a comment already named were told
+ * when that text was written, and an edit re-pinging the whole thread over a typo would be noise.
+ * Handing over the content the comment held before the write is what draws that line; a creation
+ * has none to hand over.
+ */
+readonly class TaskCommentMentionRecorder
+{
+    public function __construct(
+        private MentionParserService $mentionParserService,
+        private UserRepository $userRepository,
+        private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+    ) {
+    }
+
+    /**
+     * @return User[] the band space members this write mentions for the first time
+     */
+    public function recordNewMentions(
+        Task $task,
+        User $actor,
+        string $content,
+        string $previousContent = '',
+    ): array {
+        $newIds = array_diff($this->mentionedIds($content), $this->mentionedIds($previousContent));
+        if ($newIds === []) {
+            return [];
+        }
+
+        $mentionedMembers = $this->userRepository->findActiveBandSpaceMembersByIds(
+            $task->bandSpace,
+            array_values($newIds),
+        );
+
+        foreach ($mentionedMembers as $mentionedUser) {
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $task->bandSpace,
+                module: BandSpaceModule::Task,
+                type: BandSpaceTaskActivityType::Mention,
+                resourceId: $task->id,
+                actor: $actor,
+                payload: [
+                    'mentioned_user_id' => $mentionedUser->id,
+                    'mentioned_username' => $mentionedUser->username,
+                ],
+            );
+        }
+
+        return $mentionedMembers;
+    }
+
+    /**
+     * The mention syntax takes a uuid in either case, so the same member written two ways has to
+     * compare equal here or an edit would read them as two different people.
+     *
+     * @return string[]
+     */
+    private function mentionedIds(string $content): array
+    {
+        return array_map(strtolower(...), $this->mentionParserService->extractMentions($content));
+    }
+}

--- a/src/State/Processor/BandSpace/TaskCommentCreateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCommentCreateProcessor.php
@@ -13,10 +13,9 @@ use App\Enum\BandSpace\BandSpaceTaskActivityType;
 use App\Event\BandSpaceTaskCommentedEvent;
 use App\Event\BandSpaceTaskMentionedEvent;
 use App\Repository\BandSpace\TaskRepository;
-use App\Repository\UserRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
-use App\Service\BandSpace\MentionParserService;
+use App\Service\BandSpace\TaskCommentMentionRecorder;
 use App\Service\Builder\BandSpace\TaskCommentBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -33,8 +32,7 @@ readonly class TaskCommentCreateProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private TaskRepository $taskRepository,
-        private UserRepository $userRepository,
-        private MentionParserService $mentionParserService,
+        private TaskCommentMentionRecorder $mentionRecorder,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private TaskCommentBuilder $taskCommentBuilder,
         private Security $security,
@@ -74,21 +72,7 @@ readonly class TaskCommentCreateProcessor implements ProcessorInterface
             actor: $user,
         );
 
-        $mentionedUuids = $this->mentionParserService->extractMentions($data->content);
-        $mentionedMembers = $this->userRepository->findActiveBandSpaceMembersByIds($bandSpace, $mentionedUuids);
-        foreach ($mentionedMembers as $mentionedUser) {
-            $this->bandSpaceActivityRecorder->record(
-                bandSpace: $task->bandSpace,
-                module: BandSpaceModule::Task,
-                type: BandSpaceTaskActivityType::Mention,
-                resourceId: $task->id,
-                actor: $user,
-                payload: [
-                    'mentioned_user_id' => $mentionedUser->id,
-                    'mentioned_username' => $mentionedUser->username,
-                ],
-            );
-        }
+        $mentionedMembers = $this->mentionRecorder->recordNewMentions($task, $user, $data->content);
 
         $this->entityManager->flush();
 

--- a/src/State/Processor/BandSpace/TaskCommentUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCommentUpdateProcessor.php
@@ -8,16 +8,19 @@ use App\ApiResource\BandSpace\Task\TaskCommentResource;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceTaskActivityType;
+use App\Event\BandSpaceTaskMentionedEvent;
 use App\Repository\BandSpace\TaskCommentRepository;
 use App\Repository\BandSpace\TaskRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\TaskCommentMentionRecorder;
 use App\Service\Builder\BandSpace\TaskCommentBuilder;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @implements ProcessorInterface<TaskCommentResource, TaskCommentResource>
@@ -29,9 +32,11 @@ readonly class TaskCommentUpdateProcessor implements ProcessorInterface
         private BandSpaceMemberChecker $memberChecker,
         private TaskRepository $taskRepository,
         private TaskCommentRepository $taskCommentRepository,
+        private TaskCommentMentionRecorder $mentionRecorder,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private TaskCommentBuilder $taskCommentBuilder,
         private Security $security,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -61,6 +66,7 @@ readonly class TaskCommentUpdateProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('Seul l\'auteur peut modifier ce commentaire');
         }
 
+        $previousContent = $comment->content;
         $comment->content = $data->content;
         $comment->updateDatetime = new DateTime();
 
@@ -73,7 +79,21 @@ readonly class TaskCommentUpdateProcessor implements ProcessorInterface
             payload: ['comment_id' => (string) $comment->id],
         );
 
+        $newlyMentionedMembers = $this->mentionRecorder->recordNewMentions(
+            $task,
+            $user,
+            $data->content,
+            $previousContent,
+        );
+
         $this->entityManager->flush();
+
+        // Best-effort notification dispatched after the commit (epic #689 contract). Only the members
+        // the edit brings in are told, and there is no participant fan-out: an edit is not a new
+        // comment, so the thread must not be pinged again over one.
+        if ($newlyMentionedMembers !== []) {
+            $this->eventDispatcher->dispatch(new BandSpaceTaskMentionedEvent($comment, $newlyMentionedMembers));
+        }
 
         return $this->taskCommentBuilder->buildItem($comment);
     }

--- a/tests/Api/BandSpace/Task/TaskBulkDeleteTest.php
+++ b/tests/Api/BandSpace/Task/TaskBulkDeleteTest.php
@@ -161,6 +161,58 @@ class TaskBulkDeleteTest extends ApiTestCase
         $this->assertNotNull($repo->find($foreignId));
     }
 
+    public function test_bulk_delete_names_every_task_the_member_did_not_create(): void
+    {
+        $creator = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'mem_u', 'email' => 'm@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $creator])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+        $ownTask = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $member,
+            'title' => 'Ma tâche',
+        ])->create();
+        $firstForeign = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $creator,
+            'title' => 'Mix final',
+        ])->create();
+        $secondForeign = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $creator,
+            'title' => 'Réserver le studio',
+        ])->create();
+
+        $this->client->loginUser($member);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/bulk_delete',
+            ['task_ids' => [$ownTask->id, $firstForeign->id, $secondForeign->id]],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        // The batch is all or nothing, so the answer has to say which cards of the selection are in
+        // the way, not just that one of them was.
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $detail = 'Seul le créateur ou un administrateur peut supprimer ces tâches : Mix final, Réserver le studio';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        $repo = self::getContainer()->get(TaskRepository::class);
+        $this->assertNotNull($repo->find($ownTask->id));
+        $this->assertNotNull($repo->find($firstForeign->id));
+    }
+
     public function test_bulk_delete_rejects_unknown_task_id(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/Task/TaskBulkPatchTest.php
+++ b/tests/Api/BandSpace/Task/TaskBulkPatchTest.php
@@ -74,6 +74,61 @@ class TaskBulkPatchTest extends ApiTestCase
         $this->assertNull($reloadedDone->archiveDatetime);
     }
 
+    public function test_bulk_archive_names_every_task_that_is_not_done(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $done = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Mix final',
+            'status' => TaskStatus::Done,
+        ])->create();
+        $todo = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Réserver le studio',
+            'status' => TaskStatus::Todo,
+        ])->create();
+        $inProgress = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Écrire le pont',
+            'status' => TaskStatus::InProgress,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/bulk_patch',
+            [
+                'task_ids' => [$done->id, $todo->id, $inProgress->id],
+                'archived' => true,
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        // The batch is all or nothing, so the answer has to say which cards of the selection are in
+        // the way, not just that one of them was.
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $detail = 'Seules les tâches terminées peuvent être archivées : Réserver le studio, Écrire le pont';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        $repo = self::getContainer()->get(TaskRepository::class);
+        $this->assertNull($repo->find($done->id)->archiveDatetime);
+    }
+
     public function test_bulk_set_category(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/Task/TaskCommentNotificationTest.php
+++ b/tests/Api/BandSpace/Task/TaskCommentNotificationTest.php
@@ -156,6 +156,126 @@ class TaskCommentNotificationTest extends ApiTestCase
         $this->assertCount(0, $notificationRepository->findForRecipient($author, 10, 0));
     }
 
+    public function test_editing_a_comment_notifies_the_member_it_newly_mentions(): void
+    {
+        $author = UserFactory::new()->asBaseUser()->create();
+        $alice = UserFactory::new()->create(['username' => 'alice', 'email' => 'alice@test.com']);
+        $carol = UserFactory::new()->create(['username' => 'carol', 'email' => 'carol@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'The Rockers']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $alice])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $carol])->create();
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $author,
+            'assignees' => new ArrayCollection([$carol]),
+            'title' => 'Ma tâche',
+        ])->create();
+        $comment = TaskCommentFactory::new([
+            'task' => $task,
+            'author' => $author,
+            'content' => 'Premier jet',
+            'creationDatetime' => new \DateTime('2026-01-01 10:00:00'),
+        ])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $taskId = (string) $task->id;
+        $commentId = (string) $comment->id;
+        $content = 'Premier jet, @[' . $alice->id . '] ton avis ?';
+
+        $this->client->loginUser($author);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpaceId . '/tasks/' . $taskId . '/comments/' . $commentId,
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+        $this->assertResponseIsSuccessful();
+
+        $refreshed = self::getContainer()->get(TaskCommentRepository::class)->find($commentId);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TaskComment',
+            '@id' => '/api/band_spaces/' . $bandSpaceId . '/tasks/' . $taskId . '/comments/' . $commentId,
+            '@type' => 'TaskComment',
+            'id' => $commentId,
+            'band_space_id' => $bandSpaceId,
+            'task_id' => $taskId,
+            'author_id' => (string) $author->id,
+            'author_username' => $author->username,
+            'author_profile_picture_url' => null,
+            'content' => $content,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+        $aliceNotifications = $notificationRepository->findForRecipient($alice, 10, 0);
+        $this->assertCount(1, $aliceNotifications);
+        $this->assertSame(NotificationType::TaskMention, $aliceNotifications[0]->type);
+        $this->assertSame([
+            'band_space_id' => $bandSpaceId,
+            'task_id' => $taskId,
+            'task_title' => 'Ma tâche',
+            'comment_id' => $commentId,
+            'actor_id' => (string) $author->id,
+            'actor_username' => $author->username,
+        ], $aliceNotifications[0]->payload);
+
+        // An edit is not a new comment: the assignee who was not named hears nothing, and neither
+        // does the author.
+        $this->assertCount(0, $notificationRepository->findForRecipient($carol, 10, 0));
+        $this->assertCount(0, $notificationRepository->findForRecipient($author, 10, 0));
+        $this->assertCount(1, $notificationRepository->findAll());
+    }
+
+    public function test_editing_a_comment_does_not_notify_a_member_it_already_mentioned(): void
+    {
+        $author = UserFactory::new()->asBaseUser()->create();
+        $alice = UserFactory::new()->create(['username' => 'alice', 'email' => 'alice@test.com']);
+        $bob = UserFactory::new()->create(['username' => 'bob', 'email' => 'bob@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'The Rockers']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $alice])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bob])->create();
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $author,
+            'title' => 'Ma tâche',
+        ])->create();
+        $comment = TaskCommentFactory::new([
+            'task' => $task,
+            'author' => $author,
+            'content' => 'Salut @[' . $alice->id . ']',
+            'creationDatetime' => new \DateTime('2026-01-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($author);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id . '/comments/' . $comment->id,
+            ['content' => 'Salut @[' . $alice->id . '] et @[' . $bob->id . ']'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+        $this->assertResponseIsSuccessful();
+
+        // Alice was named by the text the comment already held, so she was told when it was written.
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+        $bobNotifications = $notificationRepository->findForRecipient($bob, 10, 0);
+        $this->assertCount(1, $bobNotifications);
+        $this->assertSame(NotificationType::TaskMention, $bobNotifications[0]->type);
+        $this->assertSame([
+            'band_space_id' => (string) $bandSpace->id,
+            'task_id' => (string) $task->id,
+            'task_title' => 'Ma tâche',
+            'comment_id' => (string) $comment->id,
+            'actor_id' => (string) $author->id,
+            'actor_username' => $author->username,
+        ], $bobNotifications[0]->payload);
+
+        $this->assertCount(0, $notificationRepository->findForRecipient($alice, 10, 0));
+        $this->assertCount(1, $notificationRepository->findAll());
+    }
+
     public function test_comment_notifies_task_participants_not_the_author(): void
     {
         $author = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/Task/TaskCommentUpdateTest.php
+++ b/tests/Api/BandSpace/Task/TaskCommentUpdateTest.php
@@ -70,6 +70,101 @@ class TaskCommentUpdateTest extends ApiTestCase
         $this->assertSame(['comment_id' => (string) $comment->id], $activities[0]->payload);
     }
 
+    public function test_editing_a_comment_records_the_mentions_it_adds(): void
+    {
+        $author = UserFactory::new()->asBaseUser()->create();
+        $alice = UserFactory::new()->create(['username' => 'alice', 'email' => 'alice@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $alice])->create();
+        $task = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $author])->create();
+        $comment = TaskCommentFactory::new([
+            'task' => $task,
+            'author' => $author,
+            'content' => 'Premier jet',
+            'creationDatetime' => new \DateTime('2026-01-01 10:00:00'),
+        ])->create();
+
+        // The editor highlights the name as soon as it is typed, so the author leaves believing the
+        // ping went out. It has to actually go out.
+        $this->client->loginUser($author);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id . '/comments/' . $comment->id,
+            ['content' => 'Premier jet, @[' . $alice->id . '] ton avis ?'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $commentRepo = self::getContainer()->get(TaskCommentRepository::class);
+        $refreshed = $commentRepo->find($comment->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/TaskComment',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id . '/comments/' . $comment->id,
+            '@type' => 'TaskComment',
+            'id' => (string) $comment->id,
+            'task_id' => (string) $task->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'author_id' => (string) $author->id,
+            'author_username' => $author->username,
+            'author_profile_picture_url' => null,
+            'content' => 'Premier jet, @[' . $alice->id . '] ton avis ?',
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepo->findForResource($bandSpace, BandSpaceModule::Task, $task->id);
+        $this->assertCount(2, $activities);
+
+        $mentions = array_values(array_filter($activities, fn($activity): bool => $activity->type === 'mention'));
+        $this->assertCount(1, $mentions);
+        $this->assertSame([
+            'mentioned_user_id' => (string) $alice->id,
+            'mentioned_username' => 'alice',
+        ], $mentions[0]->payload);
+    }
+
+    public function test_editing_a_comment_leaves_a_mention_it_already_carried_alone(): void
+    {
+        $author = UserFactory::new()->asBaseUser()->create();
+        $alice = UserFactory::new()->create(['username' => 'alice', 'email' => 'alice@test.com']);
+        $bob = UserFactory::new()->create(['username' => 'bob', 'email' => 'bob@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $alice])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bob])->create();
+        $task = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $author])->create();
+        $comment = TaskCommentFactory::new([
+            'task' => $task,
+            'author' => $author,
+            'content' => 'Salut @[' . $alice->id . ']',
+            'creationDatetime' => new \DateTime('2026-01-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($author);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id . '/comments/' . $comment->id,
+            ['content' => 'Salut @[' . $alice->id . '] et @[' . $bob->id . ']'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        // Alice was named by the text the comment already held: she heard about it then, and a typo
+        // fixed three edits later must not put her through it again.
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepo->findForResource($bandSpace, BandSpaceModule::Task, $task->id);
+        $mentions = array_values(array_filter($activities, fn($activity): bool => $activity->type === 'mention'));
+        $this->assertCount(1, $mentions);
+        $this->assertSame([
+            'mentioned_user_id' => (string) $bob->id,
+            'mentioned_username' => 'bob',
+        ], $mentions[0]->payload);
+    }
+
     public function test_admin_cannot_edit_other_users_comment(): void
     {
         $author = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/Task/TaskUpdateTest.php
+++ b/tests/Api/BandSpace/Task/TaskUpdateTest.php
@@ -377,6 +377,88 @@ class TaskUpdateTest extends ApiTestCase
         $this->assertSame('task_unarchived', $activities[0]->type);
     }
 
+    public function test_archived_task_refuses_a_status_change(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        // The board never opens an archived task, but ?task={id} does, and reopening one would leave
+        // the archive holding something it would have refused to take in.
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Master cassette',
+            'status' => TaskStatus::Done,
+            'archiveDatetime' => new \DateTimeImmutable('2026-04-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id,
+            ['status' => 'todo'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+        ]);
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findForResource($bandSpace, BandSpaceModule::Task, $task->id));
+
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        $refreshed = self::getContainer()->get(\App\Repository\BandSpace\TaskRepository::class)->find($task->id);
+        $this->assertSame(TaskStatus::Done, $refreshed->status);
+        $this->assertNotNull($refreshed->archiveDatetime);
+    }
+
+    public function test_archived_task_refuses_a_title_change(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Master cassette',
+            'status' => TaskStatus::Done,
+            'archiveDatetime' => new \DateTimeImmutable('2026-04-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id,
+            ['title' => 'Master vinyle'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+        ]);
+
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        $refreshed = self::getContainer()->get(\App\Repository\BandSpace\TaskRepository::class)->find($task->id);
+        $this->assertSame('Master cassette', $refreshed->title);
+    }
+
     public function test_update_task_not_member(): void
     {
         $owner = UserFactory::new()->asBaseUser()->create();


### PR DESCRIPTION
Closes #825 (all five items).

## Item 1: dragging inside "Terminé" reordered the wrong task (the release blocker)

`TaskColumn.vue` bound the draggable to `localTasks` (all N, position order) but rendered `visibleTasks` (re-sorted by completion date, sliced to 5). The DOM indices addressed a different ordering from the array being mutated, so dragging the 4th visible card persisted a new position for a different task, for the whole band, and the immediate re-sort made it look like nothing happened.

This is the same class as #811 reached through a different trigger. #811 added `isReorderDisabled` for the filter and search case; that gate is untouched and still applies to every column.

Fixed by disabling sorting inside the Done column rather than un-slicing it. The column is drawn by completion date, so even a correctly persisted reorder would be invisible after the re-sort, and un-slicing means rendering every done task with no pagination (#568). Cross-column drops still work: `sort` only gates the same-instance branch of Sortable `_onDragOver`, while drag in and out are gated by `checkPull`/`checkPut`. Verified against the bundled Sortable 1.15.2 source, not inferred.

A third bug turned up while fixing this: a card dragged **out** of Done was index-spliced against the wrong list and took a different card with it. It was presentation only, since the API payload is built from the store rather than the component-local array, so nothing was ever persisted wrong. Done rebuilds its local list from props after a drag out.

## Item 2: bulk archive and delete were all-or-nothing with no hint

The batch ran in one transaction and any non-done task threw 422, or any foreign task threw 403, while the action bar offered both unconditionally and showed a generic toast. A member selecting 8 cards learned nothing about which one blocked it.

Both server errors now name every blocking task (not just the first), and the client disables the action with a tooltip listing them. The server remains the enforcement point, so the race is covered. Already-archived tasks are excluded from the blocking set, since archiving them again is a no-op rather than a refusal.

## Item 3: editing a comment silently dropped @-mentions

The create processor parsed mentions, recorded an activity and dispatched the event; the update processor did none of it, so adding "@Marc" while editing rendered the highlight and pinged nobody.

New `TaskCommentMentionRecorder` shared by both processors. Dedup diffs the mentions in the new content against those the previous content already carried, case-normalised, so an edit pings only who it newly names and never re-pings someone already mentioned. The update path deliberately does not dispatch the participants event, so editing never re-fans-out to the whole thread.

## Item 4: archived tasks were unopenable from the list but editable by deep link

Archived rows were inert, yet `?task=<id>` opened the drawer for one and `TaskUpdateProcedure` had no archived guard, so status, title and assignees could be changed, breaking the archived-implies-done invariant. The store update also missed `archivedTasks`, so the drawer showed stale values after saving.

Server refuses any payload key other than `archived` on an archived task (422). Archived rows now open a genuinely read-only drawer, and the store writes back to `archivedTasks` on both update and delete.

## Item 5: destructive buttons rendered for users the API rejects

Task delete is creator-or-admin and category delete is admin-only, but both controls always rendered, so the member clicked, confirmed a destructive dialog, and only then got a red toast. Both are now gated, reading the role from the existing `useBandSpaceNavigation().isAdmin` so they do not depend on the roster having loaded.

## Verification

`tests/Api/BandSpace/` 976 passing, PHPStan level 8 clean, npm test 186/186, Biome clean, build OK. The frontend decisions live in pure modules (`taskOrdering.js`, `taskActions.js`) and were mutation-tested.

## Known gaps, disclosed rather than hidden

- `TaskMoveProcedure` writes `status`, `completedDatetime` and `position` without the archived guard. Unreachable through the UI (archived tasks never render on the board and have no drag handle), but it is a second door onto the same invariant. Follow-up.
- Comments and file attachments on an archived task are still accepted server side, only hidden in the UI, so "lecture seule" is currently a UI promise the server does not fully keep. Follow-up.
- #860 (arbitrary `position` write) is untouched and not made worse. The new guard incidentally closes it for archived tasks.