### PR TITLE
Setlists: trash and restore for setlists and songs

### DIFF
--- a/assets/js/api/bandSpace/band-space-setlists.js
+++ b/assets/js/api/bandSpace/band-space-setlists.js
@@ -5,9 +5,13 @@ import { filenameFromContentDisposition } from '../../utils/downloadBlob.js'
 import { handleApiError } from '../utils/handleApiError.js'
 
 export default {
-  getSetlists(bandSpaceId) {
+  /**
+   * @param {boolean} archived true lists the trash instead of the live setlists
+   */
+  getSetlists(bandSpaceId, { archived = false } = {}) {
+    const url = Routing.generate('api_band_space_setlists_get_collection', { bandSpaceId })
     return axios
-      .get(Routing.generate('api_band_space_setlists_get_collection', { bandSpaceId }))
+      .get(archived ? `${url}?archived=true` : url)
       .then((resp) => resp.data.member ?? [])
       .catch(handleApiError)
   },
@@ -39,9 +43,21 @@ export default {
       .catch(handleApiError)
   },
 
+  /** Soft delete: the setlist moves to the trash, it is not destroyed. */
   deleteSetlist(bandSpaceId, setlistId) {
     return axios
       .delete(Routing.generate('api_band_space_setlists_delete', { bandSpaceId, id: setlistId }))
+      .catch(handleApiError)
+  },
+
+  restoreSetlist(bandSpaceId, setlistId) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_setlists_restore', { bandSpaceId, id: setlistId }),
+        {},
+        { headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' } }
+      )
+      .then((resp) => resp.data)
       .catch(handleApiError)
   },
 

--- a/assets/js/api/bandSpace/band-space-songs.js
+++ b/assets/js/api/bandSpace/band-space-songs.js
@@ -4,11 +4,13 @@ import axios from 'axios'
 import { handleApiError } from '../utils/handleApiError.js'
 
 export default {
-  getSongs(bandSpaceId, { includeArchived = false } = {}) {
-    const params = {}
-    if (includeArchived) params.includeArchived = 1
+  /**
+   * @param {boolean} archived true lists the trash instead of the live repertoire
+   */
+  getSongs(bandSpaceId, { archived = false } = {}) {
+    const url = Routing.generate('api_band_space_songs_get_collection', { bandSpaceId })
     return axios
-      .get(Routing.generate('api_band_space_songs_get_collection', { bandSpaceId }), { params })
+      .get(archived ? `${url}?archived=true` : url)
       .then((resp) => resp.data.member ?? [])
       .catch(handleApiError)
   },
@@ -38,9 +40,21 @@ export default {
       .catch(handleApiError)
   },
 
+  /** Soft delete: the title moves to the trash, it is not destroyed. */
   deleteSong(bandSpaceId, songId) {
     return axios
       .delete(Routing.generate('api_band_space_songs_delete', { bandSpaceId, id: songId }))
+      .catch(handleApiError)
+  },
+
+  restoreSong(bandSpaceId, songId) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_songs_restore', { bandSpaceId, id: songId }),
+        {},
+        { headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' } }
+      )
+      .then((resp) => resp.data)
       .catch(handleApiError)
   },
 

--- a/assets/js/components/BandSpace/Setlist/SetlistTrashList.vue
+++ b/assets/js/components/BandSpace/Setlist/SetlistTrashList.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <div
+      class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700"
+    >
+      <h2 class="text-sm font-semibold text-surface-800 dark:text-surface-100 mb-1">Corbeille</h2>
+      <!-- No countdown here, unlike the files trash: setlists and titles are never purged on a
+           timer, so promising a deadline would be a lie. -->
+      <p class="text-xs text-surface-600 dark:text-surface-300">
+        Les setlists et les titres supprimés sont conservés ici sans limite de temps. Restaurez-les
+        quand vous voulez.
+      </p>
+    </div>
+
+    <div
+      class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-4 border border-surface-200 dark:border-surface-700"
+    >
+      <div v-if="isLoading && isEmpty" class="flex flex-col gap-2">
+        <Skeleton v-for="i in 3" :key="i" width="100%" height="3.5rem" borderRadius="0.5rem" />
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex flex-col items-center justify-center py-16 text-center text-surface-500 dark:text-surface-400"
+      >
+        <i class="pi pi-trash text-5xl mb-4" aria-hidden="true"></i>
+        <p class="text-sm italic">La corbeille est vide.</p>
+      </div>
+
+      <div v-else class="flex flex-col gap-6">
+        <section v-if="setlists.length > 0">
+          <h3
+            class="text-xs font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300 mb-2"
+          >
+            Setlists
+          </h3>
+          <ul class="flex flex-col gap-2">
+            <li
+              v-for="setlist in setlists"
+              :key="setlist.id"
+              class="flex items-center gap-3 p-3 rounded-lg border border-surface-200 dark:border-surface-700"
+            >
+              <i class="pi pi-list text-lg text-rose-600 shrink-0" aria-hidden="true"></i>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-medium text-surface-800 dark:text-surface-100 truncate">
+                  {{ setlist.name }}
+                </p>
+                <span class="text-xs text-surface-600 dark:text-surface-300">
+                  {{ setlist.items?.length ?? 0 }} {{ itemLabel(setlist.items?.length ?? 0) }} ·
+                  supprimée le {{ formatDateLong(setlist.archive_datetime) }}
+                </span>
+              </div>
+              <Button
+                label="Restaurer"
+                icon="pi pi-replay"
+                text
+                size="small"
+                :loading="busyId === setlist.id"
+                @click="handleRestoreSetlist(setlist)"
+              />
+            </li>
+          </ul>
+        </section>
+
+        <section v-if="songs.length > 0">
+          <h3
+            class="text-xs font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300 mb-2"
+          >
+            Titres
+          </h3>
+          <ul class="flex flex-col gap-2">
+            <li
+              v-for="song in songs"
+              :key="song.id"
+              class="flex items-center gap-3 p-3 rounded-lg border border-surface-200 dark:border-surface-700"
+            >
+              <i class="pi pi-book text-lg text-emerald-600 shrink-0" aria-hidden="true"></i>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-medium text-surface-800 dark:text-surface-100 truncate">
+                  {{ song.title }}
+                </p>
+                <span class="text-xs text-surface-600 dark:text-surface-300">
+                  supprimé le {{ formatDateLong(song.archive_datetime) }}
+                </span>
+              </div>
+              <Button
+                label="Restaurer"
+                icon="pi pi-replay"
+                text
+                size="small"
+                :loading="busyId === song.id"
+                @click="handleRestoreSong(song)"
+              />
+            </li>
+          </ul>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Skeleton from 'primevue/skeleton'
+import { useToast } from 'primevue/usetoast'
+import { computed, ref } from 'vue'
+import { useBandSetlistsStore } from '../../../store/bandSpace/bandSpaceSetlists.js'
+import { useBandSongsStore } from '../../../store/bandSpace/bandSpaceSongs.js'
+import { formatDateLong } from '../../../utils/date.js'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true },
+  setlists: { type: Array, required: true },
+  songs: { type: Array, required: true },
+  isLoading: { type: Boolean, default: false }
+})
+
+const setlistsStore = useBandSetlistsStore()
+const songsStore = useBandSongsStore()
+const toast = useToast()
+
+const busyId = ref(null)
+
+const isEmpty = computed(() => props.setlists.length === 0 && props.songs.length === 0)
+
+function itemLabel(count) {
+  return count === 1 ? 'élément' : 'éléments'
+}
+
+async function handleRestoreSetlist(setlist) {
+  busyId.value = setlist.id
+  try {
+    await setlistsStore.restoreSetlist(props.bandSpaceId, setlist.id)
+    toast.add({ severity: 'success', summary: 'Setlist restaurée', life: 3000 })
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: error.message || 'Impossible de restaurer la setlist',
+      life: 5000
+    })
+  } finally {
+    busyId.value = null
+  }
+}
+
+async function handleRestoreSong(song) {
+  busyId.value = song.id
+  try {
+    await songsStore.restoreSong(props.bandSpaceId, song.id)
+    toast.add({ severity: 'success', summary: 'Titre restauré', life: 3000 })
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: error.message || 'Impossible de restaurer le titre',
+      life: 5000
+    })
+  } finally {
+    busyId.value = null
+  }
+}
+</script>

--- a/assets/js/components/BandSpace/Setlist/SidebarContent.vue
+++ b/assets/js/components/BandSpace/Setlist/SidebarContent.vue
@@ -45,6 +45,22 @@
         @click="emit('new-setlist')"
       />
     </div>
+
+    <!-- Same Corbeille entry as the Files sidebar, so a member who has met one trash recognises the
+         other. It holds archived setlists and archived titles together: they are one module. -->
+    <div class="mt-3 pt-3 border-t border-surface-200 dark:border-surface-700">
+      <button
+        type="button"
+        class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left transition-colors duration-150"
+        :class="trashButtonClasses"
+        :aria-current="activeView === 'trash' ? 'true' : null"
+        @click="emit('select-trash')"
+      >
+        <i class="pi pi-trash" aria-hidden="true"></i>
+        <span class="flex-1 truncate">Corbeille</span>
+        <span class="text-xs text-surface-500 tabular-nums">{{ trashCount }}</span>
+      </button>
+    </div>
   </div>
 </template>
 
@@ -58,16 +74,23 @@ const props = defineProps({
   songsCount: { type: Number, required: true },
   setlists: { type: Array, required: true },
   isLoadingSetlists: { type: Boolean, default: false },
-  activeView: { type: String, required: true }, // 'repertoire' | 'setlist'
-  activeSetlistId: { type: String, default: null }
+  activeView: { type: String, required: true }, // 'repertoire' | 'setlist' | 'trash'
+  activeSetlistId: { type: String, default: null },
+  trashCount: { type: Number, default: 0 }
 })
 
-const emit = defineEmits(['select-repertoire', 'select-setlist', 'new-setlist'])
+const emit = defineEmits(['select-repertoire', 'select-setlist', 'select-trash', 'new-setlist'])
 
 const repertoireButtonClasses = computed(() =>
   props.activeView === 'repertoire'
     ? 'bg-surface-100 dark:bg-surface-800 text-surface-900 dark:text-surface-100'
     : 'hover:bg-surface-50 dark:hover:bg-surface-800 text-surface-700 dark:text-surface-300'
+)
+
+const trashButtonClasses = computed(() =>
+  props.activeView === 'trash'
+    ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-200 font-medium'
+    : 'text-surface-700 dark:text-surface-200 hover:bg-surface-100 dark:hover:bg-surface-800'
 )
 
 function setlistButtonClasses(id) {

--- a/assets/js/store/bandSpace/bandSpaceSetlists.js
+++ b/assets/js/store/bandSpace/bandSpaceSetlists.js
@@ -4,13 +4,25 @@ import bandSpaceSetlistsApi from '../../api/bandSpace/band-space-setlists.js'
 
 export const useBandSetlistsStore = defineStore('bandSetlists', () => {
   const setlists = ref([])
+  // Two lists rather than one filtered list, because the sidebar shows the live setlists and the
+  // trash count side by side. A band has a handful of archived setlists and the collection is
+  // unpaginated, so this costs one small request on module load.
+  const archivedSetlists = ref([])
   const activeSetlist = ref(null)
   const isLoading = ref(false)
+  const isLoadingArchived = ref(false)
   const isLoadingActive = ref(false)
   const loadError = ref(null)
 
   let setlistsRequestId = 0
+  let archivedRequestId = 0
   let activeRequestId = 0
+
+  // Both collections come back newest first, so a row moved between them locally has to be placed
+  // rather than pushed: restoring a setlist from two years ago must not park it above this month's.
+  function byCreationDesc(a, b) {
+    return new Date(b.creation_datetime) - new Date(a.creation_datetime)
+  }
 
   async function fetchSetlists(bandSpaceId) {
     const requestId = ++setlistsRequestId
@@ -27,6 +39,24 @@ export const useBandSetlistsStore = defineStore('bandSetlists', () => {
     } finally {
       if (requestId === setlistsRequestId) {
         isLoading.value = false
+      }
+    }
+  }
+
+  async function fetchArchivedSetlists(bandSpaceId) {
+    const requestId = ++archivedRequestId
+    isLoadingArchived.value = archivedSetlists.value.length === 0
+
+    try {
+      const result = await bandSpaceSetlistsApi.getSetlists(bandSpaceId, { archived: true })
+      if (requestId !== archivedRequestId) return
+      archivedSetlists.value = result
+    } catch (e) {
+      if (requestId !== archivedRequestId) return
+      loadError.value = e.message
+    } finally {
+      if (requestId === archivedRequestId) {
+        isLoadingArchived.value = false
       }
     }
   }
@@ -63,12 +93,30 @@ export const useBandSetlistsStore = defineStore('bandSetlists', () => {
     return updated
   }
 
+  /**
+   * Archiving moves the setlist to the trash rather than destroying it, so both lists are updated:
+   * the trash entry is what the sidebar counts and what offers the way back.
+   */
   async function archiveSetlist(bandSpaceId, setlistId) {
     await bandSpaceSetlistsApi.deleteSetlist(bandSpaceId, setlistId)
+    const archived = setlists.value.find((s) => s.id === setlistId)
     setlists.value = setlists.value.filter((s) => s.id !== setlistId)
+    if (archived) {
+      archivedSetlists.value = [
+        { ...archived, archive_datetime: new Date().toISOString() },
+        ...archivedSetlists.value
+      ].sort(byCreationDesc)
+    }
     if (activeSetlist.value?.id === setlistId) {
       activeSetlist.value = null
     }
+  }
+
+  async function restoreSetlist(bandSpaceId, setlistId) {
+    const restored = await bandSpaceSetlistsApi.restoreSetlist(bandSpaceId, setlistId)
+    archivedSetlists.value = archivedSetlists.value.filter((s) => s.id !== setlistId)
+    setlists.value = [restored, ...setlists.value].sort(byCreationDesc)
+    return restored
   }
 
   async function duplicateSetlist(bandSpaceId, setlistId) {
@@ -152,23 +200,29 @@ export const useBandSetlistsStore = defineStore('bandSetlists', () => {
 
   function clear() {
     setlists.value = []
+    archivedSetlists.value = []
     activeSetlist.value = null
     isLoading.value = false
+    isLoadingArchived.value = false
     isLoadingActive.value = false
     loadError.value = null
   }
 
   return {
     setlists: readonly(setlists),
+    archivedSetlists: readonly(archivedSetlists),
     activeSetlist: readonly(activeSetlist),
     isLoading: readonly(isLoading),
+    isLoadingArchived: readonly(isLoadingArchived),
     isLoadingActive: readonly(isLoadingActive),
     loadError: readonly(loadError),
     fetchSetlists,
+    fetchArchivedSetlists,
     fetchActive,
     createSetlist,
     renameSetlist,
     archiveSetlist,
+    restoreSetlist,
     duplicateSetlist,
     reorderItems,
     addItem,

--- a/assets/js/store/bandSpace/bandSpaceSongs.js
+++ b/assets/js/store/bandSpace/bandSpaceSongs.js
@@ -4,18 +4,24 @@ import bandSpaceSongsApi from '../../api/bandSpace/band-space-songs.js'
 
 export const useBandSongsStore = defineStore('bandSongs', () => {
   const songs = ref([])
+  // Two lists rather than one filtered list, because the repertoire table and the trash are separate
+  // views and the sidebar shows the trash count while the repertoire is open. A band has a handful of
+  // archived titles and the collection is unpaginated, so this costs one small request on module load.
+  const archivedSongs = ref([])
   const isLoading = ref(false)
+  const isLoadingArchived = ref(false)
   const loadError = ref(null)
 
   let songsRequestId = 0
+  let archivedRequestId = 0
 
-  async function fetchSongs(bandSpaceId, { includeArchived = false } = {}) {
+  async function fetchSongs(bandSpaceId) {
     const requestId = ++songsRequestId
     isLoading.value = songs.value.length === 0
     loadError.value = null
 
     try {
-      const result = await bandSpaceSongsApi.getSongs(bandSpaceId, { includeArchived })
+      const result = await bandSpaceSongsApi.getSongs(bandSpaceId)
       if (requestId !== songsRequestId) return
       songs.value = result
     } catch (e) {
@@ -24,6 +30,24 @@ export const useBandSongsStore = defineStore('bandSongs', () => {
     } finally {
       if (requestId === songsRequestId) {
         isLoading.value = false
+      }
+    }
+  }
+
+  async function fetchArchivedSongs(bandSpaceId) {
+    const requestId = ++archivedRequestId
+    isLoadingArchived.value = archivedSongs.value.length === 0
+
+    try {
+      const result = await bandSpaceSongsApi.getSongs(bandSpaceId, { archived: true })
+      if (requestId !== archivedRequestId) return
+      archivedSongs.value = result
+    } catch (e) {
+      if (requestId !== archivedRequestId) return
+      loadError.value = e.message
+    } finally {
+      if (requestId === archivedRequestId) {
+        isLoadingArchived.value = false
       }
     }
   }
@@ -42,25 +66,49 @@ export const useBandSongsStore = defineStore('bandSongs', () => {
     return updated
   }
 
+  /**
+   * Archiving moves the title from the repertoire to the trash rather than destroying it, so both
+   * lists are updated: the trash entry is what the sidebar counts and what offers the way back.
+   */
   async function deleteSong(bandSpaceId, songId) {
     await bandSpaceSongsApi.deleteSong(bandSpaceId, songId)
+    const archived = songs.value.find((s) => s.id === songId)
     songs.value = songs.value.filter((s) => s.id !== songId)
+    if (archived) {
+      archivedSongs.value = [
+        ...archivedSongs.value,
+        { ...archived, archive_datetime: new Date().toISOString() }
+      ].sort((a, b) => a.title.localeCompare(b.title))
+    }
+  }
+
+  async function restoreSong(bandSpaceId, songId) {
+    const restored = await bandSpaceSongsApi.restoreSong(bandSpaceId, songId)
+    archivedSongs.value = archivedSongs.value.filter((s) => s.id !== songId)
+    songs.value = [...songs.value, restored].sort((a, b) => a.title.localeCompare(b.title))
+    return restored
   }
 
   function clear() {
     songs.value = []
+    archivedSongs.value = []
     isLoading.value = false
+    isLoadingArchived.value = false
     loadError.value = null
   }
 
   return {
     songs: readonly(songs),
+    archivedSongs: readonly(archivedSongs),
     isLoading: readonly(isLoading),
+    isLoadingArchived: readonly(isLoadingArchived),
     loadError: readonly(loadError),
     fetchSongs,
+    fetchArchivedSongs,
     createSong,
     updateSong,
     deleteSong,
+    restoreSong,
     clear
   }
 })

--- a/assets/js/views/BandSpace/Setlist.vue
+++ b/assets/js/views/BandSpace/Setlist.vue
@@ -15,8 +15,10 @@
           :is-loading-setlists="setlistsStore.isLoading"
           :active-view="activeView"
           :active-setlist-id="activeSetlistId"
+          :trash-count="trashCount"
           @select-repertoire="selectRepertoire"
           @select-setlist="selectSetlist"
+          @select-trash="selectTrash"
           @new-setlist="newSetlistDialogOpen = true"
         />
       </aside>
@@ -43,8 +45,10 @@
           :is-loading-setlists="setlistsStore.isLoading"
           :active-view="activeView"
           :active-setlist-id="activeSetlistId"
+          :trash-count="trashCount"
           @select-repertoire="selectRepertoire"
           @select-setlist="selectSetlist"
+          @select-trash="selectTrash"
           @new-setlist="newSetlistDialogOpen = true"
         />
       </Drawer>
@@ -67,6 +71,13 @@
           @archived="handleSetlistArchived"
           @duplicated="handleSetlistDuplicated"
         />
+        <SetlistTrashList
+          v-else-if="activeView === 'trash'"
+          :band-space-id="bandSpaceId"
+          :setlists="[...setlistsStore.archivedSetlists]"
+          :songs="[...songsStore.archivedSongs]"
+          :is-loading="setlistsStore.isLoadingArchived || songsStore.isLoadingArchived"
+        />
       </section>
     </div>
   </div>
@@ -81,6 +92,7 @@ import { useRoute, useRouter } from 'vue-router'
 import NewSetlistDialog from '../../components/BandSpace/Setlist/NewSetlistDialog.vue'
 import RepertoireView from '../../components/BandSpace/Setlist/RepertoireView.vue'
 import SetlistEditor from '../../components/BandSpace/Setlist/SetlistEditor.vue'
+import SetlistTrashList from '../../components/BandSpace/Setlist/SetlistTrashList.vue'
 import SidebarContent from '../../components/BandSpace/Setlist/SidebarContent.vue'
 import { useBandSetlistsStore } from '../../store/bandSpace/bandSpaceSetlists.js'
 import { useBandSongsStore } from '../../store/bandSpace/bandSpaceSongs.js'
@@ -96,7 +108,7 @@ setlistsStore.clear()
 
 const bandSpaceId = computed(() => route.params.id)
 
-const activeView = ref('repertoire') // 'repertoire' | 'setlist'
+const activeView = ref('repertoire') // 'repertoire' | 'setlist' | 'trash'
 const activeSetlistId = ref(null)
 const mobileNavOpen = ref(false)
 const newSetlistDialogOpen = ref(false)
@@ -106,9 +118,16 @@ const activeSetlist = computed(() =>
     ? (setlistsStore.setlists.find((s) => s.id === activeSetlistId.value) ?? null)
     : null
 )
-const currentSelectionLabel = computed(() =>
-  activeView.value === 'setlist' && activeSetlist.value ? activeSetlist.value.name : 'Répertoire'
+
+const trashCount = computed(
+  () => setlistsStore.archivedSetlists.length + songsStore.archivedSongs.length
 )
+
+const currentSelectionLabel = computed(() => {
+  if (activeView.value === 'trash') return 'Corbeille'
+  if (activeView.value === 'setlist' && activeSetlist.value) return activeSetlist.value.name
+  return 'Répertoire'
+})
 
 function selectRepertoire() {
   activeView.value = 'repertoire'
@@ -124,11 +143,23 @@ function selectSetlist(id) {
   mobileNavOpen.value = false
 }
 
+function selectTrash() {
+  activeView.value = 'trash'
+  activeSetlistId.value = null
+  router.replace({ query: { view: 'trash' } })
+  mobileNavOpen.value = false
+}
+
 function syncFromQuery() {
   const setlistParam = route.query.setlist
   if (typeof setlistParam === 'string' && setlistParam) {
     activeView.value = 'setlist'
     activeSetlistId.value = setlistParam
+    return
+  }
+  if (route.query.view === 'trash') {
+    activeView.value = 'trash'
+    activeSetlistId.value = null
     return
   }
   activeView.value = 'repertoire'
@@ -139,6 +170,10 @@ function loadAll() {
   if (!bandSpaceId.value) return
   songsStore.fetchSongs(bandSpaceId.value)
   setlistsStore.fetchSetlists(bandSpaceId.value)
+  // The trash is loaded up front rather than on first open, because its count sits in the sidebar
+  // next to the live lists. Both collections are unpaginated and hold a handful of rows.
+  songsStore.fetchArchivedSongs(bandSpaceId.value)
+  setlistsStore.fetchArchivedSetlists(bandSpaceId.value)
 }
 
 function handleSetlistCreated(created) {

--- a/src/ApiResource/BandSpace/Setlist/SetlistResource.php
+++ b/src/ApiResource/BandSpace/Setlist/SetlistResource.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\Processor\BandSpace\Setlist\SetlistDeleteProcessor;
 use App\State\Processor\BandSpace\Setlist\SetlistUpdateProcessor;
@@ -29,6 +30,9 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('ROLE_USER')",
             name: 'api_band_space_setlists_get_collection',
             provider: SetlistCollectionProvider::class,
+            parameters: [
+                'archived' => new QueryParameter(key: 'archived'),
+            ],
         ),
         new Get(
             uriTemplate: '/band_spaces/{bandSpaceId}/setlists/{id}',

--- a/src/ApiResource/BandSpace/Setlist/SetlistRestore.php
+++ b/src/ApiResource/BandSpace/Setlist/SetlistRestore.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\Setlist;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\Setlist\SetlistRestoreProcessor;
+
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/setlists/{id}/restore',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: SetlistResource::class, identifiers: ['bandSpaceId']),
+        'id' => new Link(fromClass: SetlistResource::class, identifiers: ['id']),
+    ],
+    openapi: new Operation(tags: ['Band Space Setlist']),
+    normalizationContext: ['skip_null_values' => false],
+    security: "is_granted('ROLE_USER')",
+    input: false,
+    output: SetlistResource::class,
+    read: false,
+    name: 'api_band_space_setlists_restore',
+    processor: SetlistRestoreProcessor::class,
+)]
+class SetlistRestore
+{
+}

--- a/src/ApiResource/BandSpace/Setlist/Song/SongResource.php
+++ b/src/ApiResource/BandSpace/Setlist/Song/SongResource.php
@@ -31,9 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             name: 'api_band_space_songs_get_collection',
             provider: SongCollectionProvider::class,
             parameters: [
-                'includeArchived' => new QueryParameter(
-                    schema: ['type' => 'boolean'],
-                ),
+                'archived' => new QueryParameter(key: 'archived'),
             ],
         ),
         new Get(

--- a/src/ApiResource/BandSpace/Setlist/Song/SongRestore.php
+++ b/src/ApiResource/BandSpace/Setlist/Song/SongRestore.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\Setlist\Song;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\Setlist\Song\SongRestoreProcessor;
+
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/songs/{id}/restore',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: SongResource::class, identifiers: ['bandSpaceId']),
+        'id' => new Link(fromClass: SongResource::class, identifiers: ['id']),
+    ],
+    openapi: new Operation(tags: ['Band Space Setlist']),
+    normalizationContext: ['skip_null_values' => false],
+    security: "is_granted('ROLE_USER')",
+    input: false,
+    output: SongResource::class,
+    read: false,
+    name: 'api_band_space_songs_restore',
+    processor: SongRestoreProcessor::class,
+)]
+class SongRestore
+{
+}

--- a/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
+++ b/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
@@ -29,6 +29,13 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  *
  * Storage is always deleted before the rows: if storage fails, the rows survive and the next run retries.
  * The reverse order would lose the only pointer to the object and orphan it permanently.
+ *
+ * Archived setlists and songs are deliberately NOT swept (#761). Files get a retention window because
+ * every archived one holds bytes that cost money and count against the band's quota; a setlist row and
+ * a song row cost neither, so the deadline would buy nothing and would only add a way to lose work.
+ * Songs in particular must never be destroyed on a timer: a SetlistItem keeps pointing at its song
+ * after the song is archived, which is what lets last year's setlist still render and export, so
+ * purging the row would quietly gut setlists nobody archived. Their trash is unbounded on purpose.
  */
 #[AsCommand(
     name: 'app:band-space:purge',

--- a/src/Repository/BandSpace/SetlistRepository.php
+++ b/src/Repository/BandSpace/SetlistRepository.php
@@ -20,27 +20,17 @@ class SetlistRepository extends ServiceEntityRepository
     /**
      * @return Setlist[]
      */
-    public function findByBandSpace(BandSpace $bandSpace, bool $includeArchived = false): array
+    public function findByBandSpace(BandSpace $bandSpace, bool $archivedOnly = false): array
     {
-        $qb = $this->createQueryBuilder('s')
+        return $this->createQueryBuilder('s')
             ->where('s.bandSpace = :bandSpace')
+            ->andWhere($archivedOnly ? 's.archiveDatetime IS NOT NULL' : 's.archiveDatetime IS NULL')
             ->setParameter('bandSpace', $bandSpace)
-            ->orderBy('s.creationDatetime', 'DESC');
-
-        if (!$includeArchived) {
-            $qb->andWhere('s.archiveDatetime IS NULL');
-        }
-
-        return $qb->getQuery()->getResult();
+            ->orderBy('s.creationDatetime', 'DESC')
+            ->getQuery()
+            ->getResult();
     }
 
-    /**
-     * Direct id lookup does NOT filter archived setlists - clients need
-     * archived setlists to render in activity logs / restore flows.
-     *
-     * So this is a READ finder, and a write path cannot treat what it returns as writable: every
-     * processor that mutates the setlist has to run SetlistWriteGuard on the result.
-     */
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?Setlist
     {
         return $this->createQueryBuilder('s')

--- a/src/Repository/BandSpace/SongRepository.php
+++ b/src/Repository/BandSpace/SongRepository.php
@@ -20,27 +20,17 @@ class SongRepository extends ServiceEntityRepository
     /**
      * @return Song[]
      */
-    public function findByBandSpace(BandSpace $bandSpace, bool $includeArchived = false): array
+    public function findByBandSpace(BandSpace $bandSpace, bool $archivedOnly = false): array
     {
-        $qb = $this->createQueryBuilder('s')
+        return $this->createQueryBuilder('s')
             ->where('s.bandSpace = :bandSpace')
+            ->andWhere($archivedOnly ? 's.archiveDatetime IS NOT NULL' : 's.archiveDatetime IS NULL')
             ->setParameter('bandSpace', $bandSpace)
-            ->orderBy('s.title', 'ASC');
-
-        if (!$includeArchived) {
-            $qb->andWhere('s.archiveDatetime IS NULL');
-        }
-
-        return $qb->getQuery()->getResult();
+            ->orderBy('s.title', 'ASC')
+            ->getQuery()
+            ->getResult();
     }
 
-    /**
-     * Direct id lookup does NOT filter archived songs - clients need the
-     * archived song to render in setlist items / file detail drawers.
-     *
-     * So this is a READ finder, and a write path cannot treat what it returns as writable: every
-     * processor that mutates the song has to run SongWriteGuard on the result.
-     */
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?Song
     {
         return $this->createQueryBuilder('s')

--- a/src/Repository/BandSpace/TechRiderRepository.php
+++ b/src/Repository/BandSpace/TechRiderRepository.php
@@ -18,10 +18,6 @@ class TechRiderRepository extends ServiceEntityRepository
     }
 
     /**
-     * Live riders by default; $archivedOnly swaps to the archive view rather than
-     * widening the result, matching the files trash (?archived=true) rather than
-     * SetlistRepository::findByBandSpace, which includes both.
-     *
      * @return TechRider[]
      */
     public function findByBandSpace(BandSpace $bandSpace, bool $archivedOnly = false): array

--- a/src/Security/BandSpace/SetlistWriteGuard.php
+++ b/src/Security/BandSpace/SetlistWriteGuard.php
@@ -5,20 +5,6 @@ namespace App\Security\BandSpace;
 use App\Entity\BandSpace\Setlist;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 
-/**
- * Refuses writes to an archived setlist.
- *
- * SetlistRepository::findOneByIdAndBandSpace() returns archived rows on purpose, because reads
- * legitimately need them: the PDF of last year's gig, the activity log, the file drawer. That makes
- * the finder unable to carry the rule, so every write path states it here instead. Without it a
- * stale tab or a bookmarked ?setlist=<id> renames the list, adds songs and reorders them, each
- * answered with a 200, into a row nobody can see and nothing can restore (no restore until #761).
- *
- * Deliberately not guarded: archiving, which is how a setlist gets here, and duplicating, which
- * reads the archived list without touching it and is the only way back out of the archive today.
- *
- * Same shape as BandSpaceWriteGuard and TechRiderWriteGuard.
- */
 readonly class SetlistWriteGuard
 {
     public function assertWritable(Setlist $setlist): void

--- a/src/Security/BandSpace/SongWriteGuard.php
+++ b/src/Security/BandSpace/SongWriteGuard.php
@@ -5,16 +5,6 @@ namespace App\Security\BandSpace;
 use App\Entity\BandSpace\Song;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 
-/**
- * Refuses writes to an archived song.
- *
- * SongRepository::findOneByIdAndBandSpace() returns archived rows on purpose, because a setlist
- * item still has to render the song it was built with. The write side therefore states the rule
- * here, exactly as SetlistWriteGuard does one level up.
- *
- * Archiving is deliberately not guarded: it is how a song gets here, and the processor already
- * treats a second call as a no-op.
- */
 readonly class SongWriteGuard
 {
     public function assertWritable(Song $song): void

--- a/src/State/Processor/BandSpace/Setlist/SetlistDuplicateProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistDuplicateProcessor.php
@@ -48,10 +48,6 @@ readonly class SetlistDuplicateProcessor implements ProcessorInterface
         }
 
         [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
-
-        // Deliberately not guarded by SetlistWriteGuard: an archived setlist is a valid source and
-        // duplicating it does not touch it. It is also the only way back out of the archive while
-        // there is no restore (#761), so refusing it here would strand the work for good.
         $source = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
         if (!$source instanceof Setlist) {
             throw new NotFoundHttpException('Setlist introuvable');

--- a/src/State/Processor/BandSpace/Setlist/SetlistRestoreProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/SetlistRestoreProcessor.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\Setlist;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\Setlist\SetlistResource;
+use App\Entity\BandSpace\Setlist;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceSetlistActivityType;
+use App\Repository\BandSpace\SetlistRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\Builder\BandSpace\SetlistBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<mixed, SetlistResource>
+ */
+readonly class SetlistRestoreProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private SetlistRepository $setlistRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private SetlistBuilder $setlistBuilder,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): SetlistResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        // findOneByIdAndBandSpace does not filter archived setlists, which is exactly what the trash needs.
+        $setlist = $this->setlistRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$setlist instanceof Setlist) {
+            throw new NotFoundHttpException('Setlist introuvable');
+        }
+
+        if ($setlist->archiveDatetime === null) {
+            throw new ConflictHttpException('Cette setlist n\'est pas dans la corbeille');
+        }
+
+        $setlist->archiveDatetime = null;
+
+        $this->activityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Setlist,
+            type: BandSpaceSetlistActivityType::SetlistUnarchived,
+            resourceId: (string) $setlist->id,
+            actor: $user,
+            payload: ['name' => $setlist->name],
+        );
+
+        $this->entityManager->flush();
+
+        return $this->setlistBuilder->buildItem($setlist);
+    }
+}

--- a/src/State/Processor/BandSpace/Setlist/Song/SongRestoreProcessor.php
+++ b/src/State/Processor/BandSpace/Setlist/Song/SongRestoreProcessor.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\Setlist\Song;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\Setlist\Song\SongResource;
+use App\Entity\BandSpace\Song;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceSetlistActivityType;
+use App\Repository\BandSpace\SongRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\Builder\BandSpace\SongBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<mixed, SongResource>
+ */
+readonly class SongRestoreProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private SongRepository $songRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private SongBuilder $songBuilder,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): SongResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        // findOneByIdAndBandSpace does not filter archived songs, which is exactly what the trash needs.
+        $song = $this->songRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$song instanceof Song) {
+            throw new NotFoundHttpException('Chanson introuvable');
+        }
+
+        if ($song->archiveDatetime === null) {
+            throw new ConflictHttpException('Cette chanson n\'est pas dans la corbeille');
+        }
+
+        $song->archiveDatetime = null;
+
+        $this->activityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Setlist,
+            type: BandSpaceSetlistActivityType::SongUnarchived,
+            resourceId: (string) $song->id,
+            actor: $user,
+            payload: ['title' => $song->title],
+        );
+
+        $this->entityManager->flush();
+
+        return $this->songBuilder->buildItem($song);
+    }
+}

--- a/src/State/Provider/BandSpace/Setlist/SetlistCollectionProvider.php
+++ b/src/State/Provider/BandSpace/Setlist/SetlistCollectionProvider.php
@@ -9,6 +9,7 @@ use App\Repository\BandSpace\SetlistRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\Builder\BandSpace\SetlistBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -21,6 +22,7 @@ readonly class SetlistCollectionProvider implements ProviderInterface
         private SetlistRepository $setlistRepository,
         private SetlistBuilder $setlistBuilder,
         private Security $security,
+        private RequestStack $requestStack,
     ) {
     }
 
@@ -36,8 +38,11 @@ readonly class SetlistCollectionProvider implements ProviderInterface
 
         [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
-        $setlists = $this->setlistRepository->findByBandSpace($bandSpace);
+        // The two lists never mix: archived=true is the trash, its absence is the live sidebar.
+        $archivedOnly = $this->requestStack->getCurrentRequest()?->query->getBoolean('archived') ?? false;
 
-        return $this->setlistBuilder->buildFromList($setlists);
+        return $this->setlistBuilder->buildFromList(
+            $this->setlistRepository->findByBandSpace($bandSpace, $archivedOnly),
+        );
     }
 }

--- a/src/State/Provider/BandSpace/Setlist/Song/SongCollectionProvider.php
+++ b/src/State/Provider/BandSpace/Setlist/Song/SongCollectionProvider.php
@@ -10,6 +10,7 @@ use App\Repository\BandSpace\SongRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\Builder\BandSpace\SongBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -22,6 +23,7 @@ readonly class SongCollectionProvider implements ProviderInterface
         private SongRepository $songRepository,
         private SongBuilder $songBuilder,
         private Security $security,
+        private RequestStack $requestStack,
     ) {
     }
 
@@ -37,11 +39,11 @@ readonly class SongCollectionProvider implements ProviderInterface
 
         [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
 
-        $includeArchived = isset($context['filters']['includeArchived'])
-            && filter_var($context['filters']['includeArchived'], FILTER_VALIDATE_BOOLEAN);
+        // The two lists never mix: archived=true is the trash, its absence is the live repertoire.
+        $archivedOnly = $this->requestStack->getCurrentRequest()?->query->getBoolean('archived') ?? false;
 
-        $songs = $this->songRepository->findByBandSpace($bandSpace, $includeArchived);
-
-        return $this->songBuilder->buildFromList($songs);
+        return $this->songBuilder->buildFromList(
+            $this->songRepository->findByBandSpace($bandSpace, $archivedOnly),
+        );
     }
 }

--- a/tests/Api/BandSpace/Setlist/SetlistArchivedWriteGuardTest.php
+++ b/tests/Api/BandSpace/Setlist/SetlistArchivedWriteGuardTest.php
@@ -25,10 +25,10 @@ use Zenstruck\Foundry\Attribute\ResetDatabase;
  * Archiving a setlist used to hide it and nothing more: the finder behind every write returns
  * archived rows on purpose, so a member who still had the list open, or who came back through a
  * bookmarked ?setlist=<id>, could rename it and rework its programme, every request answered with
- * a 200, into a row nobody can see and nothing can restore.
+ * a 200, into a row that stays invisible until somebody thinks to restore it.
  *
  * Reads have to keep working, so each refusal is paired with proof the row is still readable and
- * still duplicable, which is the only way back out of the archive today.
+ * still duplicable. Restore itself is exempt by construction and is covered in SetlistRestoreTest.
  */
 #[ResetDatabase]
 class SetlistArchivedWriteGuardTest extends ApiTestCase
@@ -283,8 +283,9 @@ class SetlistArchivedWriteGuardTest extends ApiTestCase
     }
 
     /**
-     * Duplicating reads the archived list without touching it, and with no restore yet (#761) it is
-     * the only way to get the work back, so the guard must never catch it.
+     * Duplicating reads the archived list without touching it, so the guard must never catch it.
+     * Restore (#761) is now how the original comes back; duplicating serves the other case, building
+     * this year's list from last year's while the archived one stays archived.
      */
     public function test_an_archived_setlist_can_still_be_duplicated(): void
     {

--- a/tests/Api/BandSpace/Setlist/SetlistGetCollectionTest.php
+++ b/tests/Api/BandSpace/Setlist/SetlistGetCollectionTest.php
@@ -60,6 +60,98 @@ class SetlistGetCollectionTest extends ApiTestCase
         ]);
     }
 
+    /**
+     * archived=true swaps the list rather than widening it, so the trash shows the archived setlists
+     * and nothing else. Before #761 an archived setlist was reachable from no list at all.
+     */
+    public function test_collection_with_archived_lists_only_the_trash(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Active list',
+            'creationDatetime' => new \DateTime('2026-05-01T10:00:00+00:00'),
+        ])->create();
+        $archived = SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Archived list',
+            'archiveDatetime' => new \DateTimeImmutable('2026-05-10T10:00:00+00:00'),
+            'creationDatetime' => new \DateTime('2026-04-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/setlists?archived=true');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Setlist',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists',
+            '@type' => 'Collection',
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists?archived=true',
+                '@type' => 'PartialCollectionView',
+            ],
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $archived->id,
+                    '@type' => 'Setlist',
+                    'id' => $archived->id,
+                    'band_space_id' => $bandSpace->id,
+                    'name' => 'Archived list',
+                    'archive_datetime' => $archived->archiveDatetime->format(\DateTimeInterface::ATOM),
+                    'creation_datetime' => $archived->creationDatetime->format(\DateTimeInterface::ATOM),
+                    'update_datetime' => null,
+                    'items' => [],
+                    'total_duration_seconds' => 0,
+                ],
+            ],
+            'totalItems' => 1,
+        ]);
+    }
+
+    /**
+     * The live setlist in my own band is what makes this test bite: an empty trash must come back empty
+     * rather than falling back to the live list, and the other band's archived row must not leak in.
+     */
+    public function test_collection_with_archived_is_scoped_to_band(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $myBand = BandSpaceFactory::new()->create();
+        $otherBand = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $myBand, 'user' => $user])->create();
+
+        SetlistFactory::new([
+            'bandSpace' => $myBand,
+            'name' => 'My live list',
+            'creationDatetime' => new \DateTime('2026-05-01T10:00:00+00:00'),
+        ])->create();
+        SetlistFactory::new([
+            'bandSpace' => $otherBand,
+            'name' => 'Their archived list',
+            'archiveDatetime' => new \DateTimeImmutable('2026-05-10T10:00:00+00:00'),
+            'creationDatetime' => new \DateTime('2026-04-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $myBand->id . '/setlists?archived=true');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Setlist',
+            '@id' => '/api/band_spaces/' . $myBand->id . '/setlists',
+            '@type' => 'Collection',
+            'view' => [
+                '@id' => '/api/band_spaces/' . $myBand->id . '/setlists?archived=true',
+                '@type' => 'PartialCollectionView',
+            ],
+            'member' => [],
+            'totalItems' => 0,
+        ]);
+    }
+
     public function test_collection_scoped_to_band(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/Setlist/SetlistRestoreTest.php
+++ b/tests/Api/BandSpace/Setlist/SetlistRestoreTest.php
@@ -1,0 +1,351 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Setlist;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\Setlist;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Enum\BandSpace\SetlistItemType;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\BandSpace\SetlistRepository;
+use App\Security\BandSpace\SetlistWriteGuard;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\SetlistFactory;
+use App\Tests\Factory\BandSpace\SetlistItemFactory;
+use App\Tests\Factory\BandSpace\SongFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * Archiving a setlist used to be one way: nothing listed the archived row and nothing cleared the
+ * flag, so an accidental delete was invisible, and since #824 made archived setlists read only it
+ * was frozen as well. Duplicating was the only escape, and it produces a copy rather than the
+ * original back.
+ */
+#[ResetDatabase]
+class SetlistRestoreTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    /**
+     * The membership role is pinned to User rather than left to the factory default, because the rule
+     * under test is that restoring is NOT admin gated: any member may archive a setlist, so any member
+     * brings it back. A setlist has no creator to prefer over the rest of the band.
+     */
+    public function test_restore_takes_the_setlist_out_of_the_trash(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user, 'role' => Role::User])->create();
+
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $setlistId = (string) $setlist->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlistId . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Setlist',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlistId,
+            '@type' => 'Setlist',
+            'id' => $setlistId,
+            'band_space_id' => $bandSpace->id,
+            'name' => 'Concert 12/06',
+            'archive_datetime' => null,
+            'creation_datetime' => $setlist->creationDatetime->format(DateTimeInterface::ATOM),
+            'update_datetime' => null,
+            'items' => [],
+            'total_duration_seconds' => 0,
+        ]);
+
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::Setlist, $setlistId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('setlist_unarchived', $activities[0]->type);
+        $this->assertSame(['name' => 'Concert 12/06'], $activities[0]->payload);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistRepository::class)->find($setlistId);
+        $this->assertInstanceOf(Setlist::class, $stored);
+        $this->assertNull($stored->archiveDatetime);
+
+        // The other half of #824: the guard that froze this row has to let go once it is restored,
+        // otherwise the setlist comes back visible but still unwritable. Instantiated rather than
+        // pulled from the container because it has no dependencies and this is the real class.
+        (new SetlistWriteGuard())->assertWritable($stored);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * The restored setlist is back in the live collection, which is the list the sidebar renders and
+     * the one an archived row was missing from.
+     */
+    public function test_a_restored_setlist_is_listed_again(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/setlists/' . $setlist->id . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $reloadedBand = self::getContainer()->get(BandSpaceRepository::class)->find($bandSpaceId);
+        $setlistRepository = self::getContainer()->get(SetlistRepository::class);
+
+        $live = $setlistRepository->findByBandSpace($reloadedBand);
+        $this->assertCount(1, $live);
+        $this->assertSame('Concert 12/06', $live[0]->name);
+
+        $this->assertCount(0, $setlistRepository->findByBandSpace($reloadedBand, true), 'The trash is empty again');
+    }
+
+    /**
+     * A setlist item points at a Song, and a song archived separately keeps rendering in the items that
+     * already reference it, because SetlistRepository::findOneByIdAndBandSpace does not filter archived
+     * songs. So restoring a setlist gives the whole programme back, durations included, and leaves the
+     * song archived: un-archiving a title the band retired on purpose is a repertoire decision, not a
+     * side effect. The title stays out of the repertoire and out of new setlists until it is restored
+     * in its own right.
+     */
+    public function test_restore_keeps_an_item_pointing_at_an_archived_song(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $archivedSong = SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Trop tard',
+            'referenceDuration' => 210,
+            'tempo' => 128,
+            'tonality' => 'Am',
+            'creationDatetime' => new DateTime('2026-01-05T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-06-10T09:00:00+00:00'),
+        ])->create();
+        $archivedSongId = (string) $archivedSong->id;
+
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $item = SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Song,
+            'song' => $archivedSong,
+            'label' => null,
+            'position' => 0,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Setlist',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id,
+            '@type' => 'Setlist',
+            'id' => $setlist->id,
+            'band_space_id' => $bandSpace->id,
+            'name' => 'Concert 12/06',
+            'archive_datetime' => null,
+            'creation_datetime' => $setlist->creationDatetime->format(DateTimeInterface::ATOM),
+            'update_datetime' => null,
+            'items' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/items/' . $item->id,
+                    '@type' => 'SetlistItem',
+                    'id' => $item->id,
+                    'band_space_id' => $bandSpace->id,
+                    'setlist_id' => $setlist->id,
+                    'type' => 'song',
+                    'song' => [
+                        'id' => $archivedSongId,
+                        'title' => 'Trop tard',
+                        'tempo' => 128,
+                        'tonality' => 'Am',
+                        'reference_duration' => 210,
+                        'archive_datetime' => $archivedSong->archiveDatetime->format(DateTimeInterface::ATOM),
+                        '@type' => 'SetlistItemSongInfo',
+                    ],
+                    'label' => null,
+                    'duration_override' => null,
+                    'note' => null,
+                    'transition' => null,
+                    'position' => 0,
+                ],
+            ],
+            'total_duration_seconds' => 210,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $storedSong = self::getContainer()->get(\App\Repository\BandSpace\SongRepository::class)->find($archivedSongId);
+        $this->assertNotNull($storedSong?->archiveDatetime, 'Restoring a setlist does not un-archive its songs');
+    }
+
+    public function test_restore_a_live_setlist_conflicts(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $setlist = SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Still live',
+            'creationDatetime' => new DateTime('2026-06-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Cette setlist n'est pas dans la corbeille",
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => "Cette setlist n'est pas dans la corbeille",
+        ]);
+    }
+
+    public function test_restore_not_member(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+        $setlistId = (string) $setlist->id;
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlistId . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistRepository::class)->find($setlistId);
+        $this->assertNotNull($stored?->archiveDatetime);
+    }
+
+    /**
+     * The band space in the path is the one the setlist is looked up in, so a member of A cannot reach
+     * into B's trash by pointing his own space at their setlist id.
+     */
+    public function test_restore_a_setlist_of_another_band_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $myBand = BandSpaceFactory::new()->create();
+        $otherBand = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $myBand, 'user' => $user])->create();
+
+        $theirSetlist = $this->archivedSetlist($otherBand, 'Their list');
+        $theirSetlistId = (string) $theirSetlist->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $myBand->id . '/setlists/' . $theirSetlistId . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Setlist introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Setlist introuvable',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SetlistRepository::class)->find($theirSetlistId);
+        $this->assertNotNull($stored?->archiveDatetime);
+    }
+
+    public function test_restore_unauthenticated(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+        $setlist = $this->archivedSetlist($bandSpace, 'Concert 12/06');
+
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/setlists/' . $setlist->id . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    private function archivedSetlist(BandSpace $bandSpace, string $name): Setlist
+    {
+        return SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => $name,
+            'creationDatetime' => new DateTime('2026-06-01T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-06-13T09:00:00+00:00'),
+        ])->create();
+    }
+}

--- a/tests/Api/BandSpace/Setlist/Song/SongDeleteTest.php
+++ b/tests/Api/BandSpace/Setlist/Song/SongDeleteTest.php
@@ -27,8 +27,12 @@ class SongDeleteTest extends ApiTestCase
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
         BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
-        $song = SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Doomed'])->create();
+        $song = SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Trop tard'])->create();
         $songId = (string) $song->id;
+        // A second title, left alone, so the two assertions below can tell the repertoire from the
+        // trash. With only the archived song in the band, both lists hold one row under either
+        // meaning of the flag and the assertions pass without checking anything.
+        SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Toujours là'])->create();
 
         $this->client->loginUser($user);
         $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/songs/' . $songId);
@@ -43,19 +47,27 @@ class SongDeleteTest extends ApiTestCase
         $this->assertNotNull($refreshed);
         $this->assertNotNull($refreshed->archiveDatetime);
 
-        // Excluded from collection / included with includeArchived. Re-fetch
-        // the band space because clear() detached the test's reference.
+        // Out of the repertoire, into the trash: findByBandSpace($band, true) selects the archived
+        // rows, it does not widen to both lists. Asserting the titles rather than just the counts is
+        // what makes that concrete. Re-fetch the band space because clear() detached the test's
+        // reference.
         $bandSpaceId = (string) $bandSpace->id;
         $reloadedBand = self::getContainer()->get(BandSpaceRepository::class)->find($bandSpaceId);
-        $this->assertCount(0, $repo->findByBandSpace($reloadedBand));
-        $this->assertCount(1, $repo->findByBandSpace($reloadedBand, true));
+
+        $live = $repo->findByBandSpace($reloadedBand);
+        $this->assertCount(1, $live);
+        $this->assertSame('Toujours là', $live[0]->title);
+
+        $archived = $repo->findByBandSpace($reloadedBand, true);
+        $this->assertCount(1, $archived);
+        $this->assertSame('Trop tard', $archived[0]->title);
 
         // Activity row recorded
         $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
         $activities = $activityRepo->findForResource($bandSpace, BandSpaceModule::Setlist, $songId);
         $this->assertCount(1, $activities);
         $this->assertSame('song_archived', $activities[0]->type);
-        $this->assertSame(['title' => 'Doomed'], $activities[0]->payload);
+        $this->assertSame(['title' => 'Trop tard'], $activities[0]->payload);
     }
 
     public function test_delete_song_twice_is_idempotent(): void

--- a/tests/Api/BandSpace/Setlist/Song/SongGetCollectionTest.php
+++ b/tests/Api/BandSpace/Setlist/Song/SongGetCollectionTest.php
@@ -63,26 +63,31 @@ class SongGetCollectionTest extends ApiTestCase
         ]);
     }
 
-    public function test_get_collection_with_include_archived(): void
+    /**
+     * archived=true swaps the list rather than widening it, so the trash shows the archived titles and
+     * nothing else. It replaced includeArchived, which returned the repertoire and the archive mixed
+     * together: a shape no caller ever asked for and one a trash view cannot use.
+     */
+    public function test_get_collection_with_archived_lists_only_the_trash(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
         BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
-        $active = SongFactory::new([
+        SongFactory::new([
             'bandSpace' => $bandSpace,
-            'title' => 'A',
+            'title' => 'Toujours là',
             'creationDatetime' => new \DateTime('2026-05-01T10:00:00+00:00'),
         ])->create();
         $archived = SongFactory::new([
             'bandSpace' => $bandSpace,
-            'title' => 'B',
+            'title' => 'Trop tard',
             'archiveDatetime' => new \DateTimeImmutable('2026-05-10T10:00:00+00:00'),
             'creationDatetime' => new \DateTime('2026-04-01T10:00:00+00:00'),
         ])->create();
 
         $this->client->loginUser($user);
-        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/songs?includeArchived=1');
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/songs?archived=true');
 
         $this->assertResponseIsSuccessful();
         $this->assertJsonEquals([
@@ -90,30 +95,16 @@ class SongGetCollectionTest extends ApiTestCase
             '@id' => '/api/band_spaces/' . $bandSpace->id . '/songs',
             '@type' => 'Collection',
             'view' => [
-                '@id' => '/api/band_spaces/' . $bandSpace->id . '/songs?includeArchived=1',
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/songs?archived=true',
                 '@type' => 'PartialCollectionView',
             ],
             'member' => [
-                [
-                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/songs/' . $active->id,
-                    '@type' => 'Song',
-                    'id' => $active->id,
-                    'band_space_id' => $bandSpace->id,
-                    'title' => 'A',
-                    'tempo' => null,
-                    'tonality' => null,
-                    'reference_duration' => null,
-                    'notes' => null,
-                    'archive_datetime' => null,
-                    'creation_datetime' => $active->creationDatetime->format(\DateTimeInterface::ATOM),
-                    'update_datetime' => null,
-                ],
                 [
                     '@id' => '/api/band_spaces/' . $bandSpace->id . '/songs/' . $archived->id,
                     '@type' => 'Song',
                     'id' => $archived->id,
                     'band_space_id' => $bandSpace->id,
-                    'title' => 'B',
+                    'title' => 'Trop tard',
                     'tempo' => null,
                     'tonality' => null,
                     'reference_duration' => null,
@@ -123,7 +114,47 @@ class SongGetCollectionTest extends ApiTestCase
                     'update_datetime' => null,
                 ],
             ],
-            'totalItems' => 2,
+            'totalItems' => 1,
+        ]);
+    }
+
+    /**
+     * The live title in my own band is what makes this test bite: an empty trash must come back empty
+     * rather than falling back to the repertoire, and the other band's archived row must not leak in.
+     */
+    public function test_get_collection_with_archived_is_scoped_to_band(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $myBand = BandSpaceFactory::new()->create();
+        $otherBand = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $myBand, 'user' => $user])->create();
+
+        SongFactory::new([
+            'bandSpace' => $myBand,
+            'title' => 'My live title',
+            'creationDatetime' => new \DateTime('2026-05-01T10:00:00+00:00'),
+        ])->create();
+        SongFactory::new([
+            'bandSpace' => $otherBand,
+            'title' => 'Their archived title',
+            'archiveDatetime' => new \DateTimeImmutable('2026-05-10T10:00:00+00:00'),
+            'creationDatetime' => new \DateTime('2026-04-01T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $myBand->id . '/songs?archived=true');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Song',
+            '@id' => '/api/band_spaces/' . $myBand->id . '/songs',
+            '@type' => 'Collection',
+            'view' => [
+                '@id' => '/api/band_spaces/' . $myBand->id . '/songs?archived=true',
+                '@type' => 'PartialCollectionView',
+            ],
+            'member' => [],
+            'totalItems' => 0,
         ]);
     }
 

--- a/tests/Api/BandSpace/Setlist/Song/SongRestoreTest.php
+++ b/tests/Api/BandSpace/Setlist/Song/SongRestoreTest.php
@@ -1,0 +1,267 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Setlist\Song;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\Song;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\BandSpace\SongRepository;
+use App\Security\BandSpace\SongWriteGuard;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\SongFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * Archiving a title used to be one way: nothing listed the archived row and nothing cleared the flag,
+ * so an accidental delete took the title out of the repertoire for good, and since #824 it could not
+ * even be edited back into shape.
+ */
+#[ResetDatabase]
+class SongRestoreTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    /**
+     * The membership role is pinned to User rather than left to the factory default, because the rule
+     * under test is that restoring is NOT admin gated: any member may archive a title, so any member
+     * brings it back.
+     */
+    public function test_restore_puts_the_title_back_in_the_repertoire(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user, 'role' => Role::User])->create();
+
+        $song = $this->archivedSong($bandSpace, 'Trop tard');
+        $songId = (string) $song->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/songs/' . $songId . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Song',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/songs/' . $songId,
+            '@type' => 'Song',
+            'id' => $songId,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Trop tard',
+            'tempo' => 128,
+            'tonality' => 'Am',
+            'reference_duration' => 210,
+            'notes' => null,
+            'archive_datetime' => null,
+            'creation_datetime' => $song->creationDatetime->format(DateTimeInterface::ATOM),
+            'update_datetime' => null,
+        ]);
+
+        $activityRepository = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $activities = $activityRepository->findForResource($bandSpace, BandSpaceModule::Setlist, $songId);
+        $this->assertCount(1, $activities);
+        $this->assertSame('song_unarchived', $activities[0]->type);
+        $this->assertSame(['title' => 'Trop tard'], $activities[0]->payload);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SongRepository::class)->find($songId);
+        $this->assertInstanceOf(Song::class, $stored);
+        $this->assertNull($stored->archiveDatetime);
+
+        // The other half of #824: the guard that froze this row has to let go once it is restored,
+        // otherwise the title comes back visible but still unwritable. Instantiated rather than
+        // pulled from the container because it has no dependencies and this is the real class.
+        (new SongWriteGuard())->assertWritable($stored);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * The restored title is back in the live repertoire, which is the list the Répertoire table renders
+     * and the one an archived row was missing from.
+     */
+    public function test_a_restored_title_is_listed_again(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $song = $this->archivedSong($bandSpace, 'Trop tard');
+        $bandSpaceId = (string) $bandSpace->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/songs/' . $song->id . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $reloadedBand = self::getContainer()->get(BandSpaceRepository::class)->find($bandSpaceId);
+        $songRepository = self::getContainer()->get(SongRepository::class);
+
+        $live = $songRepository->findByBandSpace($reloadedBand);
+        $this->assertCount(1, $live);
+        $this->assertSame('Trop tard', $live[0]->title);
+
+        $this->assertCount(0, $songRepository->findByBandSpace($reloadedBand, true), 'The trash is empty again');
+    }
+
+    public function test_restore_a_live_title_conflicts(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $song = SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Still live',
+            'creationDatetime' => new DateTime('2026-01-05T10:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/songs/' . $song->id . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Cette chanson n'est pas dans la corbeille",
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => "Cette chanson n'est pas dans la corbeille",
+        ]);
+    }
+
+    public function test_restore_not_member(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $song = $this->archivedSong($bandSpace, 'Trop tard');
+        $songId = (string) $song->id;
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/songs/' . $songId . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SongRepository::class)->find($songId);
+        $this->assertNotNull($stored?->archiveDatetime);
+    }
+
+    /**
+     * The band space in the path is the one the title is looked up in, so a member of A cannot reach
+     * into B's trash by pointing his own space at their song id.
+     */
+    public function test_restore_a_title_of_another_band_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $myBand = BandSpaceFactory::new()->create();
+        $otherBand = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $myBand, 'user' => $user])->create();
+
+        $theirSong = $this->archivedSong($otherBand, 'Their title');
+        $theirSongId = (string) $theirSong->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $myBand->id . '/songs/' . $theirSongId . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Chanson introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Chanson introuvable',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $stored = self::getContainer()->get(SongRepository::class)->find($theirSongId);
+        $this->assertNotNull($stored?->archiveDatetime);
+    }
+
+    public function test_restore_unauthenticated(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+        $song = $this->archivedSong($bandSpace, 'Trop tard');
+
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/songs/' . $song->id . '/restore',
+            [],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    private function archivedSong(BandSpace $bandSpace, string $title): Song
+    {
+        return SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => $title,
+            'tempo' => 128,
+            'tonality' => 'Am',
+            'referenceDuration' => 210,
+            'creationDatetime' => new DateTime('2026-01-05T10:00:00+00:00'),
+            'archiveDatetime' => new DateTimeImmutable('2026-06-10T09:00:00+00:00'),
+        ])->create();
+    }
+}


### PR DESCRIPTION
Closes #761.

`SetlistDeleteProcessor` and `SongDeleteProcessor` set `archiveDatetime` rather than removing the row, but nothing listed archived rows and no endpoint cleared the field, so a deleted setlist or song was invisible and unrecoverable.

**#868 sharpened this.** Archived setlists and songs became read-only, so an accidental delete was frozen as well as invisible. Duplicate was the only escape, and it produces a copy rather than restoring the original.

## What ships

- `?archived=true` on both collections, and `POST /band_spaces/{bandSpaceId}/setlists/{id}/restore` plus the song equivalent.
- A `Corbeille` entry in the Setlist sidebar with a combined count, and a trash list with two sections.
- The enum cases `SetlistUnarchived` and `SongUnarchived` and their French activity sentences already existed with no endpoint behind them. They are now reachable.

No migration: `archiveDatetime` already exists on both entities.

## A parameter changed meaning, and this is the thing to know

`findByBandSpace($bandSpace, bool $includeArchived = false)` **widened** to live plus archived. It is now `findByBandSpace($bandSpace, bool $archivedOnly = false)`, which **selects** archived instead. Same position, same type, same default, opposite meaning, and PHP will not catch a stale caller.

Kept deliberately: it matches `TechRiderRepository` and the files trash (whose own docblock previously called this repository out as the outlier), and the old shape is unusable for a trash view. The production call-site audit came back clean, only the two collection providers, both updated here.

The review found the risk was not theoretical. `SongDeleteTest` called `findByBandSpace($band, true)` and asserted a count of 1 in a space holding exactly one song, so it read 1 under **both** meanings and provided no regression coverage at all. It now seeds a second live song and asserts titles rather than counts, and flipping the repository back to the old widen behaviour makes it fail loudly.

`?includeArchived` on `/songs` is removed, replaced by `?archived`. It was only ever pass-through plumbing; no caller ever passed it true. Still an API change worth noting.

## The four decisions

**Authorization: any member.** The files trash is owner-or-admin because *file deletion* is owner-or-admin. Setlist and song deletion require nothing beyond membership, and neither entity has a `createdBy`, so an owner rule is not merely undesirable, it is unrepresentable. The coherent rule is the one the files trash already states, that whoever could delete it can bring it back. Tests pin `Role::User` explicitly so a factory default change cannot silently turn them into admin tests.

**Purge: unbounded, on purpose**, with the reasoning written into the purge command's docblock so nobody re-litigates it. Files get 30 days because each archived one holds bytes that cost money and count against the quota; rows cost neither. Songs specifically must never die on a timer: `SetlistItem.song` is `onDelete: SET NULL`, and an item keeps pointing at its song after archiving (that is what lets last year's setlist still render and export), so hard-deleting archived songs would null out items in setlists nobody archived. Consequence: no countdown in the trash copy, unlike files.

**Restoring a setlist whose songs are archived leaves the songs alone**, and that is already correct: the fetch-join has no archive filter, the builder emits the song with its `archive_datetime`, durations still count, and the editor already badges such an item. The song stays out of the repertoire until restored in its own right. Cascading would be the bug. Pinned by a test.

**Restore deliberately skips the write guards**, and this is a structural necessity rather than a policy call: `assertWritable()` throws whenever `archiveDatetime !== null`, which is exactly the state restore starts from, so wiring it in would make restore refuse every setlist it exists to rescue. It keeps `checkMemberForWrite`, so restore is still refused on a space pending deletion. Each success test asserts the field is null and then runs the real guard against the reloaded entity, so "restored implies writable again" is asserted rather than assumed.

## Deliberately not done

No permanent-delete endpoint. Nothing purges these rows, so it would be the only way to lose a setlist forever, which is the opposite of what this issue is for.

## Verification

`tests/Api/BandSpace/` 1039 passing, PHPStan level 8 clean, Biome clean, build clean, no migration.

13 restore tests and 4 archived-collection tests fail without the change. The two cross-band cases initially passed either way, because an empty trash and an empty live list look identical, so a live row was added to make them bite.
