### PR TITLE
Files: upload several files at once

### DIFF
--- a/.docker/frankenphp/local/99-custom.ini
+++ b/.docker/frankenphp/local/99-custom.ini
@@ -3,3 +3,5 @@ opcache.revalidate_freq=0
 opcache.validate_timestamps=1
 opcache.max_accelerated_files=42013
 memory_limit = 256M
+upload_max_filesize = 512M
+post_max_size = 528M

--- a/assets/js/api/bandSpace/band-space-files.js
+++ b/assets/js/api/bandSpace/band-space-files.js
@@ -143,7 +143,9 @@ export default {
       .catch(handleApiError)
   },
 
-  uploadFile(bandSpaceId, { file, folderId, tagIds }, onProgress) {
+  // `signal` lets a batch drop a file that is still going up when the member closes the dialog,
+  // rather than spending their upstream on bytes nothing is waiting for any more.
+  uploadFile(bandSpaceId, { file, folderId, tagIds }, onProgress, signal) {
     const formData = new FormData()
     formData.append('uploadedFile', file)
     if (folderId) formData.append('folderId', folderId)
@@ -156,6 +158,7 @@ export default {
     return axios
       .post(Routing.generate('api_band_space_files_upload', { bandSpaceId }), formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
+        signal,
         onUploadProgress: (progressEvent) => {
           if (onProgress && progressEvent.total) {
             const percent = Math.round((progressEvent.loaded * 100) / progressEvent.total)

--- a/assets/js/components/BandSpace/Files/FileUploadDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileUploadDialog.vue
@@ -2,11 +2,10 @@
   <Dialog
     v-model:visible="visible"
     modal
-    header="Importer un fichier"
-    :style="{ width: '32rem' }"
-    :closable="!isUploading"
+    header="Importer des fichiers"
+    :style="{ width: '36rem' }"
     :close-on-escape="!isUploading"
-    @hide="resetForm"
+    @hide="handleHide"
   >
     <div class="flex flex-col gap-4">
       <div
@@ -21,38 +20,59 @@
           ref="fileInput"
           type="file"
           class="hidden"
+          multiple
           @change="handleFileChange"
         />
 
-        <template v-if="!selectedFile">
-          <i class="pi pi-cloud-upload text-3xl text-surface-400 mb-2"></i>
-          <p class="text-sm text-surface-600 dark:text-surface-300">
-            Glissez-déposez un fichier ou
-            <span class="text-primary-500 underline">cliquez pour parcourir</span>
-          </p>
-        </template>
-
-        <template v-else>
-          <div class="flex items-center justify-center gap-2">
-            <i class="pi pi-file text-2xl text-surface-500"></i>
-            <div class="text-left min-w-0">
-              <p class="text-sm font-medium truncate">{{ selectedFile.name }}</p>
-              <p class="text-xs text-surface-400">{{ formatSize(selectedFile.size) }}</p>
-            </div>
-            <Button
-              icon="pi pi-times"
-              aria-label="Retirer le fichier"
-              text
-              rounded
-              size="small"
-              :disabled="isUploading"
-              @click.stop="clearFile"
-            />
-          </div>
-        </template>
+        <i class="pi pi-cloud-upload text-3xl text-surface-400 mb-2" aria-hidden="true"></i>
+        <p class="text-sm text-surface-600 dark:text-surface-300">
+          Glissez-déposez un ou plusieurs fichiers ou
+          <span class="text-primary-500 underline">cliquez pour parcourir</span>
+        </p>
       </div>
 
-      <small v-if="fieldErrors.uploadedFile" class="text-red-500">{{ fieldErrors.uploadedFile }}</small>
+      <ul
+        v-if="queue.length > 0"
+        class="flex flex-col gap-2 max-h-64 overflow-y-auto"
+        aria-label="Fichiers à importer"
+      >
+        <li
+          v-for="item in queue"
+          :key="item.id"
+          class="flex items-start gap-2 rounded-md border border-surface-200 dark:border-surface-700 px-3 py-2"
+        >
+          <i
+            :class="statusIconClass(item.status)"
+            role="img"
+            :aria-label="statusLabel(item.status)"
+          ></i>
+
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium truncate" :title="item.name">{{ item.name }}</p>
+            <p class="text-xs text-surface-400">{{ formatBytes(item.size) }}</p>
+
+            <ProgressBar
+              v-if="item.status === UPLOAD_STATUS.Uploading"
+              :value="item.progress"
+              :show-value="false"
+              :aria-label="`Progression de ${item.name}`"
+              class="mt-1"
+              style="height: 4px"
+            />
+            <p v-if="item.error" class="text-xs text-red-500 mt-1">{{ item.error }}</p>
+          </div>
+
+          <Button
+            v-if="!isUploading"
+            icon="pi pi-times"
+            :aria-label="`Retirer ${item.name}`"
+            text
+            rounded
+            size="small"
+            @click.stop="handleRemoveFile(item.id)"
+          />
+        </li>
+      </ul>
 
       <div class="flex flex-col gap-1">
         <label class="text-sm font-medium text-surface-700 dark:text-surface-200">Dossier</label>
@@ -107,28 +127,54 @@
       </div>
 
       <div v-if="isUploading" class="flex flex-col gap-1">
-        <ProgressBar :value="uploadProgress" />
-        <p class="text-xs text-surface-500 text-center">Import… {{ uploadProgress }} %</p>
+        <ProgressBar :value="summary.percent" />
+        <!-- Only the file being sent is announced: the percentage changes on every chunk and would
+             turn the live region into a stream nobody can listen to. -->
+        <p class="text-xs text-surface-500 text-center">
+          <span aria-live="polite">
+            Import… fichier {{ summary.position }} sur {{ summary.total }}
+          </span>
+          <span aria-hidden="true">({{ summary.percent }} %)</span>
+        </p>
       </div>
 
-      <Message v-if="globalError" severity="error" :closable="false">{{ globalError }}</Message>
+      <Message v-if="pauseNotice" severity="warn" :closable="false">{{ pauseNotice }}</Message>
+
+      <Message v-if="batchNotice" severity="warn" :closable="false">{{ batchNotice }}</Message>
+
+      <Message
+        v-if="summary.isFinished && !isUploading"
+        :severity="summary.unsent > 0 ? 'warn' : 'success'"
+        :closable="false"
+      >
+        {{ summary.label }}
+      </Message>
     </div>
 
     <template #footer>
       <Button
-        label="Annuler"
+        v-if="isUploading"
+        label="Arrêter"
+        icon="pi pi-stop"
         severity="secondary"
-        text
-        :disabled="isUploading"
-        @click="visible = false"
+        @click="cancelBatch"
       />
-      <Button
-        label="Importer"
-        icon="pi pi-cloud-upload"
-        :disabled="!selectedFile || isUploading"
-        :loading="isUploading"
-        @click="handleUpload"
-      />
+      <template v-else>
+        <Button label="Fermer" severity="secondary" text @click="visible = false" />
+        <Button
+          v-if="hasUnsent"
+          label="Réessayer les fichiers non envoyés"
+          icon="pi pi-refresh"
+          severity="secondary"
+          @click="handleRetry"
+        />
+        <Button
+          label="Importer"
+          icon="pi pi-cloud-upload"
+          :disabled="!hasQueuedFiles"
+          @click="handleUpload"
+        />
+      </template>
     </template>
   </Dialog>
 </template>
@@ -143,6 +189,24 @@ import ProgressBar from 'primevue/progressbar'
 import Select from 'primevue/select'
 import { computed, reactive, ref, watch } from 'vue'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
+import {
+  appendToQueue,
+  applyUploadFailure,
+  cancelPendingUploads,
+  hasUnsentItems,
+  hasUploadInFlight,
+  msUntilNextUploadSlot,
+  nextQueuedItem,
+  rateLimitPauseNotice,
+  recordUploadStart,
+  removeFromQueue,
+  requeueUnsentItems,
+  sleepUnlessAborted,
+  summarizeQueue,
+  UPLOAD_STATUS,
+  withQueueItem
+} from '../../../utils/fileUploadQueue.js'
+import { formatBytes } from '../../../utils/formatBytes.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true }
@@ -156,7 +220,9 @@ const filesStore = useBandFilesStore()
 
 const fileInput = ref(null)
 const isDragging = ref(false)
-const selectedFile = ref(null)
+
+/** The files to send, in the order they were picked. See utils/fileUploadQueue.js. */
+const queue = ref([])
 
 const form = reactive({
   folderId: null,
@@ -168,9 +234,30 @@ const isCreatingTag = ref(false)
 const createTagError = ref(null)
 
 const isUploading = ref(false)
-const uploadProgress = ref(0)
-const fieldErrors = reactive({ uploadedFile: null })
-const globalError = ref(null)
+/** Why the batch is waiting rather than sending, and roughly for how long. */
+const pauseNotice = ref(null)
+/** Why the batch stopped short, when it did. */
+const batchNotice = ref(null)
+
+/**
+ * When each of the recent uploads started, so the batch paces itself under the server's limiter
+ * instead of discovering it at file thirty one. Deliberately not cleared with the form: the
+ * server's window outlives the dialog being closed and reopened.
+ */
+let sentAt = []
+
+/**
+ * Stops a batch the member walked away from writing into the state of the one after it. Every
+ * awaited step checks it back, because closing the dialog resets everything under the running loop.
+ */
+let runningBatch = 0
+let abortController = null
+
+/**
+ * What the running batch has achieved so far. Kept out of runBatch's own scope because closing the
+ * dialog has to be able to report it too, and that happens outside the loop.
+ */
+let tally = { uploadedCount: 0, quotaApproaching: false, interrupted: false }
 
 const tags = computed(() => filesStore.tags)
 
@@ -200,6 +287,10 @@ const dropZoneClasses = computed(() => {
   return 'border-surface-300 dark:border-surface-700 hover:bg-surface-50 dark:hover:bg-surface-800'
 })
 
+const summary = computed(() => summarizeQueue(queue.value))
+const hasQueuedFiles = computed(() => nextQueuedItem(queue.value) !== null)
+const hasUnsent = computed(() => hasUnsentItems(queue.value))
+
 watch(visible, (open) => {
   if (open) {
     if (!activeFolderIsVirtual.value && typeof activeFolderId.value === 'string') {
@@ -210,31 +301,31 @@ watch(visible, (open) => {
   }
 })
 
+// Open while a batch runs too: the loop reads the queue back on every turn, so files dropped in
+// mid import join the end of it rather than being swallowed.
 function triggerFilePicker() {
-  if (isUploading.value) return
   fileInput.value?.click()
 }
 
 function handleFileChange(event) {
-  const file = event.target.files?.[0]
-  if (file) {
-    selectedFile.value = file
-    fieldErrors.uploadedFile = null
-  }
+  addFiles(event.target.files)
+  // Cleared so picking the very same file again still fires a change event.
+  if (fileInput.value) fileInput.value.value = ''
 }
 
 function handleDrop(event) {
   isDragging.value = false
-  const file = event.dataTransfer?.files?.[0]
-  if (file) {
-    selectedFile.value = file
-    fieldErrors.uploadedFile = null
-  }
+  addFiles(event.dataTransfer?.files)
 }
 
-function clearFile() {
-  selectedFile.value = null
-  if (fileInput.value) fileInput.value.value = ''
+function addFiles(files) {
+  if (!files || files.length === 0) return
+  queue.value = appendToQueue(queue.value, files)
+  batchNotice.value = null
+}
+
+function handleRemoveFile(id) {
+  queue.value = removeFromQueue(queue.value, id)
 }
 
 async function handleCreateTag() {
@@ -253,65 +344,213 @@ async function handleCreateTag() {
   }
 }
 
-async function handleUpload() {
-  if (!selectedFile.value) {
-    fieldErrors.uploadedFile = 'Veuillez sélectionner un fichier'
-    return
-  }
+function handleUpload() {
+  if (!hasQueuedFiles.value) return
+  batchNotice.value = null
 
+  return runBatch()
+}
+
+function handleRetry() {
+  queue.value = requeueUnsentItems(queue.value)
+  batchNotice.value = null
+
+  return runBatch()
+}
+
+/**
+ * Sends the queue one file at a time.
+ *
+ * Every await is a place the member can close the dialog, which resets the queue under this loop,
+ * so each one is followed by a batch check before anything is written back.
+ */
+async function runBatch() {
+  const batch = ++runningBatch
+  abortController = new AbortController()
   isUploading.value = true
-  uploadProgress.value = 0
-  fieldErrors.uploadedFile = null
-  globalError.value = null
+  tally = { uploadedCount: 0, quotaApproaching: false, interrupted: false }
 
   try {
-    const result = await filesStore.uploadFile(
-      props.bandSpaceId,
-      {
-        file: selectedFile.value,
-        folderId: form.folderId,
-        tagIds: form.tagIds
-      },
-      (percent) => {
-        uploadProgress.value = percent
+    let item = nextQueuedItem(queue.value)
+    while (item) {
+      const wait = msUntilNextUploadSlot(sentAt, Date.now())
+      if (wait > 0) {
+        pauseNotice.value = rateLimitPauseNotice(wait)
+        const stopped = await sleepUnlessAborted(wait, abortController.signal)
+        if (batch !== runningBatch) return
+        if (stopped) {
+          applyCancellation()
+          break
+        }
       }
-    )
+      pauseNotice.value = null
 
-    emit('saved', { file: result.file, quotaApproaching: result.quotaApproaching })
-    visible.value = false
-  } catch (e) {
-    if (e.isValidationError) {
-      const fileViolation = e.violationsByField?.uploadedFile?.[0]?.message
-      if (fileViolation) {
-        fieldErrors.uploadedFile = fileViolation
-      } else {
-        globalError.value = e.message
+      queue.value = withQueueItem(queue.value, item.id, {
+        status: UPLOAD_STATUS.Uploading,
+        progress: 0,
+        error: null
+      })
+      sentAt = recordUploadStart(sentAt, Date.now())
+
+      try {
+        const result = await uploadOne(item, batch)
+        if (batch !== runningBatch) return
+        queue.value = withQueueItem(queue.value, item.id, {
+          status: UPLOAD_STATUS.Uploaded,
+          progress: 100
+        })
+        tally.uploadedCount += 1
+        tally.quotaApproaching = tally.quotaApproaching || result.quotaApproaching
+      } catch (e) {
+        if (batch !== runningBatch) return
+        const outcome = applyUploadFailure(queue.value, item.id, e)
+        queue.value = outcome.queue
+        // Only a cut off request can have been taken by the server without the list knowing. A
+        // batch the quota or the limiter stopped left nothing behind, so it needs no reread.
+        tally.interrupted = tally.interrupted || outcome.kind === 'cancelled'
+
+        if (outcome.pauseMs > 0) {
+          pauseNotice.value = outcome.notice
+          const stopped = await sleepUnlessAborted(outcome.pauseMs, abortController.signal)
+          if (batch !== runningBatch) return
+          pauseNotice.value = null
+          if (stopped) {
+            applyCancellation()
+            break
+          }
+        } else {
+          batchNotice.value = outcome.notice
+        }
+
+        if (outcome.stop) break
       }
-    } else {
-      globalError.value = e.message
+
+      item = nextQueuedItem(queue.value)
+    }
+
+    const summarized = summarizeQueue(queue.value)
+    reportBatch(summarized)
+
+    // Nothing left to say once everything went through: closing is the answer the single file
+    // dialog always gave. A batch with anything unsent stays open, because that report is the point.
+    if (summarized.total > 0 && summarized.unsent === 0) {
+      visible.value = false
     }
   } finally {
-    isUploading.value = false
+    if (batch === runningBatch) {
+      isUploading.value = false
+      pauseNotice.value = null
+      abortController = null
+    }
   }
 }
 
+/** @returns {Promise<{file: Object, quotaApproaching: boolean}>} */
+function uploadOne(item, batch) {
+  return filesStore.uploadFile(
+    props.bandSpaceId,
+    { file: item.file, folderId: form.folderId, tagIds: form.tagIds },
+    (percent) => {
+      if (batch !== runningBatch) return
+      queue.value = withQueueItem(queue.value, item.id, { progress: percent })
+    },
+    abortController?.signal
+  )
+}
+
+/**
+ * Drops the file in flight and everything behind it.
+ *
+ * One abort covers both states the batch can be stopped in, which is the whole reason the pauses
+ * wait on this same signal: most of a rate limited run is spent between requests, so aborting only
+ * the request would leave the button doing nothing at all for up to twenty seconds.
+ *
+ * A request cut off may already have been taken by the server, so the batch reports itself as
+ * interrupted and Files.vue reads the list back. Anything else would leave a file on screen that is
+ * not stored, or one stored that is not on screen.
+ */
+function cancelBatch() {
+  abortController?.abort()
+}
+
+/** The queue side of being stopped: whatever was not finished with is given up on and said so. */
+function applyCancellation() {
+  const cancelled = cancelPendingUploads(queue.value)
+  queue.value = cancelled.queue
+  batchNotice.value = cancelled.notice
+  pauseNotice.value = null
+}
+
+/**
+ * Tells Files.vue what the batch did, once, so the toast and the reread happen whether the batch
+ * ran to its end or the member walked out on it.
+ *
+ * `total` goes with the label because a batch of one still deserves the sentence the single file
+ * dialog has always shown, rather than a bare count.
+ *
+ * @param {{label: string, total: number}} summarized
+ */
+function reportBatch(summarized) {
+  if (tally.uploadedCount === 0 && !tally.interrupted) return
+
+  emit('saved', { ...tally, label: summarized.label, total: summarized.total })
+  tally = { uploadedCount: 0, quotaApproaching: false, interrupted: false }
+}
+
+function handleHide() {
+  // Closing on a running batch abandons a request the server may already have taken, so the batch
+  // still has to be reported: without this the file it stored is missing from a list that claims to
+  // be complete. Closing during one of the pauses has nothing on the wire to abandon, so it costs
+  // no reread. The summary is read before the queue is emptied.
+  if (isUploading.value) {
+    tally.interrupted = tally.interrupted || hasUploadInFlight(queue.value)
+    cancelBatch()
+    reportBatch(summarizeQueue(queue.value))
+  }
+
+  // Past this point the running loop belongs to nobody: the check on runningBatch stops it writing
+  // into the state the next batch is about to be given.
+  runningBatch += 1
+  isUploading.value = false
+  resetForm()
+}
+
 function resetForm() {
-  selectedFile.value = null
+  queue.value = []
   form.folderId = null
   form.tagIds = []
   newTagName.value = ''
   isCreatingTag.value = false
   createTagError.value = null
-  uploadProgress.value = 0
-  fieldErrors.uploadedFile = null
-  globalError.value = null
+  pauseNotice.value = null
+  batchNotice.value = null
+  abortController = null
   if (fileInput.value) fileInput.value.value = ''
 }
 
-function formatSize(bytes) {
-  if (bytes < 1024) return `${bytes} o`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} Ko`
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} Go`
+const STATUS_ICONS = {
+  [UPLOAD_STATUS.Queued]: 'pi pi-clock text-surface-400',
+  [UPLOAD_STATUS.Uploading]: 'pi pi-spin pi-spinner text-primary-500',
+  [UPLOAD_STATUS.Uploaded]: 'pi pi-check-circle text-green-600',
+  [UPLOAD_STATUS.Failed]: 'pi pi-times-circle text-red-600',
+  [UPLOAD_STATUS.Skipped]: 'pi pi-ban text-amber-600',
+  [UPLOAD_STATUS.Cancelled]: 'pi pi-ban text-surface-400'
+}
+
+const STATUS_LABELS = {
+  [UPLOAD_STATUS.Queued]: 'En attente',
+  [UPLOAD_STATUS.Uploading]: 'Envoi en cours',
+  [UPLOAD_STATUS.Uploaded]: 'Importé',
+  [UPLOAD_STATUS.Failed]: 'Échec',
+  [UPLOAD_STATUS.Skipped]: 'Non envoyé',
+  [UPLOAD_STATUS.Cancelled]: 'Interrompu'
+}
+
+function statusIconClass(status) {
+  return `${STATUS_ICONS[status]} mt-0.5`
+}
+
+function statusLabel(status) {
+  return STATUS_LABELS[status]
 }
 </script>

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -455,8 +455,12 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     }
   }
 
-  async function uploadFile(bandSpaceId, payload, onProgress) {
-    const result = await bandSpaceFilesApi.uploadFile(bandSpaceId, payload, onProgress)
+  /**
+   * One file. A batch calls this once per file, so each one lands in the list as it arrives and an
+   * interrupted batch leaves behind exactly what the server actually took.
+   */
+  async function uploadFile(bandSpaceId, payload, onProgress, signal) {
+    const result = await bandSpaceFilesApi.uploadFile(bandSpaceId, payload, onProgress, signal)
     files.value = [result.file, ...files.value]
     totalFiles.value = totalFiles.value + 1
     fetchQuota(bandSpaceId)

--- a/assets/js/utils/fileUploadQueue.js
+++ b/assets/js/utils/fileUploadQueue.js
@@ -1,0 +1,459 @@
+/**
+ * The rules a batch of file uploads follows, kept out of the dialog so they can be tested.
+ *
+ * Files go up one at a time, never in parallel: the endpoint is rate limited per user and the
+ * quota is checked per request, so a fan-out would trip both at once and nobody could say which
+ * of twenty photos actually landed. Sequential means every file gets its own visible outcome.
+ *
+ * The three ways a batch dies are not the same event and must not be reported the same way:
+ *
+ * - a file the server refuses (wrong type, too large) is that file's problem, the batch carries on;
+ * - the storage quota being reached is the space's problem, so every file still waiting is marked
+ *   as not sent rather than being pushed at a server that is going to refuse each one in turn,
+ *   which is what turns one full disk into twenty red lines;
+ * - the rate limit is nobody's problem, it is a wait, so the batch pauses and resumes on its own.
+ *
+ * Duplicate names are deliberately left alone. The API has no unique constraint on a file's name
+ * and stores it under a hashed path, so uploading the same name twice makes two independent files,
+ * exactly as doing it twice by hand does. The queue keeps both entries for the same reason.
+ *
+ * Pure on purpose, so the rules are tested without a browser. See fileUploadQueue.test.js.
+ */
+
+/**
+ * What the API accepts per user.
+ *
+ * Hand copied from `config/packages/rate_limiter.yaml`, key `band_space_file_upload` (`limit` and
+ * `interval`). Nothing checks the two agree, because a JS test cannot read the PHP config: changing
+ * one means changing the other by hand. That file carries the same warning pointing back here.
+ */
+export const UPLOAD_RATE_LIMIT = 30
+export const UPLOAD_RATE_WINDOW_MS = 60000
+
+/**
+ * Added to every computed wait. The limiter's window and the browser's clock are not the same
+ * clock, so asking for the slot the very millisecond it frees is how a paced batch still gets a 429.
+ */
+const SLOT_MARGIN_MS = 1500
+
+/** How long the batch waits after the server itself answers 429, and how often it may do so. */
+export const RATE_LIMIT_PAUSE_MS = 20000
+export const MAX_RATE_LIMIT_ATTEMPTS = 3
+
+export const UPLOAD_STATUS = Object.freeze({
+  Queued: 'queued',
+  Uploading: 'uploading',
+  Uploaded: 'uploaded',
+  Failed: 'failed',
+  /** Never sent, because something upstream made sending pointless. Retryable. */
+  Skipped: 'skipped',
+  Cancelled: 'cancelled'
+})
+
+/** Statuses a retry can put back in the queue. */
+const RETRYABLE_STATUSES = [UPLOAD_STATUS.Failed, UPLOAD_STATUS.Skipped, UPLOAD_STATUS.Cancelled]
+
+/** Statuses nothing more is going to happen to. */
+const TERMINAL_STATUSES = [UPLOAD_STATUS.Uploaded, ...RETRYABLE_STATUSES]
+
+const QUOTA_REACHED_MESSAGE = 'Quota de stockage atteint, fichier non envoyé'
+const QUOTA_BATCH_NOTICE =
+  "Le quota de stockage de l'espace est atteint. Les fichiers restants n'ont pas été envoyés : libérez de la place, puis réessayez."
+const RATE_LIMIT_REACHED_MESSAGE = "Limite d'envoi atteinte, fichier non envoyé"
+const RATE_LIMIT_BATCH_NOTICE =
+  "Limite d'envoi atteinte. Les fichiers restants n'ont pas été envoyés : patientez une minute, puis réessayez."
+const CANCELLED_MESSAGE = 'Import interrompu'
+const CANCELLED_BATCH_NOTICE = "Import interrompu. Les fichiers restants n'ont pas été envoyés."
+
+/**
+ * Adds files to the end of the queue, keeping whatever is already there.
+ *
+ * Two files sharing a name both stay, with their own id: see the note at the top of this file.
+ *
+ * @param {{id: number}[]} queue
+ * @param {Iterable<{name: string, size: number}>} files a FileList or an array of File
+ * @returns {Object[]} a new queue
+ */
+export function appendToQueue(queue, files) {
+  let nextId = queue.reduce((max, item) => Math.max(max, item.id), 0) + 1
+
+  const added = Array.from(files ?? []).map((file) => ({
+    id: nextId++,
+    file,
+    name: file.name,
+    size: file.size,
+    status: UPLOAD_STATUS.Queued,
+    progress: 0,
+    error: null,
+    /** How many times the rate limiter has pushed this file back. */
+    attempts: 0
+  }))
+
+  return [...queue, ...added]
+}
+
+/**
+ * @param {{id: number}[]} queue
+ * @param {number} id
+ * @returns {Object[]} a new queue
+ */
+export function removeFromQueue(queue, id) {
+  return queue.filter((item) => item.id !== id)
+}
+
+/**
+ * @param {{id: number}[]} queue
+ * @param {number} id
+ * @param {Object} patch
+ * @returns {Object[]} a new queue, so a watcher sees the change
+ */
+export function withQueueItem(queue, id, patch) {
+  return queue.map((item) => (item.id === id ? { ...item, ...patch } : item))
+}
+
+/**
+ * @param {{status: string}[]} queue
+ * @returns {Object|null} the file to send next, null when the batch is over
+ */
+export function nextQueuedItem(queue) {
+  return queue.find((item) => item.status === UPLOAD_STATUS.Queued) ?? null
+}
+
+/**
+ * Puts everything that did not make it back in the queue, so one button retries the failures
+ * without touching the files that already landed.
+ *
+ * @param {{status: string}[]} queue
+ * @returns {Object[]} a new queue
+ */
+export function requeueUnsentItems(queue) {
+  return queue.map((item) =>
+    RETRYABLE_STATUSES.includes(item.status)
+      ? { ...item, status: UPLOAD_STATUS.Queued, progress: 0, error: null, attempts: 0 }
+      : item
+  )
+}
+
+/**
+ * @param {{status: string}[]} queue
+ * @returns {boolean}
+ */
+export function hasUnsentItems(queue) {
+  return queue.some((item) => RETRYABLE_STATUSES.includes(item.status))
+}
+
+/**
+ * Drops the timestamps that have left the limiter's window and records a new send.
+ *
+ * @param {number[]} sentAt
+ * @param {number} now
+ * @returns {number[]} a new array
+ */
+export function recordUploadStart(sentAt, now) {
+  return [...withinWindow(sentAt, now), now]
+}
+
+/**
+ * How long to wait before sending the next file so the batch stays roughly inside the server's
+ * budget. A batch bigger than the limit is the case this exists for: paced, fifty photos trickle up
+ * over a couple of minutes instead of thirty arriving and twenty being refused outright.
+ *
+ * It makes a 429 unlikely, not impossible, and deliberately so. This is a true sliding log, exact
+ * timestamps in a rolling window. Symfony's `sliding_window` policy is a cheaper approximation:
+ * two fixed windows blended, `floor(previousWindowHits * (1 - elapsedFraction) + currentHits)`.
+ * The two disagree most on a fast bursty batch. Thirty small files sent inside the first fifteen
+ * seconds of a window leave this log counting slots free while the server's blend still reports
+ * thirty and refuses. Reconciling them would mean reimplementing the server's approximation and
+ * keeping it in step, for a case the retry path already absorbs, so the pacing stays honest about
+ * being an estimate and applyUploadFailure's rate_limit branch is what actually closes the gap.
+ *
+ * The error is on the safe side: Symfony's limiter never records a rejected consume, so a 429 costs
+ * no server budget while this log still counts the attempt.
+ *
+ * @param {number[]} sentAt when each of the recent uploads started
+ * @param {number} now
+ * @returns {number} 0 when a slot is free
+ */
+export function msUntilNextUploadSlot(sentAt, now) {
+  const recent = withinWindow(sentAt, now).sort((a, b) => a - b)
+  if (recent.length < UPLOAD_RATE_LIMIT) {
+    return 0
+  }
+
+  // The one whose expiry frees a slot, which is the oldest while the batch sends one at a time.
+  const freeingSlot = recent[recent.length - UPLOAD_RATE_LIMIT]
+
+  return Math.max(0, freeingSlot + UPLOAD_RATE_WINDOW_MS - now + SLOT_MARGIN_MS)
+}
+
+/**
+ * @param {number[]} sentAt
+ * @param {number} now
+ * @returns {number[]}
+ */
+function withinWindow(sentAt, now) {
+  return sentAt.filter((timestamp) => now - timestamp < UPLOAD_RATE_WINDOW_MS)
+}
+
+/** @returns {string} what the pause is for and roughly how long it lasts */
+export function rateLimitPauseNotice(waitMs) {
+  const seconds = Math.max(1, Math.ceil(waitMs / 1000))
+
+  return `Limite d'envoi atteinte (${UPLOAD_RATE_LIMIT} fichiers par minute). Reprise dans ${seconds} s.`
+}
+
+/**
+ * Reads what the API refused with.
+ *
+ * The quota is the one refusal with no violation attached: BandSpaceFileUploadProcessor answers 422
+ * from QuotaExceededException only, every other rejection it raises is a 400, a 403, a 409 or a 415,
+ * and API Platform's own 422 always carries violations. Matching on that rather than on the French
+ * sentence keeps the wording free to change, which issue #830 is going to do.
+ *
+ * @param {{status?: number, isValidationError?: boolean, originalError?: {code?: string, name?: string}}} error
+ * @returns {'quota'|'rate_limit'|'cancelled'|'file'}
+ */
+export function classifyUploadFailure(error) {
+  const cause = error?.originalError
+  if (cause?.code === 'ERR_CANCELED' || cause?.name === 'CanceledError') {
+    return 'cancelled'
+  }
+  if (error?.status === 429) {
+    return 'rate_limit'
+  }
+  if (error?.status === 422 && !error?.isValidationError) {
+    return 'quota'
+  }
+
+  return 'file'
+}
+
+/**
+ * What the batch does about a file the server just refused.
+ *
+ * @param {Object[]} queue
+ * @param {number} id the file that failed
+ * @param {Object} error a normalised error from handleApiError
+ * @returns {{queue: Object[], kind: string, notice: string|null, pauseMs: number, stop: boolean}}
+ *          `stop` ends the batch, `pauseMs` holds it before it tries the same file again, and
+ *          `kind` is what the caller needs to tell a batch that was cut off from one that was
+ *          refused: only the first can have left a file on the server nothing knows about.
+ */
+export function applyUploadFailure(queue, id, error) {
+  const kind = classifyUploadFailure(error)
+
+  if (kind === 'cancelled') {
+    const cancelled = cancelPendingUploads(queue)
+
+    return { queue: cancelled.queue, kind, notice: cancelled.notice, pauseMs: 0, stop: true }
+  }
+
+  if (kind === 'rate_limit') {
+    const attempts = (queue.find((item) => item.id === id)?.attempts ?? 0) + 1
+    if (attempts < MAX_RATE_LIMIT_ATTEMPTS) {
+      // Put back in the queue, not failed: this file has been asked to wait its turn, and the loop
+      // picks the queue up again after the pause, so this is what makes the same file the next one
+      // tried. Leaving it uploading would strand it there spinning while the batch moved past it.
+      return {
+        queue: withQueueItem(queue, id, {
+          status: UPLOAD_STATUS.Queued,
+          attempts,
+          progress: 0
+        }),
+        kind,
+        notice: rateLimitPauseNotice(RATE_LIMIT_PAUSE_MS),
+        pauseMs: RATE_LIMIT_PAUSE_MS,
+        stop: false
+      }
+    }
+
+    const failed = withQueueItem(queue, id, {
+      status: UPLOAD_STATUS.Failed,
+      attempts,
+      error: RATE_LIMIT_REACHED_MESSAGE
+    })
+
+    return {
+      queue: markUnsent(failed, UPLOAD_STATUS.Skipped, RATE_LIMIT_REACHED_MESSAGE),
+      kind,
+      notice: RATE_LIMIT_BATCH_NOTICE,
+      pauseMs: 0,
+      stop: true
+    }
+  }
+
+  if (kind === 'quota') {
+    // The server's own sentence is kept on the file that tripped it, raw byte counts and all: it is
+    // the only place the numbers appear, and issue #830 owns how they read.
+    const failed = withQueueItem(queue, id, {
+      status: UPLOAD_STATUS.Failed,
+      error: messageOf(error)
+    })
+
+    return {
+      queue: markUnsent(failed, UPLOAD_STATUS.Skipped, QUOTA_REACHED_MESSAGE),
+      kind,
+      notice: QUOTA_BATCH_NOTICE,
+      pauseMs: 0,
+      stop: true
+    }
+  }
+
+  return {
+    queue: withQueueItem(queue, id, { status: UPLOAD_STATUS.Failed, error: messageOf(error) }),
+    kind,
+    notice: null,
+    pauseMs: 0,
+    stop: false
+  }
+}
+
+/**
+ * Everything the batch has not finished with is given up on.
+ *
+ * Used for both ways a batch is cancelled, and they are not the same moment: a request cut off in
+ * flight leaves that file uploading, while a batch stopped during one of its own pauses has nothing
+ * in flight at all and only queued files to abandon. Working off "not terminal yet" covers both
+ * without the caller having to say which it is.
+ *
+ * @param {{status: string}[]} queue
+ * @returns {{queue: Object[], notice: string}}
+ */
+export function cancelPendingUploads(queue) {
+  return {
+    queue: queue.map((item) =>
+      TERMINAL_STATUSES.includes(item.status)
+        ? item
+        : { ...item, status: UPLOAD_STATUS.Cancelled, progress: 0, error: CANCELLED_MESSAGE }
+    ),
+    notice: CANCELLED_BATCH_NOTICE
+  }
+}
+
+/**
+ * Whether a request is on the wire right now.
+ *
+ * This is what separates a batch abandoned mid request, which may have left a file on the server
+ * that no listing knows about, from one abandoned during a pause, which cannot have. Only the first
+ * is worth making the file list refetch itself over.
+ *
+ * @param {{status: string}[]} queue
+ * @returns {boolean}
+ */
+export function hasUploadInFlight(queue) {
+  return queue.some((item) => item.status === UPLOAD_STATUS.Uploading)
+}
+
+/**
+ * Waits, unless the batch is called off first.
+ *
+ * The batch spends most of a rate limited run inside one of these, with no request on the wire, so
+ * a stop button that only aborts requests would sit there doing nothing for up to twenty seconds.
+ *
+ * @param {number} ms
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<boolean>} true when it was cut short rather than run to time
+ */
+export function sleepUnlessAborted(ms, signal) {
+  if (signal?.aborted) {
+    return Promise.resolve(true)
+  }
+
+  return new Promise((resolve) => {
+    let timer = null
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve(true)
+    }
+
+    timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve(false)
+    }, ms)
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * @param {Object[]} queue
+ * @param {string} status
+ * @param {string} reason
+ * @returns {Object[]} every file still waiting, given the same outcome and the same reason
+ */
+function markUnsent(queue, status, reason) {
+  return queue.map((item) =>
+    item.status === UPLOAD_STATUS.Queued ? { ...item, status, error: reason } : item
+  )
+}
+
+/** @returns {string} */
+function messageOf(error) {
+  return error?.message || 'Une erreur est survenue'
+}
+
+/**
+ * The counts the dialog and the toast are both built from.
+ *
+ * `percent` treats a file that failed as finished with, because it drives the batch's own progress
+ * bar: what is left to wait for, not what succeeded.
+ *
+ * @param {{status: string, progress: number}[]} queue
+ * @returns {{total: number, uploaded: number, unsent: number, done: number, position: number,
+ *            isFinished: boolean, percent: number, label: string}}
+ */
+export function summarizeQueue(queue) {
+  const total = queue.length
+  const uploaded = countByStatus(queue, UPLOAD_STATUS.Uploaded)
+  const unsent = queue.filter((item) => RETRYABLE_STATUSES.includes(item.status)).length
+  const done = uploaded + unsent
+
+  const percent =
+    total === 0
+      ? 0
+      : Math.round(
+          queue.reduce(
+            (sum, item) => sum + (TERMINAL_STATUSES.includes(item.status) ? 100 : item.progress),
+            0
+          ) / total
+        )
+
+  return {
+    total,
+    uploaded,
+    unsent,
+    done,
+    /** Which file the batch is on, one based, for « Fichier 3 sur 20 ». */
+    position: Math.min(total, done + 1),
+    isFinished: total > 0 && done === total,
+    percent,
+    label: outcomeLabel(uploaded, unsent)
+  }
+}
+
+/** @returns {number} */
+function countByStatus(queue, status) {
+  return queue.filter((item) => item.status === status).length
+}
+
+/**
+ * What the batch did, in one French sentence.
+ *
+ * Files that were never sent are counted apart from the ones that were refused, because « échec »
+ * would be a lie for the nineteen the queue held back when the quota filled up.
+ *
+ * @param {number} uploaded
+ * @param {number} unsent
+ * @returns {string}
+ */
+function outcomeLabel(uploaded, unsent) {
+  const importedPart =
+    uploaded === 0
+      ? 'Aucun fichier importé'
+      : `${uploaded} fichier${uploaded > 1 ? 's' : ''} importé${uploaded > 1 ? 's' : ''}`
+
+  if (unsent === 0) {
+    return importedPart
+  }
+
+  return `${importedPart}, ${unsent} non ${unsent > 1 ? 'envoyés' : 'envoyé'}`
+}

--- a/assets/js/utils/fileUploadQueue.test.js
+++ b/assets/js/utils/fileUploadQueue.test.js
@@ -1,0 +1,536 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  appendToQueue,
+  applyUploadFailure,
+  cancelPendingUploads,
+  classifyUploadFailure,
+  hasUnsentItems,
+  hasUploadInFlight,
+  MAX_RATE_LIMIT_ATTEMPTS,
+  msUntilNextUploadSlot,
+  nextQueuedItem,
+  RATE_LIMIT_PAUSE_MS,
+  rateLimitPauseNotice,
+  recordUploadStart,
+  removeFromQueue,
+  requeueUnsentItems,
+  sleepUnlessAborted,
+  summarizeQueue,
+  UPLOAD_RATE_LIMIT,
+  UPLOAD_RATE_WINDOW_MS,
+  UPLOAD_STATUS,
+  withQueueItem
+} from './fileUploadQueue.js'
+
+/**
+ * The rules a batch of file uploads follows.
+ *
+ * Run with `npm test`.
+ */
+
+/** A stand in for a File: the queue only ever reads a name and a size off it. */
+function fakeFile(name, size = 1024) {
+  return { name, size }
+}
+
+/** A queue of n files, all still waiting. */
+function queueOf(...names) {
+  return appendToQueue(
+    [],
+    names.map((name) => fakeFile(name))
+  )
+}
+
+/** What handleApiError hands back for each way the upload endpoint refuses. */
+const quotaError = {
+  status: 422,
+  isValidationError: false,
+  message:
+    'Quota de stockage dépassé : 5000 octets utilisés + 900 octets envoyés > 5200 octets autorisés'
+}
+const rateLimitError = { status: 429, isValidationError: false, message: 'Rate Limit Exceeded' }
+const tooLargeError = {
+  status: 422,
+  isValidationError: true,
+  message: 'Le fichier est trop volumineux'
+}
+const cancelledError = {
+  message: 'canceled',
+  originalError: { code: 'ERR_CANCELED', name: 'CanceledError' }
+}
+
+describe('appendToQueue', () => {
+  it('queues every file that was picked, not just the first', () => {
+    const queue = queueOf('un.jpg', 'deux.jpg', 'trois.jpg')
+
+    assert.equal(queue.length, 3)
+    assert.deepEqual(
+      queue.map((item) => item.name),
+      ['un.jpg', 'deux.jpg', 'trois.jpg']
+    )
+    assert.ok(queue.every((item) => item.status === UPLOAD_STATUS.Queued))
+    assert.ok(queue.every((item) => item.progress === 0 && item.error === null))
+  })
+
+  it('keeps both files when two share a name, like uploading the same name twice by hand does', () => {
+    const queue = queueOf('photo.jpg', 'photo.jpg')
+
+    assert.equal(queue.length, 2)
+    assert.notEqual(queue[0].id, queue[1].id)
+  })
+
+  it('keeps ids unique when files are added in a second pick', () => {
+    const queue = appendToQueue(queueOf('un.jpg', 'deux.jpg'), [fakeFile('trois.jpg')])
+
+    assert.deepEqual(
+      queue.map((item) => item.id),
+      [1, 2, 3]
+    )
+  })
+
+  it('adds nothing when the picker was dismissed', () => {
+    assert.deepEqual(appendToQueue([], null), [])
+    assert.deepEqual(appendToQueue([], undefined), [])
+    assert.deepEqual(appendToQueue([], []), [])
+  })
+
+  it('carries the file itself through, so the queue is what gets sent', () => {
+    const file = fakeFile('un.jpg', 4096)
+
+    assert.equal(appendToQueue([], [file])[0].file, file)
+    assert.equal(appendToQueue([], [file])[0].size, 4096)
+  })
+})
+
+describe('removeFromQueue', () => {
+  it('drops the file the member changed their mind about and leaves the rest alone', () => {
+    const queue = queueOf('un.jpg', 'deux.jpg', 'trois.jpg')
+
+    assert.deepEqual(
+      removeFromQueue(queue, 2).map((item) => item.name),
+      ['un.jpg', 'trois.jpg']
+    )
+  })
+})
+
+describe('withQueueItem', () => {
+  it('patches one file and returns a new array, so a watcher sees the change', () => {
+    const queue = queueOf('un.jpg', 'deux.jpg')
+    const patched = withQueueItem(queue, 1, { status: UPLOAD_STATUS.Uploading, progress: 40 })
+
+    assert.notEqual(patched, queue)
+    assert.equal(queue[0].status, UPLOAD_STATUS.Queued)
+    assert.equal(patched[0].progress, 40)
+    assert.equal(patched[1].status, UPLOAD_STATUS.Queued)
+  })
+})
+
+describe('nextQueuedItem', () => {
+  it('hands back the files in the order they were picked', () => {
+    const queue = withQueueItem(queueOf('un.jpg', 'deux.jpg'), 1, {
+      status: UPLOAD_STATUS.Uploaded
+    })
+
+    assert.equal(nextQueuedItem(queue).name, 'deux.jpg')
+  })
+
+  it('is null once nothing is waiting, which is what ends the batch', () => {
+    const queue = queueOf('un.jpg').map((item) => ({ ...item, status: UPLOAD_STATUS.Uploaded }))
+
+    assert.equal(nextQueuedItem(queue), null)
+    assert.equal(nextQueuedItem([]), null)
+  })
+})
+
+describe('msUntilNextUploadSlot', () => {
+  const now = 1_000_000
+
+  it('does not hold back a batch that fits in the budget', () => {
+    const sentAt = Array.from({ length: UPLOAD_RATE_LIMIT - 1 }, (_unused, i) => now - i * 10)
+
+    assert.equal(msUntilNextUploadSlot(sentAt, now), 0)
+  })
+
+  it('waits for the oldest send to leave the window once the budget is spent', () => {
+    const oldest = now - 50_000
+    const sentAt = [oldest, ...Array.from({ length: UPLOAD_RATE_LIMIT - 1 }, () => now - 1000)]
+
+    const wait = msUntilNextUploadSlot(sentAt, now)
+
+    // 10s left on the oldest, plus the margin that keeps the browser clock off the limiter's edge.
+    assert.ok(wait >= 10_000, `expected at least 10s, got ${wait}`)
+    assert.ok(wait <= 12_000, `expected at most 12s, got ${wait}`)
+  })
+
+  it('frees the slot again once the oldest send has aged out', () => {
+    const sentAt = Array.from({ length: UPLOAD_RATE_LIMIT }, () => now - UPLOAD_RATE_WINDOW_MS - 1)
+
+    assert.equal(msUntilNextUploadSlot(sentAt, now), 0)
+  })
+
+  it('starts from nothing sent', () => {
+    assert.equal(msUntilNextUploadSlot([], now), 0)
+  })
+})
+
+describe('recordUploadStart', () => {
+  it('records the send and forgets the ones that left the window', () => {
+    const now = 1_000_000
+    const sentAt = [now - UPLOAD_RATE_WINDOW_MS - 1, now - 5000]
+
+    assert.deepEqual(recordUploadStart(sentAt, now), [now - 5000, now])
+  })
+})
+
+describe('rateLimitPauseNotice', () => {
+  it('says what the wait is for and how long it lasts', () => {
+    assert.equal(
+      rateLimitPauseNotice(42_000),
+      "Limite d'envoi atteinte (30 fichiers par minute). Reprise dans 42 s."
+    )
+  })
+
+  it('never announces a wait of zero second', () => {
+    assert.equal(
+      rateLimitPauseNotice(120),
+      "Limite d'envoi atteinte (30 fichiers par minute). Reprise dans 1 s."
+    )
+  })
+})
+
+describe('classifyUploadFailure', () => {
+  it('reads a 422 with no violation as the storage quota', () => {
+    assert.equal(classifyUploadFailure(quotaError), 'quota')
+  })
+
+  it('reads a 422 carrying violations as that one file being refused', () => {
+    assert.equal(classifyUploadFailure(tooLargeError), 'file')
+  })
+
+  it('reads a 429 as the rate limiter', () => {
+    assert.equal(classifyUploadFailure(rateLimitError), 'rate_limit')
+  })
+
+  it('recognises the member cancelling, which axios reports as an error like any other', () => {
+    assert.equal(classifyUploadFailure(cancelledError), 'cancelled')
+    assert.equal(
+      classifyUploadFailure({ message: 'canceled', originalError: { name: 'CanceledError' } }),
+      'cancelled'
+    )
+  })
+
+  it('treats anything else as that one file failing', () => {
+    assert.equal(classifyUploadFailure({ status: 415, message: 'Type non autorisé' }), 'file')
+    assert.equal(classifyUploadFailure({ message: 'Network Error' }), 'file')
+    assert.equal(classifyUploadFailure(undefined), 'file')
+  })
+})
+
+describe('applyUploadFailure', () => {
+  it('lets the batch carry on when one file is refused', () => {
+    const queue = queueOf('un.jpg', 'deux.jpg', 'trois.jpg')
+
+    const outcome = applyUploadFailure(queue, 1, { status: 415, message: 'Type non autorisé' })
+
+    assert.equal(outcome.stop, false)
+    assert.equal(outcome.kind, 'file')
+    assert.equal(outcome.pauseMs, 0)
+    assert.equal(outcome.notice, null)
+    assert.equal(outcome.queue[0].status, UPLOAD_STATUS.Failed)
+    assert.equal(outcome.queue[0].error, 'Type non autorisé')
+    assert.equal(outcome.queue[1].status, UPLOAD_STATUS.Queued)
+    assert.equal(outcome.queue[2].status, UPLOAD_STATUS.Queued)
+  })
+
+  it('names an error the server did not word', () => {
+    const outcome = applyUploadFailure(queueOf('un.jpg'), 1, { status: 500 })
+
+    assert.equal(outcome.queue[0].error, 'Une erreur est survenue')
+  })
+
+  it('stops the batch on the quota and says why, rather than refusing each file in turn', () => {
+    const queue = queueOf('un.jpg', 'deux.jpg', 'trois.jpg')
+
+    const outcome = applyUploadFailure(queue, 1, quotaError)
+
+    assert.equal(outcome.stop, true)
+    assert.equal(outcome.kind, 'quota')
+    assert.equal(outcome.queue[0].status, UPLOAD_STATUS.Failed)
+    // The server's own sentence stays on the file that tripped it.
+    assert.equal(outcome.queue[0].error, quotaError.message)
+    assert.equal(outcome.queue[1].status, UPLOAD_STATUS.Skipped)
+    assert.equal(outcome.queue[1].error, 'Quota de stockage atteint, fichier non envoyé')
+    assert.equal(outcome.queue[2].status, UPLOAD_STATUS.Skipped)
+    assert.equal(
+      outcome.notice,
+      "Le quota de stockage de l'espace est atteint. Les fichiers restants n'ont pas été envoyés : libérez de la place, puis réessayez."
+    )
+  })
+
+  it('leaves the files that already landed alone when the quota fills up', () => {
+    const queue = withQueueItem(queueOf('un.jpg', 'deux.jpg', 'trois.jpg'), 1, {
+      status: UPLOAD_STATUS.Uploaded,
+      progress: 100
+    })
+
+    const outcome = applyUploadFailure(queue, 2, quotaError)
+
+    assert.equal(outcome.queue[0].status, UPLOAD_STATUS.Uploaded)
+    assert.equal(outcome.queue[0].error, null)
+  })
+
+  it('pauses on the rate limiter and puts the file back in the queue, because it has not failed', () => {
+    // The status the dialog sets before every request: what the pause has to undo, so the loop
+    // picks this same file up again instead of walking past it and stranding it uploading.
+    const queue = withQueueItem(queueOf('un.jpg', 'deux.jpg'), 1, {
+      status: UPLOAD_STATUS.Uploading,
+      progress: 30
+    })
+
+    const outcome = applyUploadFailure(queue, 1, rateLimitError)
+
+    assert.equal(outcome.stop, false)
+    assert.equal(outcome.kind, 'rate_limit')
+    assert.equal(outcome.pauseMs, RATE_LIMIT_PAUSE_MS)
+    assert.equal(outcome.queue[0].status, UPLOAD_STATUS.Queued)
+    assert.equal(outcome.queue[0].progress, 0)
+    assert.equal(outcome.queue[0].attempts, 1)
+    assert.equal(nextQueuedItem(outcome.queue).id, 1)
+    assert.equal(outcome.notice, rateLimitPauseNotice(RATE_LIMIT_PAUSE_MS))
+  })
+
+  it('gives up on the rate limiter after a bounded number of waits', () => {
+    let queue = queueOf('un.jpg', 'deux.jpg')
+    let outcome = null
+
+    for (let attempt = 0; attempt < MAX_RATE_LIMIT_ATTEMPTS; attempt++) {
+      queue = withQueueItem(queue, 1, { status: UPLOAD_STATUS.Uploading })
+      outcome = applyUploadFailure(queue, 1, rateLimitError)
+      queue = outcome.queue
+    }
+
+    assert.equal(outcome.stop, true)
+    // A batch the limiter stopped left nothing half sent, so it is not an interruption.
+    assert.equal(outcome.kind, 'rate_limit')
+    assert.equal(outcome.pauseMs, 0)
+    assert.equal(queue[0].status, UPLOAD_STATUS.Failed)
+    assert.equal(queue[0].error, "Limite d'envoi atteinte, fichier non envoyé")
+    assert.equal(queue[1].status, UPLOAD_STATUS.Skipped)
+    assert.equal(
+      outcome.notice,
+      "Limite d'envoi atteinte. Les fichiers restants n'ont pas été envoyés : patientez une minute, puis réessayez."
+    )
+  })
+
+  it('stops everything when the member cancels, and says so on each file', () => {
+    const queue = withQueueItem(queueOf('un.jpg', 'deux.jpg', 'trois.jpg'), 1, {
+      status: UPLOAD_STATUS.Uploaded,
+      progress: 100
+    })
+
+    const outcome = applyUploadFailure(queue, 2, cancelledError)
+
+    assert.equal(outcome.stop, true)
+    // What tells Files.vue to read the listing back: only a cut off request can have been stored
+    // without the list knowing about it.
+    assert.equal(outcome.kind, 'cancelled')
+    assert.equal(outcome.queue[0].status, UPLOAD_STATUS.Uploaded)
+    assert.equal(outcome.queue[1].status, UPLOAD_STATUS.Cancelled)
+    assert.equal(outcome.queue[1].error, 'Import interrompu')
+    assert.equal(outcome.queue[2].status, UPLOAD_STATUS.Cancelled)
+    assert.equal(outcome.notice, "Import interrompu. Les fichiers restants n'ont pas été envoyés.")
+  })
+})
+
+describe('cancelPendingUploads', () => {
+  it('gives up on the file in flight and everything behind it', () => {
+    const queue = withQueueItem(queueOf('un.jpg', 'deux.jpg', 'trois.jpg'), 2, {
+      status: UPLOAD_STATUS.Uploading,
+      progress: 60
+    })
+
+    const cancelled = cancelPendingUploads(queue)
+
+    assert.equal(cancelled.queue[1].status, UPLOAD_STATUS.Cancelled)
+    assert.equal(cancelled.queue[1].progress, 0)
+    assert.equal(cancelled.queue[2].status, UPLOAD_STATUS.Cancelled)
+    assert.equal(
+      cancelled.notice,
+      "Import interrompu. Les fichiers restants n'ont pas été envoyés."
+    )
+  })
+
+  it('gives up on a batch stopped mid pause, where nothing is in flight at all', () => {
+    const queue = withQueueItem(queueOf('un.jpg', 'deux.jpg'), 1, {
+      status: UPLOAD_STATUS.Uploaded,
+      progress: 100
+    })
+
+    const cancelled = cancelPendingUploads(queue)
+
+    assert.equal(cancelled.queue[0].status, UPLOAD_STATUS.Uploaded)
+    assert.equal(cancelled.queue[1].status, UPLOAD_STATUS.Cancelled)
+  })
+
+  it('leaves the files it is already done with alone', () => {
+    const stopped = applyUploadFailure(queueOf('un.jpg', 'deux.jpg'), 1, quotaError).queue
+
+    const cancelled = cancelPendingUploads(stopped)
+
+    assert.equal(cancelled.queue[0].status, UPLOAD_STATUS.Failed)
+    assert.equal(cancelled.queue[0].error, quotaError.message)
+    assert.equal(cancelled.queue[1].status, UPLOAD_STATUS.Skipped)
+  })
+})
+
+describe('hasUploadInFlight', () => {
+  it('is true only while a request is actually on the wire', () => {
+    const queue = queueOf('un.jpg', 'deux.jpg')
+
+    assert.equal(hasUploadInFlight(queue), false)
+    assert.equal(
+      hasUploadInFlight(withQueueItem(queue, 1, { status: UPLOAD_STATUS.Uploading })),
+      true
+    )
+  })
+
+  it('is false during a pause, which is why closing then costs no refetch', () => {
+    const paused = applyUploadFailure(
+      withQueueItem(queueOf('un.jpg', 'deux.jpg'), 1, { status: UPLOAD_STATUS.Uploading }),
+      1,
+      rateLimitError
+    ).queue
+
+    assert.equal(hasUploadInFlight(paused), false)
+  })
+})
+
+describe('sleepUnlessAborted', () => {
+  it('runs to time when nothing calls the batch off', async () => {
+    assert.equal(await sleepUnlessAborted(1), false)
+    assert.equal(await sleepUnlessAborted(1, new AbortController().signal), false)
+  })
+
+  it('is cut short the moment the batch is stopped, not when the wait was due to end', async () => {
+    const controller = new AbortController()
+    const startedAt = Date.now()
+
+    const waiting = sleepUnlessAborted(30_000, controller.signal)
+    controller.abort()
+
+    assert.equal(await waiting, true)
+    assert.ok(Date.now() - startedAt < 1000, 'the stop button must not wait out the pause')
+  })
+
+  it('does not start a wait the batch has already been stopped out of', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    assert.equal(await sleepUnlessAborted(30_000, controller.signal), true)
+  })
+})
+
+describe('requeueUnsentItems', () => {
+  it('retries the failures and never sends an imported file twice', () => {
+    const queue = applyUploadFailure(
+      withQueueItem(queueOf('un.jpg', 'deux.jpg', 'trois.jpg'), 1, {
+        status: UPLOAD_STATUS.Uploaded,
+        progress: 100
+      }),
+      2,
+      quotaError
+    ).queue
+
+    const retried = requeueUnsentItems(queue)
+
+    assert.equal(retried[0].status, UPLOAD_STATUS.Uploaded)
+    assert.equal(retried[1].status, UPLOAD_STATUS.Queued)
+    assert.equal(retried[1].error, null)
+    assert.equal(retried[2].status, UPLOAD_STATUS.Queued)
+  })
+
+  it('clears the wait count, so a retry gets the full budget again', () => {
+    let queue = queueOf('un.jpg')
+    for (let attempt = 0; attempt < MAX_RATE_LIMIT_ATTEMPTS; attempt++) {
+      queue = applyUploadFailure(queue, 1, rateLimitError).queue
+    }
+
+    assert.equal(queue[0].attempts, MAX_RATE_LIMIT_ATTEMPTS)
+    assert.equal(requeueUnsentItems(queue)[0].attempts, 0)
+  })
+})
+
+describe('hasUnsentItems', () => {
+  it('is what puts the retry button on screen', () => {
+    const allDone = queueOf('un.jpg').map((item) => ({ ...item, status: UPLOAD_STATUS.Uploaded }))
+
+    assert.equal(hasUnsentItems(allDone), false)
+    assert.equal(hasUnsentItems(applyUploadFailure(queueOf('un.jpg'), 1, quotaError).queue), true)
+  })
+})
+
+describe('summarizeQueue', () => {
+  it('counts nothing on an empty queue', () => {
+    const summary = summarizeQueue([])
+
+    assert.equal(summary.total, 0)
+    assert.equal(summary.percent, 0)
+    assert.equal(summary.isFinished, false)
+  })
+
+  it('follows the batch through, file by file', () => {
+    let queue = queueOf('un.jpg', 'deux.jpg', 'trois.jpg', 'quatre.jpg')
+    assert.equal(summarizeQueue(queue).position, 1)
+    assert.equal(summarizeQueue(queue).percent, 0)
+
+    queue = withQueueItem(queue, 1, { status: UPLOAD_STATUS.Uploaded, progress: 100 })
+    queue = withQueueItem(queue, 2, { status: UPLOAD_STATUS.Uploading, progress: 50 })
+
+    const summary = summarizeQueue(queue)
+    assert.equal(summary.position, 2)
+    assert.equal(summary.uploaded, 1)
+    assert.equal(summary.percent, 38)
+    assert.equal(summary.isFinished, false)
+  })
+
+  it('counts a file nothing more will happen to as finished with, whatever became of it', () => {
+    const queue = applyUploadFailure(queueOf('un.jpg', 'deux.jpg'), 1, quotaError).queue
+    const summary = summarizeQueue(queue)
+
+    assert.equal(summary.percent, 100)
+    assert.equal(summary.isFinished, true)
+    assert.equal(summary.unsent, 2)
+    assert.equal(summary.uploaded, 0)
+  })
+
+  it('words a batch that went through', () => {
+    const one = queueOf('un.jpg').map((item) => ({ ...item, status: UPLOAD_STATUS.Uploaded }))
+    const three = queueOf('un.jpg', 'deux.jpg', 'trois.jpg').map((item) => ({
+      ...item,
+      status: UPLOAD_STATUS.Uploaded
+    }))
+
+    assert.equal(summarizeQueue(one).label, '1 fichier importé')
+    assert.equal(summarizeQueue(three).label, '3 fichiers importés')
+  })
+
+  it('words a batch that partly went through, without calling a held back file a failure', () => {
+    const queue = applyUploadFailure(
+      withQueueItem(queueOf('un.jpg', 'deux.jpg', 'trois.jpg'), 1, {
+        status: UPLOAD_STATUS.Uploaded,
+        progress: 100
+      }),
+      2,
+      quotaError
+    ).queue
+
+    assert.equal(summarizeQueue(queue).label, '1 fichier importé, 2 non envoyés')
+  })
+
+  it('words a batch that got nowhere', () => {
+    const queue = applyUploadFailure(queueOf('un.jpg'), 1, quotaError).queue
+
+    assert.equal(summarizeQueue(queue).label, 'Aucun fichier importé, 1 non envoyé')
+  })
+})

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -441,13 +441,17 @@ watch(
   { immediate: true }
 )
 
-function handleUploadSaved({ quotaApproaching }) {
-  toast.add({
-    severity: 'success',
-    summary: 'Fichier téléversé',
-    detail: 'Le fichier a bien été ajouté.',
-    life: 3000
-  })
+function handleUploadSaved({ uploadedCount, total, label, quotaApproaching, interrupted }) {
+  if (uploadedCount > 0) {
+    toast.add({
+      severity: 'success',
+      summary: uploadedCount > 1 ? 'Fichiers téléversés' : 'Fichier téléversé',
+      // One file keeps the sentence it has always been given: a bare count reads as a fragment when
+      // there was never a batch to count. The tally is only worth quoting for a real batch.
+      detail: total === 1 ? 'Le fichier a bien été ajouté.' : label,
+      life: 3000
+    })
+  }
   if (quotaApproaching) {
     toast.add({
       severity: 'warn',
@@ -455,6 +459,11 @@ function handleUploadSaved({ quotaApproaching }) {
       detail: 'Vous avez atteint 80 % de votre quota de stockage.',
       life: 6000
     })
+  }
+  // A batch stopped in the middle may have left an upload the server took after the browser gave up
+  // on it, so the only honest listing is the one read back from the server.
+  if (interrupted) {
+    filesStore.fetchFiles(bandSpaceId.value)
   }
   filesStore.fetchFolders(bandSpaceId.value)
 }

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -82,6 +82,10 @@ framework:
             limit: 60
             interval: '1 minute'
             cache_pool: "rate_limiter.cache"
+        # Mirrored by hand in assets/js/utils/fileUploadQueue.js as UPLOAD_RATE_LIMIT and
+        # UPLOAD_RATE_WINDOW_MS: the Files import dialog paces a batch against these numbers so it
+        # does not walk into a 429 at file thirty one. Nothing checks the two agree, because a JS
+        # test cannot read this file. Changing limit or interval here means changing them there too.
         band_space_file_upload:
             policy: sliding_window
             limit: 30

--- a/tests/Api/BandSpace/File/BandSpaceFileUploadTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileUploadTest.php
@@ -10,6 +10,7 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFileTagFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFolderFactory;
+use App\Service\BandSpace\File\BandSpaceFileMimeAllowlist;
 use App\Tests\Factory\User\UserFactory;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,6 +22,21 @@ use Zenstruck\Foundry\Attribute\ResetDatabase;
 class BandSpaceFileUploadTest extends ApiTestCase
 {
     use ApiTestAssertionsTrait;
+
+    /** @var string[] */
+    private array $temporaryFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryFiles as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        $this->temporaryFiles = [];
+
+        parent::tearDown();
+    }
 
     public function test_upload_happy_path(): void
     {
@@ -217,6 +233,87 @@ class BandSpaceFileUploadTest extends ApiTestCase
             'type' => '/errors/403',
             'description' => "Vous n'êtes pas membre de ce Band Space",
         ]);
+    }
+
+    /**
+     * The other half of the contract the Files import dialog's error handling rests on.
+     *
+     * A batch tells a refusal that stops the whole batch (the space's quota is full, a 422 with no
+     * violation) from one that only concerns the file in hand (a 422 carrying violations, which is
+     * this one) by whether violations are present, and stops or carries on accordingly. Both shapes
+     * therefore have to be pinned: test_upload_no_file_returns_422 covers Assert\NotNull, and this
+     * covers a file that is simply too big, which is the one a member meets dragging in video.
+     *
+     * The message quotes PHP's upload_max_filesize rather than BandSpaceFileMimeAllowlist's 500 MiB
+     * cap because the ini limit is the lower of the two and is reached first: HttpKernelBrowser and
+     * PHP itself both reject the upload before Assert\File is consulted. Both routes end in the same
+     * shape, which is all the dialog reads. Raising the ini limit past the cap would put the
+     * constraint's own message here instead, and this assertion is what would say so.
+     */
+    public function test_upload_over_the_per_file_cap_returns_422_with_a_violation(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $oversized = $this->createSparseFile(BandSpaceFileMimeAllowlist::MAX_UPLOAD_SIZE_BYTES + 1);
+        $upload = new UploadedFile($oversized, 'concert-4k.txt', 'text/plain', null, true);
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files',
+            [],
+            ['uploadedFile' => $upload],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $violation = sprintf(
+            'Le fichier est trop volumineux. Sa taille ne doit pas dépasser %d bytes.',
+            UploadedFile::getMaxFilesize(),
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/1',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'uploaded_file',
+                    'message' => $violation,
+                    'code' => '1',
+                ],
+            ],
+            'detail' => 'uploaded_file: ' . $violation,
+            'description' => 'uploaded_file: ' . $violation,
+            'type' => '/validation_errors/1',
+            'title' => 'An error occurred',
+        ]);
+
+        // Nothing persisted: validation runs before the processor is ever called.
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertCount(0, $repo->findBy(['bandSpace' => $bandSpace]));
+    }
+
+    /**
+     * A file that reports the given size without occupying it. Half a gigabyte of real bytes would
+     * make this test unusable; the size cap is checked with filesize(), which a hole satisfies.
+     */
+    private function createSparseFile(int $size): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'm862_oversized_');
+        $this->temporaryFiles[] = $path;
+
+        $handle = fopen($path, 'w');
+        ftruncate($handle, $size);
+        fclose($handle);
+        clearstatcache(true, $path);
+
+        $this->assertSame($size, filesize($path), 'the filesystem did not honour the sparse file');
+
+        return $path;
     }
 
     public function test_upload_returns_429_when_rate_limit_exceeded(): void


### PR DESCRIPTION
Closes #862.

Both the input change handler and the drop handler took only `files?.[0]`, and the input had no `multiple`. Dropping 20 gig photos uploaded one and said nothing about the other 19, which from the user's point of view is silent data loss: they believe all 20 arrived.

## What ships

`multiple` on the input, both handlers passing the whole `FileList`, and sequential upload with a per-file row (status, size, progress, error, remove) plus a batch bar. All the batching decisions live in a new pure module, `assets/js/utils/fileUploadQueue.js`, so they can be tested; the component only drives it.

## Rate limiting: paced, not rejected

The server allows 30 uploads a minute. Rather than firing 50 and letting 20 bounce, the batch paces itself, so 50 photos take about two minutes and all 50 arrive. A real 429, from another tab sharing the limiter, pauses and retries the same file, bounded to 3 attempts.

**The docblock originally overclaimed and has been corrected.** The client keeps a true sliding log; Symfony's `sliding_window` is a two-fixed-window blend, `floor(previousWindowHits * (1 - elapsedFraction) + currentHits)`. For a fast bursty batch these disagree and a 429 can still occur despite correct pacing. So the pacing makes a 429 unlikely, not impossible, and the retry branch is what actually closes the gap. No margin was added, because a margin cannot fix a mismatch up to a full window wide.

## Quota: stop, explain, and keep the rest retryable

`QuotaExceededException` is the only 422 the upload endpoint can produce without a `violations` array, so classification keys on that **structural** fact rather than on the French sentence, which means #830 can reword the message freely without breaking this.

On quota the batch stops and every still-queued file becomes `skipped` rather than failed, so retry re-queues them and a small file that would still fit is never permanently lost.

## Cancellation

An `AbortController` per batch, plus a token checked after every await so a loop abandoned by a dialog close cannot write into the next batch's state.

Closing mid-request flags the batch `interrupted`, which forces the list to refetch: an aborted request the server had already accepted would otherwise be stored but missing from a list claiming to be complete. Quota and rate-limit stops deliberately do not set it, since nothing was persisted in either case.

**Fixed in review: the Stop button did nothing during a pause.** It only aborted the in-flight request, so during a pacing wait or the 20 s post-429 pause it was a silent no-op for up to a minute, and because `abort()` is irreversible and the controller is reused, that dead click poisoned the next request too. Both pauses now wait on the abort signal, and cancelled rows are marked immediately. A replay harness against the real module shows the batch ending in about 300 ms where it previously ran on for 40 s with nothing marked cancelled.

**A real bug fell out of that work.** The 429 branch patched `attempts` without resetting the status, so a rate-limited file stayed `Uploading` forever: never retried, spinner never stopped, the batch never finished, and the retry button could not see it. The branch's own comment claimed it was left queued while the code did not do that. The old test passed vacuously because it never seeded the status the dialog actually sets.

## Duplicate names

No unique constraint on `originalName`, and Vich's `HashNamer` is random rather than content-derived, so two files with the same name are two independent rows. The queue therefore does not dedupe or rename, matching what uploading the same name twice by hand already does.

## Deliberately left out

A drop target on the file list itself. `FileList.vue` already runs drag and drop for *moving* files into folders off the same native events an OS-file drag fires, so an external drop zone there has to disambiguate two drag sources. That is its own change, and the issue's Fix line does not ask for it. Filed as a follow-up.

## Worth knowing, pre-existing

While pinning the 422-with-violations case, the per-file cap turned out to be unreachable in this environment: the container runs PHP defaults (`upload_max_filesize = 2M`, `post_max_size = 8M`) and nothing in the repo raises them, so PHP rejects an oversized upload long before `Assert\File(maxSize: 500MB)` is consulted. `MAX_UPLOAD_SIZE_BYTES` is decorative unless the deployed image sets the ini elsewhere. Out of scope here, filed separately.

## Verification

`npm test` 278 passing, `tests/Api/BandSpace/` 1024 passing, PHPStan level 8 clean, Biome clean, build clean. Reverting the module to the old semantics fails 18 tests.
