### PR TITLE
fix(M-874): refuse comments, attachments and moves on an archived task

### DIFF
--- a/src/Procedure/BandSpace/TaskMoveProcedure.php
+++ b/src/Procedure/BandSpace/TaskMoveProcedure.php
@@ -9,6 +9,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceTaskActivityType;
 use App\Enum\BandSpace\TaskStatus;
 use App\Repository\BandSpace\TaskRepository;
+use App\Security\BandSpace\TaskWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\TaskColumnPositionsGuard;
 use DateTime;
@@ -23,6 +24,7 @@ readonly class TaskMoveProcedure
         private TaskRepository $taskRepository,
         private TaskColumnPositionsGuard $columnPositionsGuard,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
+        private TaskWriteGuard $taskWriteGuard,
     ) {
     }
 
@@ -41,6 +43,10 @@ readonly class TaskMoveProcedure
         if (!$task instanceof Task) {
             throw new BadRequestHttpException(sprintf('Tâche %s introuvable dans ce Band Space', $taskId));
         }
+
+        // Refused outright rather than per field: status, completedDatetime and position are the
+        // three this writes, and none of them means anything on a task that is out of the board.
+        $this->taskWriteGuard->assertWritable($task);
 
         $targetStatus = TaskStatus::from($newStatus);
 

--- a/src/Procedure/BandSpace/TaskUpdateProcedure.php
+++ b/src/Procedure/BandSpace/TaskUpdateProcedure.php
@@ -14,6 +14,7 @@ use App\Event\BandSpaceTaskAssignedEvent;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\TaskCategoryRepository;
 use App\Repository\UserRepository;
+use App\Security\BandSpace\TaskWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use DateTime;
 use DateTimeImmutable;
@@ -32,6 +33,7 @@ readonly class TaskUpdateProcedure
         private UserRepository $userRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private EventDispatcherInterface $eventDispatcher,
+        private TaskWriteGuard $taskWriteGuard,
     ) {
     }
 
@@ -45,7 +47,7 @@ readonly class TaskUpdateProcedure
         BandSpace $bandSpace,
         User $user,
     ): Task {
-        $this->assertArchivedTaskIsReadOnly($task, $payload);
+        $this->taskWriteGuard->assertWritableForPayload($task, $payload);
 
         if (array_key_exists('title', $payload)) {
             $task->title = $data->title;
@@ -92,28 +94,6 @@ readonly class TaskUpdateProcedure
         }
 
         return $task;
-    }
-
-    /**
-     * An archived task is a closed record: archiving demands a task be done, so anything that could
-     * reopen it, its status first of all, would leave the archive holding something it would never
-     * have accepted. The board gives no way in, but a deep link to the drawer does, so the refusal
-     * belongs here rather than in the interface. Taking the task back out of the archive is the one
-     * write left, and everything is editable again once it is out.
-     *
-     * @param array<string, mixed> $payload
-     */
-    private function assertArchivedTaskIsReadOnly(Task $task, array $payload): void
-    {
-        if (!$task->archiveDatetime instanceof DateTimeImmutable) {
-            return;
-        }
-
-        if (array_diff(array_keys($payload), ['archived']) === []) {
-            return;
-        }
-
-        throw new HttpException(422, 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier');
     }
 
     private function applyStatusChange(Task $task, string $newStatus, User $user): void

--- a/src/Security/BandSpace/TaskWriteGuard.php
+++ b/src/Security/BandSpace/TaskWriteGuard.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\BandSpace;
+
+use App\Entity\BandSpace\Task;
+use DateTimeImmutable;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * An archived task is a closed record: archiving demands a task be done, so anything that could
+ * reopen it, its status first of all, would leave the archive holding something it would never
+ * have accepted. The board never renders an archived card and the drawer opens read-only, so only
+ * a hand-crafted call gets there, which is exactly why the refusal belongs on the server.
+ *
+ * Two methods, because taking a task back out of the archive is itself a write and has to stay
+ * possible. assertWritable() refuses every write and is what the paths that cannot express
+ * unarchiving use; assertWritableForPayload() is the merge-patch door, which lets the one payload
+ * that unarchives through and refuses the rest.
+ *
+ * Unlike SongWriteGuard and SetlistWriteGuard, which answer 409, this answers 422: the message and
+ * the status are the ones the task PATCH has been returning since the invariant shipped, and one
+ * invariant on one entity should not hand out two different codes depending on the door used.
+ */
+readonly class TaskWriteGuard
+{
+    private const string ARCHIVED_MESSAGE = 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier';
+
+    public function assertWritable(Task $task): void
+    {
+        if ($task->archiveDatetime instanceof DateTimeImmutable) {
+            throw new UnprocessableEntityHttpException(self::ARCHIVED_MESSAGE);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload raw merge-patch payload, used to detect explicitly-sent fields
+     */
+    public function assertWritableForPayload(Task $task, array $payload): void
+    {
+        if (array_diff(array_keys($payload), ['archived']) === []) {
+            return;
+        }
+
+        $this->assertWritable($task);
+    }
+}

--- a/src/State/Processor/BandSpace/File/BandSpaceFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileAttachProcessor.php
@@ -22,6 +22,7 @@ use App\Repository\BandSpace\TaskRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Security\BandSpace\SetlistWriteGuard;
 use App\Security\BandSpace\SongWriteGuard;
+use App\Security\BandSpace\TaskWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\File\BandSpaceFileBuilder;
 use Doctrine\ORM\EntityManagerInterface;
@@ -41,6 +42,7 @@ readonly class BandSpaceFileAttachProcessor implements ProcessorInterface
         private BandSpaceMemberChecker $memberChecker,
         private SetlistWriteGuard $setlistWriteGuard,
         private SongWriteGuard $songWriteGuard,
+        private TaskWriteGuard $taskWriteGuard,
         private BandSpaceFileRepository $fileRepository,
         private BandSpaceFileAttachmentRepository $attachmentRepository,
         private TaskRepository $taskRepository,
@@ -124,6 +126,8 @@ readonly class BandSpaceFileAttachProcessor implements ProcessorInterface
         if (!$task instanceof \App\Entity\BandSpace\Task) {
             throw new NotFoundHttpException('Tâche introuvable');
         }
+
+        $this->taskWriteGuard->assertWritable($task);
 
         return $task->title;
     }

--- a/src/State/Processor/BandSpace/File/BandSpaceTaskFileAttachProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceTaskFileAttachProcessor.php
@@ -16,6 +16,7 @@ use App\Repository\BandSpace\BandSpaceFileTagRepository;
 use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Repository\BandSpace\TaskRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\TaskWriteGuard;
 use App\EventListener\BandSpaceFileQuotaApproachingHeaderListener;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\File\BandSpaceFileMimeAllowlist;
@@ -39,6 +40,7 @@ readonly class BandSpaceTaskFileAttachProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private TaskWriteGuard $taskWriteGuard,
         private TaskRepository $taskRepository,
         private BandSpaceFolderRepository $folderRepository,
         private BandSpaceFileTagRepository $tagRepository,
@@ -64,6 +66,10 @@ readonly class BandSpaceTaskFileAttachProcessor implements ProcessorInterface
         if (!$task instanceof \App\Entity\BandSpace\Task) {
             throw new NotFoundHttpException('Tâche introuvable');
         }
+
+        // Refused before the upload is stored or the quota is touched: this is the second door onto
+        // the same attachment, the one that uploads instead of reusing an existing file.
+        $this->taskWriteGuard->assertWritable($task);
 
         $upload = $data->uploadedFile;
         if ($upload === null) {

--- a/src/State/Processor/BandSpace/TaskCommentCreateProcessor.php
+++ b/src/State/Processor/BandSpace/TaskCommentCreateProcessor.php
@@ -14,6 +14,7 @@ use App\Event\BandSpaceTaskCommentedEvent;
 use App\Event\BandSpaceTaskMentionedEvent;
 use App\Repository\BandSpace\TaskRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\TaskWriteGuard;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\TaskCommentMentionRecorder;
 use App\Service\Builder\BandSpace\TaskCommentBuilder;
@@ -37,6 +38,7 @@ readonly class TaskCommentCreateProcessor implements ProcessorInterface
         private TaskCommentBuilder $taskCommentBuilder,
         private Security $security,
         private EventDispatcherInterface $eventDispatcher,
+        private TaskWriteGuard $taskWriteGuard,
     ) {
     }
 
@@ -56,6 +58,10 @@ readonly class TaskCommentCreateProcessor implements ProcessorInterface
         if (!$task instanceof \App\Entity\BandSpace\Task) {
             throw new NotFoundHttpException('Tâche introuvable');
         }
+
+        // The thread of an archived task is history: still read, never added to. The drawer hides
+        // the composer, so a comment arriving here at all means the call bypassed it.
+        $this->taskWriteGuard->assertWritable($task);
 
         $comment = new TaskComment();
         $comment->task = $task;

--- a/tests/Api/BandSpace/File/BandSpaceFileAttachExistingTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileAttachExistingTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Api\BandSpace\File;
 
 use App\Enum\BandSpace\FinanceEntryScope;
+use App\Enum\BandSpace\TaskStatus;
 use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Tests\ApiTestAssertionsTrait;
@@ -210,5 +211,48 @@ class BandSpaceFileAttachExistingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * Same rule as the archived song and the archived setlist, one module over: a task the band has
+     * closed takes no new document, while detaching one already attached stays possible.
+     */
+    public function test_attach_existing_to_an_archived_task_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Done,
+            'archiveDatetime' => new \DateTimeImmutable('2026-04-01 10:00:00'),
+        ])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/' . $file->id . '/attach',
+            ['sourceType' => 'task', 'sourceId' => $task->id],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+        ]);
+
+        $fileRepo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $attachmentRepo = self::getContainer()->get(BandSpaceFileAttachmentRepository::class);
+        $this->assertNull($attachmentRepo->findOneByFileAndSource($fileRepo->find($file->id), 'task', $task->id));
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceTaskFileAttachTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceTaskFileAttachTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Api\BandSpace\File;
 
 use App\Entity\BandSpace\BandSpaceFile;
+use App\Enum\BandSpace\TaskStatus;
 use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Tests\ApiTestAssertionsTrait;
@@ -118,5 +119,52 @@ class BandSpaceTaskFileAttachTest extends ApiTestCase
             'type' => '/errors/403',
             'description' => "Vous n'êtes pas membre de ce Band Space",
         ]);
+    }
+
+    /**
+     * The second door onto a task attachment: this one uploads instead of reusing an existing file,
+     * and an archived task refuses it before anything is stored or the quota is touched.
+     */
+    public function test_upload_to_an_archived_task_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Mix master',
+            'status' => TaskStatus::Done,
+            'archiveDatetime' => new \DateTimeImmutable('2026-04-01 10:00:00'),
+        ])->create();
+
+        $upload = new UploadedFile(__DIR__ . '/fixtures/sample.txt', 'sample.txt', 'text/plain', null, true);
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id . '/files',
+            [],
+            ['uploadedFile' => $upload],
+            ['CONTENT_TYPE' => 'multipart/form-data'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+        ]);
+
+        $this->assertCount(
+            0,
+            self::getContainer()->get(BandSpaceFileRepository::class)->findBy(['bandSpace' => $bandSpace->id]),
+        );
     }
 }

--- a/tests/Api/BandSpace/Task/TaskCommentCreateTest.php
+++ b/tests/Api/BandSpace/Task/TaskCommentCreateTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Api\BandSpace\Task;
 
 use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\TaskStatus;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\TaskCommentRepository;
 use App\Tests\ApiTestAssertionsTrait;
@@ -166,5 +167,47 @@ class TaskCommentCreateTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * The drawer hides the composer on an archived task and calls it read-only, so the server has
+     * to mean it: the thread of a closed record is still read, never added to.
+     */
+    public function test_comment_on_an_archived_task_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Done,
+            'archiveDatetime' => new \DateTimeImmutable('2026-04-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/' . $task->id . '/comments',
+            ['content' => 'Un mot après coup'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+        ]);
+
+        $this->assertCount(0, self::getContainer()->get(TaskCommentRepository::class)->findByTask($task));
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findForResource($bandSpace, BandSpaceModule::Task, $task->id));
     }
 }

--- a/tests/Api/BandSpace/Task/TaskMoveTest.php
+++ b/tests/Api/BandSpace/Task/TaskMoveTest.php
@@ -411,4 +411,116 @@ class TaskMoveTest extends ApiTestCase
         $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
         $this->assertCount(0, $activityRepo->findForResource($bandSpace, BandSpaceModule::Task, $moved->id));
     }
+
+    /**
+     * Archiving demands a task be done, so a move back to todo would leave the archive holding
+     * something it would have refused to take in. The board never renders an archived card as
+     * draggable, which is why only a hand-crafted call reaches this.
+     */
+    public function test_move_an_archived_task_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $archived = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Done,
+            'position' => 3,
+            'archiveDatetime' => new \DateTimeImmutable('2026-04-01 10:00:00'),
+        ])->create();
+
+        $archivedId = (string) $archived->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/move',
+            [
+                'task_id' => $archivedId,
+                'status' => 'todo',
+                'positions' => [
+                    ['id' => $archivedId, 'position' => 0],
+                ],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $refreshed = $taskRepo->find($archivedId);
+        $this->assertSame(TaskStatus::Done, $refreshed->status);
+        $this->assertSame(3, $refreshed->position);
+        $this->assertNotNull($refreshed->archiveDatetime);
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findForResource($bandSpace, BandSpaceModule::Task, $archivedId));
+    }
+
+    /**
+     * The append form skips the column-membership check entirely, so the refusal cannot depend on
+     * an ordering being sent.
+     */
+    public function test_move_an_archived_task_without_positions_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $archived = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Done,
+            'position' => 3,
+            'archiveDatetime' => new \DateTimeImmutable('2026-04-01 10:00:00'),
+        ])->create();
+
+        $archivedId = (string) $archived->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/move',
+            [
+                'task_id' => $archivedId,
+                'status' => 'in_progress',
+                'positions' => [],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Une tâche archivée est en lecture seule, désarchivez-la pour la modifier',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        \Zenstruck\Foundry\Persistence\refresh($bandSpace);
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $refreshed = $taskRepo->find($archivedId);
+        $this->assertSame(TaskStatus::Done, $refreshed->status);
+        $this->assertSame(3, $refreshed->position);
+        $this->assertNotNull($refreshed->archiveDatetime);
+    }
 }

--- a/tests/Api/BandSpace/Task/TaskReorderTest.php
+++ b/tests/Api/BandSpace/Task/TaskReorderTest.php
@@ -255,6 +255,62 @@ class TaskReorderTest extends ApiTestCase
         $this->assertSame(2, $taskRepo->find($archivedId)->position);
     }
 
+    /**
+     * Reorder is the one write path onto a Task that TaskWriteGuard does not cover, because it is
+     * already refused: assertCoversColumn compares the payload against findActiveColumn, which
+     * filters archived tasks out, so naming one is a set mismatch. That protection is a side
+     * effect of a rule written for stale filtered boards, not a decision about archived tasks, so
+     * it would disappear silently if the guard ever moved from exact-set to subset semantics.
+     */
+    public function test_reorder_refuses_a_payload_naming_an_archived_task(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $active = TaskFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'status' => TaskStatus::Todo, 'position' => 0])->create();
+        $archived = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'status' => TaskStatus::Todo,
+            'position' => 1,
+            'archiveDatetime' => new \DateTimeImmutable('-1 day'),
+        ])->create();
+
+        $activeId = (string) $active->id;
+        $archivedId = (string) $archived->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/tasks/reorder',
+            [
+                'positions' => [
+                    ['id' => $archivedId, 'position' => 0],
+                    ['id' => $activeId, 'position' => 1],
+                ],
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Les positions doivent couvrir exactement les tâches de cette colonne',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Les positions doivent couvrir exactement les tâches de cette colonne',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $taskRepo = self::getContainer()->get(TaskRepository::class);
+        $this->assertSame(0, $taskRepo->find($activeId)->position);
+        $this->assertSame(1, $taskRepo->find($archivedId)->position);
+    }
+
     public function test_reorder_rejects_non_contiguous_positions(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();


### PR DESCRIPTION
Closes #874. Closes #875.

Both issues are the same invariant seen from two sides, and both need the archived check extracted out of `TaskUpdateProcedure`, so they are fixed together rather than stacked.

#869 made an archived task read only for its own fields and the drawer says « cette tâche est archivée, elle est en lecture seule ». The API did not keep that promise. Reproduced before the fix:

- `POST /tasks/move` on an archived task returned 200 with `"status":"todo"` while `archive_datetime` stayed set, breaking archived-implies-done.
- `POST` a comment on an archived task returned 201.

## What changed

`TaskUpdateProcedure`'s private archived check becomes `src/Security/BandSpace/TaskWriteGuard.php`, shaped after `SongWriteGuard` and `SetlistWriteGuard`, with two methods because the two rules genuinely differ:

- `assertWritable()` refuses every write. Used by move, comment create and both attach paths.
- `assertWritableForPayload()` allows a payload whose only key is `archived`, which is what keeps unarchiving possible.

Collapsing those into one method would have broken unarchiving, so the extraction was verified as behaviour preserving by truth table over both boolean inputs, and all four quadrants are already covered by existing tests.

## Two things the issues got wrong

**#874 says the move endpoint is one door. It is two.** With `positions`, the archived task arrives as the `joiningTaskId`, so `TaskColumnPositionsGuard::assertCoversColumn` adds it to the expected set and lets it through. With `positions: []` the column guard is skipped entirely. Both are covered.

**#875 names two processors. There is a third.** `BandSpaceTaskFileAttachProcessor` (`POST /tasks/{taskId}/files`, the upload and attach path) also had no guard, so fixing only the two named ones would have left the issue's own claim, that a file can still be attached to an archived task, still true. Its guard sits before the mime, size and quota checks, so a refused upload stores nothing.

**#874's write path enumeration was also short.** The full map is three paths writing Task fields, plus five writing to entities attached to a Task.

`TaskReorderProcessor` is the one Task write path deliberately left unguarded, because it is already refused: `assertCoversColumn` compares the payload against `findActiveColumn`, which filters archived tasks out, so naming one is a set mismatch. That protection is a side effect of a rule written for stale filtered boards, not a decision about archived tasks, and nothing pinned it. A regression test now does.

## Deliberately not included

Comment edit and delete, and file detach, on an archived task are still accepted by the API. The decision here was to refuse comments and attachments, which are the create doors. Removal operations do not touch the task's own fields and match the existing Song and Setlist precedent for detach. The frontend already hides all three. Worth a product conversation if « lecture seule » is meant to freeze the whole history rather than block new writes.

## Note on the status code

`TaskWriteGuard` answers 422 while the four sibling guards answer 409. That is deliberate and documented in its docblock: 422 is what the task PATCH has returned since #869, and one invariant on one entity should not answer differently depending on which endpoint you hit. No frontend branches on 409 for any of these, so there is no live inconsistency, but it does make this guard the outlier of the shape.

## Testing

6 tests added, each proven to fail without the src changes. All assert the full 422 body inline and re-query the database to prove nothing was written, including a file count of 0 on the upload path so no orphan file is left.

The unarchive path is protected by 6 pre-existing tests, re-run green.

`tests/Api/BandSpace/` 1064 green, full suite 2308 green, PHPStan level 8 clean.
