### PR TITLE
fix(M-860): refuse a position write on the task update endpoint

### DIFF
--- a/src/ApiResource/BandSpace/Task/TaskResource.php
+++ b/src/ApiResource/BandSpace/Task/TaskResource.php
@@ -111,7 +111,11 @@ class TaskResource
 
     public ?\DateTimeInterface $archiveDatetime = null;
     public ?\DateTimeInterface $completedDatetime = null;
+
+    /** Column relative, so only the reorder endpoint can set it. A caller cannot write it here. */
+    #[ApiProperty(writable: false)]
     public int $position = 0;
+
     public \DateTimeInterface $creationDatetime;
     public ?\DateTimeInterface $updateDatetime = null;
     public int $commentCount = 0;

--- a/src/Procedure/BandSpace/TaskUpdateProcedure.php
+++ b/src/Procedure/BandSpace/TaskUpdateProcedure.php
@@ -48,6 +48,7 @@ readonly class TaskUpdateProcedure
         User $user,
     ): Task {
         $this->taskWriteGuard->assertWritableForPayload($task, $payload);
+        $this->assertPositionIsNotWritable($payload);
 
         if (array_key_exists('title', $payload)) {
             $task->title = $data->title;
@@ -81,10 +82,6 @@ readonly class TaskUpdateProcedure
             $this->applyArchivedChange($task, (bool) $payload['archived'], $user);
         }
 
-        if (array_key_exists('position', $payload)) {
-            $task->position = (int) $payload['position'];
-        }
-
         $task->updateDatetime = new DateTime();
 
         $this->entityManager->flush();
@@ -94,6 +91,27 @@ readonly class TaskUpdateProcedure
         }
 
         return $task;
+    }
+
+    /**
+     * A position only means something next to the rest of its column. The reorder and move endpoints
+     * take the whole column and prove the payload covers every task in it before writing a number,
+     * which is what keeps two cards off the same index. A position sent to this endpoint carries no
+     * such payload, so it could drop a task on an index another already holds, with nothing left to
+     * reconcile them, and the board comes back scrambled for every member and stays that way.
+     *
+     * Refused rather than quietly dropped: nothing in the interface sends a position here, so anyone
+     * who does is asking for a reorder and needs to hear that this is not where it happens.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private function assertPositionIsNotWritable(array $payload): void
+    {
+        if (!array_key_exists('position', $payload)) {
+            return;
+        }
+
+        throw new HttpException(422, 'La position ne se modifie pas ici, utilisez le réordonnancement de la colonne');
     }
 
     private function applyStatusChange(Task $task, string $newStatus, User $user): void

--- a/tests/Api/BandSpace/Task/TaskBulkPatchTest.php
+++ b/tests/Api/BandSpace/Task/TaskBulkPatchTest.php
@@ -129,6 +129,42 @@ class TaskBulkPatchTest extends ApiTestCase
         $this->assertNull($repo->find($done->id)->archiveDatetime);
     }
 
+    public function test_bulk_patch_drops_a_position_sent_in_the_payload(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = TaskCategoryFactory::new(['bandSpace' => $bandSpace])->create();
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Todo,
+            'category' => null,
+            'position' => 2,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/bulk_patch',
+            [
+                'task_ids' => [$task->id],
+                'category_id' => $category->id,
+                'position' => 0,
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        // This endpoint keeps a whitelist of the fields it forwards, so a position never reaches the
+        // update procedure and never gets the chance to be refused. The batch goes through.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        $refreshed = self::getContainer()->get(TaskRepository::class)->find($task->id);
+        $this->assertSame((string) $category->id, (string) $refreshed->category->id);
+        $this->assertSame(2, $refreshed->position);
+    }
+
     public function test_bulk_set_category(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/Task/TaskUpdateTest.php
+++ b/tests/Api/BandSpace/Task/TaskUpdateTest.php
@@ -377,6 +377,94 @@ class TaskUpdateTest extends ApiTestCase
         $this->assertSame('task_unarchived', $activities[0]->type);
     }
 
+    public function test_update_refuses_a_position_write(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        // The reorder endpoint proves a payload covers the whole column before it writes anything.
+        // A position sent here carries no such proof, so it would drop this task onto the number the
+        // other one holds and leave the column with two cards on 0 for every member of the band.
+        $first = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Todo,
+            'position' => 0,
+        ])->create();
+        $second = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Todo,
+            'position' => 1,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $second->id,
+            ['position' => 0],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'La position ne se modifie pas ici, utilisez le réordonnancement de la colonne',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'La position ne se modifie pas ici, utilisez le réordonnancement de la colonne',
+        ]);
+
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        $repo = self::getContainer()->get(\App\Repository\BandSpace\TaskRepository::class);
+        $this->assertSame(0, $repo->find($first->id)->position);
+        $this->assertSame(1, $repo->find($second->id)->position);
+    }
+
+    public function test_update_refuses_a_position_write_sent_alongside_an_editable_field(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Réserver le studio',
+            'status' => TaskStatus::Todo,
+            'position' => 3,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id,
+            ['title' => 'Réserver la salle', 'position' => 0],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'La position ne se modifie pas ici, utilisez le réordonnancement de la colonne',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'La position ne se modifie pas ici, utilisez le réordonnancement de la colonne',
+        ]);
+
+        // The refusal lands before any write, so the title the same request carried is not saved
+        // either: a client cannot slip a position through by pairing it with a legitimate edit.
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        $refreshed = self::getContainer()->get(\App\Repository\BandSpace\TaskRepository::class)->find($task->id);
+        $this->assertSame('Réserver le studio', $refreshed->title);
+        $this->assertSame(3, $refreshed->position);
+    }
+
     public function test_archived_task_refuses_a_status_change(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();


### PR DESCRIPTION
Closes #860.

`TaskUpdateProcedure` wrote whatever `position` the PATCH body carried, with no validation against the column it belongs to. That is a second unguarded door onto the invariant #811 exists to protect: a client can put a task at any index, including one no reorder operation could produce, and nothing reconciles the rest of the column afterwards.

Reproduced before the fix. `PATCH {"position": 0}` on a task holding position 1, in a column whose other task already held 0, returned 200 and left two cards on index 0. `TaskRepository::findByBandSpace` orders by `position ASC`, so the board comes back scrambled for every member and survives a refresh.

## What changed

`position` is refused on the update path with a 422 rather than silently dropped. Reordering has its own endpoint and nothing in the UI sends `position` on a plain edit, so a client that does is asking for a reorder and should be told where it lives. A position sent alongside a legitimate field takes the whole request down instead of letting the edit through.

`TaskResource::$position` is now `#[ApiProperty(writable: false)]`, so the OpenAPI schema stops advertising a field the server always refuses.

## Notes

- The bulk patch path was already safe: `TaskBulkPatchProcessor` whitelists `['archived', 'category_id', 'assignee_ids']` before delegating to the shared procedure. A test now locks that in rather than leaving it implicit.
- The frontend never sent `position` on an ordinary edit. `reorderTasks()` and `moveTask()` use the dedicated endpoints.

## Testing

- 3 tests added. Both update tests fail without the fix, returning 200 with the position written.
- `tests/Api/BandSpace/Task/` 118 green, full suite 2306 green, PHPStan level 8 clean.
