### PR TITLE
fix(M-734): label, link and count every file source type

### DIFF
--- a/assets/js/components/BandSpace/Files/FileActivityFeed.vue
+++ b/assets/js/components/BandSpace/Files/FileActivityFeed.vue
@@ -28,24 +28,17 @@
 <script setup>
 import { formatDistanceToNow } from 'date-fns'
 import { fr } from 'date-fns/locale'
+import { fileSourceDefiniteNoun } from '../../../constants/fileSources.js'
 import Avatar from '../../User/Avatar.vue'
 
 defineProps({
   activities: { type: Array, default: () => [] }
 })
 
-// Worded so they read correctly after « à » or « de » without contracting, which lets the attach,
-// detach and source_deleted sentences share one list.
-const SOURCE_NOUNS = {
-  task: 'la tâche',
-  finance: "l'entrée financière",
-  note: 'la note',
-  song: 'la chanson',
-  setlist: 'la setlist'
-}
-
+// The shared nouns are worded so they read correctly after « à » or « de » without contracting,
+// which lets the attach, detach and source_deleted sentences share one list.
 function sourceNoun(activity) {
-  return SOURCE_NOUNS[activity.payload?.source_type] ?? null
+  return fileSourceDefiniteNoun(activity.payload?.source_type)
 }
 
 function quotedSourceLabel(activity) {

--- a/assets/js/components/BandSpace/Files/FileDetailDrawer.vue
+++ b/assets/js/components/BandSpace/Files/FileDetailDrawer.vue
@@ -148,17 +148,29 @@
           Attaché à ({{ attachments.length }})
         </label>
         <div class="flex flex-col gap-1">
-          <div
-            v-for="att in attachments"
+          <component
+            :is="att.route ? RouterLink : 'div'"
+            v-for="att in attachmentLinks"
             :key="`${att.source_type}-${att.source_id}`"
+            :to="att.route"
             class="flex items-center gap-2 p-2 rounded-md border border-surface-200 dark:border-surface-700 text-sm"
+            :class="
+              att.route
+                ? 'transition-colors hover:border-primary-500 hover:bg-surface-50 dark:hover:bg-surface-800'
+                : ''
+            "
           >
-            <i :class="attachmentIcon(att.source_type)"></i>
+            <i :class="fileSourceIcon(att.source_type)"></i>
             <div class="flex-1 min-w-0">
-              <div class="text-xs text-surface-400">{{ attachmentTypeLabel(att.source_type) }}</div>
+              <div class="text-xs text-surface-400">{{ fileSourceLabel(att.source_type) }}</div>
               <div class="truncate font-medium">{{ att.source_label }}</div>
             </div>
-          </div>
+            <i
+              v-if="att.route"
+              class="pi pi-arrow-right text-xs text-surface-400"
+              aria-hidden="true"
+            ></i>
+          </component>
         </div>
         <small class="text-xs text-surface-400 italic">
           Pour détacher ce fichier, utilisez la ressource d'origine.
@@ -211,6 +223,13 @@ import Select from 'primevue/select'
 import Skeleton from 'primevue/skeleton'
 import { useConfirm } from 'primevue/useconfirm'
 import { computed, ref, watch } from 'vue'
+import { RouterLink } from 'vue-router'
+import {
+  fileSourceAttachedMessage,
+  fileSourceIcon,
+  fileSourceLabel,
+  fileSourceRoute
+} from '../../../constants/fileSources.js'
 import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
@@ -248,6 +267,14 @@ const canDelete = computed(() =>
 
 const attachments = computed(() => file.value?.attachments ?? [])
 
+/** Each attachment paired with where it sends the member, null when there is nowhere to go. */
+const attachmentLinks = computed(() =>
+  attachments.value.map((att) => ({
+    ...att,
+    route: fileSourceRoute(att.source_type, props.bandSpaceId, att.source_id)
+  }))
+)
+
 const isAttachedToSource = computed(() => attachments.value.length > 0)
 
 const attachedSourceMessage = computed(() => {
@@ -256,16 +283,8 @@ const attachedSourceMessage = computed(() => {
   if (list.length > 1) {
     return `Ce fichier est attaché à ${list.length} ressources. Détachez-le d'abord depuis chacune.`
   }
-  switch (list[0].source_type) {
-    case 'task':
-      return "Ce fichier est attaché à une tâche. Détachez-le d'abord depuis la tâche."
-    case 'finance':
-      return "Ce fichier est attaché à une entrée financière. Détachez-le d'abord depuis l'entrée."
-    case 'note':
-      return "Ce fichier est attaché à une note. Détachez-le d'abord depuis la note."
-    default:
-      return "Ce fichier est attaché à une autre ressource. Détachez-le d'abord."
-  }
+
+  return fileSourceAttachedMessage(list[0].source_type)
 })
 
 const deleteDisabledReason = computed(() => {
@@ -273,32 +292,6 @@ const deleteDisabledReason = computed(() => {
   if (!canDelete.value) return 'Seul le créateur ou un administrateur peut supprimer ce fichier'
   return null
 })
-
-function attachmentIcon(sourceType) {
-  switch (sourceType) {
-    case 'task':
-      return 'pi pi-check-square text-blue-500'
-    case 'finance':
-      return 'pi pi-euro text-amber-600'
-    case 'note':
-      return 'pi pi-file-edit text-purple-500'
-    default:
-      return 'pi pi-link text-surface-500'
-  }
-}
-
-function attachmentTypeLabel(sourceType) {
-  switch (sourceType) {
-    case 'task':
-      return 'Tâche'
-    case 'finance':
-      return 'Entrée financière'
-    case 'note':
-      return 'Note'
-    default:
-      return 'Ressource'
-  }
-}
 
 const folderOptions = computed(() => {
   const out = [{ label: 'Racine', value: null }]

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -124,6 +124,7 @@ import {
   canDrop,
   collectFolderAndDescendants
 } from '../../../composables/useFolderDragDrop.js'
+import { fileSourceDetachHint } from '../../../constants/fileSources.js'
 import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
@@ -173,16 +174,8 @@ const contextFileSourceLabel = computed(() => {
   if (attachments.length > 1) {
     return "Détachez-le d'abord depuis chaque ressource"
   }
-  switch (attachments[0]?.source_type) {
-    case 'task':
-      return "Détachez-le d'abord depuis la tâche"
-    case 'finance':
-      return "Détachez-le d'abord depuis l'entrée"
-    case 'note':
-      return "Détachez-le d'abord depuis la note"
-    default:
-      return "Détachez-le d'abord depuis la ressource concernée"
-  }
+
+  return fileSourceDetachHint(attachments[0]?.source_type)
 })
 
 const contextMenuItems = computed(() => {

--- a/assets/js/components/BandSpace/Files/FolderTree.vue
+++ b/assets/js/components/BandSpace/Files/FolderTree.vue
@@ -52,7 +52,7 @@
         :class="virtualButtonClasses(virtual.id)"
         @click="emit('select', virtual.id)"
       >
-        <i :class="virtualIcon(virtual.source)"></i>
+        <i :class="fileSourceIcon(virtual.source)"></i>
         <span class="flex-1 truncate">{{ virtual.name }}</span>
         <span class="text-xs text-surface-500 tabular-nums">{{ virtual.file_count }}</span>
       </button>
@@ -83,6 +83,7 @@ import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
 import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
 import { applyMove, canDrop } from '../../../composables/useFolderDragDrop.js'
+import { fileSourceIcon } from '../../../constants/fileSources.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import FolderDeleteDialog from './FolderDeleteDialog.vue'
 import FolderEditDialog from './FolderEditDialog.vue'
@@ -184,14 +185,5 @@ function virtualButtonClasses(id) {
   return props.activeFolderId === id
     ? 'bg-surface-100 dark:bg-surface-800 text-surface-900 dark:text-surface-100 font-medium'
     : 'hover:bg-surface-50 dark:hover:bg-surface-800 text-surface-700 dark:text-surface-300'
-}
-
-function virtualIcon(source) {
-  if (source === 'task') return 'pi pi-check-square text-blue-500'
-  if (source === 'finance') return 'pi pi-euro text-amber-600'
-  if (source === 'note') return 'pi pi-file-edit text-purple-500'
-  if (source === 'song') return 'pi pi-headphones text-emerald-600'
-  if (source === 'setlist') return 'pi pi-list text-rose-600'
-  return 'pi pi-folder text-surface-500'
 }
 </script>

--- a/assets/js/components/BandSpace/Files/QuotaIndicator.vue
+++ b/assets/js/components/BandSpace/Files/QuotaIndicator.vue
@@ -81,6 +81,7 @@ import ProgressBar from 'primevue/progressbar'
 import Skeleton from 'primevue/skeleton'
 import { computed, onMounted } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
+import { QUOTA_BREAKDOWN_SOURCES } from '../../../constants/fileSources.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { formatBytes } from '../../../utils/formatBytes.js'
 
@@ -101,39 +102,28 @@ const cappedPercentage = computed(() => {
 
 const quotaHint = 'Les versions précédentes des fichiers comptent dans le quota.'
 
-const SOURCE_LABELS = {
-  manual: 'Manuels',
-  task: 'Tâches',
-  finance: 'Finances'
-}
-const SOURCE_COLORS = {
-  manual: '#3b82f6',
-  task: '#8b5cf6',
-  finance: '#f59e0b'
-}
-
 const totalBreakdownBytes = computed(() => {
   if (!quota.value) return 0
   return (quota.value.breakdown_by_source ?? []).reduce((sum, row) => sum + (row.bytes || 0), 0)
 })
 
+// Walking the known buckets rather than the response keeps the order and the colours stable, and a
+// bucket the frontend has never heard of is left out on purpose: it would have no legend entry.
 const segments = computed(() => {
   if (!quota.value) return []
   const total = totalBreakdownBytes.value
-  return ['manual', 'task', 'finance']
-    .map((key) => {
-      const row = (quota.value.breakdown_by_source ?? []).find((r) => r.source === key)
-      const bytes = row?.bytes ?? 0
-      return {
-        key,
-        label: SOURCE_LABELS[key],
-        color: SOURCE_COLORS[key],
-        bytes,
-        pct: total > 0 ? (bytes / total) * 100 : 0,
-        widthPct: total > 0 ? (bytes / total) * 100 : 0
-      }
-    })
-    .filter((s) => s.bytes > 0)
+  return QUOTA_BREAKDOWN_SOURCES.map((source) => {
+    const row = (quota.value.breakdown_by_source ?? []).find((r) => r.source === source.key)
+    const bytes = row?.bytes ?? 0
+    return {
+      key: source.key,
+      label: source.label,
+      color: source.color,
+      bytes,
+      pct: total > 0 ? (bytes / total) * 100 : 0,
+      widthPct: total > 0 ? (bytes / total) * 100 : 0
+    }
+  }).filter((s) => s.bytes > 0)
 })
 
 const progressBarClass = computed(() => {

--- a/assets/js/constants/fileSources.js
+++ b/assets/js/constants/fileSources.js
@@ -1,18 +1,198 @@
 /**
- * The resources a band space file can be attached to, in the wording the API refuses with.
+ * Everything the frontend knows about the resources a band space file can be attached to.
  *
- * The backend keeps the same five in `BandSpaceFileSourceTypes::ALL` and words them in
+ * The backend allowlist is `BandSpaceFileSourceTypes::ALL` and its French wording lives in
  * `BandSpaceFileAttachmentLabels`; both delete paths refuse to trash a file attached to any of them.
- * This list is what tells the user which ones that covers, so a sixth source type is two edits, one
- * on each side, and never a screen quietly naming three of five.
+ * The screens reading `source_type` each used to carry their own three-of-five copy of that list, so
+ * a file attached to a song or a setlist read as a generic « Ressource », had no way back to its
+ * source, and its bytes were missing from the quota breakdown. One row per source type here is what
+ * keeps the file drawer, the file list, the folder tree, the activity feed and the quota breakdown
+ * saying the same thing.
+ *
+ * Ordered like `BandSpaceFileSourceTypes::ALL`, so the two sides can be read side by side. A sixth
+ * source type is one row here plus its two backend halves.
  */
-export const FILE_SOURCE_NOUNS = Object.freeze([
-  'une tâche',
-  'une note',
-  'une entrée financière',
-  'une chanson',
-  'une setlist'
+
+/**
+ * @typedef {object} FileSource
+ * @property {string} type The `source_type` the API emits.
+ * @property {string} label Heading above the source name, in the file drawer.
+ * @property {string} indefiniteNoun Reads after « attaché à ».
+ * @property {string} definiteNoun Reads after « depuis » or « à ».
+ * @property {string} icon PrimeIcons classes, colour included.
+ * @property {string} quotaLabel Legend entry in the storage breakdown, always plural.
+ * @property {string} color Segment colour in the storage breakdown.
+ * @property {string} routeName Band space route showing this kind of source.
+ * @property {?string} routeQueryKey Query param that opens the source itself, when the view reads one.
+ */
+
+/** @type {readonly FileSource[]} */
+const FILE_SOURCES = Object.freeze([
+  Object.freeze({
+    type: 'task',
+    label: 'Tâche',
+    indefiniteNoun: 'une tâche',
+    definiteNoun: 'la tâche',
+    icon: 'pi pi-check-square text-blue-500',
+    quotaLabel: 'Tâches',
+    color: '#8b5cf6',
+    routeName: 'app_band_tasks',
+    routeQueryKey: 'task'
+  }),
+  Object.freeze({
+    type: 'finance',
+    label: 'Entrée financière',
+    indefiniteNoun: 'une entrée financière',
+    definiteNoun: "l'entrée financière",
+    icon: 'pi pi-euro text-amber-600',
+    quotaLabel: 'Finances',
+    color: '#f59e0b',
+    routeName: 'app_band_finance',
+    routeQueryKey: 'entry'
+  }),
+  Object.freeze({
+    type: 'note',
+    label: 'Note',
+    indefiniteNoun: 'une note',
+    definiteNoun: 'la note',
+    icon: 'pi pi-file-edit text-purple-500',
+    quotaLabel: 'Notes',
+    color: '#06b6d4',
+    routeName: 'app_band_notes',
+    // Notes.vue selects through its store and reads no query param, so the link stops at the tree.
+    routeQueryKey: null
+  }),
+  Object.freeze({
+    type: 'song',
+    label: 'Chanson',
+    indefiniteNoun: 'une chanson',
+    definiteNoun: 'la chanson',
+    icon: 'pi pi-headphones text-emerald-600',
+    quotaLabel: 'Chansons',
+    color: '#10b981',
+    // Songs live in the Répertoire, which is what Setlist.vue shows when no query param is set.
+    routeName: 'app_band_setlist',
+    routeQueryKey: null
+  }),
+  Object.freeze({
+    type: 'setlist',
+    label: 'Setlist',
+    indefiniteNoun: 'une setlist',
+    definiteNoun: 'la setlist',
+    icon: 'pi pi-list text-rose-600',
+    quotaLabel: 'Setlists',
+    color: '#f43f5e',
+    routeName: 'app_band_setlist',
+    routeQueryKey: 'setlist'
+  })
 ])
 
-/** « une tâche, une note, ... ou une setlist », for prose listing every source at once. */
+/**
+ * Stands in for a source type the frontend has never heard of, so a backend that grew a sixth one
+ * degrades to neutral wording instead of an empty label.
+ */
+const UNKNOWN_SOURCE = Object.freeze({
+  label: 'Ressource',
+  indefiniteNoun: 'une autre ressource',
+  definiteNoun: null,
+  icon: 'pi pi-link text-surface-500'
+})
+
+const FILE_SOURCE_BY_TYPE = Object.freeze(
+  Object.fromEntries(FILE_SOURCES.map((source) => [source.type, source]))
+)
+
+/** Mirrors `BandSpaceFileSourceTypes::ALL`. */
+export const FILE_SOURCE_TYPES = Object.freeze(FILE_SOURCES.map((source) => source.type))
+
+/** « une tâche », « une entrée financière », ... for prose naming the sources one by one. */
+export const FILE_SOURCE_NOUNS = Object.freeze(FILE_SOURCES.map((source) => source.indefiniteNoun))
+
+/** « une tâche, une entrée financière, ... ou une setlist », for prose listing every source at once. */
 export const FILE_SOURCE_LIST_LABEL = `${FILE_SOURCE_NOUNS.slice(0, -1).join(', ')} ou ${FILE_SOURCE_NOUNS.at(-1)}`
+
+/**
+ * The storage breakdown the quota endpoint returns, in display order.
+ *
+ * `manual` is not a source type: the query coalesces a missing attachment into it, so it is the
+ * bucket for files nothing points at. It leads the list because it is usually the biggest one.
+ */
+export const QUOTA_BREAKDOWN_SOURCES = Object.freeze([
+  Object.freeze({ key: 'manual', label: 'Manuels', color: '#3b82f6' }),
+  ...FILE_SOURCES.map((source) =>
+    Object.freeze({ key: source.type, label: source.quotaLabel, color: source.color })
+  )
+])
+
+function sourceFor(sourceType) {
+  return FILE_SOURCE_BY_TYPE[sourceType] ?? UNKNOWN_SOURCE
+}
+
+/**
+ * @param {?string} sourceType
+ * @returns {string} « Tâche », « Setlist », ... or « Ressource » for a type we do not know.
+ */
+export function fileSourceLabel(sourceType) {
+  return sourceFor(sourceType).label
+}
+
+/**
+ * @param {?string} sourceType
+ * @returns {string} PrimeIcons classes, colour included.
+ */
+export function fileSourceIcon(sourceType) {
+  return sourceFor(sourceType).icon
+}
+
+/**
+ * @param {?string} sourceType
+ * @returns {?string} « la tâche », « l'entrée financière », ... or null, so a caller building a
+ *                    sentence around it can drop the sentence rather than name nothing.
+ */
+export function fileSourceDefiniteNoun(sourceType) {
+  return sourceFor(sourceType).definiteNoun
+}
+
+/**
+ * Why a file cannot be deleted from the library while it hangs on a source.
+ *
+ * @param {?string} sourceType
+ * @returns {string}
+ */
+export function fileSourceDetachHint(sourceType) {
+  return `Détachez-le d'abord depuis ${fileSourceDefiniteNoun(sourceType) ?? 'la ressource concernée'}`
+}
+
+/**
+ * The same refusal, as a full sentence naming what the file is attached to.
+ *
+ * @param {?string} sourceType
+ * @returns {string}
+ */
+export function fileSourceAttachedMessage(sourceType) {
+  return `Ce fichier est attaché à ${sourceFor(sourceType).indefiniteNoun}. ${fileSourceDetachHint(sourceType)}.`
+}
+
+/**
+ * Where an attachment sends the member, as a router target.
+ *
+ * The query param is only added when the destination view actually reads one, so a note or a song
+ * lands on its module rather than on a URL carrying an id nothing opens.
+ *
+ * @param {?string} sourceType
+ * @param {?string} bandSpaceId
+ * @param {?string} sourceId
+ * @returns {?{name: string, params: {id: string}, query?: Record<string, string>}} null when there is
+ *          nowhere sensible to go, so the caller renders plain text instead of a link.
+ */
+export function fileSourceRoute(sourceType, bandSpaceId, sourceId) {
+  const source = FILE_SOURCE_BY_TYPE[sourceType]
+  if (!source || !bandSpaceId) return null
+
+  const target = { name: source.routeName, params: { id: bandSpaceId } }
+  if (source.routeQueryKey && sourceId) {
+    target.query = { [source.routeQueryKey]: sourceId }
+  }
+
+  return target
+}

--- a/assets/js/constants/fileSources.test.js
+++ b/assets/js/constants/fileSources.test.js
@@ -1,20 +1,46 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { FILE_SOURCE_LIST_LABEL, FILE_SOURCE_NOUNS } from './fileSources.js'
+import {
+  FILE_SOURCE_LIST_LABEL,
+  FILE_SOURCE_NOUNS,
+  FILE_SOURCE_TYPES,
+  fileSourceAttachedMessage,
+  fileSourceDefiniteNoun,
+  fileSourceDetachHint,
+  fileSourceIcon,
+  fileSourceLabel,
+  fileSourceRoute,
+  QUOTA_BREAKDOWN_SOURCES
+} from './fileSources.js'
 
 /**
- * The folder delete dialog promises the cascade is refused when a file is attached. Naming fewer
- * sources than the API actually refuses on is the drift this pins down.
+ * Every screen reading `source_type` used to carry its own three-of-five copy of this list, so a
+ * file attached to a song or a setlist read as a generic « Ressource » and its bytes were missing
+ * from the quota breakdown. The sweeps over FILE_SOURCE_TYPES below are what pin that down: a sixth
+ * type added without wording, an icon, a destination or a quota bucket fails here.
  *
  * Run with `npm test`.
  */
+
+/** BandSpaceFileSourceTypes::ALL, spelled out rather than derived, so a silent drop fails. */
+const BACKEND_SOURCE_TYPES = ['task', 'finance', 'note', 'song', 'setlist']
+
+describe('FILE_SOURCE_TYPES', () => {
+  it('mirrors the backend allowlist, in the same order', () => {
+    assert.deepEqual(FILE_SOURCE_TYPES, BACKEND_SOURCE_TYPES)
+  })
+
+  it('cannot be edited in place by a caller', () => {
+    assert.equal(Object.isFrozen(FILE_SOURCE_TYPES), true)
+  })
+})
 
 describe('FILE_SOURCE_NOUNS', () => {
   it('covers the five source types the API accepts', () => {
     assert.deepEqual(FILE_SOURCE_NOUNS, [
       'une tâche',
-      'une note',
       'une entrée financière',
+      'une note',
       'une chanson',
       'une setlist'
     ])
@@ -29,11 +55,203 @@ describe('FILE_SOURCE_LIST_LABEL', () => {
   it('lists every source, the last one after « ou »', () => {
     assert.equal(
       FILE_SOURCE_LIST_LABEL,
-      'une tâche, une note, une entrée financière, une chanson ou une setlist'
+      'une tâche, une entrée financière, une note, une chanson ou une setlist'
     )
   })
 
   it('names as many sources as there are types', () => {
-    assert.equal(FILE_SOURCE_LIST_LABEL.split(/, | ou /).length, FILE_SOURCE_NOUNS.length)
+    assert.equal(FILE_SOURCE_LIST_LABEL.split(/, | ou /).length, FILE_SOURCE_TYPES.length)
+  })
+})
+
+describe('fileSourceLabel', () => {
+  it('names each source type', () => {
+    assert.equal(fileSourceLabel('task'), 'Tâche')
+    assert.equal(fileSourceLabel('finance'), 'Entrée financière')
+    assert.equal(fileSourceLabel('note'), 'Note')
+    assert.equal(fileSourceLabel('song'), 'Chanson')
+    assert.equal(fileSourceLabel('setlist'), 'Setlist')
+  })
+
+  it('never falls back to the generic label for a type the API can emit', () => {
+    for (const sourceType of BACKEND_SOURCE_TYPES) {
+      assert.notEqual(fileSourceLabel(sourceType), 'Ressource', `${sourceType} has no label`)
+    }
+  })
+
+  it('falls back for an unknown type, and for none at all', () => {
+    assert.equal(fileSourceLabel('gigposter'), 'Ressource')
+    assert.equal(fileSourceLabel(undefined), 'Ressource')
+    assert.equal(fileSourceLabel(null), 'Ressource')
+  })
+})
+
+describe('fileSourceIcon', () => {
+  it('gives each source type its own icon', () => {
+    const icons = BACKEND_SOURCE_TYPES.map((sourceType) => fileSourceIcon(sourceType))
+
+    assert.equal(new Set(icons).size, BACKEND_SOURCE_TYPES.length)
+  })
+
+  it('never falls back to the generic icon for a type the API can emit', () => {
+    for (const sourceType of BACKEND_SOURCE_TYPES) {
+      assert.notEqual(
+        fileSourceIcon(sourceType),
+        'pi pi-link text-surface-500',
+        `${sourceType} has no icon`
+      )
+    }
+  })
+
+  it('is a PrimeIcons class list', () => {
+    assert.equal(fileSourceIcon('setlist'), 'pi pi-list text-rose-600')
+    assert.equal(fileSourceIcon('song'), 'pi pi-headphones text-emerald-600')
+  })
+
+  it('falls back for an unknown type', () => {
+    assert.equal(fileSourceIcon('gigposter'), 'pi pi-link text-surface-500')
+  })
+})
+
+describe('fileSourceDefiniteNoun', () => {
+  it('reads after « depuis »', () => {
+    assert.equal(fileSourceDefiniteNoun('task'), 'la tâche')
+    assert.equal(fileSourceDefiniteNoun('finance'), "l'entrée financière")
+    assert.equal(fileSourceDefiniteNoun('note'), 'la note')
+    assert.equal(fileSourceDefiniteNoun('song'), 'la chanson')
+    assert.equal(fileSourceDefiniteNoun('setlist'), 'la setlist')
+  })
+
+  it('is null for an unknown type, so a sentence around it can be dropped', () => {
+    assert.equal(fileSourceDefiniteNoun('gigposter'), null)
+    assert.equal(fileSourceDefiniteNoun(undefined), null)
+  })
+})
+
+describe('fileSourceDetachHint', () => {
+  it('names the source to detach from', () => {
+    assert.equal(fileSourceDetachHint('setlist'), "Détachez-le d'abord depuis la setlist")
+    assert.equal(fileSourceDetachHint('song'), "Détachez-le d'abord depuis la chanson")
+  })
+
+  it('never names the generic resource for a type the API can emit', () => {
+    for (const sourceType of BACKEND_SOURCE_TYPES) {
+      assert.equal(
+        fileSourceDetachHint(sourceType).includes('la ressource concernée'),
+        false,
+        `${sourceType} is described generically`
+      )
+    }
+  })
+
+  it('stays a sentence for an unknown type', () => {
+    assert.equal(
+      fileSourceDetachHint('gigposter'),
+      "Détachez-le d'abord depuis la ressource concernée"
+    )
+  })
+})
+
+describe('fileSourceAttachedMessage', () => {
+  it('says what the file hangs on and how to free it', () => {
+    assert.equal(
+      fileSourceAttachedMessage('song'),
+      "Ce fichier est attaché à une chanson. Détachez-le d'abord depuis la chanson."
+    )
+    assert.equal(
+      fileSourceAttachedMessage('task'),
+      "Ce fichier est attaché à une tâche. Détachez-le d'abord depuis la tâche."
+    )
+  })
+
+  it('stays a sentence for an unknown type', () => {
+    assert.equal(
+      fileSourceAttachedMessage('gigposter'),
+      "Ce fichier est attaché à une autre ressource. Détachez-le d'abord depuis la ressource concernée."
+    )
+  })
+})
+
+describe('fileSourceRoute', () => {
+  it('sends every source type somewhere inside its band space', () => {
+    for (const sourceType of BACKEND_SOURCE_TYPES) {
+      const target = fileSourceRoute(sourceType, 'space-1', 'source-1')
+
+      assert.notEqual(target, null, `${sourceType} has no destination`)
+      assert.deepEqual(target.params, { id: 'space-1' })
+      assert.match(target.name, /^app_band_/)
+    }
+  })
+
+  it('opens the source itself when the destination view reads a query param', () => {
+    assert.deepEqual(fileSourceRoute('task', 'space-1', 'task-1'), {
+      name: 'app_band_tasks',
+      params: { id: 'space-1' },
+      query: { task: 'task-1' }
+    })
+    assert.deepEqual(fileSourceRoute('finance', 'space-1', 'entry-1'), {
+      name: 'app_band_finance',
+      params: { id: 'space-1' },
+      query: { entry: 'entry-1' }
+    })
+    assert.deepEqual(fileSourceRoute('setlist', 'space-1', 'setlist-1'), {
+      name: 'app_band_setlist',
+      params: { id: 'space-1' },
+      query: { setlist: 'setlist-1' }
+    })
+  })
+
+  it('stops at the module for a source no view can deep link to', () => {
+    assert.deepEqual(fileSourceRoute('note', 'space-1', 'note-1'), {
+      name: 'app_band_notes',
+      params: { id: 'space-1' }
+    })
+    assert.deepEqual(fileSourceRoute('song', 'space-1', 'song-1'), {
+      name: 'app_band_setlist',
+      params: { id: 'space-1' }
+    })
+  })
+
+  it('drops the query param when the source id is missing', () => {
+    assert.deepEqual(fileSourceRoute('setlist', 'space-1', null), {
+      name: 'app_band_setlist',
+      params: { id: 'space-1' }
+    })
+  })
+
+  it('is null when there is nowhere sensible to go', () => {
+    assert.equal(fileSourceRoute('gigposter', 'space-1', 'x'), null)
+    assert.equal(fileSourceRoute(undefined, 'space-1', 'x'), null)
+    assert.equal(fileSourceRoute('task', null, 'task-1'), null)
+  })
+})
+
+describe('QUOTA_BREAKDOWN_SOURCES', () => {
+  it('covers every source type the API can emit, plus the unattached bucket', () => {
+    assert.deepEqual(
+      QUOTA_BREAKDOWN_SOURCES.map((source) => source.key),
+      ['manual', ...BACKEND_SOURCE_TYPES]
+    )
+  })
+
+  it('labels every bucket in the plural', () => {
+    assert.deepEqual(
+      QUOTA_BREAKDOWN_SOURCES.map((source) => source.label),
+      ['Manuels', 'Tâches', 'Finances', 'Notes', 'Chansons', 'Setlists']
+    )
+  })
+
+  it('gives every bucket its own colour, so two segments never merge', () => {
+    const colors = QUOTA_BREAKDOWN_SOURCES.map((source) => source.color)
+
+    assert.equal(new Set(colors).size, QUOTA_BREAKDOWN_SOURCES.length)
+    for (const color of colors) {
+      assert.match(color, /^#[0-9a-f]{6}$/)
+    }
+  })
+
+  it('cannot be edited in place by a caller', () => {
+    assert.equal(Object.isFrozen(QUOTA_BREAKDOWN_SOURCES), true)
+    assert.equal(Object.isFrozen(QUOTA_BREAKDOWN_SOURCES[0]), true)
   })
 })


### PR DESCRIPTION
Closes #734.

Reported via beta feedback as "le lien entre les notes / setlists et l'onglet fichiers ne se fait pas". The data pipeline was already correct: the backend has been sending `source_type` / `source_id` / `source_label` all along. The drift was entirely in the frontend, which only ever handled `task` / `finance` / `note`, so a setlist or song attachment rendered as a generic "Ressource" and read to a user as a missing link.

## What changed

The label, icon, noun, detach hint and destination for every source type now live in one place, `assets/js/constants/fileSources.js`, and every consumer reads from it.

- Setlist and song attachments get their own label and icon instead of falling through to "Ressource".
- "Attaché à" in the file detail drawer is a real `RouterLink` instead of a static div. As a side effect it is now focusable and keyboard operable where it used to be inert.
- The quota breakdown covers all six buckets. `manual` is not a source type, it is the `COALESCE(a.source_type, 'manual')` group in `BandSpaceFileVersionRepository`, so the list is that plus the five real types.

The source list is pinned in a test against `BandSpaceFileSourceTypes::ALL`, so a new backend source type fails the suite instead of silently rendering as "Ressource" again.

## Five copies, not three

The issue named three components. There were five: `FolderTree.vue` carried a complete icon map and `FileActivityFeed.vue` a complete noun map. Both were already correct, so folding them in is a no-op today, but leaving them out would have left the same drift free to reappear.

That was verified rather than assumed: every key of both old maps was asserted against the new module and all five match. The only value that differs is the unknown-type fallback icon, on a branch `FolderTree.vue` cannot reach, since its sources come from a hardcoded list of the same five keys in `BandSpaceFolderVirtualFoldersListener`.

## Two copy changes worth signing off consciously

Neither was requested by the issue.

- The noun order now follows `BandSpaceFileSourceTypes::ALL`, so the folder deletion dialog sentence reads `une tâche, une entrée financière, une note, une chanson ou une setlist` instead of putting the note second. Same five nouns, and the point is that the two sides can be read side by side, but it is a copy change to a delete confirmation.
- The finance detach hint reads "depuis l'entrée financière" rather than "depuis l'entrée". This is not new wording: `FileActivityFeed.vue` already shipped "l'entrée financière", and consolidating meant picking one of the two live variants.

## Not included

Note and song attachments link to their module page with no deep link, so a song lands on the Répertoire rather than on that song. `Notes.vue` has no route param and selects purely through its Pinia store, and songs have none either, so deep linking them means new route params and watchers in views outside this change. The setlist case does open the exact setlist.

## Testing

24 cases in `assets/js/constants/fileSources.test.js`, sweeping the backend type list to assert no type falls back to the generic label, icon or hint, that every type has a destination, and that the quota list is complete.

Proven to fail without the fix by restoring the module with the `song` and `setlist` rows removed, which is the exact state on master: 18 failures, including `expected: 'Chanson', actual: 'Ressource'`.

`npm test` 309 green, biome clean, build succeeds.
