### PR TITLE
fix(M-806): resolve the dragged stage plot element by id on every pointer event

### DIFF
--- a/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
+++ b/assets/js/components/BandSpace/TechRider/StagePlot/StagePlotCanvas.vue
@@ -141,19 +141,24 @@ import {
   describePosition,
   FINE_NUDGE_STEP,
   findAlignmentGuides,
-  MAX_SCALE,
-  MIN_SCALE,
   NUDGE_STEP,
   nextQuarterTurn,
-  rotationFromPointer,
-  rotationGrabOffset,
-  SCALE_STEP,
   SNAP_STEP,
   SYMBOL_SIZE_PERCENT,
   snapFraction,
   toFraction
 } from '../../../../constants/stagePlot.js'
 import { TECH_RIDER_COLOURS } from '../../../../constants/techRiderColours.js'
+import {
+  distanceFrom,
+  moveDraggedElement,
+  placeFraction,
+  rotateDraggedElement,
+  scaleDraggedElement,
+  startMoveDrag,
+  startRotateDrag,
+  startScaleDrag
+} from '../../../../utils/stagePlotDrag.js'
 import StagePlotIcon from './StagePlotIcon.vue'
 
 const props = defineProps({
@@ -233,12 +238,6 @@ function stageFractions(event) {
   }
 }
 
-// Alt places freely; without it everything lands on the grid, because a plot where nothing lines
-// up looks careless on a printed page.
-function applySnap(value, event) {
-  return event.altKey ? toFraction(value) : snapFraction(value)
-}
-
 function handleStagePointerDown() {
   if (props.readOnly) return
   emit('select', null)
@@ -251,13 +250,7 @@ function handleElementPointerDown(event, element) {
   if (drag || scaleDrag || rotateDrag) return
 
   emit('select', element.id)
-  const start = stageFractions(event)
-  drag = {
-    element,
-    offsetX: element.x - start.x,
-    offsetY: element.y - start.y,
-    pointerId: event.pointerId
-  }
+  drag = startMoveDrag(element, stageFractions(event), event.pointerId)
 
   // Captured on the stage, so a fast drag that outruns the pointer keeps moving the element
   // instead of dropping it the moment the cursor leaves the icon.
@@ -267,27 +260,36 @@ function handleElementPointerDown(event, element) {
   stageRef.value.addEventListener('pointercancel', handlePointerUp)
 }
 
+function endMoveDrag(pointerId) {
+  drag = null
+  alignmentGuides.value = NO_GUIDES
+
+  stageRef.value.releasePointerCapture(pointerId)
+  stageRef.value.removeEventListener('pointermove', handlePointerMove)
+  stageRef.value.removeEventListener('pointerup', handlePointerUp)
+  stageRef.value.removeEventListener('pointercancel', handlePointerUp)
+}
+
 function handlePointerMove(event) {
   if (!drag || event.pointerId !== drag.pointerId) return
 
-  const position = stageFractions(event)
-  drag.element.x = applySnap(position.x + drag.offsetX, event)
-  drag.element.y = applySnap(position.y + drag.offsetY, event)
+  const moved = moveDraggedElement(drag, props.elements, stageFractions(event), event.altKey)
+  // The element left the list under the gesture, a reseed dropping it or a delete elsewhere. There
+  // is nothing to move, so the gesture ends here rather than throwing on every further move.
+  if (!moved) {
+    endMoveDrag(event.pointerId)
 
-  alignmentGuides.value = findAlignmentGuides(drag.element, props.elements)
+    return
+  }
+
+  alignmentGuides.value = findAlignmentGuides(moved, props.elements)
 }
 
 function handlePointerUp(event) {
   if (!drag || event.pointerId !== drag.pointerId) return
 
-  const id = drag.element.id
-  drag = null
-  alignmentGuides.value = NO_GUIDES
-
-  stageRef.value.releasePointerCapture(event.pointerId)
-  stageRef.value.removeEventListener('pointermove', handlePointerMove)
-  stageRef.value.removeEventListener('pointerup', handlePointerUp)
-  stageRef.value.removeEventListener('pointercancel', handlePointerUp)
+  const id = drag.elementId
+  endMoveDrag(event.pointerId)
 
   // No change event to emit: the parent's dirty state is computed from the same reactive elements
   // this mutates, so it already knows. Focus follows the drag so the arrows act on what moved.
@@ -321,12 +323,7 @@ function handleRotatePointerDown(event, element) {
   }
   const point = { x: event.clientX, y: event.clientY }
 
-  rotateDrag = {
-    element,
-    centre,
-    grabOffset: rotationGrabOffset(centre, point, element.rotation ?? 0),
-    pointerId: event.pointerId
-  }
+  rotateDrag = startRotateDrag(element, centre, point, event.pointerId)
 
   stageRef.value.setPointerCapture(event.pointerId)
   stageRef.value.addEventListener('pointermove', handleRotatePointerMove)
@@ -334,27 +331,28 @@ function handleRotatePointerDown(event, element) {
   stageRef.value.addEventListener('pointercancel', handleRotatePointerUp)
 }
 
+function endRotateDrag(pointerId) {
+  rotateDrag = null
+
+  stageRef.value.releasePointerCapture(pointerId)
+  stageRef.value.removeEventListener('pointermove', handleRotatePointerMove)
+  stageRef.value.removeEventListener('pointerup', handleRotatePointerUp)
+  stageRef.value.removeEventListener('pointercancel', handleRotatePointerUp)
+}
+
 function handleRotatePointerMove(event) {
   if (!rotateDrag || event.pointerId !== rotateDrag.pointerId) return
 
-  rotateDrag.element.rotation = rotationFromPointer(
-    rotateDrag.centre,
-    { x: event.clientX, y: event.clientY },
-    rotateDrag.grabOffset,
-    !event.altKey
-  )
+  const point = { x: event.clientX, y: event.clientY }
+  const turned = rotateDraggedElement(rotateDrag, props.elements, point, !event.altKey)
+  if (!turned) endRotateDrag(event.pointerId)
 }
 
 function handleRotatePointerUp(event) {
   if (!rotateDrag || event.pointerId !== rotateDrag.pointerId) return
 
-  const id = rotateDrag.element.id
-  rotateDrag = null
-
-  stageRef.value.releasePointerCapture(event.pointerId)
-  stageRef.value.removeEventListener('pointermove', handleRotatePointerMove)
-  stageRef.value.removeEventListener('pointerup', handleRotatePointerUp)
-  stageRef.value.removeEventListener('pointercancel', handleRotatePointerUp)
+  const id = rotateDrag.elementId
+  endRotateDrag(event.pointerId)
 
   elementRefs.get(id)?.focus()
 }
@@ -372,16 +370,10 @@ function handleScalePointerDown(event, element) {
     x: box.left + box.width * element.x,
     y: box.top + box.height * element.y
   }
-  const startDistance = Math.hypot(event.clientX - centre.x, event.clientY - centre.y)
+  const startDistance = distanceFrom(centre, { x: event.clientX, y: event.clientY })
   if (startDistance < 1) return
 
-  scaleDrag = {
-    element,
-    centre,
-    startDistance,
-    startScale: element.scale ?? 1,
-    pointerId: event.pointerId
-  }
+  scaleDrag = startScaleDrag(element, centre, startDistance, event.pointerId)
 
   stageRef.value.setPointerCapture(event.pointerId)
   stageRef.value.addEventListener('pointermove', handleScalePointerMove)
@@ -389,33 +381,28 @@ function handleScalePointerDown(event, element) {
   stageRef.value.addEventListener('pointercancel', handleScalePointerUp)
 }
 
+function endScaleDrag(pointerId) {
+  scaleDrag = null
+
+  stageRef.value.releasePointerCapture(pointerId)
+  stageRef.value.removeEventListener('pointermove', handleScalePointerMove)
+  stageRef.value.removeEventListener('pointerup', handleScalePointerUp)
+  stageRef.value.removeEventListener('pointercancel', handleScalePointerUp)
+}
+
 function handleScalePointerMove(event) {
   if (!scaleDrag || event.pointerId !== scaleDrag.pointerId) return
 
-  const distance = Math.hypot(
-    event.clientX - scaleDrag.centre.x,
-    event.clientY - scaleDrag.centre.y
-  )
-  const next = (scaleDrag.startScale * distance) / scaleDrag.startDistance
-
-  // Clamped and stepped to what the inspector's slider offers, so dragging cannot produce a value
-  // the panel is then unable to show or the server would refuse.
-  scaleDrag.element.scale = Math.min(
-    MAX_SCALE,
-    Math.max(MIN_SCALE, Math.round(next / SCALE_STEP) * SCALE_STEP)
-  )
+  const point = { x: event.clientX, y: event.clientY }
+  const resized = scaleDraggedElement(scaleDrag, props.elements, point)
+  if (!resized) endScaleDrag(event.pointerId)
 }
 
 function handleScalePointerUp(event) {
   if (!scaleDrag || event.pointerId !== scaleDrag.pointerId) return
 
-  const id = scaleDrag.element.id
-  scaleDrag = null
-
-  stageRef.value.releasePointerCapture(event.pointerId)
-  stageRef.value.removeEventListener('pointermove', handleScalePointerMove)
-  stageRef.value.removeEventListener('pointerup', handleScalePointerUp)
-  stageRef.value.removeEventListener('pointercancel', handleScalePointerUp)
+  const id = scaleDrag.elementId
+  endScaleDrag(event.pointerId)
 
   elementRefs.get(id)?.focus()
 }
@@ -428,7 +415,11 @@ function handleDrop(event) {
   if (!slug) return
 
   const position = stageFractions(event)
-  emit('place', { slug, x: applySnap(position.x, event), y: applySnap(position.y, event) })
+  emit('place', {
+    slug,
+    x: placeFraction(position.x, event.altKey),
+    y: placeFraction(position.y, event.altKey)
+  })
 }
 
 /**

--- a/assets/js/utils/stagePlotDrag.js
+++ b/assets/js/utils/stagePlotDrag.js
@@ -1,0 +1,157 @@
+import {
+  MAX_SCALE,
+  MIN_SCALE,
+  rotationFromPointer,
+  rotationGrabOffset,
+  SCALE_STEP,
+  snapFraction,
+  toFraction
+} from '../constants/stagePlot.js'
+
+/**
+ * The three stage plot pointer gestures, held as plain data keyed by element id.
+ *
+ * The canvas used to keep the element object itself for the length of a drag. That object is only
+ * the current one until the editor reseeds: seeding rebuilds the list from the stored document and
+ * replaces every entry, so a reseed landing mid gesture left the handlers writing to an orphan
+ * while the keyed v-for had already bound the DOM node to the fresh object. The element visibly
+ * stopped following the pointer, and everything the rest of the gesture did went nowhere. The
+ * alignment guides went with it: the scan skips the dragged element by identity, and an orphan
+ * matches none of the entries, so it lined itself up against its own replacement.
+ *
+ * Resolving the element by id on every event costs one scan of at most MAX_ELEMENTS entries, the
+ * order the guide scan already runs at, and what it finds is always the object on screen. Ids are
+ * unique and non empty across a plot, which TechRiderStagePlotValidator enforces on the way in, so
+ * the scan resolves to exactly one element, or to nothing at all when it has been removed under the
+ * gesture. That is the caller's cue to end the gesture, not a reason to throw.
+ *
+ * The arithmetic lives here rather than in the component because a pointer gesture needs a browser
+ * and the numbers behind it do not. See stagePlotDrag.test.js.
+ */
+
+/**
+ * Alt places freely; without it everything lands on the grid, because a plot where nothing lines up
+ * looks careless on a printed page. Shared by the move drag and by the picker's drop, so the two
+ * cannot drift apart on what Alt means.
+ */
+export function placeFraction(value, freePlacement) {
+  return freePlacement ? toFraction(value) : snapFraction(value)
+}
+
+/** Pixels between a captured centre and a pointer, for the scale ratio. */
+export function distanceFrom(centre, point) {
+  return Math.hypot(point.x - centre.x, point.y - centre.y)
+}
+
+/**
+ * @param {{id: string, x: number, y: number}} element
+ * @param {{x: number, y: number}} start Where the pointer went down, in stage fractions.
+ * @param {number} pointerId
+ */
+export function startMoveDrag(element, start, pointerId) {
+  return {
+    elementId: element.id,
+    pointerId,
+    // Taken once, so grabbing an icon by its edge does not centre it under the pointer.
+    offsetX: element.x - start.x,
+    offsetY: element.y - start.y
+  }
+}
+
+/**
+ * How far the reseed guarantee goes, for scale and rotate alike. Resolving by id keeps the gesture
+ * writing to the element on screen, but the pivot geometry below is measured once at pointerdown.
+ * A reseed that brings the same id back at different coordinates therefore leaves the rest of that
+ * one gesture turning around where the icon used to sit. Cosmetic, and the next gesture measures
+ * again. Recomputing the centre per event would fix rotate on its own, but scale reads
+ * startDistance against that same centre, so moving one without re-deriving the other makes the
+ * icon jump size mid-drag.
+ *
+ * @param {{id: string, scale?: number}} element
+ * @param {{x: number, y: number}} centre The element's centre in client pixels.
+ * @param {number} startDistance Where the grip was grabbed, as a distance from that centre.
+ * @param {number} pointerId
+ */
+export function startScaleDrag(element, centre, startDistance, pointerId) {
+  return {
+    elementId: element.id,
+    pointerId,
+    centre,
+    startDistance,
+    startScale: element.scale ?? 1
+  }
+}
+
+/**
+ * @param {{id: string, rotation?: number}} element
+ * @param {{x: number, y: number}} centre The element's centre in client pixels.
+ * @param {{x: number, y: number}} point Where the grip was grabbed, in client pixels.
+ * @param {number} pointerId
+ */
+export function startRotateDrag(element, centre, point, pointerId) {
+  return {
+    elementId: element.id,
+    pointerId,
+    centre,
+    // Recorded once and added back on every move, so grabbing the grip anywhere leaves the icon
+    // where it was instead of swinging it round to meet the pointer.
+    grabOffset: rotationGrabOffset(centre, point, element.rotation ?? 0)
+  }
+}
+
+/** The element a gesture is acting on as the list stands now, or null once it is gone. */
+export function draggedElement(drag, elements) {
+  return elements.find((element) => element.id === drag.elementId) ?? null
+}
+
+/**
+ * Moves the grabbed element to where the pointer is, offset included.
+ *
+ * @returns The element moved, so the caller can line the guides up against it, or null when it is
+ *   no longer in the list and the gesture has nothing left to act on.
+ */
+export function moveDraggedElement(drag, elements, position, freePlacement) {
+  const element = draggedElement(drag, elements)
+  if (!element) return null
+
+  element.x = placeFraction(position.x + drag.offsetX, freePlacement)
+  element.y = placeFraction(position.y + drag.offsetY, freePlacement)
+
+  return element
+}
+
+/**
+ * Resizes the grabbed element from how far the pointer now sits from its centre.
+ *
+ * An absolute ratio against the grab distance rather than incremental deltas, so the size never
+ * drifts away from the pointer over a long drag. Clamped and stepped to what the inspector's slider
+ * offers, so dragging cannot produce a value the panel is unable to show or the server would refuse.
+ *
+ * @returns The element resized, or null when it is no longer in the list.
+ */
+export function scaleDraggedElement(drag, elements, point) {
+  const element = draggedElement(drag, elements)
+  if (!element) return null
+
+  const next = (drag.startScale * distanceFrom(drag.centre, point)) / drag.startDistance
+  element.scale = Math.min(
+    MAX_SCALE,
+    Math.max(MIN_SCALE, Math.round(next / SCALE_STEP) * SCALE_STEP)
+  )
+
+  return element
+}
+
+/**
+ * Turns the grabbed element to the pointer's bearing around its own centre.
+ *
+ * @returns The element turned, or null when it is no longer in the list.
+ */
+export function rotateDraggedElement(drag, elements, point, snapRotation) {
+  const element = draggedElement(drag, elements)
+  if (!element) return null
+
+  element.rotation = rotationFromPointer(drag.centre, point, drag.grabOffset, snapRotation)
+
+  return element
+}

--- a/assets/js/utils/stagePlotDrag.test.js
+++ b/assets/js/utils/stagePlotDrag.test.js
@@ -1,0 +1,249 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  distanceFrom,
+  draggedElement,
+  moveDraggedElement,
+  placeFraction,
+  rotateDraggedElement,
+  scaleDraggedElement,
+  startMoveDrag,
+  startRotateDrag,
+  startScaleDrag
+} from './stagePlotDrag.js'
+
+/**
+ * These pin the fix for the mid gesture reseed: the three drags used to hold the element object
+ * itself, and RiderStagePlotEditor.seed() replaces every object rather than mutating it. A save
+ * landing while a fresh drag had started but not yet dirtied the document reseeded under the
+ * gesture, and the handlers went on writing to an orphan while the keyed v-for had already bound
+ * the DOM node to the fresh one. The element stopped following the pointer for the rest of the
+ * gesture.
+ *
+ * Run with `npm test`. Node's own runner, so this costs no dependency. The pointer wiring itself
+ * still has no coverage, because that would need jsdom and a component harness.
+ */
+
+function element(id, values = {}) {
+  return { id, icon: 'ampli', x: 0.5, y: 0.5, scale: 1, rotation: 0, ...values }
+}
+
+/** What seed() does to the list: the same document, rebuilt as brand new objects. */
+function reseed(elements) {
+  return elements.map((entry) => ({ ...entry }))
+}
+
+describe('draggedElement', () => {
+  it('resolves the element a gesture was started on', () => {
+    const elements = [element('a'), element('b')]
+    const drag = startMoveDrag(elements[1], { x: 0.5, y: 0.5 }, 1)
+
+    assert.equal(draggedElement(drag, elements), elements[1])
+  })
+
+  it('resolves the fresh object after a reseed, never the one the gesture started on', () => {
+    const elements = [element('a'), element('b')]
+    const grabbed = elements[0]
+    const drag = startMoveDrag(grabbed, { x: 0.5, y: 0.5 }, 1)
+
+    const reseeded = reseed(elements)
+
+    assert.equal(draggedElement(drag, reseeded), reseeded[0])
+    assert.notEqual(draggedElement(drag, reseeded), grabbed)
+  })
+
+  it('returns null when the element left the list, rather than throwing', () => {
+    const drag = startMoveDrag(element('a'), { x: 0.5, y: 0.5 }, 1)
+
+    assert.equal(draggedElement(drag, [element('b')]), null)
+    assert.equal(draggedElement(drag, []), null)
+  })
+})
+
+describe('startMoveDrag', () => {
+  it('holds the id and not the element, so a reseed has nothing to orphan', () => {
+    const drag = startMoveDrag(element('a', { x: 0.5, y: 0.75 }), { x: 0.25, y: 0.75 }, 7)
+
+    assert.deepEqual(drag, { elementId: 'a', pointerId: 7, offsetX: 0.25, offsetY: 0 })
+  })
+})
+
+describe('moveDraggedElement', () => {
+  it('moves the element the user grabbed after a reseed has replaced it', () => {
+    const elements = [element('a', { x: 0.4, y: 0.4 }), element('b', { x: 0.8, y: 0.8 })]
+    const grabbed = elements[0]
+    const drag = startMoveDrag(grabbed, { x: 0.4, y: 0.4 }, 1)
+
+    // The save from a previous edit lands, the editor reseeds, and the drag is still running.
+    const reseeded = reseed(elements)
+    const moved = moveDraggedElement(drag, reseeded, { x: 0.6, y: 0.5 }, false)
+
+    assert.equal(moved, reseeded[0])
+    assert.equal(reseeded[0].x, 0.6)
+    assert.equal(reseeded[0].y, 0.5)
+    // The object the gesture started on is the one that used to be moved instead, invisibly.
+    assert.equal(grabbed.x, 0.4)
+    assert.equal(grabbed.y, 0.4)
+  })
+
+  it('keeps the grab offset across a reseed, so the element does not jump under the pointer', () => {
+    const elements = [element('a', { x: 0.4, y: 0.4 })]
+    const drag = startMoveDrag(elements[0], { x: 0.35, y: 0.35 }, 1)
+
+    const reseeded = reseed(elements)
+    moveDraggedElement(drag, reseeded, { x: 0.55, y: 0.55 }, false)
+
+    assert.equal(reseeded[0].x, 0.6)
+    assert.equal(reseeded[0].y, 0.6)
+  })
+
+  it('leaves the moved element inside the list, so the guides can skip it by identity', () => {
+    const elements = [element('a', { x: 0.4, y: 0.4 }), element('b')]
+    const drag = startMoveDrag(elements[0], { x: 0.4, y: 0.4 }, 1)
+
+    const reseeded = reseed(elements)
+    const moved = moveDraggedElement(drag, reseeded, { x: 0.6, y: 0.5 }, false)
+
+    assert.ok(reseeded.includes(moved))
+  })
+
+  it('snaps to the grid, and places freely when the pointer asks for it', () => {
+    const elements = [element('a', { x: 0.4, y: 0.4 })]
+    const drag = startMoveDrag(elements[0], { x: 0.4, y: 0.4 }, 1)
+
+    moveDraggedElement(drag, elements, { x: 0.61, y: 0.61 }, false)
+    assert.deepEqual({ x: elements[0].x, y: elements[0].y }, { x: 0.6, y: 0.6 })
+
+    moveDraggedElement(drag, elements, { x: 0.61, y: 0.61 }, true)
+    assert.deepEqual({ x: elements[0].x, y: elements[0].y }, { x: 0.61, y: 0.61 })
+  })
+
+  it('reports nothing to move once the element has been deleted mid drag', () => {
+    const elements = [element('a', { x: 0.4, y: 0.4 }), element('b')]
+    const drag = startMoveDrag(elements[0], { x: 0.4, y: 0.4 }, 1)
+
+    // Deleted server side, so the reseed comes back without it.
+    const reseeded = reseed([elements[1]])
+
+    assert.equal(moveDraggedElement(drag, reseeded, { x: 0.6, y: 0.5 }, false), null)
+    assert.deepEqual(reseeded, [element('b')])
+  })
+})
+
+describe('scaleDraggedElement', () => {
+  const CENTRE = { x: 0, y: 0 }
+
+  it('resizes the element the user grabbed after a reseed has replaced it', () => {
+    const elements = [element('a', { scale: 1 }), element('b', { scale: 1 })]
+    const grabbed = elements[0]
+    const drag = startScaleDrag(grabbed, CENTRE, distanceFrom(CENTRE, { x: 100, y: 0 }), 1)
+
+    const reseeded = reseed(elements)
+    const resized = scaleDraggedElement(drag, reseeded, { x: 200, y: 0 })
+
+    assert.equal(resized, reseeded[0])
+    assert.equal(reseeded[0].scale, 2)
+    assert.equal(grabbed.scale, 1)
+  })
+
+  it('clamps and steps to what the inspector slider offers', () => {
+    const elements = [element('a', { scale: 1 })]
+    const drag = startScaleDrag(elements[0], CENTRE, 100, 1)
+
+    scaleDraggedElement(drag, elements, { x: 1000, y: 0 })
+    assert.equal(elements[0].scale, 4)
+
+    scaleDraggedElement(drag, elements, { x: 1, y: 0 })
+    assert.equal(elements[0].scale, 0.25)
+
+    scaleDraggedElement(drag, elements, { x: 130, y: 0 })
+    assert.equal(elements[0].scale, 1.25)
+  })
+
+  it('measures against the scale the element had when the grip was grabbed', () => {
+    const elements = [element('a', { scale: 2 })]
+    const drag = startScaleDrag(elements[0], CENTRE, 100, 1)
+
+    const reseeded = reseed(elements)
+    scaleDraggedElement(drag, reseeded, { x: 150, y: 0 })
+
+    assert.equal(reseeded[0].scale, 3)
+  })
+
+  it('reports nothing to resize once the element has been deleted mid drag', () => {
+    const elements = [element('a'), element('b')]
+    const drag = startScaleDrag(elements[0], CENTRE, 100, 1)
+
+    assert.equal(scaleDraggedElement(drag, reseed([elements[1]]), { x: 200, y: 0 }), null)
+  })
+})
+
+describe('rotateDraggedElement', () => {
+  const CENTRE = { x: 0, y: 0 }
+  const GRABBED_AT = { x: 100, y: 0 }
+
+  it('turns the element the user grabbed after a reseed has replaced it', () => {
+    const elements = [element('a', { rotation: 0 }), element('b', { rotation: 0 })]
+    const grabbed = elements[0]
+    const drag = startRotateDrag(grabbed, CENTRE, GRABBED_AT, 1)
+
+    const reseeded = reseed(elements)
+    const turned = rotateDraggedElement(drag, reseeded, { x: 0, y: 100 }, true)
+
+    assert.equal(turned, reseeded[0])
+    assert.equal(reseeded[0].rotation, 90)
+    assert.equal(grabbed.rotation, 0)
+  })
+
+  it('keeps the grab offset across a reseed, so the icon does not swing to meet the pointer', () => {
+    const elements = [element('a', { rotation: 45 })]
+    const drag = startRotateDrag(elements[0], CENTRE, GRABBED_AT, 1)
+
+    const reseeded = reseed(elements)
+    rotateDraggedElement(drag, reseeded, GRABBED_AT, true)
+
+    assert.equal(reseeded[0].rotation, 45)
+  })
+
+  it('snaps to fifteen degrees, and takes whole degrees when the pointer asks for it', () => {
+    const elements = [element('a', { rotation: 0 })]
+    const drag = startRotateDrag(elements[0], CENTRE, GRABBED_AT, 1)
+    const twentyDegrees = { x: Math.cos(Math.PI / 9), y: Math.sin(Math.PI / 9) }
+
+    rotateDraggedElement(drag, elements, twentyDegrees, true)
+    assert.equal(elements[0].rotation, 15)
+
+    rotateDraggedElement(drag, elements, twentyDegrees, false)
+    assert.equal(elements[0].rotation, 20)
+  })
+
+  it('reports nothing to turn once the element has been deleted mid drag', () => {
+    const elements = [element('a'), element('b')]
+    const drag = startRotateDrag(elements[0], CENTRE, GRABBED_AT, 1)
+
+    assert.equal(rotateDraggedElement(drag, reseed([elements[1]]), { x: 0, y: 100 }, true), null)
+  })
+})
+
+describe('placeFraction', () => {
+  it('lands on the grid by default', () => {
+    assert.equal(placeFraction(0.61, false), 0.6)
+    assert.equal(placeFraction(0.64, false), 0.65)
+  })
+
+  it('places freely when Alt is held', () => {
+    assert.equal(placeFraction(0.61, true), 0.61)
+  })
+
+  it('keeps a placement inside the stage either way', () => {
+    assert.equal(placeFraction(1.4, false), 1)
+    assert.equal(placeFraction(-0.3, true), 0)
+  })
+})
+
+describe('distanceFrom', () => {
+  it('measures a pointer against a centre', () => {
+    assert.equal(distanceFrom({ x: 0, y: 0 }, { x: 3, y: 4 }), 5)
+    assert.equal(distanceFrom({ x: 10, y: 10 }, { x: 10, y: 10 }), 0)
+  })
+})


### PR DESCRIPTION
Closes #806.

All three stage plot pointer gestures captured the element being moved by object reference, while `seed()` in `RiderStagePlotEditor.vue` replaces the objects rather than mutating them. A reseed landing mid-gesture left the handler writing to an orphan while Vue's keyed `v-for` had already rebound the DOM node to the fresh object, so the element visibly stopped following the pointer and the rest of that gesture was thrown away.

## What changed

Gesture state moved to `assets/js/utils/stagePlotDrag.js`, keyed by `elementId` rather than holding a live object, and the element is re-resolved from `props.elements` on every pointer event. Move, rotate and scale all get the same treatment.

Ids are safe to key on: `TechRiderStagePlotValidator` enforces both non-empty strings and uniqueness across the list.

Two things fall out of this:

- The alignment guides are fixed as a side effect. `findAlignmentGuides` skips the dragged element by identity, so an orphan matched nothing and the element aligned itself against its own replacement.
- An element deleted server side mid-drag now ends the gesture cleanly instead of throwing.

The dirty guard is untouched and stays: refusing to reseed over unsaved edits is what stops a background refresh eating someone's work. The bug was only that "not dirty" is not the same as "no gesture in progress".

## Known limitation, documented in the module

Resolving by id keeps the gesture writing to the element on screen, but the rotate and scale pivot geometry is still measured once at pointerdown. A reseed that brings the same id back at different coordinates leaves the rest of that one gesture turning around the old position. It is cosmetic and the next gesture measures again. Recomputing the centre per event fixes rotate alone, but scale reads `startDistance` against that same centre, so changing one without re-deriving the other makes the icon jump size mid-drag. Left as is and written down rather than half fixed.

## Notes

- Two incidental extractions ride along: `applySnap` became a shared `placeFraction(value, freePlacement)` used by both the move drag and the picker drop path, and a duplicated `Math.hypot` became `distanceFrom`. Both were checked call site by call site as behaviour preserving.
- The module is still gated to super admins and unreleased.

## Testing

21 tests in `assets/js/utils/stagePlotDrag.test.js`. The headline case for each gesture starts a drag, replaces the array with fresh objects, then asserts the fresh object moved and the orphan did not. Deleted-mid-drag is covered for all three.

Proven to fail without the fix by swapping in a same-export-shape module implemented the old by-reference way: 12 of 21 fail, the headline one showing the orphan moving to `x: 0.6` while the on-screen object stayed at `x: 0.4`.

`npm test` 305 green, biome clean, build succeeds.
