### PR TITLE
Notes: repair notes left entity encoded by the old sanitizer

### DIFF
--- a/src/Command/BandSpace/RepairNoteContentEncodingCommand.php
+++ b/src/Command/BandSpace/RepairNoteContentEncodingCommand.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceNote;
+use App\Repository\BandSpace\BandSpaceNoteRepository;
+use App\Service\BandSpace\NoteContentEncodingInspector;
+use App\Service\BandSpace\NoteContentEncodingReport;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Rewrites the note bodies the read path removed by #808 entity encoded (#859).
+ *
+ * That path only broke the note on the way out, but the editor autosaved what it was shown, so the
+ * entities reached the database and stayed there once the fix landed. This is the only way back for
+ * the rows already in that state, and it is a one shot: nothing writes that encoding any more.
+ *
+ * Reports by default and writes only on --write, because the detection rule cannot be right in every
+ * case and the operator is the last check. Idempotent: a repaired body no longer matches, so a second
+ * run is a no op.
+ *
+ * Three lists come out of a run, and they are printed apart because they ask different things of the
+ * reader. Notes attributed node by node need no reading at all. Notes carrying at least one inferred
+ * text are repaired too, but one of their paragraphs is only attributed by a neighbour, and a
+ * paragraph pasted or typed after the fix has no such neighbour, so every inferred change is printed
+ * in full and has to be read before --write. Notes left for review are not touched at all.
+ */
+#[AsCommand(
+    name: 'app:band-space:repair-note-encoding',
+    description: 'Repair band space notes whose text was entity encoded by the read path fixed in #808',
+)]
+class RepairNoteContentEncodingCommand extends Command
+{
+    private const string DEFAULT_SAMPLE_SIZE = '10';
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly BandSpaceNoteRepository $noteRepository,
+        private readonly NoteContentEncodingInspector $inspector,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('write', null, InputOption::VALUE_NONE, 'Apply the repair; without it the command only reports')
+            ->addOption(
+                'sample',
+                's',
+                InputOption::VALUE_REQUIRED,
+                'Maximum number of attributed text changes to print, 0 for all of them; inferred changes are always printed in full',
+                self::DEFAULT_SAMPLE_SIZE,
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $sampleSize = (int) $input->getOption('sample');
+        if ($sampleSize < 0) {
+            $io->error('Option --sample cannot be negative');
+
+            return Command::FAILURE;
+        }
+
+        $notes = $this->noteRepository->findAllWithContent();
+
+        /** @var list<array{note: BandSpaceNote, report: NoteContentEncodingReport}> $attributed */
+        $attributed = [];
+        /** @var list<array{note: BandSpaceNote, report: NoteContentEncodingReport}> $inferred */
+        $inferred = [];
+        /** @var list<array{note: BandSpaceNote, report: NoteContentEncodingReport}> $review */
+        $review = [];
+
+        foreach ($notes as $note) {
+            $report = $this->inspector->inspect($note->content);
+
+            if ($report->isRepairable()) {
+                // Classified by the weakest evidence any of its rewritten texts rests on, so a note
+                // can never reach the attributed list by carrying one proven paragraph.
+                if ($report->isInferred()) {
+                    $inferred[] = ['note' => $note, 'report' => $report];
+                } else {
+                    $attributed[] = ['note' => $note, 'report' => $report];
+                }
+            } elseif ($report->needsReview()) {
+                $review[] = ['note' => $note, 'report' => $report];
+            }
+        }
+
+        $io->title('Band Space notes: entity encoded content');
+        $io->writeln(sprintf('%d note(s) with a body scanned', count($notes)));
+        $io->writeln(sprintf('%d note(s) to repair, attributed node by node', count($attributed)));
+        $io->writeln(sprintf('%d note(s) to repair with at least one inferred text', count($inferred)));
+        $io->writeln(sprintf('%d note(s) left for a manual review', count($review)));
+
+        $this->reportRepairs($io, 'Notes to repair, attributed node by node', $attributed, $sampleSize);
+        $this->reportRepairs($io, 'Notes to repair with at least one inferred text, read these before writing', $inferred, 0);
+        $this->reportReview($io, $review);
+
+        $repairable = [...$attributed, ...$inferred];
+        if ($repairable === []) {
+            $io->success('No note to repair.');
+
+            return Command::SUCCESS;
+        }
+
+        if (!(bool) $input->getOption('write')) {
+            $io->warning('Nothing was written. Re-run with --write to apply the repair.');
+
+            return Command::SUCCESS;
+        }
+
+        foreach ($repairable as $row) {
+            $note = $row['note'];
+            $note->content = $row['report']->repairedContent;
+
+            // The revision is bumped so a member who still has the pre repair body open is refused
+            // by the guard of #809 on their next autosave instead of quietly writing the entities
+            // back over the repair. updateDatetime is left alone on purpose: the note is being put
+            // back to what its author wrote, and dating that today, in a column the band reads as
+            // "last edited", would be a worse lie than saying nothing. No activity is recorded for
+            // the same reason.
+            ++$note->contentVersion;
+        }
+
+        $this->entityManager->flush();
+
+        $io->success(sprintf(
+            'Repaired %d note(s), %d of them carrying an inferred text.',
+            count($repairable),
+            count($inferred),
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param list<array{note: BandSpaceNote, report: NoteContentEncodingReport}> $rows
+     * @param int $sampleSize the number of change pairs to print, 0 for all of them
+     */
+    private function reportRepairs(SymfonyStyle $io, string $title, array $rows, int $sampleSize): void
+    {
+        if ($rows === []) {
+            return;
+        }
+
+        $io->section($title);
+
+        $budget = $sampleSize === 0 ? PHP_INT_MAX : $sampleSize;
+        $hidden = 0;
+
+        foreach ($rows as $row) {
+            $io->writeln(' * ' . $this->describe($row['note']));
+
+            foreach ($row['report']->changes as $change) {
+                if ($budget === 0) {
+                    ++$hidden;
+
+                    continue;
+                }
+
+                if ($change['inferred']) {
+                    $io->writeln('     inferred, attributed only by another node of the same note:');
+                }
+
+                // Escaped because a repaired text is allowed to hold a raw < again, and the console
+                // formatter would read that as a style tag and swallow it.
+                $io->writeln('     - ' . OutputFormatter::escape($change['before']));
+                $io->writeln('     + ' . OutputFormatter::escape($change['after']));
+                --$budget;
+            }
+        }
+
+        if ($hidden > 0) {
+            $io->writeln(sprintf('   %d further text change(s) not shown, raise --sample to see them', $hidden));
+        }
+    }
+
+    /**
+     * @param list<array{note: BandSpaceNote, report: NoteContentEncodingReport}> $review
+     */
+    private function reportReview(SymfonyStyle $io, array $review): void
+    {
+        if ($review === []) {
+            return;
+        }
+
+        $io->section('Notes left for a manual review');
+        $io->writeln('Nothing is decided for these and --write skips them. Open each one in the editor and repair it by hand if it reads wrong.');
+
+        foreach ($review as $row) {
+            $io->writeln(' * ' . $this->describe($row['note']));
+            $io->writeln('     ' . OutputFormatter::escape((string) $row['report']->reviewReason));
+        }
+    }
+
+    private function describe(BandSpaceNote $note): string
+    {
+        return OutputFormatter::escape(sprintf(
+            '%s  "%s"  (band space: %s)',
+            (string) $note->id,
+            $note->title,
+            $note->bandSpace->name,
+        ));
+    }
+}

--- a/src/Repository/BandSpace/BandSpaceNoteRepository.php
+++ b/src/Repository/BandSpace/BandSpaceNoteRepository.php
@@ -30,6 +30,31 @@ class BandSpaceNoteRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Every note that has a body, oldest first, with its band space already loaded.
+     *
+     * Deliberately unfiltered. The one shot encoding repair of #859 has to read inside the JSON to
+     * tell a note the old read path mangled from one whose author typed the entities by hand, and no
+     * index reaches in there, so narrowing on a LIKE would make the scan count a lie while still
+     * reading the whole table. Notes are a handful per band space, so the set fits in memory.
+     *
+     * The band space is join fetched rather than merely joined: the repair names every note it
+     * reports by its space, so a lazy association would mean one extra query per reported note.
+     *
+     * @return BandSpaceNote[]
+     */
+    public function findAllWithContent(): array
+    {
+        return $this->createQueryBuilder('n')
+            ->addSelect('bs')
+            ->join('n.bandSpace', 'bs')
+            ->where('n.content IS NOT NULL')
+            ->orderBy('n.creationDatetime', 'ASC')
+            ->addOrderBy('n.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?BandSpaceNote
     {
         return $this->createQueryBuilder('n')

--- a/src/Service/BandSpace/NoteContentEncodingInspector.php
+++ b/src/Service/BandSpace/NoteContentEncodingInspector.php
@@ -1,0 +1,269 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+/**
+ * Decides whether a note body carries the entity encoded text the read path removed by #808 wrote,
+ * and what that body should read instead.
+ *
+ * Until #808, BandSpaceNoteBuilder ran every text node of a note through Symfony's HtmlSanitizer on
+ * the way out. The editor renders a text node as a DOM text node, so the member saw the entity
+ * itself on screen, and the two second autosave wrote that back. The damage is exactly one
+ * application of StringSanitizer::encodeHtmlEntities() per text node:
+ *
+ *     strtr(htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'), REPLACEMENTS)
+ *
+ * so `C'est l'heure` became `C&#039;est l&#039;heure` and `contact@salle.fr` became
+ * `contact&#64;salle.fr`. It did not compound: the sanitizer is a fixed point on its own output, so
+ * every later read and autosave rewrote the same bytes. The database therefore holds one encoding
+ * deep, never two, whatever the number of times the note was opened.
+ *
+ * The encode half is exactly invertible. strtr() scans once and takes the longest key at each
+ * position without reprocessing what it replaced, so decoding `&amp;lt;` yields `&lt;` and not `<`.
+ * The parse half is not: the sanitizer decoded `&eacute;` to `é` and dropped `<b>bold</b>` whole,
+ * and nothing in the row records that it ever existed. This inspector only undoes the encode half.
+ */
+final readonly class NoteContentEncodingInspector
+{
+    /**
+     * The exact inverse of encodeHtmlEntities(), so decode(encode($text)) === $text for every input.
+     * Order is irrelevant: strtr() takes the longest match at each position in a single pass.
+     */
+    private const array DECODE = [
+        '&amp;' => '&',
+        '&lt;' => '<',
+        '&gt;' => '>',
+        '&#34;' => '"',
+        '&#039;' => "'",
+        '&#43;' => '+',
+        '&#61;' => '=',
+        '&#64;' => '@',
+        '&#96;' => '`',
+        '&#xFF1C;' => '＜',
+        '&#xFF1E;' => '＞',
+        '&#xFF0B;' => '＋',
+        '&#xFF1D;' => '＝',
+        '&#xFF20;' => '＠',
+        '&#xFF40;' => '｀',
+    ];
+
+    /**
+     * A copy of StringSanitizer::REPLACEMENTS, which is @internal to the component and cannot be
+     * called. It is copied rather than reused on purpose: this is a one shot repair of what the code
+     * did in August 2026, so it has to keep matching that, not whatever Symfony ships next.
+     * NoteContentEncodingInspectorTest pins it against the real sanitizer.
+     */
+    private const array REPLACEMENTS = [
+        '&quot;' => '&#34;',
+        '+' => '&#43;',
+        '=' => '&#61;',
+        '@' => '&#64;',
+        '`' => '&#96;',
+        '＜' => '&#xFF1C;',
+        '＞' => '&#xFF1E;',
+        '＋' => '&#xFF0B;',
+        '＝' => '&#xFF1D;',
+        '＠' => '&#xFF20;',
+        '｀' => '&#xFF40;',
+    ];
+
+    /**
+     * The entities that only a machine writes, and the whole reason the repair can be attributed.
+     *
+     * `+`, `=`, `@` and a backtick mean nothing in HTML, so no member and no pasted code sample has a
+     * reason to spell them out; Symfony encodes them anyway, to protect unquoted attribute values.
+     * `&#039;` and `&#34;` are signatures too: a person writing about entities types `&apos;` or
+     * `&quot;`, while htmlspecialchars() pads the apostrophe to three digits and Symfony shortens the
+     * quote to `&#34;` because it is one byte less. Every one of them is also normalised on the way
+     * in, so `&apos;`, `&#39;` and `&#x27;` all came out as `&#039;`.
+     *
+     * `&amp;`, `&lt;` and `&gt;` are deliberately absent. They are the three a member writing about
+     * markup types by hand, so on their own they prove nothing.
+     */
+    private const array FINGERPRINTS = [
+        '&#34;',
+        '&#039;',
+        '&#43;',
+        '&#61;',
+        '&#64;',
+        '&#96;',
+        '&#xFF1C;',
+        '&#xFF1E;',
+        '&#xFF0B;',
+        '&#xFF1D;',
+        '&#xFF20;',
+        '&#xFF40;',
+    ];
+
+    public const string REVIEW_MIXED = 'carries encoded text next to text the old read path could not have written, so it was edited after the fix';
+    public const string REVIEW_STILL_ENCODED = 'still reads as encoded after one decode, so it is either encoded twice or written that way on purpose';
+    public const string REVIEW_AMBIGUOUS_ONLY = 'carries only &amp;, &lt; or &gt;, which a member can type by hand, so nothing attributes it to the old read path';
+
+    /**
+     * @param array<string, mixed>|null $content
+     */
+    public function inspect(?array $content): NoteContentEncodingReport
+    {
+        if ($content === null) {
+            return NoteContentEncodingReport::clean();
+        }
+
+        /** @var list<string> $texts */
+        $texts = [];
+        $this->collectTexts($content, $texts);
+
+        $encoded = array_values(array_filter($texts, fn(string $text): bool => $this->decode($text) !== $text));
+        if ($encoded === []) {
+            return NoteContentEncodingReport::clean();
+        }
+
+        // The fingerprint is read over the whole document, not node by node. sanitizeNode() called
+        // the sanitizer once per text node, not on the body as a whole, but it walked the tree
+        // unconditionally, so every node that existed when the note was read came back encoded. One
+        // machine only entity therefore attributes every node already present at that read, and that
+        // is what licenses decoding the `&amp;` in a sibling, which on its own would prove nothing.
+        //
+        // What it does not license: a node added or edited after #808 shipped was never walked by
+        // that code, so a pasted `&amp;amp;` sitting beside a leftover corrupted paragraph would be
+        // decoded on the word of a sibling that says nothing about it. Those nodes are marked
+        // inferred below and reported apart, because a human is the only thing that can tell them
+        // from the real ones.
+        if (!$this->carriesAnyFingerprint($encoded)) {
+            // Every remaining case is a coin flip: `Rock &amp; Roll` reads the same whether the member
+            // typed an ampersand and the old read path encoded it, or the member typed the entity.
+            return $this->isEncoderOutput($encoded)
+                ? NoteContentEncodingReport::forReview(self::REVIEW_AMBIGUOUS_ONLY)
+                : NoteContentEncodingReport::clean();
+        }
+
+        // A body the sanitizer wrote holds no raw apostrophe, ampersand or `@` anywhere, so one that
+        // does was written to after the fix shipped. Its encoded nodes are still repairable, but the
+        // note is no longer a single event and a human should look before anything rewrites it.
+        if (!$this->isEncoderOutput($encoded)) {
+            return NoteContentEncodingReport::forReview(self::REVIEW_MIXED);
+        }
+
+        $changes = [];
+        foreach ($encoded as $text) {
+            $decoded = $this->decode($text);
+            // Decoding `&amp;#039;` gives `&#039;`, which would be detected again on the next run.
+            // Refusing it keeps the command idempotent by construction, and it is also the right
+            // answer: only a member typing `&amp;#039;` produces that, so there is nothing to repair.
+            if ($this->carriesFingerprint($decoded)) {
+                return NoteContentEncodingReport::forReview(self::REVIEW_STILL_ENCODED);
+            }
+
+            $changes[] = [
+                'before' => $text,
+                'after' => $decoded,
+                // A node carrying no fingerprint of its own rests entirely on the sibling argument
+                // above, which does not reach a node written after the fix. It is still decoded,
+                // because leaving it behind would half repair the body, but it is flagged so the
+                // command can put it in front of the operator instead of burying it.
+                'inferred' => !$this->carriesFingerprint($text),
+            ];
+        }
+
+        /** @var array<string, mixed> $repaired */
+        $repaired = $this->decodeNode($content);
+
+        return NoteContentEncodingReport::repairable($repaired, $changes);
+    }
+
+    /**
+     * Walks exactly the nodes the old builder walked, so the repair reaches everything it damaged and
+     * nothing else. An image `src` and a link `href` are never touched: only `text` was sanitized.
+     *
+     * @param array<array-key, mixed> $node
+     * @param list<string> $texts
+     */
+    private function collectTexts(array $node, array &$texts): void
+    {
+        if (isset($node['text']) && is_string($node['text'])) {
+            $texts[] = $node['text'];
+        }
+
+        if (!isset($node['content']) || !is_array($node['content'])) {
+            return;
+        }
+
+        foreach ($node['content'] as $child) {
+            if (is_array($child)) {
+                $this->collectTexts($child, $texts);
+            }
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     * @return array<array-key, mixed>
+     */
+    private function decodeNode(array $node): array
+    {
+        if (isset($node['text']) && is_string($node['text'])) {
+            $node['text'] = $this->decode($node['text']);
+        }
+
+        if (isset($node['content']) && is_array($node['content'])) {
+            $node['content'] = array_map(
+                fn(mixed $child): mixed => is_array($child) ? $this->decodeNode($child) : $child,
+                $node['content'],
+            );
+        }
+
+        return $node;
+    }
+
+    /**
+     * Whether every one of these texts is byte for byte something encodeHtmlEntities() can emit. It
+     * is checked by re-encoding what was decoded rather than by a pattern, so the answer is the
+     * definition itself and cannot drift from it.
+     *
+     * @param list<string> $texts
+     */
+    private function isEncoderOutput(array $texts): bool
+    {
+        foreach ($texts as $text) {
+            if ($this->encode($this->decode($text)) !== $text) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<string> $texts
+     */
+    private function carriesAnyFingerprint(array $texts): bool
+    {
+        foreach ($texts as $text) {
+            if ($this->carriesFingerprint($text)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function carriesFingerprint(string $text): bool
+    {
+        foreach (self::FINGERPRINTS as $fingerprint) {
+            if (str_contains($text, $fingerprint)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function decode(string $text): string
+    {
+        return strtr($text, self::DECODE);
+    }
+
+    private function encode(string $text): string
+    {
+        return strtr(htmlspecialchars($text, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8'), self::REPLACEMENTS);
+    }
+}

--- a/src/Service/BandSpace/NoteContentEncodingReport.php
+++ b/src/Service/BandSpace/NoteContentEncodingReport.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+/**
+ * What NoteContentEncodingInspector concluded about one note body.
+ *
+ * Three outcomes, and only one of them writes: a body that carries nothing the old read path could
+ * have produced is clean, a body the inspector can attribute to that path is repairable, and a body
+ * that carries entities it cannot attribute is handed back for a human to look at. The reason of a
+ * review is text rather than a code because it is written for the operator reading the command
+ * output, and each one names a different unprovable case.
+ *
+ * A repairable body is not one grade of evidence. Every rewritten text carries the strength of what
+ * attributes it, and isInferred() answers the only question the operator has to ask before writing:
+ * does any part of this repair rest on a sibling node rather than on the text in front of them.
+ */
+final readonly class NoteContentEncodingReport
+{
+    /**
+     * @param array<string, mixed>|null $repairedContent the body as it should read, null unless repairable
+     * @param list<array{before: string, after: string, inferred: bool}> $changes every text the repair rewrites
+     */
+    private function __construct(
+        public ?array $repairedContent,
+        public ?string $reviewReason,
+        public array $changes,
+    ) {
+    }
+
+    public static function clean(): self
+    {
+        return new self(null, null, []);
+    }
+
+    /**
+     * @param array<string, mixed> $repairedContent
+     * @param list<array{before: string, after: string, inferred: bool}> $changes
+     */
+    public static function repairable(array $repairedContent, array $changes): self
+    {
+        return new self($repairedContent, null, $changes);
+    }
+
+    public static function forReview(string $reason): self
+    {
+        return new self(null, $reason, []);
+    }
+
+    public function isRepairable(): bool
+    {
+        return $this->repairedContent !== null;
+    }
+
+    public function needsReview(): bool
+    {
+        return $this->reviewReason !== null;
+    }
+
+    /**
+     * Whether the repair rewrites at least one text that nothing in itself attributes to the old
+     * read path. Read off the changes rather than stored, so there is one source of truth and no
+     * way for the flag and the list under it to disagree.
+     */
+    public function isInferred(): bool
+    {
+        foreach ($this->changes as $change) {
+            if ($change['inferred']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Integration/Command/BandSpace/RepairNoteContentEncodingCommandTest.php
+++ b/tests/Integration/Command/BandSpace/RepairNoteContentEncodingCommandTest.php
@@ -1,0 +1,223 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Integration\Command\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceNote;
+use App\Repository\BandSpace\BandSpaceNoteRepository;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceNoteFactory;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class RepairNoteContentEncodingCommandTest extends KernelTestCase
+{
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        parent::setUp();
+
+        $application = new Application(self::$kernel);
+        $command = $application->find('app:band-space:repair-note-encoding');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function test_reports_without_writing_when_no_flag_is_given(): void
+    {
+        $noteId = $this->createNote('Répét', $this->doc('C&#039;est l&#039;heure'));
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('1 note(s) with a body scanned', $output);
+        $this->assertStringContainsString('1 note(s) to repair, attributed node by node', $output);
+        $this->assertStringContainsString('0 note(s) to repair with at least one inferred text', $output);
+        $this->assertStringContainsString('- C&#039;est l&#039;heure', $output);
+        $this->assertStringContainsString("+ C'est l'heure", $output);
+        $this->assertStringContainsString('Nothing was written', $output);
+
+        $note = $this->reload($noteId);
+        $this->assertSame($this->doc('C&#039;est l&#039;heure'), $note->content);
+        $this->assertSame(1, $note->contentVersion);
+    }
+
+    public function test_write_repairs_the_body_and_bumps_the_revision(): void
+    {
+        $noteId = $this->createNote('Répét', $this->doc('C&#039;est l&#039;heure'));
+
+        $this->commandTester->execute(['--write' => true]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('Repaired 1 note(s), 0 of them carrying an inferred text', $this->commandTester->getDisplay());
+
+        $note = $this->reload($noteId);
+        $this->assertSame($this->doc("C'est l'heure"), $note->content);
+        $this->assertSame(2, $note->contentVersion);
+        $this->assertEquals(new DateTime('2026-08-01 09:00:00'), $note->updateDatetime);
+    }
+
+    /**
+     * The report has to say which repair rests on what. A note whose every encoded text carries a
+     * machine only entity needs no reading; one holding a text attributed only by a neighbour does,
+     * because a paragraph pasted after #808 shipped has no such neighbour. Both are repaired, and
+     * they are never printed in the same list.
+     */
+    public function test_separates_a_note_attributed_node_by_node_from_one_resting_on_a_sibling(): void
+    {
+        $attributedId = $this->createNote('Balance', $this->doc('C&#039;est l&#039;heure'));
+        $inferredId = $this->createNote('Concert', $this->doc('C&#039;est complet', 'Le concert AC&amp;DC affiche complet'));
+
+        $this->commandTester->execute(['--write' => true]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('1 note(s) to repair, attributed node by node', $output);
+        $this->assertStringContainsString('1 note(s) to repair with at least one inferred text', $output);
+        $this->assertStringContainsString('Notes to repair, attributed node by node', $output);
+        $this->assertStringContainsString('Notes to repair with at least one inferred text, read these before writing', $output);
+        $this->assertStringContainsString('inferred, attributed only by another node of the same note:', $output);
+        $this->assertStringContainsString('- Le concert AC&amp;DC affiche complet', $output);
+        $this->assertStringContainsString('+ Le concert AC&DC affiche complet', $output);
+        $this->assertStringContainsString('Repaired 2 note(s), 1 of them carrying an inferred text', $output);
+
+        $this->assertSame($this->doc("C'est l'heure"), $this->reload($attributedId)->content);
+        $this->assertSame(
+            $this->doc("C'est complet", 'Le concert AC&DC affiche complet'),
+            $this->reload($inferredId)->content,
+        );
+    }
+
+    /**
+     * The sample cap exists so a proven list does not flood the terminal. It must never hide an
+     * inferred change, which is the one thing the operator has to read.
+     */
+    public function test_inferred_changes_are_printed_in_full_whatever_the_sample(): void
+    {
+        $this->createNote('Concert', $this->doc('C&#039;est complet', 'AC&amp;DC', 'Rock &amp; Roll'));
+
+        $this->commandTester->execute(['--sample' => '1']);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('+ AC&DC', $output);
+        $this->assertStringContainsString('+ Rock & Roll', $output);
+        $this->assertStringNotContainsString('not shown', $output);
+    }
+
+    public function test_a_second_write_run_changes_nothing(): void
+    {
+        $noteId = $this->createNote('Répét', $this->doc('C&#039;est l&#039;heure'));
+
+        $this->commandTester->execute(['--write' => true]);
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+
+        $this->commandTester->execute(['--write' => true]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('0 note(s) to repair, attributed node by node', $output);
+        $this->assertStringContainsString('0 note(s) to repair with at least one inferred text', $output);
+        $this->assertStringContainsString('No note to repair', $output);
+
+        $note = $this->reload($noteId);
+        $this->assertSame($this->doc("C'est l'heure"), $note->content);
+        $this->assertSame(2, $note->contentVersion);
+    }
+
+    public function test_leaves_a_clean_note_and_a_note_needing_review_untouched(): void
+    {
+        $cleanContent = $this->doc("C'est l'heure de la répét");
+        $reviewContent = $this->doc('Pour afficher une esperluette, tapez &amp;');
+
+        $cleanId = $this->createNote('Propre', $cleanContent);
+        $reviewId = $this->createNote('Entités HTML', $reviewContent);
+
+        $this->commandTester->execute(['--write' => true]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('2 note(s) with a body scanned', $output);
+        $this->assertStringContainsString('0 note(s) to repair, attributed node by node', $output);
+        $this->assertStringContainsString('0 note(s) to repair with at least one inferred text', $output);
+        $this->assertStringContainsString('1 note(s) left for a manual review', $output);
+        $this->assertStringContainsString('Entités HTML', $output);
+        $this->assertStringContainsString('which a member can type by hand', $output);
+        $this->assertStringContainsString('Open each one in the editor and repair it by hand', $output);
+
+        $this->assertSame($cleanContent, $this->reload($cleanId)->content);
+        $this->assertSame($reviewContent, $this->reload($reviewId)->content);
+        $this->assertSame(1, $this->reload($reviewId)->contentVersion);
+    }
+
+    public function test_sample_option_caps_the_printed_changes(): void
+    {
+        $this->createNote('Répét', $this->doc('C&#039;est l&#039;heure', 'On dit &#34;oui&#34;', 'Écrire à x&#64;y.fr'));
+
+        $this->commandTester->execute(['--sample' => '1']);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString("+ C'est l'heure", $output);
+        $this->assertStringNotContainsString('+ On dit "oui"', $output);
+        $this->assertStringContainsString('2 further text change(s) not shown', $output);
+    }
+
+    public function test_a_negative_sample_is_refused(): void
+    {
+        $this->commandTester->execute(['--sample' => '-1']);
+
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('Option --sample cannot be negative', $this->commandTester->getDisplay());
+    }
+
+    /**
+     * @param array<string, mixed> $content
+     */
+    private function createNote(string $title, array $content): string
+    {
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => BandSpaceFactory::new(['name' => 'Les Copains']),
+            'title' => $title,
+            'content' => $content,
+            'position' => 0,
+            'creationDatetime' => new DateTime('2026-07-01 10:00:00'),
+            'updateDatetime' => new DateTime('2026-08-01 09:00:00'),
+        ])->create();
+
+        return (string) $note->id;
+    }
+
+    private function reload(string $noteId): BandSpaceNote
+    {
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+
+        $note = self::getContainer()->get(BandSpaceNoteRepository::class)->find($noteId);
+        $this->assertInstanceOf(BandSpaceNote::class, $note);
+
+        return $note;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function doc(string ...$texts): array
+    {
+        return [
+            'type' => 'doc',
+            'content' => array_map(
+                static fn(string $text): array => [
+                    'type' => 'paragraph',
+                    'content' => [['type' => 'text', 'text' => $text]],
+                ],
+                $texts,
+            ),
+        ];
+    }
+}

--- a/tests/Unit/Service/BandSpace/NoteContentEncodingInspectorTest.php
+++ b/tests/Unit/Service/BandSpace/NoteContentEncodingInspectorTest.php
@@ -1,0 +1,409 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\BandSpace;
+
+use App\Service\BandSpace\NoteContentEncodingInspector;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+
+/**
+ * The detection rule of #859, which is the whole risk of the repair.
+ *
+ * Rewriting a note body is easy; deciding that it should be rewritten is not. A member who wrote
+ * about markup, or pasted a code sample, typed entities on purpose, and a repair that decodes those
+ * corrupts a note that was never broken. These tests pin where the line sits and, just as much,
+ * which cases the inspector refuses to decide.
+ */
+class NoteContentEncodingInspectorTest extends TestCase
+{
+    private NoteContentEncodingInspector $inspector;
+
+    protected function setUp(): void
+    {
+        $this->inspector = new NoteContentEncodingInspector();
+    }
+
+    public function test_null_body_is_clean(): void
+    {
+        $report = $this->inspector->inspect(null);
+
+        $this->assertFalse($report->isRepairable());
+        $this->assertFalse($report->needsReview());
+    }
+
+    public function test_repairs_a_body_the_old_read_path_encoded(): void
+    {
+        $report = $this->inspector->inspect($this->doc(
+            'C&#039;est l&#039;heure de la répét',
+            'Écrire à contact&#64;salle.fr avant le 12/03',
+        ));
+
+        $this->assertTrue($report->isRepairable());
+        $this->assertSame(
+            ["C'est l'heure de la répét", 'Écrire à contact@salle.fr avant le 12/03'],
+            $this->textsOf($report->repairedContent),
+        );
+        $this->assertFalse($report->isInferred());
+        $this->assertSame([
+            ['before' => 'C&#039;est l&#039;heure de la répét', 'after' => "C'est l'heure de la répét", 'inferred' => false],
+            ['before' => 'Écrire à contact&#64;salle.fr avant le 12/03', 'after' => 'Écrire à contact@salle.fr avant le 12/03', 'inferred' => false],
+        ], $report->changes);
+    }
+
+    /**
+     * The one thing the sibling argument cannot carry, and the reason a repair resting on it is never
+     * reported next to a proven one.
+     *
+     * The pre #808 walk was unconditional over the nodes present when the note was read, so a machine
+     * only entity does attribute its neighbours. It says nothing about a paragraph written after the
+     * fix, and `&amp;amp;` pasted from a view source, a chat or an email export is exactly what such a
+     * paragraph can hold. Both readings of this text stay live, so the same bytes have to be
+     * classified by what sits next to them, and the operator is the one who decides.
+     */
+    public function test_the_same_ambiguous_text_is_classified_by_what_attributes_it(): void
+    {
+        $pasted = 'Le concert AC&amp;DC est complet ce soir';
+
+        $alone = $this->inspector->inspect($this->doc($pasted));
+
+        $this->assertFalse($alone->isRepairable());
+        $this->assertTrue($alone->needsReview());
+        $this->assertSame(NoteContentEncodingInspector::REVIEW_AMBIGUOUS_ONLY, $alone->reviewReason);
+
+        $besideAFingerprint = $this->inspector->inspect($this->doc(
+            'C&#039;est l&#039;heure de la balance ce soir.',
+            $pasted,
+        ));
+
+        $this->assertTrue($besideAFingerprint->isRepairable());
+        $this->assertTrue($besideAFingerprint->isInferred());
+        $this->assertSame([
+            [
+                'before' => 'C&#039;est l&#039;heure de la balance ce soir.',
+                'after' => "C'est l'heure de la balance ce soir.",
+                'inferred' => false,
+            ],
+            [
+                'before' => $pasted,
+                'after' => 'Le concert AC&DC est complet ce soir',
+                'inferred' => true,
+            ],
+        ], $besideAFingerprint->changes);
+    }
+
+    public function test_leaves_a_clean_french_body_alone(): void
+    {
+        $report = $this->inspector->inspect($this->doc(
+            "C'est l'heure de la répét « Rock & Roll »",
+            'Écrire à contact@salle.fr, 2+2=4, et on dit "oui" à 100 %',
+        ));
+
+        $this->assertFalse($report->isRepairable());
+        $this->assertFalse($report->needsReview());
+    }
+
+    /**
+     * The case the repair exists not to break. `&amp;` is what a member writing about markup types,
+     * and nothing in the row says whether it was typed or encoded, so the note is named and left.
+     */
+    public function test_leaves_a_body_carrying_only_hand_typable_entities_for_review(): void
+    {
+        $report = $this->inspector->inspect($this->doc(
+            'Pour afficher une esperluette en HTML, tapez &amp;',
+            'Une balise ouvre sur &lt; et ferme sur &gt;',
+        ));
+
+        $this->assertFalse($report->isRepairable());
+        $this->assertTrue($report->needsReview());
+        $this->assertSame(NoteContentEncodingInspector::REVIEW_AMBIGUOUS_ONLY, $report->reviewReason);
+    }
+
+    /**
+     * Same entities, but sitting next to an apostrophe the sanitizer would have encoded. That proves
+     * the body never went through it, so the entities are the author's and there is nothing to flag.
+     */
+    public function test_leaves_hand_typed_entities_next_to_raw_text_alone(): void
+    {
+        $report = $this->inspector->inspect($this->doc(
+            "Pour l'esperluette, tapez &amp; dans l'éditeur",
+        ));
+
+        $this->assertFalse($report->isRepairable());
+        $this->assertFalse($report->needsReview());
+    }
+
+    public function test_leaves_a_pasted_code_sample_alone(): void
+    {
+        $report = $this->inspector->inspect([
+            'type' => 'doc',
+            'content' => [[
+                'type' => 'codeBlock',
+                'attrs' => ['language' => 'php'],
+                'content' => [['type' => 'text', 'text' => 'if ($a < $b && $c > $d) { return "ok"; }']],
+            ]],
+        ]);
+
+        $this->assertFalse($report->isRepairable());
+        $this->assertFalse($report->needsReview());
+    }
+
+    /**
+     * A code sample that went through the old read path is repaired like any other text: the
+     * sanitizer ran on every text node, code block or not.
+     */
+    public function test_repairs_a_code_sample_the_old_read_path_encoded(): void
+    {
+        $report = $this->inspector->inspect([
+            'type' => 'doc',
+            'content' => [[
+                'type' => 'codeBlock',
+                'attrs' => ['language' => 'php'],
+                'content' => [['type' => 'text', 'text' => 'if ($a &lt; $b &amp;&amp; $c &gt; $d) { return &#34;ok&#34;; }']],
+            ]],
+        ]);
+
+        $this->assertTrue($report->isRepairable());
+        $this->assertFalse($report->isInferred());
+        $this->assertSame(['if ($a < $b && $c > $d) { return "ok"; }'], $this->textsOf($report->repairedContent));
+    }
+
+    /**
+     * The body is repaired whole rather than paragraph by paragraph, because leaving the two nodes
+     * that carry no fingerprint of their own behind would produce a note reading half repaired with
+     * nothing on the row to say why. They are still marked inferred, one by one, so the command can
+     * put them in front of the operator.
+     */
+    public function test_repairs_hand_typable_entities_once_a_sibling_attributes_them(): void
+    {
+        $report = $this->inspector->inspect($this->doc(
+            'C&#039;est reparti',
+            'Rock &amp; Roll',
+            'a &lt; b',
+        ));
+
+        $this->assertTrue($report->isRepairable());
+        $this->assertTrue($report->isInferred());
+        $this->assertSame(
+            ["C'est reparti", 'Rock & Roll', 'a < b'],
+            $this->textsOf($report->repairedContent),
+        );
+        $this->assertSame([false, true, true], array_column($report->changes, 'inferred'));
+    }
+
+    public function test_a_repaired_body_is_untouched_on_a_second_pass(): void
+    {
+        $first = $this->inspector->inspect($this->doc(
+            'C&#039;est l&#039;heure',
+            'Rock &amp; Roll',
+            'Écrire à contact&#64;salle.fr',
+        ));
+        $this->assertTrue($first->isRepairable());
+
+        $second = $this->inspector->inspect($first->repairedContent);
+
+        $this->assertFalse($second->isRepairable());
+        $this->assertFalse($second->needsReview());
+    }
+
+    /**
+     * A body the sanitizer wrote holds no raw apostrophe anywhere, so one that does was written to
+     * after #808 shipped. Its encoded nodes are still repairable, but the body is no longer a single
+     * event and the command hands it to a human rather than deciding on its own.
+     */
+    public function test_leaves_a_body_edited_after_the_fix_for_review(): void
+    {
+        $report = $this->inspector->inspect($this->doc(
+            'C&#039;est l&#039;heure',
+            "Nouveau paragraphe tapé aujourd'hui, avec &amp; dedans",
+        ));
+
+        $this->assertFalse($report->isRepairable());
+        $this->assertTrue($report->needsReview());
+        $this->assertSame(NoteContentEncodingInspector::REVIEW_MIXED, $report->reviewReason);
+    }
+
+    /**
+     * Freshly typed text that carries no entity at all is inert: decoding it would be a no op, so it
+     * does not stop the encoded node next to it from being repaired.
+     */
+    public function test_freshly_typed_text_without_entities_does_not_block_the_repair(): void
+    {
+        $report = $this->inspector->inspect($this->doc(
+            'C&#039;est l&#039;heure',
+            "Nouveau paragraphe tapé aujourd'hui",
+        ));
+
+        $this->assertTrue($report->isRepairable());
+        $this->assertSame(
+            ["C'est l'heure", "Nouveau paragraphe tapé aujourd'hui"],
+            $this->textsOf($report->repairedContent),
+        );
+    }
+
+    /**
+     * Only a member typing `&amp;#039;` produces this, and decoding it once would leave `&#039;`,
+     * which the next run would decode again. Refusing it is both the honest answer and what makes
+     * the command idempotent by construction.
+     */
+    public function test_leaves_a_body_still_encoded_after_one_decode_for_review(): void
+    {
+        $report = $this->inspector->inspect($this->doc(
+            'Une apostrophe s&#039;écrit &amp;#039; en HTML',
+        ));
+
+        $this->assertFalse($report->isRepairable());
+        $this->assertTrue($report->needsReview());
+        $this->assertSame(NoteContentEncodingInspector::REVIEW_STILL_ENCODED, $report->reviewReason);
+    }
+
+    public function test_walks_nested_nodes_and_leaves_attributes_alone(): void
+    {
+        $report = $this->inspector->inspect([
+            'type' => 'doc',
+            'content' => [
+                ['type' => 'image', 'attrs' => ['src' => '/media/repet.jpg?w=800&h=600']],
+                [
+                    'type' => 'bulletList',
+                    'content' => [[
+                        'type' => 'listItem',
+                        'content' => [[
+                            'type' => 'paragraph',
+                            'content' => [[
+                                'type' => 'text',
+                                'marks' => [['type' => 'link', 'attrs' => ['href' => 'https://salle.fr/?a=1&b=2']]],
+                                'text' => 'Réserver l&#039;ampli',
+                            ]],
+                        ]],
+                    ]],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($report->isRepairable());
+        $this->assertSame(["Réserver l'ampli"], $this->textsOf($report->repairedContent));
+
+        $repaired = $report->repairedContent;
+        $this->assertSame('/media/repet.jpg?w=800&h=600', $repaired['content'][0]['attrs']['src']);
+        $this->assertSame(
+            'https://salle.fr/?a=1&b=2',
+            $repaired['content'][1]['content'][0]['content'][0]['content'][0]['marks'][0]['attrs']['href'],
+        );
+    }
+
+    /**
+     * The test that pins the rule to the code that actually did the damage.
+     *
+     * BandSpaceNoteBuilder ran the autowired HtmlSanitizerInterface, which is the `default` sanitizer
+     * of config/packages/html_sanitizer.yaml: allow_safe_elements and allow_static_elements both off,
+     * which is a bare HtmlSanitizerConfig. Feeding it the strings a French band actually writes and
+     * asserting the inspector gives them back byte for byte proves the inverse is the real inverse,
+     * not a table that merely looks like one.
+     */
+    public function test_repair_inverts_the_sanitizer_that_caused_the_damage(): void
+    {
+        $sanitizer = new HtmlSanitizer(new HtmlSanitizerConfig());
+
+        $original = [
+            "C'est l'heure de la répét",
+            'Écrire à contact@salle.fr avant le 12/03',
+            '2+2=4 et on est prêts à 100 %',
+            'On dit "oui" à la date',
+            '`intro` puis solo, déjà répété',
+            'Rock & Roll',
+            'a < b > c',
+            'Balances « à 18h », ça marche ?',
+        ];
+
+        $corrupted = $this->doc(...array_map(
+            static fn(string $text): string => $sanitizer->sanitize($text),
+            $original,
+        ));
+
+        $report = $this->inspector->inspect($corrupted);
+
+        $this->assertTrue($report->isRepairable());
+        $this->assertSame($original, $this->textsOf($report->repairedContent));
+
+        // And why the inferred bucket is repaired rather than held back: a real French note carries
+        // `Rock & Roll` and `a < b > c` alongside its apostrophes, and neither comes back with a
+        // fingerprint of its own. Refusing every body that holds one would leave most of the damage
+        // in place; refusing only those nodes would leave the body half repaired.
+        $this->assertTrue($report->isInferred());
+        $this->assertSame(
+            [false, false, false, false, false, true, true],
+            array_column($report->changes, 'inferred'),
+        );
+    }
+
+    /**
+     * The sanitizer is a fixed point on its own output, so opening a broken note again and again
+     * never stacked a second encoding. The repair therefore decodes once, and that is the whole fix.
+     */
+    public function test_reopening_a_broken_note_never_stacked_a_second_encoding(): void
+    {
+        $sanitizer = new HtmlSanitizer(new HtmlSanitizerConfig());
+
+        $once = $sanitizer->sanitize("C'est l'heure & c'est parti");
+        $twice = $sanitizer->sanitize($once);
+        $thrice = $sanitizer->sanitize($twice);
+
+        $this->assertSame($once, $twice);
+        $this->assertSame($once, $thrice);
+
+        $report = $this->inspector->inspect($this->doc($thrice));
+
+        $this->assertTrue($report->isRepairable());
+        $this->assertSame(["C'est l'heure & c'est parti"], $this->textsOf($report->repairedContent));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function doc(string ...$texts): array
+    {
+        return [
+            'type' => 'doc',
+            'content' => array_map(
+                static fn(string $text): array => [
+                    'type' => 'paragraph',
+                    'content' => [['type' => 'text', 'text' => $text]],
+                ],
+                $texts,
+            ),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed>|null $content
+     * @return list<string>
+     */
+    private function textsOf(?array $content): array
+    {
+        $texts = [];
+        $this->collect($content ?? [], $texts);
+
+        return $texts;
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     * @param list<string> $texts
+     */
+    private function collect(array $node, array &$texts): void
+    {
+        if (isset($node['text']) && is_string($node['text'])) {
+            $texts[] = $node['text'];
+        }
+
+        if (!isset($node['content']) || !is_array($node['content'])) {
+            return;
+        }
+
+        foreach ($node['content'] as $child) {
+            if (is_array($child)) {
+                $this->collect($child, $texts);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #859. Follow-up to #808, which stopped the corruption but could not undo what had already been written.

**This command rewrites production data and there is no undo.** Read the runbook at the bottom before running it.

## What the old code actually did

Before #808, `BandSpaceNoteBuilder::sanitizeNode()` ran every text node through the HTML sanitizer on the **read** path. That is parse-then-render:

- **parse** decoded entities and ate markup: `&amp;eacute;` became `é`, `&lt;b&gt;bold&lt;/b&gt;` was destroyed. Irreversible.
- **render** re-encoded through `StringSanitizer::encodeHtmlEntities()`, producing exactly 15 entities.

So `C&amp;#039;est l&amp;#039;heure` was shown to the member literally, and the two second autosave wrote it back.

This command undoes the **encode** half only. What the parse half ate is gone, and the command does not pretend otherwise.

**The issue text said "double-encoded". That was wrong.** `sanitize()` is a fixed point on its own output, so reopening a broken note rewrote the same bytes: the database is one encoding deep, never two. A repeat-until-stable decoder would have over-decoded genuine author text. Pinned by a test that runs the real vendor component rather than a reimplementation.

## The detection rule

`encodeHtmlEntities` is exactly invertible by `strtr` with the inverted map. Three gates decide whether to apply it:

1. **Fingerprint**, document-wide: at least one text node carrying `&amp;#34;`, `&amp;#039;`, `&amp;#43;`, `&amp;#61;`, `&amp;#64;`, `&amp;#96;` or a full-width variant. `+ = @` mean nothing in HTML so nobody spells them out, and `&amp;#039;` is PHP zero-padded where a human types `&amp;apos;`. `&amp;amp;`, `&amp;lt;` and `&amp;gt;` are **deliberately excluded**, because those are exactly what an author writing about markup types.
2. **Consistency**, as `encode(decode($t)) === $t`, expressed as the definition rather than a regex that could drift from it.
3. **Post-decode guard**: refuse if the decoded text still carries a fingerprint, which makes idempotence hold by construction.

## The blocker the review caught, and the fix

The document-wide fingerprint scope silently rewrote uncorrupted text. `Le concert AC&amp;amp;DC est complet ce soir` **alone** was correctly held back as ambiguous; the identical text sharing a document with a fingerprinted paragraph was silently decoded, reported indistinguishably from a proven repair.

The justifying comment was also factually wrong: it claimed the sanitizer ran on the body as a whole, when it ran **per text node**. The true, weaker warrant does not cover a paragraph added after #808 shipped, which is the exact failure mode: paste text containing literal `&amp;amp;` into a note that still carries old corruption.

Now every change carries `inferred`, true when the node has no fingerprint of its own, and the report has two sections that are never merged:

```
3 note(s) to repair, attributed node by node
1 note(s) to repair with at least one inferred text
2 note(s) left for a manual review
```

Whole documents are still repaired rather than held back, because feeding the real sanitizer eight realistic French strings shows ampersand-only and angle-bracket-only paragraphs come back with no fingerprint of their own: holding back every document containing one would leave most of the real damage in place, and repairing only fingerprinted nodes would leave a body visibly half fixed. The inferred section prints every change in full and is **exempt from `--sample`**, since that cap exists to stop the proven list flooding the terminal and must never hide the one thing needing to be read.

## Deliberately skipped

`REVIEW_AMBIGUOUS_ONLY` (`Rock &amp;amp; Roll` reads identically whether the sanitizer encoded it or the author typed it), `REVIEW_MIXED`, `REVIEW_STILL_ENCODED`. One case is genuinely indistinguishable and is documented as such: an author who, after the fix, typed text byte-identical to sanitizer output containing a fingerprint.

## Interaction with #809

On write it bumps `contentVersion`, so a member holding the pre-repair body is refused by the stale-copy guard instead of quietly autosaving the entities back over the repair.

## Runbook

1. `bin/console app:band-space:repair-note-encoding --sample=0` (writes nothing).
2. **Read the "at least one inferred text" section node by node.** For each pair marked `inferred`, ask whether that paragraph could have been pasted or typed after 8 Aug 2026. If any looks pasted, fix that note by hand in the editor first so it leaves the bucket, and do not run `--write` yet.
3. **Quiesce autosave traffic** (maintenance mode, or a genuinely dead hour). The read-then-flush is not atomic.
4. `mysqldump --single-transaction musicall band_space_note &gt; band_space_note.pre859.sql`.
5. `bin/console app:band-space:repair-note-encoding --write`.
6. Re-run without `--write`: must report zero in both buckets. That is idempotence verified in production.
7. **The review bucket does not clear itself.** Take the printed list into a follow-up and have the band fix those notes in the editor.

## Verification

Full suite 2291 passing, PHPStan level 8 clean, no migration. Reverting the inferred flag fails 5 tests.