### PR TITLE
Band Space: allow admins to rename a space

### DIFF
--- a/assets/js/api/bandSpace/band-space.js
+++ b/assets/js/api/bandSpace/band-space.js
@@ -35,5 +35,27 @@ export default {
       )
       .then((resp) => resp.data)
       .catch(handleApiError)
+  },
+
+  /**
+   * Renames a band space. Admin only, the server refuses a plain member.
+   * @param {string} id - The band space id
+   * @param {string} name - The new name
+   * @returns {Promise<Object>} The updated band space
+   */
+  rename(id, name) {
+    return axios
+      .patch(
+        Routing.generate('api_band_spaces_patch', { id }),
+        { name },
+        {
+          headers: {
+            'Content-Type': 'application/merge-patch+json',
+            Accept: 'application/ld+json'
+          }
+        }
+      )
+      .then((resp) => resp.data)
+      .catch(handleApiError)
   }
 }

--- a/assets/js/components/BandSpace/Settings/GeneralSection.vue
+++ b/assets/js/components/BandSpace/Settings/GeneralSection.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-6">
+    <h3 class="text-base font-semibold text-surface-800 dark:text-surface-100 mb-4">
+      Nom du Band Space
+    </h3>
+
+    <!-- Rename form, admin only: the server refuses a rename sent by a plain member -->
+    <form v-if="isAdmin" @submit.prevent="handleRename" class="flex flex-col gap-3 sm:flex-row">
+      <div class="flex-1 min-w-0">
+        <label for="band-space-name" class="sr-only">Nom du Band Space</label>
+        <InputText
+          id="band-space-name"
+          v-model="name"
+          class="w-full"
+          maxlength="255"
+          autocomplete="off"
+          placeholder="Nom du Band Space"
+          :invalid="Boolean(renameError)"
+          :disabled="bandSpaceStore.isRenaming"
+        />
+        <small class="text-surface-500 dark:text-surface-400 mt-2 block">
+          Ce nom apparaît dans le menu, dans les notifications et sur les tech riders.
+        </small>
+      </div>
+      <Button
+        type="submit"
+        label="Enregistrer"
+        icon="pi pi-check"
+        class="shrink-0 self-start"
+        :loading="bandSpaceStore.isRenaming"
+        :disabled="!canSubmit"
+      />
+    </form>
+
+    <p v-else class="text-surface-700 dark:text-surface-200">
+      {{ currentSpace?.name }}
+      <span class="text-sm text-surface-500 dark:text-surface-400 block mt-2">
+        Seul un administrateur peut renommer cet espace.
+      </span>
+    </p>
+
+    <Message v-if="renameError" severity="error" :closable="false" class="mt-3">
+      {{ renameError }}
+    </Message>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import { useToast } from 'primevue/usetoast'
+import { computed, ref, watch } from 'vue'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
+import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
+
+const toast = useToast()
+const bandSpaceStore = useBandSpaceStore()
+const { currentSpaceId, currentSpace, isAdmin } = useBandSpaceNavigation()
+
+const name = ref(currentSpace.value?.name ?? '')
+const renameError = ref(null)
+
+// The space list is loaded by the band layout, so the name can still be missing on first render, and
+// it also changes under us when another tab renames the space or the user switches space.
+watch(
+  () => currentSpace.value?.name,
+  (spaceName) => {
+    name.value = spaceName ?? ''
+    renameError.value = null
+  }
+)
+
+const canSubmit = computed(() => {
+  const trimmed = name.value.trim()
+
+  return trimmed.length > 0 && trimmed !== currentSpace.value?.name
+})
+
+async function handleRename() {
+  if (!canSubmit.value) return
+
+  renameError.value = null
+
+  try {
+    await bandSpaceStore.renameBandSpace(currentSpaceId.value, name.value.trim())
+    toast.add({ severity: 'success', summary: 'Band Space renommé', life: 3000 })
+  } catch (e) {
+    renameError.value = e.message
+  }
+}
+</script>

--- a/assets/js/components/BandSpace/Settings/activitySentences.js
+++ b/assets/js/components/BandSpace/Settings/activitySentences.js
@@ -173,6 +173,8 @@ const SENTENCES = {
 
   // Settings — band
   'settings.band_created': (a) => `a créé le Band Space « ${a.payload?.name ?? '—'} »`,
+  'settings.band_renamed': (a) =>
+    `a renommé le Band Space de « ${a.payload?.from} » à « ${a.payload?.to} »`,
 
   // Settings — membership
   'settings.member_role_changed': (a) =>

--- a/assets/js/store/bandSpace/bandSpace.js
+++ b/assets/js/store/bandSpace/bandSpace.js
@@ -7,6 +7,7 @@ export const useBandSpaceStore = defineStore('bandSpaces', () => {
   const isLoading = ref(false)
   const isCreateModalOpen = ref(false)
   const isCreating = ref(false)
+  const isRenaming = ref(false)
   const error = ref(null)
 
   // Computed getters for derived state
@@ -53,6 +54,21 @@ export const useBandSpaceStore = defineStore('bandSpaces', () => {
     }
   }
 
+  // Replaces the entry rather than reloading the list: the sidebar, the page title and the space
+  // selector all read the name through getById, so swapping the one space is enough for the new name
+  // to appear everywhere it is shown.
+  async function renameBandSpace(id, name) {
+    isRenaming.value = true
+
+    try {
+      const updated = await bandSpaceApi.rename(id, name)
+      spaces.value = spaces.value.map((space) => (space.id === id ? updated : space))
+      return updated
+    } finally {
+      isRenaming.value = false
+    }
+  }
+
   function getById(id) {
     return spacesMap.value.get(id) || null
   }
@@ -78,6 +94,7 @@ export const useBandSpaceStore = defineStore('bandSpaces', () => {
     // Actions
     loadMyBandSpaces,
     createBandSpace,
+    renameBandSpace,
     getById,
     openCreateModal,
     closeCreateModal,
@@ -88,6 +105,7 @@ export const useBandSpaceStore = defineStore('bandSpaces', () => {
     isLoading: readonly(isLoading),
     isCreateModalOpen: readonly(isCreateModalOpen),
     isCreating: readonly(isCreating),
+    isRenaming: readonly(isRenaming),
     error: readonly(error),
     // Computed getters
     hasSpaces,

--- a/assets/js/views/BandSpace/Settings.vue
+++ b/assets/js/views/BandSpace/Settings.vue
@@ -33,6 +33,7 @@
             <ActivitySection v-else-if="activeSection === 'activity'" />
             <ActiveSharesSection v-else-if="activeSection === 'shares'" />
             <QuotaIndicator v-else-if="activeSection === 'storage'" />
+            <GeneralSection v-else-if="activeSection === 'general'" />
             <DangerZoneSection v-else-if="activeSection === 'danger'" />
             <ComingSoonSection v-else :title="activeSectionLabel" />
           </div>
@@ -50,6 +51,7 @@ import ActiveSharesSection from '../../components/BandSpace/Settings/ActiveShare
 import ActivitySection from '../../components/BandSpace/Settings/ActivitySection.vue'
 import ComingSoonSection from '../../components/BandSpace/Settings/ComingSoonSection.vue'
 import DangerZoneSection from '../../components/BandSpace/Settings/DangerZoneSection.vue'
+import GeneralSection from '../../components/BandSpace/Settings/GeneralSection.vue'
 import MembersSection from '../../components/BandSpace/Settings/MembersSection.vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
 import {

--- a/src/ApiResource/BandSpace/BandSpace.php
+++ b/src/ApiResource/BandSpace/BandSpace.php
@@ -7,10 +7,13 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\Processor\BandSpace\BandSpaceDeleteProcessor;
+use App\State\Processor\BandSpace\BandSpaceUpdateProcessor;
 use App\State\Provider\BandSpace\BandSpaceCollectionProvider;
 use App\State\Provider\BandSpace\BandSpaceItemProvider;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
@@ -29,6 +32,14 @@ use App\State\Provider\BandSpace\BandSpaceItemProvider;
             name: 'api_band_spaces_get_item',
             provider: BandSpaceItemProvider::class,
         ),
+        new Patch(
+            uriTemplate: '/band_spaces/{id}',
+            openapi: new Operation(tags: ['Band Space']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_spaces_patch',
+            provider: BandSpaceItemProvider::class,
+            processor: BandSpaceUpdateProcessor::class,
+        ),
         // Schedules the deletion, it does not delete: app:band-space:purge removes the space and its
         // files once deletionScheduledDatetime has passed. Restore with api_band_space_restore.
         new Delete(
@@ -45,6 +56,19 @@ use App\State\Provider\BandSpace\BandSpaceItemProvider;
 class BandSpace
 {
     public string $id;
+
+    /**
+     * Same rules as BandSpaceCreate, so a rename cannot produce a name creation would have refused.
+     * The trim normalizer makes both constraints judge the value the processor actually stores.
+     */
+    #[Assert\NotBlank(message: 'Veuillez spécifier un nom', normalizer: 'trim')]
+    #[Assert\Length(
+        min: 3,
+        max: 255,
+        minMessage: 'Le nom doit contenir au moins {{ limit }} caractères',
+        maxMessage: 'Le nom ne peut pas dépasser {{ limit }} caractères',
+        normalizer: 'trim'
+    )]
     public string $name;
     public string $role;
 

--- a/src/ApiResource/BandSpace/BandSpaceCreate.php
+++ b/src/ApiResource/BandSpace/BandSpaceCreate.php
@@ -24,8 +24,8 @@ class BandSpaceCreate
     #[Assert\Length(
         min: 3,
         max: 255,
-        minMessage: 'Band space name must be at least {{ limit }} characters long',
-        maxMessage: 'Band space name cannot be longer than {{ limit }} characters'
+        minMessage: 'Le nom doit contenir au moins {{ limit }} caractères',
+        maxMessage: 'Le nom ne peut pas dépasser {{ limit }} caractères'
     )]
     public string $name;
 }

--- a/src/Enum/BandSpace/BandSpaceSettingsActivityType.php
+++ b/src/Enum/BandSpace/BandSpaceSettingsActivityType.php
@@ -5,6 +5,7 @@ namespace App\Enum\BandSpace;
 enum BandSpaceSettingsActivityType: string
 {
     case BandCreated = 'band_created';
+    case BandRenamed = 'band_renamed';
     case MemberRoleChanged = 'member_role_changed';
     case MemberRemoved = 'member_removed';
     case MemberLeft = 'member_left';

--- a/src/State/Processor/BandSpace/BandSpaceUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceUpdateProcessor.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\BandSpace as BandSpaceDto;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceSettingsActivityType;
+use App\Security\BandSpace\BandSpaceAdminChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\Builder\BandSpace\BandSpaceBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @implements ProcessorInterface<BandSpaceDto, BandSpaceDto>
+ */
+readonly class BandSpaceUpdateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceAdminChecker $adminChecker,
+        private BandSpaceBuilder $bandSpaceBuilder,
+        private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param BandSpaceDto $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): BandSpaceDto
+    {
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        [$bandSpace, $membership] = $this->adminChecker->checkAdminForWrite((string) $uriVariables['id'], $user);
+
+        // The name is the only writable field, and a PATCH that omits it arrives here carrying the
+        // current one, so comparing values is enough to tell a real rename from a no-op. Nothing to
+        // record and nothing to flush when they match.
+        $oldName = $bandSpace->name;
+        $newName = trim($data->name);
+
+        if ($oldName !== $newName) {
+            $bandSpace->name = $newName;
+
+            $this->bandSpaceActivityRecorder->record(
+                bandSpace: $bandSpace,
+                module: BandSpaceModule::Settings,
+                type: BandSpaceSettingsActivityType::BandRenamed,
+                resourceId: $bandSpace->id,
+                actor: $user,
+                payload: ['from' => $oldName, 'to' => $newName],
+            );
+
+            $this->entityManager->flush();
+        }
+
+        return $this->bandSpaceBuilder->buildItem($bandSpace, $membership->role);
+    }
+}

--- a/tests/Api/BandSpace/BandSpaceUpdateTest.php
+++ b/tests/Api/BandSpace/BandSpaceUpdateTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BandSpaceUpdateTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = [
+        'CONTENT_TYPE' => 'application/merge-patch+json',
+        'HTTP_ACCEPT' => 'application/ld+json',
+    ];
+
+    public function test_an_admin_renames_the_space(): void
+    {
+        [$admin, $bandSpace] = $this->spaceWithAdmin();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => 'Les Nouveaux Rockeurs'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpace',
+            '@id' => '/api/band_spaces/' . $bandSpace->id,
+            '@type' => 'BandSpace',
+            'id' => $bandSpace->id,
+            'name' => 'Les Nouveaux Rockeurs',
+            'role' => 'admin',
+            'deletion_scheduled_datetime' => null,
+        ]);
+
+        $reloaded = $this->reload($bandSpace);
+        $this->assertSame('Les Nouveaux Rockeurs', $reloaded->name);
+
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($reloaded, BandSpaceModule::Settings, $reloaded->id);
+        $this->assertCount(1, $activities);
+        $this->assertSame('band_renamed', $activities[0]->type);
+        $this->assertSame(['from' => 'The Rockers', 'to' => 'Les Nouveaux Rockeurs'], $activities[0]->payload);
+        $this->assertSame($admin->id, $activities[0]->actor?->id);
+    }
+
+    public function test_the_new_name_is_trimmed(): void
+    {
+        [$admin, $bandSpace] = $this->spaceWithAdmin();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => '   Les Nouveaux Rockeurs   '],
+            self::HEADERS,
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpace',
+            '@id' => '/api/band_spaces/' . $bandSpace->id,
+            '@type' => 'BandSpace',
+            'id' => $bandSpace->id,
+            'name' => 'Les Nouveaux Rockeurs',
+            'role' => 'admin',
+            'deletion_scheduled_datetime' => null,
+        ]);
+
+        $this->assertSame('Les Nouveaux Rockeurs', $this->reload($bandSpace)->name);
+    }
+
+    /**
+     * A rename that changes nothing must not pile up an activity row every time the form is submitted.
+     */
+    public function test_renaming_to_the_same_name_records_no_activity(): void
+    {
+        [$admin, $bandSpace] = $this->spaceWithAdmin();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => 'The Rockers'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpace',
+            '@id' => '/api/band_spaces/' . $bandSpace->id,
+            '@type' => 'BandSpace',
+            'id' => $bandSpace->id,
+            'name' => 'The Rockers',
+            'role' => 'admin',
+            'deletion_scheduled_datetime' => null,
+        ]);
+
+        $reloaded = $this->reload($bandSpace);
+        $this->assertCount(0, self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($reloaded, BandSpaceModule::Settings, $reloaded->id));
+    }
+
+    public function test_a_plain_member_cannot_rename_the_space(): void
+    {
+        [, $bandSpace] = $this->spaceWithAdmin();
+        $member = UserFactory::new()->create(['username' => 'member', 'email' => 'member@example.com']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $this->client->loginUser($member);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => 'Le groupe du batteur'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous devez être administrateur pour effectuer cette action',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous devez être administrateur pour effectuer cette action',
+        ]);
+
+        $this->assertSame('The Rockers', $this->reload($bandSpace)->name);
+    }
+
+    public function test_a_non_member_cannot_rename_the_space(): void
+    {
+        [, $bandSpace] = $this->spaceWithAdmin();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@example.com']);
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => 'Mon groupe maintenant'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'You are not a member of this band space',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'You are not a member of this band space',
+        ]);
+
+        $this->assertSame('The Rockers', $this->reload($bandSpace)->name);
+    }
+
+    public function test_an_anonymous_request_cannot_rename_the_space(): void
+    {
+        [, $bandSpace] = $this->spaceWithAdmin();
+
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => 'Groupe anonyme'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+
+        $this->assertSame('The Rockers', $this->reload($bandSpace)->name);
+    }
+
+    public function test_a_whitespace_only_name_is_refused(): void
+    {
+        [$admin, $bandSpace] = $this->spaceWithAdmin();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => '   '],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/0=c1051bb4-d103-4f74-8988-acbcafc7fdc3;1=9ff3fdc4-b214-49db-8718-39c315e33d45',
+            '@type' => 'ConstraintViolation',
+            'title' => 'An error occurred',
+            'detail' => "name: Veuillez spécifier un nom\nname: Le nom doit contenir au moins 3 caractères",
+            'description' => "name: Veuillez spécifier un nom\nname: Le nom doit contenir au moins 3 caractères",
+            'status' => 422,
+            'type' => '/validation_errors/0=c1051bb4-d103-4f74-8988-acbcafc7fdc3;1=9ff3fdc4-b214-49db-8718-39c315e33d45',
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Veuillez spécifier un nom',
+                    'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                ],
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Le nom doit contenir au moins 3 caractères',
+                    'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('The Rockers', $this->reload($bandSpace)->name);
+    }
+
+    /**
+     * The case the trim normalizer exists for: padding must not buy a name its way past the minimum,
+     * because the padding is gone by the time the processor stores it.
+     */
+    public function test_a_padded_name_that_trims_below_the_minimum_is_refused(): void
+    {
+        [$admin, $bandSpace] = $this->spaceWithAdmin();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => '  ab  '],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
+            '@type' => 'ConstraintViolation',
+            'title' => 'An error occurred',
+            'detail' => 'name: Le nom doit contenir au moins 3 caractères',
+            'description' => 'name: Le nom doit contenir au moins 3 caractères',
+            'status' => 422,
+            'type' => '/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Le nom doit contenir au moins 3 caractères',
+                    'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('The Rockers', $this->reload($bandSpace)->name);
+    }
+
+    public function test_an_over_long_name_is_refused(): void
+    {
+        [$admin, $bandSpace] = $this->spaceWithAdmin();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => str_repeat('a', 256)],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            '@type' => 'ConstraintViolation',
+            'title' => 'An error occurred',
+            'detail' => 'name: Le nom ne peut pas dépasser 255 caractères',
+            'description' => 'name: Le nom ne peut pas dépasser 255 caractères',
+            'status' => 422,
+            'type' => '/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Le nom ne peut pas dépasser 255 caractères',
+                    'code' => 'd94b19cc-114f-4f44-9cc4-4138e80a87b9',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('The Rockers', $this->reload($bandSpace)->name);
+    }
+
+    public function test_a_space_pending_deletion_cannot_be_renamed(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create([
+            'name' => 'The Rockers',
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+30 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id,
+            ['name' => 'Groupe condamné'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+        ]);
+
+        $this->assertSame('The Rockers', $this->reload($bandSpace)->name);
+    }
+
+    /**
+     * @return array{User, BandSpace}
+     */
+    private function spaceWithAdmin(): array
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'The Rockers']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+
+        return [$admin, $bandSpace];
+    }
+
+    /**
+     * The request reboots the kernel, so the entity held by the test belongs to a dead entity manager.
+     */
+    private function reload(BandSpace $bandSpace): BandSpace
+    {
+        $reloaded = self::getContainer()->get(BandSpaceRepository::class)
+            ->findOneByIdWithMemberships((string) $bandSpace->id);
+        $this->assertInstanceOf(BandSpace::class, $reloaded);
+
+        return $reloaded;
+    }
+}


### PR DESCRIPTION
Closes #861. Split out of #822 (item 2), which was otherwise a bugfix batch.

`src/ApiResource/BandSpace/BandSpace.php` declared GetCollection, Get and Delete only, there was no update processor, and the "Général" settings tab said "Bientôt disponible". The name is stamped on notifications and tech riders, and a mistyped name could only be fixed by deleting the entire space and starting over.

## What ships

`PATCH /api/band_spaces/{id}` with `{"name": "..."}`, admin only through the existing `BandSpaceAdminChecker::checkAdminForWrite()`, which is the same call eight sibling processors already use and which also refuses a space pending deletion (409, shared `BandSpaceWriteGuard`). Only writes, records and flushes when the name actually changed.

Activity type `band_renamed` with a `{from, to}` payload, matching `agenda.title_changed` and `task.status_changed`, plus the French sentence in `activitySentences.js`.

Frontend: `GeneralSection.vue` replaces the placeholder, with the rename form for admins and a read-only name plus explanation for everyone else. The new name propagates without a reload because every hop from the store to the page title is a computed.

No schema change: `BandSpace.name` already existed.

## Validation messages are now French on both paths

Review flagged that the new constraints used English messages, copied from `BandSpaceCreate`. That turned out to be the single outlier in the domain: all six other shared Get+Patch DTOs in this module use French. The English string reached the user error banner verbatim, and a too-short name produced no French at all.

Both paths are now French, reusing wording already in the codebase rather than inventing new phrasing: `Le nom ne peut pas dépasser {{ limit }} caractères` is verbatim what six other DTOs use, and the minimum message follows `UserPublicationCreate` shape with the accents `UserGalleryEdit` is missing.

## Deploy prerequisite

This adds a new **operation** to an already shipped `#[ApiResource]`. API Platform resource and operation metadata pools are Valkey-backed and `deploy.php` has no cache-clearing step, so shipping this needs a metadata pool clear or a `php-web` restart. This is the same mechanism that caused the stale-metadata problem seen with M-809 in dev. Noted in the commit body as well.

## Verification

Full suite 2189 passing, PHPStan level 8 clean, Biome clean, build OK. Reverting `src/` makes all 9 endpoint tests fail with 405.

Tests cover admin rename with the activity payload, trimming, a no-op rename recording no activity, plain member 403, non-member 403, anonymous 401, whitespace-only 422, a padded name that trims below the minimum 422, over-long 422, and pending deletion 409. All with full-body `assertJsonEquals` and a name-unchanged assertion on every refusal.

Review specifically verified that putting the constraints on the shared read DTO does not break reads: a legacy 2-character name still returns 200 on both the item and collection endpoints, checked with a real test.

## Known gap, follow-up

`BandSpaceCreate` still does not trim, while rename does. So `POST` with a padded short name is stored padded, and a later rename resubmitting the visually identical trimmed value is refused: a name accepted at creation cannot be repaired through the feature meant to fix typos. Left alone here because adding trimming to a shipped creation endpoint is a behaviour change that deserves its own ticket, and already-padded rows would stay stuck until renamed anyway.