### PR TITLE
fix(M-873): resolve a single activity on the band space item route

### DIFF
--- a/src/ApiResource/BandSpace/BandSpaceActivityResource.php
+++ b/src/ApiResource/BandSpace/BandSpaceActivityResource.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\Provider\BandSpace\BandSpaceActivityCollectionProvider;
+use App\State\Provider\BandSpace\BandSpaceActivityItemProvider;
 
 #[ApiResource(
     shortName: 'BandSpaceActivity',
@@ -35,7 +36,7 @@ use App\State\Provider\BandSpace\BandSpaceActivityCollectionProvider;
             openapi: new Operation(tags: ['Band Space Activity']),
             security: "is_granted('ROLE_USER')",
             name: 'api_band_space_activities_get_item',
-            provider: BandSpaceActivityCollectionProvider::class,
+            provider: BandSpaceActivityItemProvider::class,
         ),
     ],
     normalizationContext: ['skip_null_values' => false],

--- a/src/Repository/BandSpace/BandSpaceActivityRepository.php
+++ b/src/Repository/BandSpace/BandSpaceActivityRepository.php
@@ -10,6 +10,7 @@ use App\Service\BandSpace\BandSpaceActivityFilter;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
 /**
@@ -68,6 +69,29 @@ class BandSpaceActivityRepository extends ServiceEntityRepository
             ->setParameter('actor', $actor)
             ->orderBy('a.creationDatetime', 'DESC')
             ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * Scoped by band space so an activity id belonging to another space resolves to null
+     * rather than leaking that row. The uuid check only short circuits an id that cannot match
+     * anything: a QueryBuilder lookup already returns null on a malformed id, unlike find() and
+     * findOneBy(), which coerce the identifier through the field type first and do throw.
+     */
+    public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?BandSpaceActivity
+    {
+        if (!Uuid::isValid($id)) {
+            return null;
+        }
+
+        return $this->createQueryBuilder('a')
+            ->addSelect('u')
+            ->leftJoin('a.actor', 'u')
+            ->where('a.id = :id')
+            ->andWhere('a.bandSpace = :bandSpace')
+            ->setParameter('id', $id)
+            ->setParameter('bandSpace', $bandSpace)
             ->getQuery()
             ->getOneOrNullResult();
     }

--- a/src/State/Provider/BandSpace/BandSpaceActivityItemProvider.php
+++ b/src/State/Provider/BandSpace/BandSpaceActivityItemProvider.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\BandSpaceActivityResource;
+use App\Entity\BandSpace\BandSpaceActivity;
+use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\BandSpaceActivityBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * The item route used to share the collection provider, which reads only bandSpaceId, so it answered
+ * every single-activity request with the whole paginated feed. The DTO is built through
+ * BandSpaceActivityBuilder so the payload keeps going through ActivityPayloadMask.
+ *
+ * @implements ProviderInterface<BandSpaceActivityResource>
+ */
+readonly class BandSpaceActivityItemProvider implements ProviderInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private BandSpaceActivityRepository $bandSpaceActivityRepository,
+        private BandSpaceActivityBuilder $bandSpaceActivityBuilder,
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): BandSpaceActivityResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // Same membership check as the collection: the feed is open to every member, not just admins.
+        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+
+        $activity = $this->bandSpaceActivityRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$activity instanceof BandSpaceActivity) {
+            throw new NotFoundHttpException('Activité introuvable');
+        }
+
+        return $this->bandSpaceActivityBuilder->buildItem($activity);
+    }
+}

--- a/tests/Api/BandSpace/BandSpaceActivityItemTest.php
+++ b/tests/Api/BandSpace/BandSpaceActivityItemTest.php
@@ -1,0 +1,289 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceActivityFactory;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * #873: the item route was wired to the collection provider, which only reads bandSpaceId, so it
+ * answered every single-activity request with the whole paginated feed instead of the row asked for.
+ */
+#[ResetDatabase]
+class BandSpaceActivityItemTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_member_reads_a_single_activity(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $wanted = BandSpaceActivityFactory::new([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Task,
+            'type' => 'status_changed',
+            'actor' => $admin,
+            'payload' => ['from' => 'todo', 'to' => 'done'],
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+
+        // A second row in the same space: the response must not carry it.
+        BandSpaceActivityFactory::new([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Finance,
+            'type' => 'entry_created',
+            'actor' => $admin,
+            'payload' => ['label' => 'Studio'],
+            'creationDatetime' => new \DateTime('2026-04-02 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($member);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/activities/' . $wanted->id,
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceActivity',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/activities/' . $wanted->id,
+            '@type' => 'BandSpaceActivity',
+            'id' => $wanted->id,
+            'band_space_id' => $bandSpace->id,
+            'module' => 'task',
+            'resource_id' => null,
+            'type' => 'status_changed',
+            'payload' => ['from' => 'todo', 'to' => 'done'],
+            'actor' => [
+                'id' => $admin->id,
+                'username' => $admin->username,
+                'profile_picture_url' => null,
+            ],
+            'creation_datetime' => '2026-04-01T10:00:00+00:00',
+        ]);
+    }
+
+    /**
+     * #866 masking has to survive on this route too: the item DTO is built by BandSpaceActivityBuilder,
+     * so the invitee address goes through ActivityPayloadMask exactly as it does in the feed.
+     */
+    public function test_an_invitee_email_is_masked_on_the_item_route(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+
+        $activity = BandSpaceActivityFactory::new([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Settings,
+            'type' => 'invitation_sent',
+            'actor' => $admin,
+            'payload' => ['email' => 'john.doe@gmail.com', 'invited_user_id' => null, 'invited_username' => null],
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($member);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/activities/' . $activity->id,
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceActivity',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/activities/' . $activity->id,
+            '@type' => 'BandSpaceActivity',
+            'id' => $activity->id,
+            'band_space_id' => $bandSpace->id,
+            'module' => 'settings',
+            'resource_id' => null,
+            'type' => 'invitation_sent',
+            'payload' => [
+                'email' => 'j***@gmail.com',
+                'invited_user_id' => null,
+                'invited_username' => null,
+            ],
+            'actor' => [
+                'id' => $admin->id,
+                'username' => $admin->username,
+                'profile_picture_url' => null,
+            ],
+            'creation_datetime' => '2026-04-01T10:00:00+00:00',
+        ]);
+        $this->assertStringNotContainsString('john.doe@gmail.com', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function test_an_activity_of_another_band_space_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $mine = BandSpaceFactory::new()->create();
+        $other = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $mine, 'user' => $user, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $other, 'user' => $user, 'role' => Role::Admin])->create();
+
+        $foreign = BandSpaceActivityFactory::new([
+            'bandSpace' => $other,
+            'module' => BandSpaceModule::Settings,
+            'type' => 'invitation_sent',
+            'actor' => $user,
+            'payload' => ['email' => 'john.doe@gmail.com', 'invited_user_id' => null, 'invited_username' => null],
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $mine->id . '/activities/' . $foreign->id,
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Activité introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Activité introuvable',
+        ]);
+    }
+
+    public function test_an_unknown_activity_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user, 'role' => Role::Admin])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/activities/2fd0c2a2-6b02-4f14-8c8a-90e2a5b6a1d3',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Activité introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Activité introuvable',
+        ]);
+    }
+
+    /**
+     * A non-uuid id must not reach the uuid column, where it would raise ValueNotConvertible and 500.
+     */
+    public function test_a_malformed_activity_id_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user, 'role' => Role::Admin])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/activities/not-a-uuid',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Activité introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Activité introuvable',
+        ]);
+    }
+
+    public function test_non_member_forbidden(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create();
+        $owner = UserFactory::new()->create(['username' => 'owner', 'email' => 'owner@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner, 'role' => Role::Admin])->create();
+
+        $activity = BandSpaceActivityFactory::new([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Task,
+            'type' => 'status_changed',
+            'actor' => $owner,
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($stranger);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/activities/' . $activity->id,
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+        ]);
+    }
+
+    public function test_anonymous_unauthorized(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner, 'role' => Role::Admin])->create();
+
+        $activity = BandSpaceActivityFactory::new([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Task,
+            'type' => 'status_changed',
+            'actor' => $owner,
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/activities/' . $activity->id,
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
+    }
+}


### PR DESCRIPTION
Closes #873.

`BandSpaceActivityResource` declared both `GetCollection` and `Get` and wired both to `BandSpaceActivityCollectionProvider`, which only ever reads `uriVariables['bandSpaceId']`. Reproduced before the fix: `GET /band_spaces/{id}/activities/{id}` returned 200 with `"@type":"Collection"`, `totalItems: 2` and every row in the space.

## Why the item operation was kept rather than deleted

The issue suggests dropping `Get` if nothing consumes it, and nothing does. That was tested rather than assumed, and it is the wrong fix.

Removing the operation degrades the collection members' `@id` from `/api/band_spaces/{bandSpaceId}/activities/{id}` to `/api/band_space_activities/id={id};bandSpaceId={bandSpaceId}`, a route that does not exist. It fails the existing full-body test in `BandSpaceActivityCollectionTest`, which is the only one of that file's ten tests asserting down to `@id`.

So the item operation is load-bearing for the collection's IRIs regardless of whether anything calls it. It gets a real provider instead.

## What changed

- `BandSpaceActivityItemProvider` resolves the single row. Its authorization mirrors the collection provider exactly: same check, same order, same exceptions.
- `BandSpaceActivityRepository::findOneByIdAndBandSpace()`, scoped by band space so a row from another space resolves to null. It joins the actor so the builder does not fire a second query.
- The `Get` operation points at the new provider.

The masking guarantee from #866 survives structurally rather than by convention: the provider returns `BandSpaceActivityBuilder::buildItem()`, which is the same method `buildFromList()` already calls for every collection row, so there is no second implementation to drift. No builder file is touched, so `BandSpaceActivityPayloadMaskCoverageTest` stays meaningful.

A row in another space and a row that does not exist produce byte-identical 404 bodies, so the item route cannot be used to probe for existence. A non-member gets 403 before the repository is queried at all.

## Testing

7 tests, each asserting the full body inline, including all three 404 shapes plus 403 and 401. The cross-space test deliberately makes the user a legitimate admin of both spaces, so it isolates the row-scoping guarantee from the membership one instead of conflating them.

Reversing only the `src/` hunks fails 5 of the 7. The 2 that still pass are the pure auth gates, which the shared provider already handled correctly.

Full suite 2310 green, PHPStan level 8 clean.
