### PR TITLE
Notes: surface failed autosaves, guard navigation, coalesce the activity flood

### DIFF
--- a/assets/js/components/BandSpace/Notes/NoteEditor.vue
+++ b/assets/js/components/BandSpace/Notes/NoteEditor.vue
@@ -325,9 +325,10 @@ import { useToast } from 'primevue/usetoast'
 import EmojiPicker from 'vue3-emoji-picker'
 import 'vue3-emoji-picker/css'
 import { onClickOutside } from '@vueuse/core'
-import { onMounted, ref, watch } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import bandSpaceNoteImagesApi from '../../../api/bandSpace/band-space-note-images.js'
 import { useRichTextEditor } from '../../../composables/useRichTextEditor.js'
+import { useBandSpaceNotesStore } from '../../../store/bandSpace/bandSpaceNotes.js'
 
 const props = defineProps({
   note: { type: Object, required: true },
@@ -336,9 +337,10 @@ const props = defineProps({
   isReloading: { type: Boolean, default: false }
 })
 
-const emit = defineEmits(['update-content', 'update-title', 'update-emoji', 'reload'])
+const emit = defineEmits(['update-title', 'update-emoji', 'reload', 'pending-edits-change'])
 
 const toast = useToast()
+const notesStore = useBandSpaceNotesStore()
 
 const showEmojiPicker = ref(false)
 const emojiPickerRef = ref(null)
@@ -390,34 +392,75 @@ onMounted(() => {
 
 // Shared with the tech rider section editor. Images are Notes only, and so is the detach
 // pass on save, which is why it lives in the callback rather than in the composable.
-const { editor, stopSaving } = useRichTextEditor({
+const { editor, stopSaving, hasPendingEdits } = useRichTextEditor({
   content: props.note.content,
   placeholder: 'Commencez à écrire...',
   extensions: [Image.configure({ inline: false, allowBase64: false })],
   onSave: (json) => {
     detachRemovedImages(json)
+
     // The revision travels with the save because this component is the only place that still knows
     // it on the unmount flush: by then the store has already moved on to whichever note was clicked.
-    emit('update-content', {
-      noteId: props.note.id,
-      content: json,
-      contentVersion: props.note.content_version
-    })
+    //
+    // Returned rather than fired and forgotten, because that is what holds the next save until this
+    // one has answered. Two saves in flight both name the revision they started from, so the second
+    // comes back refused as though another member had written, when nobody but this editor has.
+    return saveContent(props.note.id, json, props.note.content_version)
   }
 })
 
-// A refused save ends the loop for this editor. Retrying every two seconds would refuse every
-// time, and the flush on unmount would send the same document once more on the way out. The
-// editor stays writable so the member can select and copy what they wrote; the notice above
-// says plainly that none of it is being saved any more.
-watch(
-  () => props.saveStatus,
-  (status) => {
-    if (status === 'conflict') {
-      stopSaving()
-    }
+/**
+ * Nobody pressed save here, a timer did, so a failure has to say so out loud. The status in the
+ * header is eleven pixels wide, and once the note has been left it is not on screen at all, which
+ * is exactly when the last save of a writing session goes out.
+ */
+async function saveContent(noteId, content, contentVersion) {
+  const { status, noteTitle } = await notesStore.updateNoteContent(
+    props.bandSpaceId,
+    noteId,
+    content,
+    contentVersion
+  )
+  if (status === 'saved') return
+
+  const noteName = noteTitle ? `« ${noteTitle} »` : 'La note'
+  if (status === 'conflict') {
+    // Ends the loop here rather than from a watcher on the status, and that placement is the whole
+    // guarantee: the saver only re-checks `stopped` once this callback has been awaited, so a save
+    // queued behind this one while the request was in flight can no longer go out. Stopping from a
+    // watcher instead would put that behind Vue's scheduler, one flush option or one extra await
+    // away from letting the refused document be sent again. See "is stopped in time by a save that
+    // stops the loop itself" in debouncedSaver.test.js.
+    //
+    // The editor stays writable so the member can select and copy what they wrote; the notice
+    // above says plainly that none of it is being saved any more.
+    stopSaving()
+
+    toast.add({
+      severity: 'warn',
+      summary: 'Modifications non enregistrées',
+      detail: `${noteName} a été modifiée par un autre membre. Vos modifications n'ont pas été enregistrées afin de ne pas effacer les siennes.`,
+      life: 8000
+    })
+
+    return
   }
-)
+
+  toast.add({
+    severity: 'error',
+    summary: 'Sauvegarde impossible',
+    detail: `${noteName} n'a pas pu être enregistrée. Ne fermez pas cet onglet : votre texte est toujours affiché et sera renvoyé à votre prochaine modification.`,
+    life: 8000
+  })
+}
+
+// The guard that protects this text lives one level up, on the route and on the tab, because both
+// destroy this component without asking.
+watch(hasPendingEdits, (pending) => emit('pending-edits-change', pending))
+
+// Unmounting flushes what was waiting, so the save owns it from here and the guard must not go on
+// warning about typing that is on its way to the server.
+onBeforeUnmount(() => emit('pending-edits-change', false))
 
 async function handleCopyMyText() {
   try {

--- a/assets/js/components/BandSpace/Notes/NoteTree.vue
+++ b/assets/js/components/BandSpace/Notes/NoteTree.vue
@@ -63,7 +63,7 @@
 import Button from 'primevue/button'
 import Menu from 'primevue/menu'
 import Tree from 'primevue/tree'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 const MAX_DEPTH = 3
 
@@ -119,17 +119,11 @@ function canCreateChild(nodeKey) {
   return (depthMap.value[nodeKey] || 1) < MAX_DEPTH
 }
 
-watch(
-  () => props.selectedKey,
-  (newKey) => {
-    if (newKey) {
-      selectionKeys.value = { [newKey]: true }
-    } else {
-      selectionKeys.value = {}
-    }
-  },
-  { immediate: true }
-)
+function highlightOpenNote(noteId) {
+  selectionKeys.value = noteId ? { [noteId]: true } : {}
+}
+
+watch(() => props.selectedKey, highlightOpenNote, { immediate: true })
 
 function expandNode(key) {
   expandedKeys.value = { ...expandedKeys.value, [key]: true }
@@ -137,8 +131,16 @@ function expandNode(key) {
 
 defineExpose({ expandNode })
 
-function handleSelect(node) {
+/**
+ * Tree moves its own highlight before it tells us, and the parent may refuse the switch when the
+ * open note holds text no save has taken. The highlight is therefore put back on whatever note is
+ * actually open once the answer is in, so the sidebar never points at a note the editor did not
+ * open. Idempotent when the switch went through.
+ */
+async function handleSelect(node) {
   emit('select', node.key)
+  await nextTick()
+  highlightOpenNote(props.selectedKey)
 }
 </script>
 

--- a/assets/js/composables/useRichTextEditor.js
+++ b/assets/js/composables/useRichTextEditor.js
@@ -5,7 +5,7 @@ import { Table } from '@tiptap/extension-table/table'
 import TextAlign from '@tiptap/extension-text-align'
 import StarterKit from '@tiptap/starter-kit'
 import { useEditor } from '@tiptap/vue-3'
-import { onBeforeUnmount } from 'vue'
+import { onBeforeUnmount, ref } from 'vue'
 import { createDebouncedSaver } from '../utils/debouncedSaver.js'
 
 /**
@@ -24,6 +24,10 @@ import { createDebouncedSaver } from '../utils/debouncedSaver.js'
  * body moved on under the writer being the case that exists today. It ends the loop rather
  * than letting it re-send the same refused document every couple of seconds.
  *
+ * `hasPendingEdits` is what the unsaved changes guards read. The flush on unmount covers
+ * navigating away inside the app, but nothing covers a closed tab or an F5, so the view has to
+ * be able to ask whether there is typing in here that no save has been started for.
+ *
  * @param {object}   options
  * @param {object|string|null} options.content        initial TipTap document
  * @param {string}   options.placeholder
@@ -40,7 +44,19 @@ export function useRichTextEditor({
   editable = true,
   onSave
 }) {
-  const saver = createDebouncedSaver({ delayMs: debounceMs, onSave })
+  // True from the first keystroke until the debounce hands the text to a save. What happens to that
+  // save afterwards is the consumer's business; this only answers "is there typing no save has been
+  // started for", which is what a tab closed mid sentence would take with it.
+  const hasPendingEdits = ref(false)
+
+  const saver = createDebouncedSaver({
+    delayMs: debounceMs,
+    onSave: (content) => {
+      hasPendingEdits.value = false
+
+      return onSave(content)
+    }
+  })
 
   const editor = useEditor({
     editable,
@@ -59,6 +75,9 @@ export function useRichTextEditor({
     ],
     content: content || '',
     onUpdate: ({ editor }) => {
+      // Set even when the loop has been stopped: a refused save leaves the text on screen, and it
+      // is unsaved whether or not anything is still trying.
+      hasPendingEdits.value = true
       saver.schedule(editor.getJSON())
     }
   })
@@ -70,6 +89,7 @@ export function useRichTextEditor({
 
   return {
     editor,
+    hasPendingEdits,
     flushPendingSave: saver.flush,
     cancelDebouncedSave: saver.cancel,
     stopSaving: saver.stop

--- a/assets/js/store/bandSpace/bandSpaceNotes.js
+++ b/assets/js/store/bandSpace/bandSpaceNotes.js
@@ -1,9 +1,14 @@
 import { defineStore } from 'pinia'
 import { computed, readonly, ref } from 'vue'
 import bandSpaceNotesApi from '../../api/bandSpace/band-space-notes.js'
-
-/** What the API answers when the body was written against a revision that is no longer current. */
-const HTTP_CONFLICT = 409
+import { saveNoteContentWithRetries } from '../../utils/noteContentSave.js'
+import {
+  failedSaveNoteIds,
+  holdsUnsavedContent,
+  noteSaveStatus,
+  withNoteSaveStatus,
+  withoutNoteSaveStatus
+} from '../../utils/noteSaveStatus.js'
 
 export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
   const notes = ref([])
@@ -15,7 +20,10 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
   const isCreating = ref(false)
   const isDeleting = ref(false)
   const isReloadingNote = ref(false)
-  const saveStatus = ref(null) // 'saving' | 'saved' | 'error' | 'conflict'
+  // Per note, because a save is fired by a timer and can land long after the member has opened
+  // another note: a single store wide status put the previous note's failure on whichever note
+  // happened to be open, an error badge on a note nobody had touched.
+  const saveStatusByNoteId = ref({}) // noteId -> 'saving' | 'saved' | 'error' | 'conflict'
   const loadError = ref(null)
   // Bumped only by an explicit reload, and part of the editor's key, so the editor is rebuilt
   // around the note that came back. A save must never remount it: that would drop the caret
@@ -28,6 +36,46 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
   let selectedNoteLoadToken = 0
 
   const tree = computed(() => buildTree(notes.value))
+
+  const saveStatus = computed(() => noteSaveStatus(saveStatusByNoteId.value, selectedNoteId.value))
+
+  const hasUnsavedContent = computed(() => holdsUnsavedContent(saveStatusByNoteId.value))
+
+  function setSaveStatus(noteId, status) {
+    saveStatusByNoteId.value = withNoteSaveStatus(saveStatusByNoteId.value, noteId, status)
+  }
+
+  function clearSaveStatus(noteId) {
+    saveStatusByNoteId.value = withoutNoteSaveStatus(saveStatusByNoteId.value, noteId)
+  }
+
+  /**
+   * Asks once, and only about text nothing is going to save. A save still on the debounce is
+   * deliberately not asked about: leaving the route unmounts the editor, which flushes it, so the
+   * question would be about a save already on its way.
+   *
+   * Returns true when it is safe to carry on, so callers read as
+   * `if (!confirmDiscardingEdits()) return`.
+   */
+  function confirmDiscardingEdits() {
+    const unsaved = failedSaveNoteIds(saveStatusByNoteId.value)
+    if (unsaved.length === 0) return true
+
+    const confirmed = window.confirm(
+      'Des modifications ne sont pas enregistrées et seront perdues. Continuer ?'
+    )
+    if (confirmed) {
+      for (const noteId of unsaved) {
+        clearSaveStatus(noteId)
+      }
+    }
+
+    return confirmed
+  }
+
+  function titleOf(noteId) {
+    return notes.value.find((note) => note.id === noteId)?.title ?? null
+  }
 
   function buildTree(flatList) {
     const map = new Map()
@@ -87,10 +135,11 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
     selectedNote.value = null
     isLoadingNote.value = true
     loadError.value = null
-    // The save status belongs to the note being left, not to the one being opened. Carrying a
-    // conflict across would show the next note a blocking banner about an edit nobody made to it,
-    // and the editor only watches for the transition into that state, so it would never clear.
-    saveStatus.value = null
+    // What comes back is a fresh copy, so whatever the last save of this note answered no longer
+    // says anything about it. Above all a leftover conflict would open the note under a blocking
+    // banner about an edit nobody has made to it, and the editor only watches for the transition
+    // into that state, so it would never clear.
+    clearSaveStatus(noteId)
 
     try {
       const data = await bandSpaceNotesApi.getNote(bandSpaceId, noteId)
@@ -131,25 +180,37 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
    *
    * Every response carries the new revision, so replacing the open note here is what keeps the
    * following save valid.
+   *
+   * A failure is retried before it is reported, and always with the same payload, so a retry is
+   * refused rather than allowed to overwrite. Nothing else would ever send this text: it was never
+   * a member pressing save, so there is nothing for them to press again. What the caller gets back
+   * is the outcome, because a note whose save failed on the way out is no longer the one on
+   * screen, and a toast is then the only place it can be said.
+   *
+   * @returns {Promise<{status: 'saved'|'conflict'|'error', noteTitle: string|null}>}
    */
   async function updateNoteContent(bandSpaceId, noteId, content, contentVersion) {
-    saveStatus.value = 'saving'
+    // Read now rather than at the end: the last save of a session answers after the module has been
+    // left, and by then the tree it would have been looked up in has been cleared.
+    const noteTitle = titleOf(noteId)
+
+    setSaveStatus(noteId, 'saving')
     isSaving.value = true
     try {
-      const updated = await bandSpaceNotesApi.update(bandSpaceId, noteId, {
-        content,
-        expected_content_version: contentVersion
+      const outcome = await saveNoteContentWithRetries({
+        save: () =>
+          bandSpaceNotesApi.update(bandSpaceId, noteId, {
+            content,
+            expected_content_version: contentVersion
+          })
       })
-      if (selectedNote.value && selectedNote.value.id === noteId) {
-        selectedNote.value = updated
+
+      if (outcome.status === 'saved' && selectedNote.value && selectedNote.value.id === noteId) {
+        selectedNote.value = outcome.note
       }
-      saveStatus.value = 'saved'
-    } catch (error) {
-      // A conflict belongs to the note that was refused. A save flushed on the way out of a note
-      // can land once another one is open, and flagging that one would stop an editor that has
-      // nothing to resolve, so it falls back to the plain error state.
-      const isStillOpen = selectedNote.value !== null && selectedNote.value.id === noteId
-      saveStatus.value = isStillOpen && error.status === HTTP_CONFLICT ? 'conflict' : 'error'
+      setSaveStatus(noteId, outcome.status)
+
+      return { status: outcome.status, noteTitle }
     } finally {
       isSaving.value = false
     }
@@ -173,13 +234,20 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
       const data = await bandSpaceNotesApi.getNote(bandSpaceId, noteId)
       if (token !== selectedNoteLoadToken) return
       selectedNote.value = data
-      saveStatus.value = null
+      clearSaveStatus(noteId)
       selectedNoteReloadCount.value++
     } finally {
       isReloadingNote.value = false
     }
   }
 
+  /**
+   * Renaming and picking an emoji are single deliberate acts, so a failure is rolled back and
+   * reported rather than left as a status: the save badge belongs to the body, and showing "Erreur"
+   * there for a rename that has already been undone points the member at the wrong thing.
+   *
+   * @returns {Promise<{status: 'saved'|'error'}>}
+   */
   async function updateNoteTitle(bandSpaceId, noteId, title) {
     const noteIndex = notes.value.findIndex((n) => n.id === noteId)
     const previousTitle = noteIndex !== -1 ? notes.value[noteIndex].title : null
@@ -193,14 +261,18 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
       if (selectedNote.value && selectedNote.value.id === noteId) {
         selectedNote.value = updated
       }
+
+      return { status: 'saved' }
     } catch {
       if (noteIndex !== -1 && previousTitle !== null) {
         notes.value[noteIndex] = { ...notes.value[noteIndex], title: previousTitle }
       }
-      saveStatus.value = 'error'
+
+      return { status: 'error' }
     }
   }
 
+  /** @returns {Promise<{status: 'saved'|'error'}>} */
   async function updateNoteEmoji(bandSpaceId, noteId, emoji) {
     const noteIndex = notes.value.findIndex((n) => n.id === noteId)
     const previousEmoji = noteIndex !== -1 ? notes.value[noteIndex].emoji : null
@@ -214,11 +286,14 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
       if (selectedNote.value && selectedNote.value.id === noteId) {
         selectedNote.value = updated
       }
+
+      return { status: 'saved' }
     } catch {
       if (noteIndex !== -1) {
         notes.value[noteIndex] = { ...notes.value[noteIndex], emoji: previousEmoji }
       }
-      saveStatus.value = 'error'
+
+      return { status: 'error' }
     }
   }
 
@@ -240,7 +315,7 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
     notes.value = []
     selectedNoteId.value = null
     selectedNote.value = null
-    saveStatus.value = null
+    saveStatusByNoteId.value = {}
     loadError.value = null
     selectedNoteReloadCount.value = 0
   }
@@ -255,7 +330,8 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
     isCreating: readonly(isCreating),
     isDeleting: readonly(isDeleting),
     isReloadingNote: readonly(isReloadingNote),
-    saveStatus: readonly(saveStatus),
+    saveStatus,
+    hasUnsavedContent,
     loadError: readonly(loadError),
     selectedNoteReloadCount: readonly(selectedNoteReloadCount),
     tree,
@@ -266,6 +342,7 @@ export const useBandSpaceNotesStore = defineStore('bandSpaceNotes', () => {
     updateNoteContent,
     updateNoteTitle,
     updateNoteEmoji,
+    confirmDiscardingEdits,
     deleteNote,
     clear
   }

--- a/assets/js/utils/debouncedSaver.test.js
+++ b/assets/js/utils/debouncedSaver.test.js
@@ -145,6 +145,45 @@ describe('createDebouncedSaver', () => {
 
       assert.deepEqual(saves, ['première'], 'the queued document is never sent after a stop')
     })
+
+    /**
+     * The contract the note editor relies on: it stops from inside the save callback, on the
+     * refused answer, rather than from a watcher on the save status where the stop would land a
+     * scheduling hop later and the refused document could go out once more.
+     *
+     * Stated rather than defended: the saver guards this twice, since `stop` clears the queue as
+     * well as raising the flag, so no single change to it makes this fail on its own. What it fixes
+     * in place is that a stop made from inside an awaited save is in time, which is what allows the
+     * editor to have no ordering assumption left to get wrong.
+     */
+    it('is stopped in time by a save that stops the loop itself', async () => {
+      const saves = []
+      let releaseFirstSave = null
+      const saver = createDebouncedSaver({
+        delayMs: DELAY_MS,
+        onSave: async (content) => {
+          saves.push(content)
+          await new Promise((resolve) => {
+            releaseFirstSave = resolve
+          })
+          saver.stop()
+        }
+      })
+
+      saver.schedule('première')
+      mock.timers.tick(DELAY_MS)
+      await settle()
+
+      // The writer keeps typing while the save that is about to be refused is still in flight.
+      saver.schedule('deuxième')
+      mock.timers.tick(DELAY_MS)
+      await settle()
+
+      releaseFirstSave()
+      await settle()
+
+      assert.deepEqual(saves, ['première'], 'the queued document is never sent after the refusal')
+    })
   })
 
   describe('flush, which is what runs when the editor is unmounted', () => {

--- a/assets/js/utils/noteContentSave.js
+++ b/assets/js/utils/noteContentSave.js
@@ -1,0 +1,96 @@
+/**
+ * One attempt at saving a note body, plus the rules for when a failed one may be tried again.
+ *
+ * A note body is written by a two second timer, never by a member pressing anything, so a failure
+ * has no natural retry: the text stays on screen looking saved and disappears with the tab. What
+ * follows is the only thing that gets it to the server, hence the retries.
+ *
+ * The revision is what makes retrying safe. Every attempt re-sends the same payload, including the
+ * revision the text was written against, so a retry landing after another member has written comes
+ * back refused instead of replacing their work. Retrying with a fresh revision would turn this
+ * helper into the blind overwrite the revision check was added to remove.
+ *
+ * Which failures may be retried therefore matters more than how many times:
+ *
+ * - a refused revision (409) is a decision, not a hiccup. Trying again sends the same refused
+ *   document and gets the same answer, so it stops immediately and the caller shows the conflict;
+ * - a missing revision (428) means the payload was built wrong. No number of attempts adds the
+ *   field, so it stops too;
+ * - anything else the server answered (403, 404, 422) is equally settled;
+ * - a request that never got an answer, or a 5xx, is the transient case. That one is retried.
+ *
+ * A retry can be refused as a conflict because the first attempt did reach the server and only its
+ * answer was lost. The text is then saved and the member is told it is not, which is the safe way
+ * round: the alternative overwrites somebody else's paragraph to spare a wrong warning.
+ *
+ * Pure on purpose, with no store and no component around it, so the rules are tested without a
+ * browser. See noteContentSave.test.js.
+ */
+
+/** The revision named by the write is no longer the current one. */
+const HTTP_CONFLICT = 409
+
+/** The write named no revision at all. */
+const HTTP_PRECONDITION_REQUIRED = 428
+
+const HTTP_SERVER_ERROR = 500
+
+/** Short enough that a blip is invisible, spread out enough to outlast a reconnection. */
+export const SAVE_RETRY_DELAYS_MS = [1000, 4000]
+
+/**
+ * @param {{status?: number}} error a normalized API error, see handleApiError
+ * @returns {{status: 'conflict'|'error', canRetry: boolean}} status is the save status to show
+ */
+export function classifyNoteSaveFailure(error) {
+  const httpStatus = error?.status
+
+  if (httpStatus === HTTP_CONFLICT) {
+    return { status: 'conflict', canRetry: false }
+  }
+
+  // Spelled out rather than left to the rule below: sending the payload again builds the same
+  // payload, so this one is settled for a reason of its own.
+  if (httpStatus === HTTP_PRECONDITION_REQUIRED) {
+    return { status: 'error', canRetry: false }
+  }
+
+  // No status at all means the request never reached an answer: offline, dropped connection, or a
+  // page in the middle of being closed.
+  if (typeof httpStatus !== 'number') {
+    return { status: 'error', canRetry: true }
+  }
+
+  return { status: 'error', canRetry: httpStatus >= HTTP_SERVER_ERROR }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * @param {object} options
+ * @param {function(): Promise<object>} options.save one attempt, resolving to the saved note
+ * @param {number[]} [options.delaysMs] one delay per retry, so its length is the retry count
+ * @param {function(number): Promise<void>} [options.wait] injectable for the tests
+ * @returns {Promise<{status: 'saved', note: object}|{status: 'conflict'|'error', error: Error}>}
+ */
+export async function saveNoteContentWithRetries({
+  save,
+  delaysMs = SAVE_RETRY_DELAYS_MS,
+  wait = sleep
+}) {
+  let retriesUsed = 0
+
+  for (;;) {
+    try {
+      return { status: 'saved', note: await save() }
+    } catch (error) {
+      const failure = classifyNoteSaveFailure(error)
+      if (!failure.canRetry || retriesUsed >= delaysMs.length) {
+        return { status: failure.status, error }
+      }
+
+      await wait(delaysMs[retriesUsed])
+      retriesUsed++
+    }
+  }
+}

--- a/assets/js/utils/noteContentSave.test.js
+++ b/assets/js/utils/noteContentSave.test.js
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  classifyNoteSaveFailure,
+  SAVE_RETRY_DELAYS_MS,
+  saveNoteContentWithRetries
+} from './noteContentSave.js'
+
+/**
+ * These pin what a failed autosave does, which used to be nothing at all: the status went to
+ * 'error', an eleven pixel word appeared in the editor header, and the text sat there until the tab
+ * closed.
+ *
+ * The half that matters most is what is not retried. A body write names the revision it was made
+ * against, so retrying is only safe while the payload stays untouched: a retry that re-sends the
+ * same revision is refused when somebody else has written since, and refusing is the whole point.
+ *
+ * Run with `npm test`.
+ */
+
+const savedNote = { id: 'note-1', content_version: 4 }
+
+/** Records how long each retry waited, and returns immediately so the tests do not sleep. */
+function fakeWait() {
+  const waited = []
+  const wait = async (ms) => {
+    waited.push(ms)
+  }
+
+  return { waited, wait }
+}
+
+function apiError(status) {
+  const error = new Error('échec')
+  error.status = status
+
+  return error
+}
+
+/** No `status` at all is what handleApiError produces when no answer ever came back. */
+function networkError() {
+  return new Error('Network Error')
+}
+
+describe('classifyNoteSaveFailure', () => {
+  it('reads a refused revision as a conflict, and never retries it', () => {
+    assert.deepEqual(classifyNoteSaveFailure(apiError(409)), {
+      status: 'conflict',
+      canRetry: false
+    })
+  })
+
+  it('does not retry a write that named no revision, because trying again names none either', () => {
+    assert.deepEqual(classifyNoteSaveFailure(apiError(428)), { status: 'error', canRetry: false })
+  })
+
+  it('does not retry anything else the server decided', () => {
+    for (const status of [400, 403, 404, 422]) {
+      assert.deepEqual(
+        classifyNoteSaveFailure(apiError(status)),
+        { status: 'error', canRetry: false },
+        `HTTP ${status}`
+      )
+    }
+  })
+
+  it('retries a server error and a request that never got an answer', () => {
+    assert.deepEqual(classifyNoteSaveFailure(apiError(500)), { status: 'error', canRetry: true })
+    assert.deepEqual(classifyNoteSaveFailure(apiError(503)), { status: 'error', canRetry: true })
+    assert.deepEqual(classifyNoteSaveFailure(networkError()), { status: 'error', canRetry: true })
+  })
+})
+
+describe('saveNoteContentWithRetries', () => {
+  it('returns the saved note and never waits when the first attempt works', async () => {
+    const { waited, wait } = fakeWait()
+
+    const outcome = await saveNoteContentWithRetries({ save: async () => savedNote, wait })
+
+    assert.deepEqual(outcome, { status: 'saved', note: savedNote })
+    assert.deepEqual(waited, [])
+  })
+
+  it('retries a dropped connection and saves without bothering the member', async () => {
+    const { waited, wait } = fakeWait()
+    let attempts = 0
+    const save = async () => {
+      attempts++
+      if (attempts === 1) throw networkError()
+
+      return savedNote
+    }
+
+    const outcome = await saveNoteContentWithRetries({ save, wait })
+
+    assert.deepEqual(outcome, { status: 'saved', note: savedNote })
+    assert.equal(attempts, 2)
+    assert.deepEqual(waited, [SAVE_RETRY_DELAYS_MS[0]])
+  })
+
+  it('gives up after the last delay and reports the failure', async () => {
+    const { waited, wait } = fakeWait()
+    let attempts = 0
+    const save = async () => {
+      attempts++
+      throw networkError()
+    }
+
+    const outcome = await saveNoteContentWithRetries({ save, delaysMs: [10, 20], wait })
+
+    assert.equal(outcome.status, 'error')
+    assert.equal(attempts, 3, 'the first attempt plus one per delay')
+    assert.deepEqual(waited, [10, 20])
+  })
+
+  /**
+   * The retry that must not happen. Sending it again means sending the same refused document, and
+   * sending it with a fresh revision means erasing whatever the other member wrote.
+   */
+  it('stops on a refused revision, on the very first answer', async () => {
+    const { waited, wait } = fakeWait()
+    let attempts = 0
+    const save = async () => {
+      attempts++
+      throw apiError(409)
+    }
+
+    const outcome = await saveNoteContentWithRetries({ save, wait })
+
+    assert.equal(outcome.status, 'conflict')
+    assert.equal(attempts, 1)
+    assert.deepEqual(waited, [])
+  })
+
+  /**
+   * The case the unchanged payload buys: between the dropped connection and the retry, somebody
+   * else wrote to the note. The retry names the revision the text was written against, so it comes
+   * back refused rather than replacing their paragraph.
+   */
+  it('reports a conflict when a retry lands after another member has written', async () => {
+    const { wait } = fakeWait()
+    let attempts = 0
+    const save = async () => {
+      attempts++
+      throw attempts === 1 ? networkError() : apiError(409)
+    }
+
+    const outcome = await saveNoteContentWithRetries({ save, wait })
+
+    assert.equal(outcome.status, 'conflict')
+    assert.equal(attempts, 2, 'the conflict ends it, the second delay is never used')
+  })
+
+  it('sends the same payload on every attempt', async () => {
+    const { wait } = fakeWait()
+    const sent = []
+    const payload = { content: { type: 'doc' }, expected_content_version: 3 }
+    let attempts = 0
+    const save = async () => {
+      attempts++
+      sent.push(payload)
+      if (attempts < 3) throw networkError()
+
+      return savedNote
+    }
+
+    await saveNoteContentWithRetries({ save, wait })
+
+    assert.equal(sent.length, 3)
+    assert.deepEqual(sent, [payload, payload, payload])
+  })
+})

--- a/assets/js/utils/noteSaveStatus.js
+++ b/assets/js/utils/noteSaveStatus.js
@@ -1,0 +1,55 @@
+/**
+ * What the last save of each open note answered, kept per note id.
+ *
+ * A note body is saved by a timer, so a save can land well after its note has been left: the last
+ * one of a writing session goes out on the way out. A single status for the whole module therefore
+ * described whichever note happened to be open rather than the one that was written, which put an
+ * error badge on an untouched note and, worse, said nothing at all about the one that was lost.
+ *
+ * Two questions are asked of these statuses, and they deliberately count different things:
+ *
+ * - `failedSaveNoteIds` is text nothing is going to save, so anything unmounting the editor holding
+ *   it loses it, whether that is leaving the module or opening another note, and the member has to
+ *   be asked first;
+ * - `holdsUnsavedContent` also counts a save still in flight, because a closed tab takes that one
+ *   with it just the same. Navigating away does not: the request is already on its way.
+ *
+ * Pure on purpose, so the rules are tested without a browser. See noteSaveStatus.test.js.
+ */
+
+/** Statuses meaning the server does not have this text. */
+const UNSAVED_STATUSES = ['saving', 'error', 'conflict']
+
+/** Of those, the ones nothing is going to resolve on its own. */
+const FAILED_STATUSES = ['error', 'conflict']
+
+/**
+ * @param {Object<string, string>} statuses
+ * @param {string|null} noteId
+ * @returns {string|null} null for a note that has never been saved, and for no note at all
+ */
+export function noteSaveStatus(statuses, noteId) {
+  return statuses[noteId] ?? null
+}
+
+/** @returns {Object<string, string>} a new map, so a watcher sees the change */
+export function withNoteSaveStatus(statuses, noteId, status) {
+  return { ...statuses, [noteId]: status }
+}
+
+/** @returns {Object<string, string>} */
+export function withoutNoteSaveStatus(statuses, noteId) {
+  const { [noteId]: _dropped, ...rest } = statuses
+
+  return rest
+}
+
+/** @returns {string[]} notes holding text that no save is going to write */
+export function failedSaveNoteIds(statuses) {
+  return Object.keys(statuses).filter((noteId) => FAILED_STATUSES.includes(statuses[noteId]))
+}
+
+/** @returns {boolean} true when closing the tab now would lose text */
+export function holdsUnsavedContent(statuses) {
+  return Object.values(statuses).some((status) => UNSAVED_STATUSES.includes(status))
+}

--- a/assets/js/utils/noteSaveStatus.test.js
+++ b/assets/js/utils/noteSaveStatus.test.js
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  failedSaveNoteIds,
+  holdsUnsavedContent,
+  noteSaveStatus,
+  withNoteSaveStatus,
+  withoutNoteSaveStatus
+} from './noteSaveStatus.js'
+
+/**
+ * The bug these pin: one status for the whole module, written by whichever save answered last. A
+ * save fired by a timer lands when it lands, so a failure on the note being left painted an error
+ * badge on the note being opened, and the note that actually failed said nothing.
+ *
+ * Run with `npm test`.
+ */
+
+describe('noteSaveStatus', () => {
+  it('answers only for the note that was saved', () => {
+    const statuses = withNoteSaveStatus({}, 'note-a', 'error')
+
+    assert.equal(noteSaveStatus(statuses, 'note-a'), 'error')
+    assert.equal(noteSaveStatus(statuses, 'note-b'), null, 'the untouched note stays untouched')
+  })
+
+  it('answers null when no note is open', () => {
+    assert.equal(noteSaveStatus({ 'note-a': 'saved' }, null), null)
+  })
+
+  it('replaces the status of one note and leaves the others alone', () => {
+    const statuses = withNoteSaveStatus(
+      withNoteSaveStatus({}, 'note-a', 'saving'),
+      'note-b',
+      'error'
+    )
+
+    assert.deepEqual(withNoteSaveStatus(statuses, 'note-a', 'saved'), {
+      'note-a': 'saved',
+      'note-b': 'error'
+    })
+  })
+
+  /** Reopening a note fetches a fresh copy, so whatever its last save answered no longer holds. */
+  it('drops one note without disturbing the rest', () => {
+    const statuses = { 'note-a': 'conflict', 'note-b': 'error' }
+
+    assert.deepEqual(withoutNoteSaveStatus(statuses, 'note-a'), { 'note-b': 'error' })
+  })
+
+  it('drops a note it does not hold without complaining', () => {
+    assert.deepEqual(withoutNoteSaveStatus({ 'note-a': 'saved' }, 'note-b'), { 'note-a': 'saved' })
+  })
+})
+
+describe('failedSaveNoteIds, asked before leaving the module and before opening another note', () => {
+  it('lists a refused save and a failed one', () => {
+    const statuses = { 'note-a': 'conflict', 'note-b': 'error', 'note-c': 'saved' }
+
+    assert.deepEqual(failedSaveNoteIds(statuses).sort(), ['note-a', 'note-b'])
+  })
+
+  /**
+   * Both exits unmount the editor, which flushes what was waiting, so a save in flight is on its
+   * way to the server. Asking about it would be asking about nothing, and a confirm popped every
+   * time somebody opens another note within two seconds of typing is a confirm nobody reads.
+   */
+  it('leaves out a save still in flight', () => {
+    assert.deepEqual(failedSaveNoteIds({ 'note-a': 'saving' }), [])
+  })
+
+  it('is empty for a module where everything saved', () => {
+    assert.deepEqual(failedSaveNoteIds({ 'note-a': 'saved', 'note-b': 'saved' }), [])
+  })
+})
+
+describe('holdsUnsavedContent, which is what the tab is closed on', () => {
+  it('counts a save still in flight, because closing the tab kills it', () => {
+    assert.equal(holdsUnsavedContent({ 'note-a': 'saving' }), true)
+  })
+
+  it('counts a failed and a refused save', () => {
+    assert.equal(holdsUnsavedContent({ 'note-a': 'error' }), true)
+    assert.equal(holdsUnsavedContent({ 'note-a': 'conflict' }), true)
+  })
+
+  it('is false once everything has been written', () => {
+    assert.equal(holdsUnsavedContent({ 'note-a': 'saved', 'note-b': 'saved' }), false)
+    assert.equal(holdsUnsavedContent({}), false)
+  })
+})

--- a/assets/js/views/BandSpace/Notes.vue
+++ b/assets/js/views/BandSpace/Notes.vue
@@ -55,10 +55,10 @@
         :band-space-id="bandSpaceId"
         :saveStatus="notesStore.saveStatus"
         :isReloading="notesStore.isReloadingNote"
-        @update-content="handleUpdateContent"
         @update-title="handleUpdateTitle"
         @update-emoji="handleUpdateEmoji"
         @reload="handleReloadNote"
+        @pending-edits-change="editorHasPendingEdits = $event"
       />
 
       <div v-else class="hidden md:flex flex-col items-center justify-center flex-1 text-center p-8">
@@ -85,8 +85,8 @@ import Message from 'primevue/message'
 import ProgressSpinner from 'primevue/progressspinner'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
-import { onMounted, onUnmounted, ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { onBeforeUnmount, onMounted, onUnmounted, ref } from 'vue'
+import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute } from 'vue-router'
 import CreateNoteDialog from '../../components/BandSpace/Notes/CreateNoteDialog.vue'
 import NoteEditor from '../../components/BandSpace/Notes/NoteEditor.vue'
 import NoteTree from '../../components/BandSpace/Notes/NoteTree.vue'
@@ -105,19 +105,69 @@ const showCreateDialog = ref(false)
 const createParentId = ref(null)
 const mobileView = ref('tree') // 'tree' | 'editor'
 const noteTreeRef = ref(null)
+// Only one editor is ever mounted, the open note's, so one flag is the whole answer.
+const editorHasPendingEdits = ref(false)
 
 const bandSpaceId = route.params.id
 
 onMounted(() => {
+  window.addEventListener('beforeunload', warnOnUnload)
   notesStore.loadNotes(bandSpaceId)
 })
+
+onBeforeUnmount(() => window.removeEventListener('beforeunload', warnOnUnload))
 
 onUnmounted(() => {
   notesStore.clear()
 })
 
-function handleSelect(noteId) {
+/**
+ * Covers closing the tab and reloading, which the router never sees and which the flush on unmount
+ * never runs for. Up to two seconds of typing lives on the debounce, and a save the server refused
+ * lives nowhere else at all.
+ *
+ * The browser shows its own wording here; returnValue is what makes it show anything at all.
+ */
+function warnOnUnload(event) {
+  if (!editorHasPendingEdits.value && !notesStore.hasUnsavedContent) return
+  event.preventDefault()
+  event.returnValue = ''
+}
+
+onBeforeRouteLeave(() => notesStore.confirmDiscardingEdits())
+
+// Switching band space changes only the id param, which keeps this route matched and so never
+// fires onBeforeRouteLeave. The keyed router-view then rebuilds this view around the new space and
+// the notes of the old one are gone, so the question has to be asked here, before the param change
+// is committed.
+onBeforeRouteUpdate(() => notesStore.confirmDiscardingEdits())
+
+/**
+ * Guarded like the route guards above, and for the same reason: opening another note unmounts the
+ * editor holding this one, so text a save was refused for goes with it. This is the exit path the
+ * conflict banner tells the member to copy their text before taking, so it is the one that most
+ * has to enforce what the banner says.
+ *
+ * The route leave predicate is the right one here rather than the tab close one: the unmount
+ * flushes whatever is still on the debounce, so pending keystrokes are on their way to the server
+ * and only a save already refused is actually lost.
+ *
+ * @returns {boolean} false when the member chose to keep what is open
+ */
+function openNote(noteId) {
+  // Re-opening the note already on screen unmounts nothing, so there is nothing to ask about.
+  if (noteId === notesStore.selectedNoteId) return true
+
+  if (!notesStore.confirmDiscardingEdits()) return false
+
   notesStore.selectNote(bandSpaceId, noteId)
+
+  return true
+}
+
+function handleSelect(noteId) {
+  if (!openNote(noteId)) return
+
   mobileView.value = 'editor'
 }
 
@@ -141,7 +191,9 @@ async function handleCreateNote({ title, parentId }) {
       summary: 'Note créée',
       life: 3000
     })
-    notesStore.selectNote(bandSpaceId, newNote.id)
+    // Created either way, opened only if the note being left has nothing to lose. Same unmount,
+    // same loss, so the same question as clicking another note in the tree.
+    openNote(newNote.id)
   } catch (error) {
     toast.add({
       severity: 'error',
@@ -152,19 +204,31 @@ async function handleCreateNote({ title, parentId }) {
   }
 }
 
-function handleUpdateContent({ noteId, content, contentVersion }) {
-  notesStore.updateNoteContent(bandSpaceId, noteId, content, contentVersion)
-}
+async function handleUpdateTitle(title) {
+  if (!notesStore.selectedNoteId) return
 
-function handleUpdateTitle(title) {
-  if (notesStore.selectedNoteId) {
-    notesStore.updateNoteTitle(bandSpaceId, notesStore.selectedNoteId, title)
+  const { status } = await notesStore.updateNoteTitle(bandSpaceId, notesStore.selectedNoteId, title)
+  if (status === 'error') {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: "Le titre n'a pas pu être modifié",
+      life: 5000
+    })
   }
 }
 
-function handleUpdateEmoji(emoji) {
-  if (notesStore.selectedNoteId) {
-    notesStore.updateNoteEmoji(bandSpaceId, notesStore.selectedNoteId, emoji)
+async function handleUpdateEmoji(emoji) {
+  if (!notesStore.selectedNoteId) return
+
+  const { status } = await notesStore.updateNoteEmoji(bandSpaceId, notesStore.selectedNoteId, emoji)
+  if (status === 'error') {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: "L'emoji n'a pas pu être modifié",
+      life: 5000
+    })
   }
 }
 

--- a/src/Service/BandSpace/BandSpaceActivityRecorder.php
+++ b/src/Service/BandSpace/BandSpaceActivityRecorder.php
@@ -6,15 +6,31 @@ use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceActivity;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
 use BackedEnum;
+use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
 readonly class BandSpaceActivityRecorder
 {
+    /**
+     * How long one member's work on one resource counts as a single act.
+     *
+     * Both surfaces with a rich text editor, notes and tech rider items, save on a two second
+     * debounce, so recording every write turns one writing session into dozens of near identical
+     * feed rows. The dashboard widget shows only the ten most recent activities of the whole space,
+     * so that one session pushes agenda, finance, files and tasks off every member's dashboard.
+     *
+     * Fifteen minutes is long enough to cover a continuous session and short enough that a resource
+     * picked up again after a break still leaves a trace.
+     */
+    private const int COALESCE_WINDOW_MINUTES = 15;
+
     public function __construct(
         private EntityManagerInterface $entityManager,
+        private BandSpaceActivityRepository $activityRepository,
     ) {
     }
 
@@ -40,5 +56,48 @@ readonly class BandSpaceActivityRecorder
         $this->entityManager->persist($activity);
 
         return $activity;
+    }
+
+    /**
+     * Records nothing when the same member already logged the same thing on the same resource
+     * inside the window. For anything written by an autosave timer, which is what both rich text
+     * editors do, this is what keeps the feed a history rather than a keystroke log.
+     *
+     * The resource and the actor are required here, unlike on `record`: "the same subject by the
+     * same person" is the whole definition of what may be folded together, and neither half can be
+     * left out. It stays per member on purpose, because two people writing in the same note are two
+     * facts and collapsing them would hide who did what.
+     *
+     * Only a save is ever coalesced. A rename, an emoji pick or an inclusion toggle is a single
+     * deliberate act, so callers record those every time.
+     *
+     * @param array<string, mixed>|null $payload
+     *
+     * @return BandSpaceActivity|null null when the write was folded into the existing entry
+     */
+    public function recordCoalesced(
+        BandSpace $bandSpace,
+        BandSpaceModule $module,
+        BackedEnum|string $type,
+        UuidInterface|string $resourceId,
+        User $actor,
+        ?array $payload = null,
+    ): ?BandSpaceActivity {
+        $typeValue = $type instanceof BackedEnum ? (string) $type->value : $type;
+
+        $latest = $this->activityRepository->findLatestForResource(
+            $bandSpace,
+            $module,
+            $typeValue,
+            $resourceId,
+            $actor,
+        );
+
+        $window = new DateTime(sprintf('-%d minutes', self::COALESCE_WINDOW_MINUTES));
+        if ($latest instanceof BandSpaceActivity && $latest->creationDatetime >= $window) {
+            return null;
+        }
+
+        return $this->record($bandSpace, $module, $typeValue, $resourceId, $actor, $payload);
     }
 }

--- a/src/State/Processor/BandSpace/BandSpaceNoteUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceNoteUpdateProcessor.php
@@ -83,6 +83,9 @@ readonly class BandSpaceNoteUpdateProcessor implements ProcessorInterface
 
         $note->updateDatetime = new DateTime();
 
+        // A rename and an emoji pick are deliberate single acts, made by leaving a field or by
+        // choosing in a picker, so they are recorded every time. Only the body is written by a
+        // timer, and only the body is coalesced.
         if ($oldTitle !== $note->title) {
             $this->bandSpaceActivityRecorder->record(
                 bandSpace: $bandSpace,
@@ -110,11 +113,13 @@ readonly class BandSpaceNoteUpdateProcessor implements ProcessorInterface
             // work, and bumping there would reject the next autosave of everyone else editing.
             ++$note->contentVersion;
 
-            $this->bandSpaceActivityRecorder->record(
+            // Coalesced, unlike the two above: this one is written by the two second autosave, so
+            // recording each one would bury the whole space's feed under a single writing session.
+            $this->bandSpaceActivityRecorder->recordCoalesced(
                 bandSpace: $bandSpace,
                 module: BandSpaceModule::Notes,
                 type: BandSpaceNoteActivityType::ContentUpdated,
-                resourceId: $note->id,
+                resourceId: (string) $note->id,
                 actor: $user,
             );
         }

--- a/src/State/Processor/BandSpace/TechRider/TechRiderItemUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/TechRider/TechRiderItemUpdateProcessor.php
@@ -12,7 +12,6 @@ use App\Entity\BandSpace\TechRiderItem;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceRiderActivityType;
-use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\TechRiderRepository;
 use App\Repository\BandSpace\TechRiderItemRepository;
@@ -34,20 +33,12 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
  */
 readonly class TechRiderItemUpdateProcessor implements ProcessorInterface
 {
-    /**
-     * A content change by the same person on the same item inside this window reuses the
-     * existing activity row instead of adding one. The editor autosaves on a debounce, so
-     * without this an afternoon of writing becomes forty near identical feed entries.
-     */
-    private const int ACTIVITY_COALESCE_MINUTES = 15;
-
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private TechRiderWriteGuard $writeGuard,
         private TechRiderRepository $techRiderRepository,
         private TechRiderItemRepository $itemRepository,
-        private BandSpaceActivityRepository $activityRepository,
         private BandSpaceFileRepository $fileRepository,
         private BandSpaceActivityRecorder $activityRecorder,
         private TechRiderItemBuilder $itemBuilder,
@@ -149,8 +140,8 @@ readonly class TechRiderItemUpdateProcessor implements ProcessorInterface
             );
         }
 
-        if ($contentChanged && $this->shouldRecordContentUpdate($bandSpace, $item, $user)) {
-            $this->activityRecorder->record(
+        if ($contentChanged) {
+            $this->activityRecorder->recordCoalesced(
                 bandSpace: $bandSpace,
                 module: BandSpaceModule::Rider,
                 type: BandSpaceRiderActivityType::RiderItemUpdated,
@@ -190,22 +181,5 @@ readonly class TechRiderItemUpdateProcessor implements ProcessorInterface
         }
 
         return $file;
-    }
-
-    private function shouldRecordContentUpdate(BandSpace $bandSpace, TechRiderItem $item, User $user): bool
-    {
-        $latest = $this->activityRepository->findLatestForResource(
-            $bandSpace,
-            BandSpaceModule::Rider,
-            BandSpaceRiderActivityType::RiderItemUpdated->value,
-            (string) $item->id,
-            $user,
-        );
-
-        if ($latest === null) {
-            return true;
-        }
-
-        return $latest->creationDatetime < new DateTime(sprintf('-%d minutes', self::ACTIVITY_COALESCE_MINUTES));
     }
 }

--- a/tests/Api/BandSpace/BandSpaceNoteActivityTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteActivityTest.php
@@ -1,0 +1,250 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceActivity;
+use App\Entity\BandSpace\BandSpaceNote;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceNoteRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceActivityFactory;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\BandSpaceNoteFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use Ramsey\Uuid\Uuid;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * The note editor autosaves every two seconds, so recording every body change turned one writing
+ * session into dozens of near identical feed rows. The dashboard widget shows the ten most recent
+ * activities of the whole space, so that one session pushed agenda, finance, files and tasks off
+ * every member's dashboard. These pin the coalescing that prevents it, and the four things it must
+ * not swallow.
+ *
+ * Each test makes a single API call and seeds any earlier activity directly, because loginUser()
+ * only survives one request.
+ */
+#[ResetDatabase]
+class BandSpaceNoteActivityTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array PATCH_HEADERS = [
+        'CONTENT_TYPE' => 'application/merge-patch+json',
+        'HTTP_ACCEPT' => 'application/ld+json',
+    ];
+
+    public function test_a_first_content_save_records_an_activity(): void
+    {
+        [$user, $bandSpace, $note] = $this->seedNote();
+
+        $this->patchAs($user, $bandSpace, $note, [
+            'content' => $this->doc('Premier jet'),
+            'expected_content_version' => 1,
+        ]);
+
+        $activities = $this->activitiesFor($bandSpace, $note);
+        $this->assertCount(1, $activities);
+        $this->assertSame('note_content_updated', $activities[0]->type);
+        $this->assertNull($activities[0]->payload);
+    }
+
+    public function test_a_second_content_save_inside_the_window_records_nothing_new(): void
+    {
+        [$user, $bandSpace, $note] = $this->seedNote();
+        $this->seedContentActivity($bandSpace, $note, $user, new DateTime('-2 minutes'));
+
+        $this->patchAs($user, $bandSpace, $note, [
+            'content' => $this->doc('Deuxième jet'),
+            'expected_content_version' => 1,
+        ]);
+
+        $this->assertCount(1, $this->activitiesFor($bandSpace, $note));
+    }
+
+    /**
+     * Past the window the trail resumes, otherwise a note revisited every week would show a single
+     * entry forever.
+     */
+    public function test_a_content_save_after_the_window_records_a_new_activity(): void
+    {
+        [$user, $bandSpace, $note] = $this->seedNote();
+        $this->seedContentActivity($bandSpace, $note, $user, new DateTime('-1 hour'));
+
+        $this->patchAs($user, $bandSpace, $note, [
+            'content' => $this->doc('Repris plus tard'),
+            'expected_content_version' => 1,
+        ]);
+
+        $this->assertCount(2, $this->activitiesFor($bandSpace, $note));
+    }
+
+    /**
+     * Coalescing is per member as well as per note: two people writing in the same note inside the
+     * same window are two facts, and collapsing them would hide who did what.
+     */
+    public function test_another_member_editing_inside_the_window_records_their_own_activity(): void
+    {
+        [$user, $bandSpace, $note] = $this->seedNote();
+
+        $other = UserFactory::new()->create(['username' => 'second_member', 'email' => 'second@test.com']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other])->create();
+        $this->seedContentActivity($bandSpace, $note, $other, new DateTime('-2 minutes'));
+
+        $this->patchAs($user, $bandSpace, $note, [
+            'content' => $this->doc('Par quelqu\'un d\'autre'),
+            'expected_content_version' => 1,
+        ]);
+
+        $this->assertCount(2, $this->activitiesFor($bandSpace, $note));
+    }
+
+    /**
+     * Coalescing hides feed rows, never revisions: the next autosave of everyone else editing this
+     * note still has to be refused.
+     */
+    public function test_a_coalesced_content_save_still_bumps_the_revision(): void
+    {
+        [$user, $bandSpace, $note] = $this->seedNote();
+        $this->seedContentActivity($bandSpace, $note, $user, new DateTime('-2 minutes'));
+
+        $this->patchAs($user, $bandSpace, $note, [
+            'content' => $this->doc('Deuxième jet'),
+            'expected_content_version' => 1,
+        ]);
+
+        $refreshed = self::getContainer()->get(BandSpaceNoteRepository::class)->find($note->id);
+        $this->assertSame(2, $refreshed->contentVersion);
+        $this->assertCount(1, $this->activitiesFor($bandSpace, $note));
+    }
+
+    /** A rename is a deliberate act, not an autosave, so coalescing must never swallow it. */
+    public function test_a_rename_is_recorded_even_when_the_content_change_is_coalesced(): void
+    {
+        [$user, $bandSpace, $note] = $this->seedNote();
+        $this->seedContentActivity($bandSpace, $note, $user, new DateTime('-2 minutes'));
+
+        $this->patchAs($user, $bandSpace, $note, [
+            'title' => 'Répétition du 12',
+            'content' => $this->doc('Contenu revu'),
+            'expected_content_version' => 1,
+        ]);
+
+        $this->assertSame(
+            ['note_content_updated', 'note_renamed'],
+            $this->activityTypesFor($bandSpace, $note),
+        );
+    }
+
+    /** Same for the emoji picker: one pick, one entry, whatever the body is doing. */
+    public function test_an_emoji_change_is_recorded_even_when_the_content_change_is_coalesced(): void
+    {
+        [$user, $bandSpace, $note] = $this->seedNote();
+        $this->seedContentActivity($bandSpace, $note, $user, new DateTime('-2 minutes'));
+
+        $this->patchAs($user, $bandSpace, $note, [
+            'emoji' => '🎵',
+            'content' => $this->doc('Contenu revu'),
+            'expected_content_version' => 1,
+        ]);
+
+        $this->assertSame(
+            ['note_content_updated', 'note_emoji_changed'],
+            $this->activityTypesFor($bandSpace, $note),
+        );
+    }
+
+    /**
+     * @return array{0: User, 1: BandSpace, 2: BandSpaceNote}
+     */
+    private function seedNote(): array
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Répétition',
+            'position' => 0,
+            'creationDatetime' => new DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        return [$user, $bandSpace, $note];
+    }
+
+    private function seedContentActivity(
+        BandSpace $bandSpace,
+        BandSpaceNote $note,
+        User $actor,
+        DateTime $when,
+    ): void {
+        BandSpaceActivityFactory::new([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Notes,
+            'type' => 'note_content_updated',
+            'resourceId' => Uuid::fromString((string) $note->id),
+            'actor' => $actor,
+            'creationDatetime' => $when,
+        ])->create();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function patchAs(User $user, BandSpace $bandSpace, BandSpaceNote $note, array $payload): void
+    {
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            $payload,
+            self::PATCH_HEADERS,
+        );
+        $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return array<int, BandSpaceActivity>
+     */
+    private function activitiesFor(BandSpace $bandSpace, BandSpaceNote $note): array
+    {
+        return self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($bandSpace, BandSpaceModule::Notes, $note->id);
+    }
+
+    /**
+     * Sorted, because two activities recorded in the same request share a timestamp and the feed
+     * order between them is not decided by anything.
+     *
+     * @return array<int, string>
+     */
+    private function activityTypesFor(BandSpace $bandSpace, BandSpaceNote $note): array
+    {
+        $types = array_map(
+            static fn (BandSpaceActivity $activity): string => $activity->type,
+            $this->activitiesFor($bandSpace, $note),
+        );
+        sort($types);
+
+        return $types;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function doc(string $text): array
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $text]]],
+            ],
+        ];
+    }
+}

--- a/tests/Integration/Service/BandSpace/BandSpaceActivityRecorderTest.php
+++ b/tests/Integration/Service/BandSpace/BandSpaceActivityRecorderTest.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Service\BandSpace;
 
+use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceActivity;
+use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Tests\Factory\BandSpace\BandSpaceActivityFactory;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\User\UserFactory;
+use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -151,9 +156,152 @@ class BandSpaceActivityRecorderTest extends KernelTestCase
         $this->assertSame(['renamed', 'uploaded'], $types);
     }
 
+    /**
+     * Both rich text editors, notes and tech rider items, save on a two second debounce. Recording
+     * every one of those writes turns a writing session into dozens of near identical feed rows and
+     * pushes every other module off the dashboard widget, which shows ten activities for the whole
+     * space. These pin the folding that prevents it, and the four things it must not fold.
+     */
+    public function test_record_coalesced_records_when_the_resource_has_no_earlier_activity(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $activity = $this->getRecorder()->recordCoalesced(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Notes,
+            type: 'note_content_updated',
+            resourceId: Uuid::uuid4(),
+            actor: $user,
+        );
+        $this->getEntityManager()->flush();
+
+        $this->assertNotNull($activity);
+        $this->assertSame('note_content_updated', $activity->type);
+    }
+
+    public function test_record_coalesced_records_nothing_inside_the_window(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $resourceId = Uuid::uuid4();
+        $this->seedActivity($bandSpace, $resourceId, $user, new DateTime('-2 minutes'));
+
+        $activity = $this->getRecorder()->recordCoalesced(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Notes,
+            type: 'note_content_updated',
+            resourceId: $resourceId,
+            actor: $user,
+        );
+        $this->getEntityManager()->flush();
+
+        $this->assertNull($activity);
+        $this->assertCount(1, $this->getRepository()->findForResource($bandSpace, BandSpaceModule::Notes, $resourceId));
+    }
+
+    /**
+     * Past the window the trail resumes, otherwise a resource picked up every week would show a
+     * single entry forever.
+     */
+    public function test_record_coalesced_records_again_past_the_window(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $resourceId = Uuid::uuid4();
+        $this->seedActivity($bandSpace, $resourceId, $user, new DateTime('-16 minutes'));
+
+        $activity = $this->getRecorder()->recordCoalesced(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Notes,
+            type: 'note_content_updated',
+            resourceId: $resourceId,
+            actor: $user,
+        );
+        $this->getEntityManager()->flush();
+
+        $this->assertNotNull($activity);
+        $this->assertCount(2, $this->getRepository()->findForResource($bandSpace, BandSpaceModule::Notes, $resourceId));
+    }
+
+    /** Two people writing in the same note are two facts, and folding them would hide who did what. */
+    public function test_record_coalesced_records_for_another_actor_inside_the_window(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->create(['username' => 'second_member', 'email' => 'second@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $resourceId = Uuid::uuid4();
+        $this->seedActivity($bandSpace, $resourceId, $other, new DateTime('-2 minutes'));
+
+        $activity = $this->getRecorder()->recordCoalesced(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Notes,
+            type: 'note_content_updated',
+            resourceId: $resourceId,
+            actor: $user,
+        );
+        $this->getEntityManager()->flush();
+
+        $this->assertNotNull($activity);
+    }
+
+    /** A rename inside the window of a body save is a different act, so it stands on its own. */
+    public function test_record_coalesced_records_for_another_type_inside_the_window(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $resourceId = Uuid::uuid4();
+        $this->seedActivity($bandSpace, $resourceId, $user, new DateTime('-2 minutes'));
+
+        $activity = $this->getRecorder()->recordCoalesced(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Notes,
+            type: 'note_renamed',
+            resourceId: $resourceId,
+            actor: $user,
+        );
+        $this->getEntityManager()->flush();
+
+        $this->assertNotNull($activity);
+    }
+
+    public function test_record_coalesced_records_for_another_resource_inside_the_window(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $this->seedActivity($bandSpace, Uuid::uuid4(), $user, new DateTime('-2 minutes'));
+
+        $activity = $this->getRecorder()->recordCoalesced(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Notes,
+            type: 'note_content_updated',
+            resourceId: Uuid::uuid4(),
+            actor: $user,
+        );
+        $this->getEntityManager()->flush();
+
+        $this->assertNotNull($activity);
+    }
+
+    private function seedActivity(
+        BandSpace $bandSpace,
+        UuidInterface $resourceId,
+        User $actor,
+        DateTime $when,
+    ): void {
+        BandSpaceActivityFactory::new([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Notes,
+            'type' => 'note_content_updated',
+            'resourceId' => $resourceId,
+            'actor' => $actor,
+            'creationDatetime' => $when,
+        ])->create();
+    }
+
     private function getRecorder(): BandSpaceActivityRecorder
     {
-        return new BandSpaceActivityRecorder($this->getEntityManager());
+        return new BandSpaceActivityRecorder($this->getEntityManager(), $this->getRepository());
     }
 
     private function getRepository(): BandSpaceActivityRepository


### PR DESCRIPTION
Closes #826 (items 1, 2, 4). Items 3 (re-parent and reorder) and 5 (authorship) were split to #864 and #865. No migration.

Sits on top of #808 (sanitizer) and #809 (revision check).

## Item 1: a failed autosave lost text silently

The store swallowed the failure into `saveStatus = error`: no toast, no retry, no buffer, with the only surface an 11px "Erreur" in the editor header. Worse, `saveStatus` was a single store-wide value never reset on note select, so after switching notes a previous failure painted the error badge on the wrong, untouched note.

Status is now per note, so a failure on the note being left cannot paint the note being opened. Failures raise a toast naming the note, because by then it is often not the one on screen.

**Retry respects the revision check rather than fighting it.** The processor answers 409 for a stale revision and 428 for a body write carrying no revision at all (the issue text said 428 for both; the code disagrees, and the code is right). So: 409 is never retried, since the same refused document gets the same answer, and surfaces as a conflict; 428 is never retried either, since the payload was built wrong and rebuilding it changes nothing; only a 5xx or a request that got no answer is retried, twice, at 1s and 4s. Every attempt re-sends the identical payload including the original `expected_content_version`, so a retry landing after another member has written comes back 409 rather than overwriting them.

One cost accepted deliberately: if attempt 1 reached the server and only its response was lost, the retry is refused as a conflict for the member own saved text. A wrong warning, chosen over a right-looking overwrite.

**Switching notes now enforces what the banner promises.** The toast tells the user to copy their text "avant de... den ouvrir une autre", and nothing stopped them doing exactly that: selecting another note unmounted the editor synchronously and the text was gone. Sidebar selection and post-create auto-select now run the same guard as the router. Review caught that PrimeVue `Tree` moves its selection before emitting, so a refused confirm left the sidebar highlighting a note the editor never opened; that is fixed too.

**One extra fix the retry work exposed.** `createDebouncedSaver` only holds the next save while `onSave` returns a promise, but `NoteEditor` emitted and returned `undefined`, so the documented one-save-at-a-time rule was never actually in force. Latent before; with retries taking up to 5s it becomes a bogus self-conflict. `NoteEditor` now calls the store and returns the promise.

## Item 2: no unsaved-changes guard on navigation

`Notes.vue` registered no `beforeunload` and no route guard, while the two sibling views using the same composable both do. `useRichTextEditor` only flushes on unmount, which never fires on tab close or F5.

Both guards added, plus `onBeforeRouteUpdate`, because switching band space only changes `:id` and the keyed `router-view` rebuilds the view without ever firing `onBeforeRouteLeave`.

The two guards deliberately read different predicates. Route leave asks only about failed saves, because leaving unmounts the editor and flushes the debounce, so prompting for pending keystrokes would prompt about a save already on its way, and a confirm nobody reads protects nothing. `beforeunload` also counts pending keystrokes and a save in flight, because closing the tab kills both.

## Item 4: every autosave flooded the activity feed

Content updates were recorded on every diff with no coalescing and a 2 second autosave, so one writing session produced dozens of rows. The dashboard widget shows the 10 most recent activities for the whole space, so a single note session wiped agenda, finance, files and tasks off every member dashboard.

Coalesced on a 15 minute window keyed by space, module, type, resource **and actor**, so two members editing the same note in the same window each still get their own row. The window matches the existing tech rider editor.

Content only. A rename and an emoji pick are single deliberate acts carrying a from/to payload that collapsing would destroy, and neither is fired by a timer. The version bump sits outside the guard, so coalescing hides feed rows but never a revision, which would have reintroduced #809. Both are pinned by tests.

Review asked for the duplicated coalescing to be extracted, so it now lives in `BandSpaceActivityRecorder::recordCoalesced()` and both processors call it. Mutating it to never fold fails 7 tests across three suites, including 2 on the tech rider side, so both consumers stayed covered through the consolidation.

## Verification

`tests/Api/BandSpace/` 975 and `tests/Integration/` 205 passing, PHPStan level 8 clean, npm test 190/190, Biome unchanged from baseline, build OK.

There is no component test harness in this repo, so the decisions were pushed into pure modules and pinned there; the `beforeunload` registration and toast calls themselves are verified by build and review, not automated tests.