### PR TITLE
Agenda: expand recurring series in civil time, reconcile exceptions, stop stranding entries

### DIFF
--- a/src/Repository/BandSpace/AgendaEntryExceptionRepository.php
+++ b/src/Repository/BandSpace/AgendaEntryExceptionRepository.php
@@ -18,6 +18,18 @@ class AgendaEntryExceptionRepository extends ServiceEntityRepository
         parent::__construct($registry, AgendaEntryException::class);
     }
 
+    /**
+     * Every cancelled occurrence of an entry. Read through the repository rather than through
+     * `AgendaEntry::$exceptions`, which is the inverse side of the association and therefore only
+     * ever holds what has already been loaded from the database.
+     *
+     * @return AgendaEntryException[]
+     */
+    public function findByEntry(AgendaEntry $entry): array
+    {
+        return $this->findBy(['agendaEntry' => $entry]);
+    }
+
     public function findOneByEntryAndDate(AgendaEntry $entry, DateTimeImmutable $occurrenceDate): ?AgendaEntryException
     {
         return $this->findOneBy([

--- a/src/Service/BandSpace/AgendaAggregator.php
+++ b/src/Service/BandSpace/AgendaAggregator.php
@@ -18,9 +18,16 @@ use App\Service\Builder\User\UserProfilePictureUrlBuilder;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 
 readonly class AgendaAggregator
 {
+    /**
+     * The civil timezone a band reads its agenda in. France and Belgium share it, which covers the
+     * whole audience, and a per band space timezone would replace this single constant.
+     */
+    private const string CIVIL_TIMEZONE = 'Europe/Paris';
+
     public function __construct(
         private AgendaEntryRepository $agendaEntryRepository,
         private TaskRepository $taskRepository,
@@ -108,9 +115,26 @@ readonly class AgendaAggregator
     }
 
     /**
+     * Every calendar date the entry's recurrence rule lands on, from its anchor to its horizon.
+     *
+     * Cancellations are deliberately not applied: this is the rule itself, which is what the write
+     * side needs to tell a cancellation that still points at a real occurrence from one the rule no
+     * longer produces. Empty for a one-off entry, and for a rule with no horizon, which has no
+     * finite set of dates to list.
+     *
+     * @return string[] 'Y-m-d', in chronological order
+     */
+    public function ruleOccurrenceDates(AgendaEntry $entry): array
+    {
+        return array_map(
+            static fn(DateTimeImmutable $occurrence): string => $occurrence->format('Y-m-d'),
+            $this->expandRule($entry, $entry->eventDatetime, null),
+        );
+    }
+
+    /**
      * Expand a recurring entry into the list of occurrence start datetimes whose date falls
-     * within [$from, $to] and on or before `recurrenceUntilDate`. Bounded by the 5-year horizon
-     * enforced at validation time, so the iteration count is safe.
+     * within [$from, $to] and on or before `recurrenceUntilDate`.
      *
      * Cancelled occurrences (entries in `$entry->exceptions`) are filtered out by date here -
      * matching the user-perceived "this occurrence" granularity (date-only, not date+time).
@@ -119,22 +143,7 @@ readonly class AgendaAggregator
      */
     private function expandOccurrences(AgendaEntry $entry, DateTimeImmutable $from, DateTimeImmutable $to): array
     {
-        if ($entry->recurrenceFrequency === null || $entry->recurrenceUntilDate === null) {
-            return [];
-        }
-
-        // Use the end of `recurrenceUntilDate` so occurrences scheduled later that day still count.
-        $horizon = $entry->recurrenceUntilDate->setTime(23, 59, 59);
-        $windowEnd = $to < $horizon ? $to : $horizon;
-
-        $occurrences = match ($entry->recurrenceFrequency) {
-            AgendaRecurrenceFrequency::Daily => $this->expandFixedStep($entry->eventDatetime, $from, $windowEnd, new DateInterval('P1D')),
-            AgendaRecurrenceFrequency::Weekly => $this->expandFixedStep($entry->eventDatetime, $from, $windowEnd, new DateInterval('P7D')),
-            AgendaRecurrenceFrequency::Monthly => $entry->recurrenceMonthlyMode === AgendaRecurrenceMonthlyMode::ByWeekday
-                ? $this->expandMonthlyByWeekday($entry->eventDatetime, $from, $windowEnd)
-                : $this->expandMonthlyByDate($entry->eventDatetime, $from, $windowEnd),
-            AgendaRecurrenceFrequency::Yearly => $this->expandYearly($entry->eventDatetime, $from, $windowEnd),
-        };
+        $occurrences = $this->expandRule($entry, $from, $to);
 
         if ($entry->exceptions->isEmpty()) {
             return $occurrences;
@@ -152,17 +161,90 @@ readonly class AgendaAggregator
     }
 
     /**
+     * Every occurrence the recurrence rule lands on inside [$from, $to], cancellations included.
+     * A `$to` of null means "as far as the horizon goes", which is what enumerating a whole series
+     * needs. Bounded by the 5-year horizon enforced at validation time, so the iteration count is
+     * safe.
+     *
+     * The stepping happens in civil time and the result is converted back to UTC. Adding a fixed
+     * interval to a UTC instant preserves the UTC time of day, so a weekly 20:00 Paris rehearsal
+     * anchored in winter starts showing as 21:00 the moment the clocks go forward, and keeps that
+     * hour for the whole remainder of the series. Stepping in civil time preserves the wall clock,
+     * which is what a band means by "every Monday at 20:00".
+     *
      * @return DateTimeImmutable[]
      */
-    private function expandFixedStep(DateTimeImmutable $start, DateTimeImmutable $from, DateTimeImmutable $windowEnd, DateInterval $step): array
+    private function expandRule(AgendaEntry $entry, DateTimeImmutable $from, ?DateTimeImmutable $to): array
+    {
+        if ($entry->recurrenceFrequency === null || $entry->recurrenceUntilDate === null) {
+            return [];
+        }
+
+        $timezone = $this->expansionTimezone($entry);
+        $anchor = $entry->eventDatetime->setTimezone($timezone);
+
+        // The horizon is a calendar date, so the series runs to the end of that civil day and an
+        // occurrence scheduled later that day still counts.
+        $horizon = new DateTimeImmutable($entry->recurrenceUntilDate->format('Y-m-d') . ' 23:59:59', $timezone);
+        $windowEnd = $to instanceof DateTimeImmutable && $to < $horizon ? $to : $horizon;
+
+        $occurrences = match ($entry->recurrenceFrequency) {
+            AgendaRecurrenceFrequency::Daily => $this->expandFixedStep($anchor, $from, $windowEnd, 1),
+            AgendaRecurrenceFrequency::Weekly => $this->expandFixedStep($anchor, $from, $windowEnd, 7),
+            AgendaRecurrenceFrequency::Monthly => $entry->recurrenceMonthlyMode === AgendaRecurrenceMonthlyMode::ByWeekday
+                ? $this->expandMonthlyByWeekday($anchor, $from, $windowEnd)
+                : $this->expandMonthlyByDate($anchor, $from, $windowEnd),
+            AgendaRecurrenceFrequency::Yearly => $this->expandYearly($anchor, $from, $windowEnd),
+        };
+
+        // Back to UTC. The occurrence is the same instant either way, and every consumer reads it
+        // as UTC: the ATOM datetime on the item, the date an exception is matched on, and the date
+        // the front end slices back off that ATOM string to cancel an occurrence.
+        $utc = new DateTimeZone('UTC');
+
+        return array_map(
+            static fn(DateTimeImmutable $occurrence): DateTimeImmutable => $occurrence->setTimezone($utc),
+            $occurrences,
+        );
+    }
+
+    /**
+     * The timezone a series is stepped in.
+     *
+     * A timed entry stores a real instant, so it is stepped in the civil timezone the band reads
+     * its agenda in. An all-day entry stores no instant at all: it is a calendar date pinned at UTC
+     * midnight by the create and update processors. Reading that marker in Paris and writing it
+     * back would land it on 23:00 the day before every winter, which is the off-by-one #819 fixed
+     * on the front end, so an all-day series keeps being stepped in UTC.
+     */
+    private function expansionTimezone(AgendaEntry $entry): DateTimeZone
+    {
+        return new DateTimeZone($entry->isAllDay ? 'UTC' : self::CIVIL_TIMEZONE);
+    }
+
+    /**
+     * Every occurrence is measured from the anchor rather than from the one before it.
+     *
+     * Chaining the cursor makes any normalisation permanent. An occurrence that lands in the hour
+     * the clocks skip on the spring forward night (02:00 to 03:00 does not exist) is pushed to
+     * 03:30 by PHP, and stepping on from there keeps every later occurrence at 03:30 for the rest
+     * of the series. Measuring from the anchor confines the shift to the one occurrence that really
+     * has no valid time, which is what the monthly and yearly expanders already do by recomputing
+     * from the anchor with setDate().
+     *
+     * @return DateTimeImmutable[]
+     */
+    private function expandFixedStep(DateTimeImmutable $start, DateTimeImmutable $from, DateTimeImmutable $windowEnd, int $stepDays): array
     {
         $occurrences = [];
-        $cursor = $start;
-        while ($cursor <= $windowEnd) {
-            if ($cursor >= $from) {
-                $occurrences[] = $cursor;
+        for ($stepCount = 0; ; ++$stepCount) {
+            $occurrence = $start->add(new DateInterval('P' . ($stepCount * $stepDays) . 'D'));
+            if ($occurrence > $windowEnd) {
+                break;
             }
-            $cursor = $cursor->add($step);
+            if ($occurrence >= $from) {
+                $occurrences[] = $occurrence;
+            }
         }
 
         return $occurrences;

--- a/src/Service/BandSpace/AgendaSeriesReconciler.php
+++ b/src/Service/BandSpace/AgendaSeriesReconciler.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+use App\Entity\BandSpace\AgendaEntry;
+use App\Repository\BandSpace\AgendaEntryExceptionRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Keeps a recurring agenda entry and its cancellations coherent after a write.
+ *
+ * An AgendaEntryException only says "not on that date": it is matched against the expanded
+ * occurrences by 'Y-m-d' and nothing ties it to the rule that produced the date in the first place.
+ * So a write that changes the rule can leave cancellations pointing at dates the series no longer
+ * has, and cancellations can also eat a short series whole.
+ *
+ * The cancellations are read through the repository rather than through `AgendaEntry::$exceptions`.
+ * That collection is the inverse side of the association, so it only reflects what has been loaded
+ * from the database: a row another caller has just persisted in the same request is not in it, and
+ * neither is anything at all when the entry it hangs on was created in the same request.
+ */
+readonly class AgendaSeriesReconciler
+{
+    public function __construct(
+        private AgendaAggregator $agendaAggregator,
+        private AgendaEntryExceptionRepository $exceptionRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * Drop the cancellations the recurrence rule no longer produces. The caller flushes.
+     *
+     * Move a Monday series to Tuesday and every cancelled Monday matches nothing: the occurrence
+     * the band explicitly cancelled comes back either way, but the dead row would otherwise stay
+     * forever and re-apply itself the day the rule happens to land on that date again. Truncating a
+     * series has the same effect on the cancellations past the new horizon.
+     */
+    public function dropExceptionsOutsideRule(AgendaEntry $entry): void
+    {
+        $cancellations = $this->exceptionRepository->findByEntry($entry);
+        if ($cancellations === []) {
+            return;
+        }
+
+        // A rule with no horizon has no finite list of dates, so nothing can be shown to be outside
+        // it. Only reachable if ValidRecurrence were bypassed, and dropping every cancellation on
+        // that basis would destroy rows the band still wants.
+        if ($entry->recurrenceFrequency !== null && $entry->recurrenceUntilDate === null) {
+            return;
+        }
+
+        // Dropping the repetition leaves a single event, so the rule produces no date at all and
+        // every cancellation goes: there is no occurrence left for one to point at.
+        $ruleDates = array_flip($this->agendaAggregator->ruleOccurrenceDates($entry));
+
+        foreach ($cancellations as $cancellation) {
+            if (!isset($ruleDates[$cancellation->occurrenceDate->format('Y-m-d')])) {
+                $this->entityManager->remove($cancellation);
+            }
+        }
+    }
+
+    /**
+     * Whether the series still shows at least one occurrence nobody has cancelled.
+     *
+     * `$pendingCancellation` is a date the caller is about to cancel and has not written yet, so a
+     * processor can ask the question before it commits.
+     */
+    public function hasLiveOccurrence(AgendaEntry $entry, ?DateTimeImmutable $pendingCancellation = null): bool
+    {
+        // A one-off entry is its own occurrence, and an open-ended rule keeps producing new ones
+        // forever: neither can be cancelled down to nothing, so neither is ever cleaned up. Every
+        // recurring entry does get a horizon from ValidRecurrence; the column is nullable only
+        // because one-off entries share the table.
+        if ($entry->recurrenceFrequency === null || $entry->recurrenceUntilDate === null) {
+            return true;
+        }
+
+        $cancelledDates = $pendingCancellation instanceof DateTimeImmutable
+            ? [$pendingCancellation->format('Y-m-d')]
+            : [];
+        foreach ($this->exceptionRepository->findByEntry($entry) as $cancellation) {
+            $cancelledDates[] = $cancellation->occurrenceDate->format('Y-m-d');
+        }
+
+        return array_diff($this->agendaAggregator->ruleOccurrenceDates($entry), $cancelledDates) !== [];
+    }
+}

--- a/src/State/Processor/BandSpace/AgendaEntryFromOccurrenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryFromOccurrenceDeleteProcessor.php
@@ -11,6 +11,7 @@ use App\Enum\BandSpace\BandSpaceAgendaActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\AgendaEntryRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\AgendaSeriesReconciler;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
@@ -36,6 +37,7 @@ readonly class AgendaEntryFromOccurrenceDeleteProcessor implements ProcessorInte
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private AgendaEntryRepository $agendaEntryRepository,
+        private AgendaSeriesReconciler $agendaSeriesReconciler,
         private BandSpaceActivityRecorder $activityRecorder,
         private Security $security,
         private RequestStack $requestStack,
@@ -69,10 +71,19 @@ readonly class AgendaEntryFromOccurrenceDeleteProcessor implements ProcessorInte
         $occurrenceDate = $this->parseDate($rawDate);
         $firstOccurrenceDate = new DateTimeImmutable($entry->eventDatetime->format('Y-m-d'));
 
-        if ($occurrenceDate <= $firstOccurrenceDate) {
-            // Picked date is on or before the first occurrence - the resulting
-            // series would be empty, so remove the entry outright (matches the
-            // user-facing semantic of "and all the rest").
+        $newUntil = $occurrenceDate->modify('-1 day');
+        if ($occurrenceDate > $firstOccurrenceDate) {
+            $entry->recurrenceUntilDate = $newUntil;
+            // The cancellations past the new horizon are now dead rows. Left behind, they would
+            // silently re-apply themselves the day someone extends the series again.
+            $this->agendaSeriesReconciler->dropExceptionsOutsideRule($entry);
+        }
+
+        // Either the picked date is on or before the first occurrence, or everything the truncated
+        // series still produces has already been cancelled one occurrence at a time. Both leave a
+        // series that expands to nothing, which renders nowhere and can no longer be reached from
+        // the agenda, so the entry goes (this is the user-facing semantic of "and all the rest").
+        if ($occurrenceDate <= $firstOccurrenceDate || !$this->agendaSeriesReconciler->hasLiveOccurrence($entry)) {
             $this->activityRecorder->record(
                 bandSpace: $bandSpace,
                 module: BandSpaceModule::Agenda,
@@ -87,9 +98,6 @@ readonly class AgendaEntryFromOccurrenceDeleteProcessor implements ProcessorInte
 
             return;
         }
-
-        $newUntil = $occurrenceDate->modify('-1 day');
-        $entry->recurrenceUntilDate = $newUntil;
 
         $this->activityRecorder->record(
             bandSpace: $bandSpace,

--- a/src/State/Processor/BandSpace/AgendaEntryOccurrenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryOccurrenceDeleteProcessor.php
@@ -13,6 +13,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\AgendaEntryExceptionRepository;
 use App\Repository\BandSpace\AgendaEntryRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\AgendaSeriesReconciler;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
@@ -39,6 +40,7 @@ readonly class AgendaEntryOccurrenceDeleteProcessor implements ProcessorInterfac
         private BandSpaceMemberChecker $memberChecker,
         private AgendaEntryRepository $agendaEntryRepository,
         private AgendaEntryExceptionRepository $exceptionRepository,
+        private AgendaSeriesReconciler $agendaSeriesReconciler,
         private BandSpaceActivityRecorder $activityRecorder,
         private Security $security,
         private RequestStack $requestStack,
@@ -73,6 +75,27 @@ readonly class AgendaEntryOccurrenceDeleteProcessor implements ProcessorInterfac
 
         $existing = $this->exceptionRepository->findOneByEntryAndDate($entry, $occurrenceDate);
         if ($existing instanceof AgendaEntryException) {
+            return;
+        }
+
+        // Cancelling the last occurrence would leave a series that expands to nothing: it renders
+        // nowhere, and the expanded agenda is the only place it can be reached from, so it could
+        // never be edited or deleted again. Remove it outright instead, the way truncating a series
+        // before its first occurrence already does. The cancellation itself is not written: it
+        // would be cascaded away with the entry on the same flush.
+        if (!$this->agendaSeriesReconciler->hasLiveOccurrence($entry, $occurrenceDate)) {
+            $this->activityRecorder->record(
+                bandSpace: $bandSpace,
+                module: BandSpaceModule::Agenda,
+                type: BandSpaceAgendaActivityType::EntryDeleted,
+                resourceId: $entry->id,
+                actor: $user,
+                payload: ['title' => $entry->title],
+            );
+
+            $this->entityManager->remove($entry);
+            $this->entityManager->flush();
+
             return;
         }
 

--- a/src/State/Processor/BandSpace/AgendaEntryUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryUpdateProcessor.php
@@ -13,6 +13,7 @@ use App\Enum\BandSpace\BandSpaceAgendaActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\AgendaEntryRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\AgendaSeriesReconciler;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\AgendaEntryBuilder;
 use DateTimeImmutable;
@@ -34,6 +35,7 @@ readonly class AgendaEntryUpdateProcessor implements ProcessorInterface
         private BandSpaceMemberChecker $memberChecker,
         private AgendaEntryRepository $agendaEntryRepository,
         private AgendaEntryBuilder $agendaEntryBuilder,
+        private AgendaSeriesReconciler $agendaSeriesReconciler,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
         private RequestStack $requestStack,
@@ -142,6 +144,12 @@ readonly class AgendaEntryUpdateProcessor implements ProcessorInterface
                 $entry->recurrenceMonthlyMode = null;
             }
         }
+
+        // The anchor and the rule have just been rewritten, so cancellations may now point at dates
+        // the series no longer has. Asked unconditionally rather than only when a recurrence field
+        // was in the payload: a cancellation outside the rule is dead data whatever wrote it, and
+        // the entries that carry no cancellation at all leave here without expanding anything.
+        $this->agendaSeriesReconciler->dropExceptionsOutsideRule($entry);
 
         $this->recordChanges(
             $entry,

--- a/tests/Api/BandSpace/Agenda/AgendaGetCollectionTest.php
+++ b/tests/Api/BandSpace/Agenda/AgendaGetCollectionTest.php
@@ -531,6 +531,9 @@ class AgendaGetCollectionTest extends ApiTestCase
 
         $this->assertResponseIsSuccessful();
         // First Mondays: 2026-01-05, 2026-02-02, 2026-03-02, 2026-04-06, 2026-05-04, 2026-06-01.
+        // The anchor is 20:00 in Paris, and the window straddles the 29 March switch to summer
+        // time, so the last three occurrences are an hour earlier in UTC for the same 20:00 on the
+        // clock. AgendaRecurrenceDstTest covers that on its own.
         $metadata = [
             'location' => null,
             'is_recurring_occurrence' => true,
@@ -566,9 +569,9 @@ class AgendaGetCollectionTest extends ApiTestCase
                 $member('20260105-1900', '2026-01-05T19:00:00+00:00'),
                 $member('20260202-1900', '2026-02-02T19:00:00+00:00'),
                 $member('20260302-1900', '2026-03-02T19:00:00+00:00'),
-                $member('20260406-1900', '2026-04-06T19:00:00+00:00'),
-                $member('20260504-1900', '2026-05-04T19:00:00+00:00'),
-                $member('20260601-1900', '2026-06-01T19:00:00+00:00'),
+                $member('20260406-1800', '2026-04-06T18:00:00+00:00'),
+                $member('20260504-1800', '2026-05-04T18:00:00+00:00'),
+                $member('20260601-1800', '2026-06-01T18:00:00+00:00'),
             ],
             'view' => [
                 '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-01-01&to=2026-06-30',

--- a/tests/Api/BandSpace/Agenda/AgendaRecurrenceDstTest.php
+++ b/tests/Api/BandSpace/Agenda/AgendaRecurrenceDstTest.php
@@ -1,0 +1,619 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Agenda;
+
+use App\Enum\BandSpace\AgendaRecurrenceFrequency;
+use App\Enum\BandSpace\AgendaRecurrenceMonthlyMode;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\AgendaEntryFactory;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTimeImmutable;
+use DateTimeZone;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * A recurring series must keep the wall clock time the band typed, on both sides of a daylight
+ * saving change.
+ *
+ * Datetimes are stored as UTC instants, so 20:00 in Paris is 19:00Z in winter and 18:00Z in summer.
+ * Stepping the rule in UTC preserves the UTC time of day instead of the wall clock, which is what
+ * turned a 20:00 rehearsal anchored in February into a 21:00 rehearsal for the whole rest of the
+ * year. Every window below straddles a boundary, so the expected UTC times deliberately differ
+ * inside one response while the Paris time never does.
+ *
+ * Europe switched to summer time on 29 March 2026 and back on 25 October 2026.
+ */
+#[ResetDatabase]
+class AgendaRecurrenceDstTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_weekly_series_keeps_its_local_time_when_the_clocks_go_forward(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // Monday 2 February 2026, 20:00 in Paris, which is 19:00Z while winter time is in force.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-02-02 19:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-12-31'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-23&to=2026-04-07',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $metadata = [
+            'location' => null,
+            'is_recurring_occurrence' => true,
+            'recurrence_frequency' => 'weekly',
+            'recurrence_monthly_mode' => null,
+            'recurrence_until_date' => '2026-12-31',
+            'series_id' => $entry->id,
+            'series_start_datetime' => '2026-02-02T19:00:00+00:00',
+        ];
+        $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
+            $id = 'manual-' . $entry->id . '-' . $occKey;
+            return [
+                '@id' => '/api/agenda_items/id=' . $id . ';bandSpaceId=' . $bandSpace->id,
+                '@type' => 'AgendaItem',
+                'id' => $id,
+                'band_space_id' => $bandSpace->id,
+                'source' => 'manual',
+                'source_id' => $entry->id,
+                'datetime' => $datetime,
+                'end_datetime' => null,
+                'is_all_day' => false,
+                'title' => 'Répétition',
+                'description' => null,
+                'metadata' => $metadata,
+            ];
+        };
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 3,
+            'member' => [
+                // 20:00 Paris on all three, one hour of UTC apart because the clocks moved between
+                // the first and the second.
+                $member('20260323-1900', '2026-03-23T19:00:00+00:00'),
+                $member('20260330-1800', '2026-03-30T18:00:00+00:00'),
+                $member('20260406-1800', '2026-04-06T18:00:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-23&to=2026-04-07',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_weekly_series_keeps_its_local_time_when_the_clocks_go_back(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // Monday 3 August 2026, 20:00 in Paris, which is 18:00Z while summer time is in force.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-08-03 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-12-31'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-10-19&to=2026-11-03',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $metadata = [
+            'location' => null,
+            'is_recurring_occurrence' => true,
+            'recurrence_frequency' => 'weekly',
+            'recurrence_monthly_mode' => null,
+            'recurrence_until_date' => '2026-12-31',
+            'series_id' => $entry->id,
+            'series_start_datetime' => '2026-08-03T18:00:00+00:00',
+        ];
+        $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
+            $id = 'manual-' . $entry->id . '-' . $occKey;
+            return [
+                '@id' => '/api/agenda_items/id=' . $id . ';bandSpaceId=' . $bandSpace->id,
+                '@type' => 'AgendaItem',
+                'id' => $id,
+                'band_space_id' => $bandSpace->id,
+                'source' => 'manual',
+                'source_id' => $entry->id,
+                'datetime' => $datetime,
+                'end_datetime' => null,
+                'is_all_day' => false,
+                'title' => 'Répétition',
+                'description' => null,
+                'metadata' => $metadata,
+            ];
+        };
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 3,
+            'member' => [
+                $member('20261019-1800', '2026-10-19T18:00:00+00:00'),
+                $member('20261026-1900', '2026-10-26T19:00:00+00:00'),
+                $member('20261102-1900', '2026-11-02T19:00:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-10-19&to=2026-11-03',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_daily_series_keeps_its_local_time_across_the_switch_night(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // 27 March 2026, 20:00 in Paris: the series runs straight through the night of the switch.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Résidence',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-03-27 19:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Daily,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-04-30'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-28&to=2026-03-31',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $metadata = [
+            'location' => null,
+            'is_recurring_occurrence' => true,
+            'recurrence_frequency' => 'daily',
+            'recurrence_monthly_mode' => null,
+            'recurrence_until_date' => '2026-04-30',
+            'series_id' => $entry->id,
+            'series_start_datetime' => '2026-03-27T19:00:00+00:00',
+        ];
+        $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
+            $id = 'manual-' . $entry->id . '-' . $occKey;
+            return [
+                '@id' => '/api/agenda_items/id=' . $id . ';bandSpaceId=' . $bandSpace->id,
+                '@type' => 'AgendaItem',
+                'id' => $id,
+                'band_space_id' => $bandSpace->id,
+                'source' => 'manual',
+                'source_id' => $entry->id,
+                'datetime' => $datetime,
+                'end_datetime' => null,
+                'is_all_day' => false,
+                'title' => 'Résidence',
+                'description' => null,
+                'metadata' => $metadata,
+            ];
+        };
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 3,
+            'member' => [
+                $member('20260328-1900', '2026-03-28T19:00:00+00:00'),
+                // The night of 28 to 29 March is the short one: still 20:00 in Paris.
+                $member('20260329-1800', '2026-03-29T18:00:00+00:00'),
+                $member('20260330-1800', '2026-03-30T18:00:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-28&to=2026-03-31',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    /**
+     * The hour between 02:00 and 03:00 does not exist on 29 March, so an occurrence landing in it
+     * has no valid time and PHP pushes it to 03:30. That much is unavoidable. What must not happen
+     * is the shift outliving the night: measuring each occurrence from the one before it would
+     * carry the pushed hour into every occurrence for the rest of the series.
+     */
+    public function test_a_series_anchored_in_the_skipped_hour_recovers_after_the_switch_night(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // 02:30 in Paris, the time the clocks skip on 29 March.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Veille',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-03-27 01:30:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Daily,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-04-30'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-28&to=2026-04-01',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $metadata = [
+            'location' => null,
+            'is_recurring_occurrence' => true,
+            'recurrence_frequency' => 'daily',
+            'recurrence_monthly_mode' => null,
+            'recurrence_until_date' => '2026-04-30',
+            'series_id' => $entry->id,
+            'series_start_datetime' => '2026-03-27T01:30:00+00:00',
+        ];
+        $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
+            $id = 'manual-' . $entry->id . '-' . $occKey;
+            return [
+                '@id' => '/api/agenda_items/id=' . $id . ';bandSpaceId=' . $bandSpace->id,
+                '@type' => 'AgendaItem',
+                'id' => $id,
+                'band_space_id' => $bandSpace->id,
+                'source' => 'manual',
+                'source_id' => $entry->id,
+                'datetime' => $datetime,
+                'end_datetime' => null,
+                'is_all_day' => false,
+                'title' => 'Veille',
+                'description' => null,
+                'metadata' => $metadata,
+            ];
+        };
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 4,
+            'member' => [
+                // 02:30 Paris, winter time.
+                $member('20260328-0130', '2026-03-28T01:30:00+00:00'),
+                // The one occurrence with no valid time: 03:30 Paris, the only hour available.
+                $member('20260329-0130', '2026-03-29T01:30:00+00:00'),
+                // Back to 02:30 Paris, now summer time, and it stays there.
+                $member('20260330-0030', '2026-03-30T00:30:00+00:00'),
+                $member('20260331-0030', '2026-03-31T00:30:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-28&to=2026-04-01',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_monthly_by_date_series_keeps_its_local_time_when_the_clocks_go_forward(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // The 15th of every month at 20:00 in Paris, anchored in January.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Réunion',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-01-15 19:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Monthly,
+            'recurrenceMonthlyMode' => AgendaRecurrenceMonthlyMode::ByDate,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-12-31'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-01&to=2026-06-01',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $metadata = [
+            'location' => null,
+            'is_recurring_occurrence' => true,
+            'recurrence_frequency' => 'monthly',
+            'recurrence_monthly_mode' => 'by_date',
+            'recurrence_until_date' => '2026-12-31',
+            'series_id' => $entry->id,
+            'series_start_datetime' => '2026-01-15T19:00:00+00:00',
+        ];
+        $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
+            $id = 'manual-' . $entry->id . '-' . $occKey;
+            return [
+                '@id' => '/api/agenda_items/id=' . $id . ';bandSpaceId=' . $bandSpace->id,
+                '@type' => 'AgendaItem',
+                'id' => $id,
+                'band_space_id' => $bandSpace->id,
+                'source' => 'manual',
+                'source_id' => $entry->id,
+                'datetime' => $datetime,
+                'end_datetime' => null,
+                'is_all_day' => false,
+                'title' => 'Réunion',
+                'description' => null,
+                'metadata' => $metadata,
+            ];
+        };
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 3,
+            'member' => [
+                $member('20260315-1900', '2026-03-15T19:00:00+00:00'),
+                $member('20260415-1800', '2026-04-15T18:00:00+00:00'),
+                $member('20260515-1800', '2026-05-15T18:00:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-01&to=2026-06-01',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_monthly_by_weekday_series_keeps_its_local_time_when_the_clocks_go_back(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // 2026-06-02 is the first Tuesday of June, 20:00 in Paris.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Conseil',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-06-02 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Monthly,
+            'recurrenceMonthlyMode' => AgendaRecurrenceMonthlyMode::ByWeekday,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-12-31'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-10-01&to=2026-11-04',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $metadata = [
+            'location' => null,
+            'is_recurring_occurrence' => true,
+            'recurrence_frequency' => 'monthly',
+            'recurrence_monthly_mode' => 'by_weekday',
+            'recurrence_until_date' => '2026-12-31',
+            'series_id' => $entry->id,
+            'series_start_datetime' => '2026-06-02T18:00:00+00:00',
+        ];
+        $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
+            $id = 'manual-' . $entry->id . '-' . $occKey;
+            return [
+                '@id' => '/api/agenda_items/id=' . $id . ';bandSpaceId=' . $bandSpace->id,
+                '@type' => 'AgendaItem',
+                'id' => $id,
+                'band_space_id' => $bandSpace->id,
+                'source' => 'manual',
+                'source_id' => $entry->id,
+                'datetime' => $datetime,
+                'end_datetime' => null,
+                'is_all_day' => false,
+                'title' => 'Conseil',
+                'description' => null,
+                'metadata' => $metadata,
+            ];
+        };
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 2,
+            'member' => [
+                $member('20261006-1800', '2026-10-06T18:00:00+00:00'),
+                $member('20261103-1900', '2026-11-03T19:00:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-10-01&to=2026-11-04',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    /**
+     * Yearly never straddles a boundary, since a series lands on the same calendar date every year
+     * and therefore in the same half of the year. The case is pinned all the same: the anchor now
+     * makes a round trip through civil time, and getting that wrong would show up here first.
+     */
+    public function test_yearly_series_keeps_its_local_time_year_after_year(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // 14 July at 20:00 in Paris, which is 18:00Z every single year.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Concert annuel',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-07-14 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Yearly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2029-12-31'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-01-01&to=2029-12-31',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $metadata = [
+            'location' => null,
+            'is_recurring_occurrence' => true,
+            'recurrence_frequency' => 'yearly',
+            'recurrence_monthly_mode' => null,
+            'recurrence_until_date' => '2029-12-31',
+            'series_id' => $entry->id,
+            'series_start_datetime' => '2026-07-14T18:00:00+00:00',
+        ];
+        $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
+            $id = 'manual-' . $entry->id . '-' . $occKey;
+            return [
+                '@id' => '/api/agenda_items/id=' . $id . ';bandSpaceId=' . $bandSpace->id,
+                '@type' => 'AgendaItem',
+                'id' => $id,
+                'band_space_id' => $bandSpace->id,
+                'source' => 'manual',
+                'source_id' => $entry->id,
+                'datetime' => $datetime,
+                'end_datetime' => null,
+                'is_all_day' => false,
+                'title' => 'Concert annuel',
+                'description' => null,
+                'metadata' => $metadata,
+            ];
+        };
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 4,
+            'member' => [
+                $member('20260714-1800', '2026-07-14T18:00:00+00:00'),
+                $member('20270714-1800', '2027-07-14T18:00:00+00:00'),
+                $member('20280714-1800', '2028-07-14T18:00:00+00:00'),
+                $member('20290714-1800', '2029-07-14T18:00:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-01-01&to=2029-12-31',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    /**
+     * An all-day entry is not an instant: the create and update processors pin it at UTC midnight
+     * and it stands for a calendar date. Stepping it in Paris and converting back would put it at
+     * 23:00 the day before as soon as winter time returns, which is exactly the off-by-one #819
+     * fixed on the front end, so it stays on UTC midnight whatever the clocks do.
+     */
+    public function test_all_day_series_stays_on_utc_midnight_across_the_switch(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Tournée',
+            'description' => null,
+            'location' => null,
+            'isAllDay' => true,
+            'eventDatetime' => new DateTimeImmutable('2026-03-23 00:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-12-31'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-23&to=2026-04-07',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $metadata = [
+            'location' => null,
+            'is_recurring_occurrence' => true,
+            'recurrence_frequency' => 'weekly',
+            'recurrence_monthly_mode' => null,
+            'recurrence_until_date' => '2026-12-31',
+            'series_id' => $entry->id,
+            'series_start_datetime' => '2026-03-23T00:00:00+00:00',
+        ];
+        $member = function (string $occKey, string $datetime) use ($entry, $bandSpace, $metadata): array {
+            $id = 'manual-' . $entry->id . '-' . $occKey;
+            return [
+                '@id' => '/api/agenda_items/id=' . $id . ';bandSpaceId=' . $bandSpace->id,
+                '@type' => 'AgendaItem',
+                'id' => $id,
+                'band_space_id' => $bandSpace->id,
+                'source' => 'manual',
+                'source_id' => $entry->id,
+                'datetime' => $datetime,
+                'end_datetime' => null,
+                'is_all_day' => true,
+                'title' => 'Tournée',
+                'description' => null,
+                'metadata' => $metadata,
+            ];
+        };
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 3,
+            'member' => [
+                $member('20260323-0000', '2026-03-23T00:00:00+00:00'),
+                $member('20260330-0000', '2026-03-30T00:00:00+00:00'),
+                $member('20260406-0000', '2026-04-06T00:00:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-03-23&to=2026-04-07',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/AgendaEntry/AgendaEntryScopedDeleteTest.php
+++ b/tests/Api/BandSpace/AgendaEntry/AgendaEntryScopedDeleteTest.php
@@ -125,6 +125,93 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         $this->assertCount(1, $exceptionRepo->findBy(['agendaEntry' => $entryId]), 'no duplicate row created');
     }
 
+    public function test_cancelling_the_last_live_occurrence_deletes_the_series(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        // Three Mondays: 1, 8 and 15 June. The first two are already cancelled.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'eventDatetime' => new DateTimeImmutable('2026-06-01 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-06-15'),
+        ])->create();
+        $entryId = $entry->id;
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        foreach (['2026-06-01', '2026-06-08'] as $cancelledDate) {
+            $cancellation = new \App\Entity\BandSpace\AgendaEntryException();
+            $cancellation->agendaEntry = $entry;
+            $cancellation->occurrenceDate = new DateTimeImmutable($cancelledDate);
+            $entityManager->persist($cancellation);
+        }
+        $entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId . '/occurrences/2026-06-15',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // A series with nothing left to expand renders nowhere, and the expanded agenda is the only
+        // place it could be reached from, so it goes instead of being left unreachable.
+        $entityManager->clear();
+        $reloadedBand = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceRepository::class)->find((string) $bandSpace->id);
+        $repo = self::getContainer()->get(AgendaEntryRepository::class);
+        $this->assertNull($repo->findOneByIdAndBandSpace($entryId, $reloadedBand));
+        $exceptionRepo = self::getContainer()->get(AgendaEntryExceptionRepository::class);
+        $this->assertSame([], $exceptionRepo->findBy(['agendaEntry' => $entryId]));
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepo->findForResource($reloadedBand, BandSpaceModule::Agenda, $entryId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('entry_deleted', $activities[0]->type);
+        $this->assertSame(['title' => 'Répétition'], $activities[0]->payload);
+    }
+
+    public function test_cancelling_an_occurrence_of_an_endless_series_keeps_the_entry(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        // No horizon, so the rule has no finite list of occurrences and can never be cancelled down
+        // to nothing. ValidRecurrence forbids writing that through the API; the guard is here so a
+        // row that ever escaped it is left alone rather than deleted for being unenumerable.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'eventDatetime' => new DateTimeImmutable('2026-06-01 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => null,
+        ])->create();
+        $entryId = $entry->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId . '/occurrences/2026-06-15',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $reloadedBand = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceRepository::class)->find((string) $bandSpace->id);
+        $repo = self::getContainer()->get(AgendaEntryRepository::class);
+        $this->assertNotNull($repo->findOneByIdAndBandSpace($entryId, $reloadedBand));
+        $exceptionRepo = self::getContainer()->get(AgendaEntryExceptionRepository::class);
+        $this->assertCount(1, $exceptionRepo->findBy(['agendaEntry' => $entryId]));
+    }
+
     public function test_delete_single_occurrence_on_non_recurring_entry_returns_422(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();
@@ -317,6 +404,157 @@ class AgendaEntryScopedDeleteTest extends ApiTestCase
         // Reloaded for the same reason as the band space: the clear above detached it, and the
         // aggregator binds it as a query parameter to filter personal finance entries.
         $reloadedMembership = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceMembershipRepository::class)->find((string) $viewerMembership->id);
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepo->findForResource($reloadedBand, BandSpaceModule::Agenda, $entryId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('entry_deleted', $activities[0]->type);
+    }
+
+    public function test_truncating_a_series_drops_the_cancellations_past_the_new_horizon(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'eventDatetime' => new DateTimeImmutable('2026-06-01 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-07-31'),
+        ])->create();
+        $entryId = $entry->id;
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        foreach (['2026-06-15', '2026-07-20'] as $cancelledDate) {
+            $cancellation = new \App\Entity\BandSpace\AgendaEntryException();
+            $cancellation->agendaEntry = $entry;
+            $cancellation->occurrenceDate = new DateTimeImmutable($cancelledDate);
+            $entityManager->persist($cancellation);
+        }
+        $entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId . '/from/2026-07-01',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // The series now stops on 30 June, so the July cancellation points at nothing. Left behind,
+        // it would silently re-apply itself the day someone pushes the horizon back out.
+        $entityManager->clear();
+        $exceptionRepo = self::getContainer()->get(AgendaEntryExceptionRepository::class);
+        $this->assertSame(
+            ['2026-06-15'],
+            array_map(
+                static fn(\App\Entity\BandSpace\AgendaEntryException $e): string => $e->occurrenceDate->format('Y-m-d'),
+                $exceptionRepo->findBy(['agendaEntry' => $entryId]),
+            ),
+        );
+    }
+
+    /**
+     * Dropping a stale cancellation and deleting the whole entry both happen inside this one call:
+     * the reconciler schedules a single AgendaEntryException for removal, and the entry is then
+     * removed too, which cascades onto that same row. Doctrine tolerates the double scheduling, but
+     * nothing else in the suite exercises the two together, so a refactor of either the reconciler
+     * or this processor could reintroduce an orphaned row or an error with no test noticing.
+     */
+    public function test_truncating_deletes_the_series_while_dropping_a_cancellation_it_orphans(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'eventDatetime' => new DateTimeImmutable('2026-06-01 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-07-31'),
+        ])->create();
+        $entryId = $entry->id;
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        // The first three survive the truncation and cancel everything it leaves; 20 July falls
+        // outside the shortened rule and is the row the reconciler has to drop.
+        foreach (['2026-06-01', '2026-06-08', '2026-06-15', '2026-07-20'] as $cancelledDate) {
+            $cancellation = new \App\Entity\BandSpace\AgendaEntryException();
+            $cancellation->agendaEntry = $entry;
+            $cancellation->occurrenceDate = new DateTimeImmutable($cancelledDate);
+            $entityManager->persist($cancellation);
+        }
+        $entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId . '/from/2026-06-22',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $entityManager->clear();
+        $reloadedBand = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceRepository::class)->find((string) $bandSpace->id);
+        $repo = self::getContainer()->get(AgendaEntryRepository::class);
+        $this->assertNull($repo->findOneByIdAndBandSpace($entryId, $reloadedBand));
+        $exceptionRepo = self::getContainer()->get(AgendaEntryExceptionRepository::class);
+        $this->assertSame([], $exceptionRepo->findBy(['agendaEntry' => $entryId]), 'no cancellation row outlives its entry');
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepo->findForResource($reloadedBand, BandSpaceModule::Agenda, $entryId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('entry_deleted', $activities[0]->type);
+    }
+
+    public function test_truncating_onto_an_entirely_cancelled_tail_deletes_the_series(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        // Mondays from 1 June, and every one that survives the truncation below is cancelled.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'eventDatetime' => new DateTimeImmutable('2026-06-01 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-07-31'),
+        ])->create();
+        $entryId = $entry->id;
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        foreach (['2026-06-01', '2026-06-08', '2026-06-15'] as $cancelledDate) {
+            $cancellation = new \App\Entity\BandSpace\AgendaEntryException();
+            $cancellation->agendaEntry = $entry;
+            $cancellation->occurrenceDate = new DateTimeImmutable($cancelledDate);
+            $entityManager->persist($cancellation);
+        }
+        $entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId . '/from/2026-06-22',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // Truncating on 22 June leaves 1, 8 and 15 June, all three already cancelled: the series
+        // expands to nothing and would be as unreachable as one cancelled occurrence by occurrence.
+        $entityManager->clear();
+        $reloadedBand = self::getContainer()->get(\App\Repository\BandSpace\BandSpaceRepository::class)->find((string) $bandSpace->id);
+        $repo = self::getContainer()->get(AgendaEntryRepository::class);
+        $this->assertNull($repo->findOneByIdAndBandSpace($entryId, $reloadedBand));
+
         $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
         $activities = $activityRepo->findForResource($reloadedBand, BandSpaceModule::Agenda, $entryId);
         $this->assertCount(1, $activities);

--- a/tests/Api/BandSpace/AgendaEntry/AgendaEntryUpdateTest.php
+++ b/tests/Api/BandSpace/AgendaEntry/AgendaEntryUpdateTest.php
@@ -3,7 +3,10 @@
 namespace App\Tests\Api\BandSpace\AgendaEntry;
 
 use App\Entity\BandSpace\AgendaEntry;
+use App\Entity\BandSpace\AgendaEntryException;
+use App\Enum\BandSpace\AgendaRecurrenceFrequency;
 use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\AgendaEntryExceptionRepository;
 use App\Repository\BandSpace\AgendaEntryRepository;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
@@ -15,6 +18,8 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\User\UserFactory;
 use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -635,6 +640,197 @@ class AgendaEntryUpdateTest extends ApiTestCase
             'creator_username' => $user->username,
             'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
         ]);
+    }
+
+    public function test_moving_a_series_to_another_weekday_drops_the_cancellations_it_orphans(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        // Every Monday from 1 June. 15 June is one of its occurrences, 16 June is not.
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-06-01 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-07-31'),
+        ])->create();
+        $entryId = $entry->id;
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        foreach (['2026-06-15', '2026-06-16'] as $cancelledDate) {
+            $cancellation = new AgendaEntryException();
+            $cancellation->agendaEntry = $entry;
+            $cancellation->occurrenceDate = new DateTimeImmutable($cancelledDate);
+            $entityManager->persist($cancellation);
+        }
+        $entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId,
+            ['eventDatetime' => '2026-06-02T18:00:00+00:00'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId,
+            '@type' => 'AgendaEntry',
+            'id' => $entryId,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Répétition',
+            'description' => null,
+            'location' => null,
+            'event_datetime' => '2026-06-02T18:00:00+00:00',
+            'end_datetime' => null,
+            'is_all_day' => false,
+            'recurrence_frequency' => 'weekly',
+            'recurrence_until_date' => '2026-07-31',
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        // The series runs on Tuesdays now: the cancelled Monday points at nothing and goes, while
+        // the Tuesday the rule has just started producing is a real cancellation and stays.
+        $entityManager->clear();
+        $cancellations = self::getContainer()->get(AgendaEntryExceptionRepository::class)
+            ->findBy(['agendaEntry' => $entryId]);
+        $this->assertSame(
+            ['2026-06-16'],
+            array_map(static fn(AgendaEntryException $e): string => $e->occurrenceDate->format('Y-m-d'), $cancellations),
+        );
+    }
+
+    public function test_an_edit_that_leaves_the_rule_alone_keeps_the_cancellations(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-06-01 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-07-31'),
+        ])->create();
+        $entryId = $entry->id;
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $cancellation = new AgendaEntryException();
+        $cancellation->agendaEntry = $entry;
+        $cancellation->occurrenceDate = new DateTimeImmutable('2026-06-15');
+        $entityManager->persist($cancellation);
+        $entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId,
+            ['title' => 'Répétition générale'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId,
+            '@type' => 'AgendaEntry',
+            'id' => $entryId,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Répétition générale',
+            'description' => null,
+            'location' => null,
+            'event_datetime' => '2026-06-01T18:00:00+00:00',
+            'end_datetime' => null,
+            'is_all_day' => false,
+            'recurrence_frequency' => 'weekly',
+            'recurrence_until_date' => '2026-07-31',
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        $entityManager->clear();
+        $cancellations = self::getContainer()->get(AgendaEntryExceptionRepository::class)
+            ->findBy(['agendaEntry' => $entryId]);
+        $this->assertSame(
+            ['2026-06-15'],
+            array_map(static fn(AgendaEntryException $e): string => $e->occurrenceDate->format('Y-m-d'), $cancellations),
+        );
+    }
+
+    public function test_dropping_the_recurrence_drops_every_cancellation(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-06-01 18:00:00', new DateTimeZone('UTC')),
+            'recurrenceFrequency' => AgendaRecurrenceFrequency::Weekly,
+            'recurrenceUntilDate' => new DateTimeImmutable('2026-07-31'),
+        ])->create();
+        $entryId = $entry->id;
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $cancellation = new AgendaEntryException();
+        $cancellation->agendaEntry = $entry;
+        $cancellation->occurrenceDate = new DateTimeImmutable('2026-06-15');
+        $entityManager->persist($cancellation);
+        $entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId,
+            ['recurrenceFrequency' => null],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entryId,
+            '@type' => 'AgendaEntry',
+            'id' => $entryId,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Répétition',
+            'description' => null,
+            'location' => null,
+            'event_datetime' => '2026-06-01T18:00:00+00:00',
+            'end_datetime' => null,
+            'is_all_day' => false,
+            'recurrence_frequency' => null,
+            'recurrence_until_date' => null,
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        // A single event has nothing to cancel, so the rows would never be read again and would
+        // come back to life the day someone turns the repetition on again.
+        $entityManager->clear();
+        $this->assertSame(
+            [],
+            self::getContainer()->get(AgendaEntryExceptionRepository::class)->findBy(['agendaEntry' => $entryId]),
+        );
     }
 
     public function test_update_agenda_entry_not_member(): void


### PR DESCRIPTION
Closes #821 (items 1, 2, 4). Item 3 (notifications on move or cancel) was split to #876.

## Item 1: recurring series drifted an hour across DST, and were wrong on screen today

`AgendaEntry.eventDatetime` is a plain datetime with no timezone column, PHP runs in UTC, and expansion stepped in UTC. Adding a fixed interval to a UTC instant preserves the UTC time of day, so the Paris wall clock moved by an hour at each transition. Europe went to summer time on 29 March 2026, so a weekly 20:00 rehearsal anchored before that date has been displaying as 21:00 ever since, and the clocks going back on 25 October would flip it again.

Expansion now converts the anchor into the civil timezone, steps there so the wall clock survives the switch, and converts back to UTC, so every existing consumer keeps reading `+00:00`. `CIVIL_TIMEZONE` is a single named constant, the one place a future per-space timezone would replace.

**No data migration, and that was verified rather than assumed.** The stored anchor is already a correct UTC instant: the drawer serialises with `date.toISOString()`, and both processors pass that into `new DateTimeImmutable`. Every write path was enumerated (one entity constructor, two processors, one frontend caller, no fixtures, no drag-to-reschedule path). The bug was confined to expansion, so only future rendering changes.

**All-day entries deliberately keep stepping in UTC.** They are stored as `T00:00:00+00:00`, a calendar-date marker rather than an instant, so reading one in Paris and writing it back lands on 23:00 the previous day every winter, which is the off-by-one #819 fixed. Pinned by its own test. This also avoids stacking a second day-shift mechanism on top of #877, which is still open.

**A pre-existing test was asserting the bug.** `test_monthly_by_weekday_expansion` expected 19:00Z for April, May and June; the correct value for a 20:00 Paris anchor under summer time is 18:00Z. Corrected. The review verified this three ways: derivation from the fixture, direct execution, and a mutation showing the pre-fix code reproduces the old expectation byte for byte.

**A second drift, found in review.** `expandFixedStep` chained its cursor from itself, so an occurrence normalised forward out of the hour that does not exist on 29 March stayed shifted for the rest of the expansion. It now measures every occurrence from the anchor, matching what the monthly and yearly expanders already did.

## Item 2: cancellations were never reconciled when the series changed

The update processor rewrote the anchor, frequency, until-date and monthly mode and never touched the exception rows, while the aggregator matches them by date string. So moving Monday rehearsals to Tuesday orphaned every cancellation: they matched nothing, the occurrence the band had explicitly cancelled reappeared, and the dead rows stayed forever.

`AgendaSeriesReconciler::dropExceptionsOutsideRule` now drops cancellations that are **not a valid occurrence date under the new rule**, rather than merely outside the current window. The cruder reading does not fix the reported bug, since stale Mondays are still inside the window. It is called unconditionally, because a cancellation outside the rule is dead data whatever wrote it; an edit that leaves the rule alone recomputes identically and drops nothing, which is pinned by a guard test.

## Item 4: a series could be cancelled down to zero and become unreachable

Cancelling occurrences one at a time never checked how many survived, so the row lived on, expanded to nothing, rendered nowhere, and could no longer be edited or deleted from the UI.

When the last live occurrence is cancelled the entry is now deleted outright, mirroring what the from-occurrence processor already did. An unenumerable series (one-off, or a rule with no horizon) is never deleted. The same fix was extended to the truncation path, where truncating onto an already fully cancelled tail left the same unreachable row.

## Verification

`tests/Api/BandSpace/` 1039 passing, full suite 2283, PHPStan level 8 clean, no migration, no frontend changes.

Each item was neutralised individually: item 1 fails 5 of 7 DST tests, item 2 exactly 3, item 4 exactly 2, with the guard tests still passing in each case.

Reviewed independently. The review also resolved by execution that Doctrine tolerates an exception being individually scheduled for removal while its parent entry is cascade-deleted in the same call, and that case now has a regression pin.