### PR TITLE
Agenda: hide the clock time on all-day and finance dashboard items

### DIFF
--- a/assets/js/components/BandSpace/Dashboard/AgendaWidget.vue
+++ b/assets/js/components/BandSpace/Dashboard/AgendaWidget.vue
@@ -21,7 +21,7 @@
         <div class="flex-1 min-w-0">
           <p class="font-medium text-surface-900 dark:text-surface-0 truncate">{{ item.title }}</p>
           <p class="text-xs text-surface-500 dark:text-surface-400 mt-0.5">
-            {{ formatDayLabel(item.datetime) }} - {{ formatTime(item.datetime) }}
+            {{ formatDayLabel(item.datetime) }}<template v-if="!isAllDayItem(item)"> - {{ formatTime(item.datetime) }}</template>
           </p>
         </div>
       </li>
@@ -35,6 +35,7 @@ import { fr } from 'date-fns/locale'
 import { onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import bandSpaceAgendaApi from '../../../api/bandSpace/band-space-agenda.js'
+import { isAllDayItem } from '../../../utils/agendaItem.js'
 import DashboardWidget from './DashboardWidget.vue'
 
 const WINDOW_DAYS = 7

--- a/assets/js/utils/agendaItem.js
+++ b/assets/js/utils/agendaItem.js
@@ -1,0 +1,26 @@
+/**
+ * The rule that decides whether an agenda item has a time worth showing.
+ *
+ * It lives outside the components because the agenda view and the dashboard widget both render
+ * agenda items and have to answer this the same way. They did not: the widget printed a clock on
+ * every item and so showed 02:00 on all day events and on finance due dates. It is a pure
+ * predicate, so it is unit tested without a browser (npm test).
+ */
+
+/** The only source whose datetime carries a time the user actually typed. */
+const TIMED_SOURCE = 'manual'
+
+/**
+ * Whether the item covers a day rather than happening at a moment.
+ *
+ * All day entries are stored at UTC midnight, and task and finance items are built from date only
+ * columns the aggregator pads to midnight too. Formatting any of them as a clock therefore prints
+ * the reader's own UTC offset, so 02:00 in France in summer and 01:00 in winter: a time nobody
+ * ever entered. An unknown source reads as all day, so a future aggregated source cannot start
+ * printing that padding before anyone notices.
+ *
+ * Takes the API shape of an agenda item, so snake_case properties.
+ */
+export function isAllDayItem(item) {
+  return item?.source !== TIMED_SOURCE || item?.is_all_day === true
+}

--- a/assets/js/utils/agendaItem.test.js
+++ b/assets/js/utils/agendaItem.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { isAllDayItem } from './agendaItem.js'
+
+/**
+ * The shared all day rule for agenda items. Datetimes are written the way the API sends them,
+ * pinned to UTC, because that offset is exactly what used to leak into the dashboard as a 02:00
+ * that nobody had typed.
+ *
+ * Run with `npm test`.
+ */
+
+/** An agenda item as the aggregator returns it. */
+function item(fields) {
+  return { source: 'manual', is_all_day: false, datetime: '2026-08-12T20:30:00+02:00', ...fields }
+}
+
+describe('isAllDayItem', () => {
+  it('keeps the time of a manual event the user gave an hour to', () => {
+    assert.equal(isAllDayItem(item({})), false)
+  })
+
+  it('drops the time of a manual all day event', () => {
+    const festivalDay = item({ is_all_day: true, datetime: '2026-08-12T00:00:00+00:00' })
+
+    assert.equal(isAllDayItem(festivalDay), true)
+  })
+
+  // The aggregator sends is_all_day false on finance items and pads their date only column to
+  // midnight, so trusting that flag alone shows a due date as 02:00.
+  it('drops the time of a finance due date despite its is_all_day being false', () => {
+    const dueDate = item({ source: 'finance', datetime: '2026-08-12T00:00:00+00:00' })
+
+    assert.equal(isAllDayItem(dueDate), true)
+  })
+
+  it('drops the time of a task due date despite its is_all_day being false', () => {
+    const dueDate = item({ source: 'task', datetime: '2026-08-12T00:00:00+00:00' })
+
+    assert.equal(isAllDayItem(dueDate), true)
+  })
+
+  it('drops the time of a source it does not know rather than trusting the padding', () => {
+    assert.equal(isAllDayItem(item({ source: 'gig' })), true)
+  })
+
+  it('reads a missing item as all day instead of throwing', () => {
+    assert.equal(isAllDayItem(null), true)
+    assert.equal(isAllDayItem(undefined), true)
+  })
+})

--- a/assets/js/views/BandSpace/Agenda.vue
+++ b/assets/js/views/BandSpace/Agenda.vue
@@ -240,6 +240,7 @@ import AgendaEntryDrawer from '../../components/BandSpace/Agenda/AgendaEntryDraw
 import AgendaEventChip from '../../components/BandSpace/Agenda/AgendaEventChip.vue'
 import Avatar from '../../components/User/Avatar.vue'
 import { useBandAgendaStore } from '../../store/bandSpace/bandSpaceAgenda.js'
+import { isAllDayItem } from '../../utils/agendaItem.js'
 import { agendaViewForSavedEntry } from '../../utils/agendaRange.js'
 import { formatDateCompactWithYear, formatDateLong } from '../../utils/date.js'
 
@@ -644,10 +645,6 @@ function calendarEnd(item) {
   if (!item.is_all_day) return item.end_datetime
   // FullCalendar all-day events use exclusive end: bump last-day-inclusive to the day after.
   return format(addDays(parseISO(item.end_datetime), 1), 'yyyy-MM-dd')
-}
-
-function isAllDayItem(item) {
-  return item.is_all_day || item.source === 'finance' || item.source === 'task'
 }
 
 function sourceLabel(source) {


### PR DESCRIPTION
Closes #834.

`AgendaWidget.vue` rendered `formatTime(item.datetime)` unconditionally and never read `is_all_day`, unlike the main agenda view which already had its own `isAllDayItem()`.

All-day entries are normalised to `T00:00:00+00:00` and finance items are forced to midnight UTC, so in France every festival day, every "Toute la journée" event and every finance due date on the dashboard read **02:00** in summer and 01:00 in winter: a time the user never entered. The dashboard is the first screen every member sees.

## The fix

A shared `isAllDayItem()` in `assets/js/utils/agendaItem.js`, with the local copy in `Agenda.vue` deleted and pointed at it. Two surfaces disagreeing is what caused this bug, so the point is that they can no longer drift.

Written as `source !== manual` rather than enumerating `finance | task`, so an unknown source defaults to all-day and a future aggregated source cannot silently start printing the midnight padding. It also always returns a strict boolean; the old copy could hand `undefined` to FullCalendar `allDay`.

## Hide, not "Toute la journée"

The widget shows source only as a coloured left border with no label, so printing "Toute la journée" on a **finance** line would assert something false about a payment deadline. `mercredi 12 août` alone is true for all three cases. Width was not the constraint.

## Surfaces checked

Grepped `formatTime`, `is_all_day`, `isAllDay` and every time format string across `assets/js`. No third buggy surface: the calendar chip is driven by `allDay` and now goes through the shared predicate, the drawer gates on its own form state, and the notification sentence and activity sentences render no times.

## Verification

`npm test` 239 passing, Biome clean, build clean, no PHP touched.

Substituting the two retired rules: the widget's old "always show the time" fails 5 of 6 cases, and the old local copy in `Agenda.vue` fails 2 (unknown source, missing item). So the shared predicate is strictly better than either original. The review confirmed those edge cases are dead code against the data that exists today (the aggregator only ever emits manual, task and finance, both non-manual sources hardcoding `isAllDay=false`), so they are defensive rather than behaviour changes.

## Related, deliberately not fixed here

The review proved by executing the installed FullCalendar that all-day items are drawn in the **wrong day cell** west of UTC, not merely mislabelled, and found a third affected site in the notification sentence. Guadeloupe and Martinique are UTC-4 and French. That is a different root cause (the wire format read with local getters) and a different fix shape, so it is filed separately as **#877**, scoped to include the calendar feed rather than just the two text labels.
