### PR TITLE
Band Space: trim a band space name on creation

### DIFF
--- a/src/ApiResource/BandSpace/BandSpaceCreate.php
+++ b/src/ApiResource/BandSpace/BandSpaceCreate.php
@@ -20,10 +20,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 class BandSpaceCreate
 {
-    #[Assert\NotBlank(message: 'Veuillez spécifier un nom')]
+    #[Assert\NotBlank(message: 'Veuillez spécifier un nom', normalizer: 'trim')]
     #[Assert\Length(
         min: 3,
         max: 255,
+        normalizer: 'trim',
         minMessage: 'Le nom doit contenir au moins {{ limit }} caractères',
         maxMessage: 'Le nom ne peut pas dépasser {{ limit }} caractères'
     )]

--- a/src/State/Processor/BandSpace/BandSpaceCreateProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceCreateProcessor.php
@@ -55,7 +55,8 @@ readonly class BandSpaceCreateProcessor implements ProcessorInterface
 
         // Create BandSpace entity
         $bandSpace = new BandSpace();
-        $bandSpace->name = $data->name;
+        // Trimmed like the rename path, so the stored name is the one the constraints measured.
+        $bandSpace->name = trim($data->name);
 
         // Create creator membership
         $creatorMembership = new BandSpaceMembership();

--- a/tests/Api/BandSpace/BandSpaceCreateTest.php
+++ b/tests/Api/BandSpace/BandSpaceCreateTest.php
@@ -68,6 +68,120 @@ class BandSpaceCreateTest extends ApiTestCase
         $this->assertSame($user->id, $activities[0]->actor?->id);
     }
 
+    public function test_a_padded_name_is_stored_trimmed(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces',
+            ['name' => '   The Rockers   '],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $result = self::getContainer()->get(BandSpaceRepository::class)->findByUser($user);
+        $this->assertCount(1, $result);
+        $bandSpace = $result[0];
+        $this->assertSame('The Rockers', $bandSpace->name);
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpace',
+            '@id' => '/api/band_spaces/' . $bandSpace->id,
+            '@type' => 'BandSpace',
+            'id' => $bandSpace->id,
+            'name' => 'The Rockers',
+            'role' => 'admin',
+            'deletion_scheduled_datetime' => null,
+        ]);
+
+        // The activity feed reads the stored name, so it must not keep a copy of the padded input.
+        $activities = self::getContainer()->get(BandSpaceActivityRepository::class)
+            ->findForResource($bandSpace, BandSpaceModule::Settings, $bandSpace->id);
+        $this->assertCount(1, $activities);
+        $this->assertSame(['name' => 'The Rockers'], $activities[0]->payload);
+    }
+
+    /**
+     * The case the trim normalizer exists for: padding must not buy a name its way past the minimum,
+     * because the padding is gone by the time the processor stores it. The rename path refuses this
+     * name, so creation has to refuse it too, otherwise the space can never be renamed to it.
+     */
+    public function test_a_padded_name_that_trims_below_the_minimum_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces',
+            ['name' => '  ab  '],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
+            '@type' => 'ConstraintViolation',
+            'title' => 'An error occurred',
+            'detail' => 'name: Le nom doit contenir au moins 3 caractères',
+            'description' => 'name: Le nom doit contenir au moins 3 caractères',
+            'status' => 422,
+            'type' => '/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Le nom doit contenir au moins 3 caractères',
+                    'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
+                ],
+            ],
+        ]);
+
+        $this->assertCount(0, self::getContainer()->get(BandSpaceRepository::class)->findByUser($user));
+    }
+
+    public function test_a_whitespace_only_name_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces',
+            ['name' => '   '],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/0=c1051bb4-d103-4f74-8988-acbcafc7fdc3;1=9ff3fdc4-b214-49db-8718-39c315e33d45',
+            '@type' => 'ConstraintViolation',
+            'title' => 'An error occurred',
+            'detail' => "name: Veuillez spécifier un nom\nname: Le nom doit contenir au moins 3 caractères",
+            'description' => "name: Veuillez spécifier un nom\nname: Le nom doit contenir au moins 3 caractères",
+            'status' => 422,
+            'type' => '/validation_errors/0=c1051bb4-d103-4f74-8988-acbcafc7fdc3;1=9ff3fdc4-b214-49db-8718-39c315e33d45',
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Veuillez spécifier un nom',
+                    'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                ],
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'Le nom doit contenir au moins 3 caractères',
+                    'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
+                ],
+            ],
+        ]);
+
+        $this->assertCount(0, self::getContainer()->get(BandSpaceRepository::class)->findByUser($user));
+    }
+
     public function testCreateBandSpaceWithoutNameFails(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();


### PR DESCRIPTION
Closes #872. Follow-up from #871, which added the rename endpoint and exposed the asymmetry.

`BandSpaceCreate` had no `normalizer: trim` and the create processor assigned the name verbatim, while the rename path added in #871 has both.

So `POST {"name": "  ab  "}` measured 6 raw characters against `Length(min: 3)`, passed, and was stored padded. A later rename resubmitting the visually identical `ab` measured 2 and was refused. A name the product accepted at creation could not be repaired through the feature built to fix typos.

Both DTOs now carry the normalizer and the processor trims, so the two write paths agree. Only two places in the codebase ever write `BandSpace::$name`, and both now behave identically; the 422 body for a padded-below-minimum name is byte-identical to what the rename path already returns.

## A worse bug this closes, not in the issue

`NotBlank` **without** a normalizer does not treat `"   "` as blank, because PHP's `empty("   ")` is false, and `Length` measured 3 raw characters. So `POST {"name": "   "}` returned **201** and created a band space literally named three spaces. Confirmed live by reverting only the source change and watching it come back `201 Created` with `"name":"   "`. Unusable, and until #871 shipped, unnameable.

## Affected rows: zero, measured rather than assumed

Swept every schema on the local server holding a `band_space` table, read-only through `bin/console dbal:run-sql` so the connection came from the application's own config rather than a hand-derived URL, echoing the resolved target before each query: **0 padded rows out of 22**.

The reason is structural, not luck: `CreateBandSpaceModal.vue` has sent `name.value.trim()` since the commit that introduced it, so the shipped UI has never been able to submit a padded name. Only a direct API call could.

**So no repair command was built.** The failure mode is also self-healing: once this lands, one rename clears the padding, because the update processor compares old against new and a padded value differs from its trimmed form.

## For the deployer, if you want to check production

```sql
SELECT id, CONCAT('[', name, ']') AS padded
FROM band_space
WHERE name REGEXP '^[[:space:]]|[[:space:]]$';
```

**Do not use `WHERE name <> TRIM(name)` for this.** MariaDB's `TRIM()` strips plain spaces only, while PHP's `trim()` also strips tab, newline, carriage return, NUL and vertical tab, so the `TRIM()` form silently reports all-clear on a tab-padded row. Verified directly: `SELECT TRIM('\tMetal\t')` returns the string unchanged, while the regex above catches it.

If rows come back, the population will be tiny; fix them through the rename endpoint rather than with SQL, so validation applies.

## One residual, by design

A row already stored as `"  ab  "` still cannot become `"ab"`, because two characters is not a legal name on either path. The admin has to choose a name of at least three characters. What this fix buys is that no new such row can be created.

## Verification

`tests/Api/BandSpace/` 1026 passing, PHPStan level 8 clean over 1128 files, no migration. Reverting the source change fails exactly the 3 new tests.
