### PR TITLE
fix(M-858): refuse turning a finance entry or recurrence personal while splits exist

### DIFF
--- a/assets/js/components/BandSpace/Finance/FinanceDrawer.vue
+++ b/assets/js/components/BandSpace/Finance/FinanceDrawer.vue
@@ -212,6 +212,7 @@ import Select from 'primevue/select'
 import SelectButton from 'primevue/selectbutton'
 import { useConfirm } from 'primevue/useconfirm'
 import { computed, nextTick, reactive, ref, watch } from 'vue'
+import { ERROR_CODES } from '../../../constants/errorCodes.js'
 import { useBandSpaceFinanceStore } from '../../../store/bandSpace/bandSpaceFinance.js'
 import { attachedFilesNotice } from '../../../utils/attachedFilesNotice.js'
 import { centsToCurrency, currencyToCents } from '../../../utils/currency.js'
@@ -480,8 +481,25 @@ async function handleSave() {
 
     emit('saved')
   } catch (error) {
+    await restoreScopeIfSplitsBlockedIt(error)
     formError.value = error.message || 'Impossible d\u2019enregistrer l\u2019entrée'
   }
+}
+
+/**
+ * The refusal asks for the répartition to be cleared first, but the SplitManager only renders on a band
+ * entry: left on « Personnel », the drawer would show the instruction with nothing to act on. Putting
+ * the select back brings the splits into view, already expanded.
+ */
+async function restoreScopeIfSplitsBlockedIt(error) {
+  const blockedBySplits = (error.violationsByField?.scope ?? []).some(
+    (violation) => violation.code === ERROR_CODES.PERSONAL_SCOPE_WITH_SPLITS
+  )
+  if (!blockedBySplits) return
+
+  form.scope = 'band'
+  await nextTick()
+  await splitManagerRef.value?.reset(props.entry?.id ?? null)
 }
 
 function handleDelete() {

--- a/assets/js/constants/errorCodes.js
+++ b/assets/js/constants/errorCodes.js
@@ -4,5 +4,6 @@
  */
 export const ERROR_CODES = {
   EXISTING_VIDEO: 'music_all_99153e73-dd44-4557-90aa-3c0e354fce62',
+  PERSONAL_SCOPE_WITH_SPLITS: 'music_all_02e21b18-a797-46ed-83a2-aaacf5ee1992',
   SELF_RECIPIENT: 'music_all_b8c3e2f1-5a4d-4e6b-9c7f-1a2b3c4d5e6f'
 }

--- a/src/ApiResource/BandSpace/Finance/FinanceEntryResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceEntryResource.php
@@ -16,6 +16,7 @@ use App\State\Processor\BandSpace\FinanceEntryUpdateProcessor;
 use App\State\Provider\BandSpace\FinanceEntryCollectionProvider;
 use App\State\Provider\BandSpace\FinanceEntryItemProvider;
 use App\Validator\BandSpace\FinanceAmountRange;
+use App\Validator\BandSpace\PersonalScopeWithoutSplits;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -27,6 +28,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * failed inside new DateTime().
  */
 #[FinanceAmountRange]
+#[PersonalScopeWithoutSplits]
 #[ApiResource(
     shortName: 'FinanceEntry',
     operations: [

--- a/src/ApiResource/BandSpace/Finance/FinanceRecurrenceResource.php
+++ b/src/ApiResource/BandSpace/Finance/FinanceRecurrenceResource.php
@@ -14,10 +14,12 @@ use App\State\Processor\BandSpace\FinanceRecurrenceDeleteProcessor;
 use App\State\Processor\BandSpace\FinanceRecurrenceUpdateProcessor;
 use App\State\Provider\BandSpace\FinanceRecurrenceCollectionProvider;
 use App\State\Provider\BandSpace\FinanceRecurrenceItemProvider;
+use App\Validator\BandSpace\PersonalScopeWithoutSplits;
 use App\Validator\BandSpace\RecurrenceEndDate;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[RecurrenceEndDate]
+#[PersonalScopeWithoutSplits]
 #[ApiResource(
     shortName: 'FinanceRecurrence',
     operations: [

--- a/src/Repository/BandSpace/FinanceEntrySplitRepository.php
+++ b/src/Repository/BandSpace/FinanceEntrySplitRepository.php
@@ -86,6 +86,23 @@ class FinanceEntrySplitRepository extends ServiceEntityRepository
         return $sums;
     }
 
+    /**
+     * @param FinanceEntry[] $entries
+     */
+    public function countByEntries(array $entries): int
+    {
+        if (\count($entries) === 0) {
+            return 0;
+        }
+
+        return (int) $this->createQueryBuilder('s')
+            ->select('COUNT(s.id)')
+            ->where('s.entry IN (:entries)')
+            ->setParameter('entries', array_map(fn (FinanceEntry $e): string => (string) $e->id, $entries))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
     public function getSumByEntry(FinanceEntry $entry): int
     {
         $result = $this->createQueryBuilder('s')

--- a/src/Validator/BandSpace/PersonalScopeWithoutSplits.php
+++ b/src/Validator/BandSpace/PersonalScopeWithoutSplits.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\Validator\BandSpace;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class PersonalScopeWithoutSplits extends Constraint
+{
+    public string $message = 'Supprimez d\'abord la répartition de cette entrée pour la passer en personnelle.';
+    public string $recurrenceMessage = 'Supprimez d\'abord la répartition des échéances de cette récurrence pour la passer en personnelle.';
+
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/BandSpace/PersonalScopeWithoutSplitsValidator.php
+++ b/src/Validator/BandSpace/PersonalScopeWithoutSplitsValidator.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace App\Validator\BandSpace;
+
+use App\ApiResource\BandSpace\Finance\FinanceEntryResource;
+use App\ApiResource\BandSpace\Finance\FinanceRecurrenceResource;
+use App\Entity\BandSpace\FinanceEntry;
+use App\Entity\BandSpace\FinanceRecurrence;
+use App\Enum\BandSpace\FinanceEntryScope;
+use App\Repository\BandSpace\FinanceEntryRepository;
+use App\Repository\BandSpace\FinanceEntrySplitRepository;
+use App\Repository\BandSpace\FinanceRecurrenceRepository;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * The mirror of SplitNotPersonal, which refuses a split on an entry that is already personal. Without
+ * this one the same state was reachable in reverse: split a band entry between members, then turn the
+ * entry personal. The splits stayed behind, naming members who could no longer see the entry they
+ * belonged to and still weighing on their contribution total.
+ *
+ * Two write paths reach that flip, so both are guarded here. A recurrence PATCH pushes the series scope
+ * onto every forecast it still owns, which turns those entries personal without ever touching the entry
+ * endpoint.
+ */
+class PersonalScopeWithoutSplitsValidator extends ConstraintValidator
+{
+    public const string ERROR_CODE = 'music_all_02e21b18-a797-46ed-83a2-aaacf5ee1992';
+
+    public function __construct(
+        private readonly FinanceEntryRepository $entryRepository,
+        private readonly FinanceRecurrenceRepository $recurrenceRepository,
+        private readonly FinanceEntrySplitRepository $splitRepository,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof PersonalScopeWithoutSplits) {
+            throw new UnexpectedTypeException($constraint, PersonalScopeWithoutSplits::class);
+        }
+
+        if (!$value instanceof FinanceEntryResource && !$value instanceof FinanceRecurrenceResource) {
+            return;
+        }
+
+        if (!isset($value->id, $value->scope) || $value->scope !== FinanceEntryScope::Personal->value) {
+            return;
+        }
+
+        if ($value instanceof FinanceEntryResource) {
+            $this->validateEntry($value->id, $constraint);
+
+            return;
+        }
+
+        $this->validateRecurrence($value->id, $constraint);
+    }
+
+    private function validateEntry(string $entryId, PersonalScopeWithoutSplits $constraint): void
+    {
+        $entry = $this->entryRepository->find($entryId);
+
+        // Only the transition is refused. An entry that is already personal stays editable even if rows
+        // written before this rule left splits on it, otherwise a PATCH of its libellé would be refused
+        // by a rule it can do nothing about.
+        if (!$entry instanceof FinanceEntry || $entry->scope !== FinanceEntryScope::Band) {
+            return;
+        }
+
+        if ($this->splitRepository->countByEntries([$entry]) > 0) {
+            $this->addViolation($constraint->message);
+        }
+    }
+
+    private function validateRecurrence(string $recurrenceId, PersonalScopeWithoutSplits $constraint): void
+    {
+        $recurrence = $this->recurrenceRepository->find($recurrenceId);
+
+        if (!$recurrence instanceof FinanceRecurrence || $recurrence->scope !== FinanceEntryScope::Band) {
+            return;
+        }
+
+        // Exactly the forecasts FinanceRecurrenceUpdateProcessor::syncFutureForecasts() would rewrite:
+        // a split sitting on an occurrence the edit leaves alone is no reason to refuse the edit.
+        $forecasts = $this->entryRepository->findPlannedByRecurrenceAfter($recurrence, new \DateTime());
+
+        if ($this->splitRepository->countByEntries($forecasts) > 0) {
+            $this->addViolation($constraint->recurrenceMessage);
+        }
+    }
+
+    private function addViolation(string $message): void
+    {
+        $this->context->buildViolation($message)
+            ->atPath('scope')
+            ->setCode(self::ERROR_CODE)
+            ->addViolation();
+    }
+}

--- a/tests/Api/BandSpace/Finance/FinanceEntryUpdateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceEntryUpdateTest.php
@@ -18,8 +18,10 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
 use App\Tests\Factory\BandSpace\FinanceEntryFactory;
+use App\Tests\Factory\BandSpace\FinanceEntrySplitFactory;
 use App\Tests\Factory\User\UserFactory;
 use App\Validator\BandSpace\FinanceAmountRangeValidator;
+use App\Validator\BandSpace\PersonalScopeWithoutSplitsValidator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints\Choice;
@@ -1000,5 +1002,211 @@ class FinanceEntryUpdateTest extends ApiTestCase
             'type' => '/validation_errors/' . Choice::NO_SUCH_CHOICE_ERROR,
             'title' => 'An error occurred',
         ]);
+    }
+
+    /**
+     * The flip was the one way to reach a personal entry carrying splits: creating a split on an entry
+     * that is already personal is refused by SplitNotPersonal. Left open, it turned shared accounting
+     * into a private row while the splits stayed behind, naming members who could no longer see the
+     * entry they belonged to and still weighing on their contribution total.
+     */
+    public function test_update_entry_scope_to_personal_is_refused_while_splits_exist(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $otherMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        FinanceEntrySplitFactory::new(['entry' => $entry, 'member' => $otherMembership, 'amount' => 25000])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['scope' => 'personal'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . PersonalScopeWithoutSplitsValidator::ERROR_CODE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'scope',
+                    'message' => 'Supprimez d\'abord la répartition de cette entrée pour la passer en personnelle.',
+                    'code' => PersonalScopeWithoutSplitsValidator::ERROR_CODE,
+                ],
+            ],
+            'detail' => 'scope: Supprimez d\'abord la répartition de cette entrée pour la passer en personnelle.',
+            'description' => 'scope: Supprimez d\'abord la répartition de cette entrée pour la passer en personnelle.',
+            'type' => '/validation_errors/' . PersonalScopeWithoutSplitsValidator::ERROR_CODE,
+            'title' => 'An error occurred',
+        ]);
+
+        $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
+        $this->assertSame(FinanceEntryScope::Band, $entryRepository->find($entry->id)->scope);
+    }
+
+    /** The refusal is the transition, not the scope: nothing to strand means nothing to refuse. */
+    public function test_update_entry_scope_to_personal_is_allowed_without_splits(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['scope' => 'personal'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
+        $updatedEntry = $entryRepository->find($entry->id);
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/FinanceEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            '@type' => 'FinanceEntry',
+            'id' => $entry->id,
+            'band_space_id' => $bandSpace->id,
+            'category_id' => $category->id,
+            'category_name' => 'Studio',
+            'label' => 'Mixage',
+            'type' => 'expense',
+            'status' => 'planned',
+            'amount' => 50000,
+            'amount_min' => null,
+            'amount_max' => null,
+            'date' => '2024-01-15',
+            'scope' => 'personal',
+            'member_id' => $membership->id,
+            'member_name' => 'base_admin',
+            'recurrence_id' => null,
+            'is_former_member' => false,
+            'split_warning' => false,
+            'creation_datetime' => '2024-02-01T10:00:00+00:00',
+            'update_datetime' => $updatedEntry->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /** The other direction widens who may see the entry, so it stays open. */
+    public function test_update_entry_scope_from_personal_to_band_is_allowed(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+
+        $entry = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Mon achat perso',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Personal,
+            'amount' => 50000,
+            'member' => $membership,
+            'date' => new \DateTime('2024-01-15'),
+            'creationDatetime' => new \DateTime('2024-02-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['scope' => 'band'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
+        $this->assertSame(FinanceEntryScope::Band, $entryRepository->find($entry->id)->scope);
+    }
+
+    /**
+     * The guard watches the band to personal transition, not the personal scope itself. An entry
+     * stranded before this rule existed still carries splits, and the drawer sends scope on every
+     * save, so guarding the scope rather than the change would leave those entries uneditable with
+     * no way out: the split UI is hidden on a personal entry, so the user cannot clear what blocks
+     * them. The early return this pins reads as redundant until you know that.
+     */
+    public function test_update_a_personal_entry_that_already_carries_splits_is_allowed(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $otherMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+
+        $entry = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Entrée héritée',
+            'type' => FinanceEntryType::Expense,
+            'status' => FinanceEntryStatus::Planned,
+            'scope' => FinanceEntryScope::Personal,
+            'amount' => 50000,
+            'member' => $membership,
+            'date' => new \DateTime('2024-01-15'),
+            'creationDatetime' => new \DateTime('2024-02-01 10:00:00'),
+        ])->create();
+        FinanceEntrySplitFactory::new(['entry' => $entry, 'member' => $otherMembership, 'amount' => 25000])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['label' => 'Entrée héritée renommée', 'scope' => 'personal'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
+        $saved = $entryRepository->find($entry->id);
+        $this->assertSame('Entrée héritée renommée', $saved->label);
+        $this->assertSame(FinanceEntryScope::Personal, $saved->scope);
+    }
+
+    /**
+     * A band entry carrying splits stays fully editable: the drawer sends the whole form on every save,
+     * so scope: band travels with a libellé change and must not be read as a transition.
+     */
+    public function test_update_entry_with_splits_is_untouched_when_the_scope_does_not_change(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $otherMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other])->create();
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio', 'position' => 0])->create();
+        $entry = $this->createPlannedEntry($category);
+
+        FinanceEntrySplitFactory::new(['entry' => $entry, 'member' => $otherMembership, 'amount' => 25000])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/finance/entries/' . $entry->id,
+            ['label' => 'Mixage final', 'scope' => 'band'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $entryRepository = self::getContainer()->get(FinanceEntryRepository::class);
+        $this->assertSame('Mixage final', $entryRepository->find($entry->id)->label);
     }
 }

--- a/tests/Api/BandSpace/Finance/FinanceRecurrenceUpdateTest.php
+++ b/tests/Api/BandSpace/Finance/FinanceRecurrenceUpdateTest.php
@@ -24,8 +24,10 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
 use App\Tests\Factory\BandSpace\FinanceEntryFactory;
+use App\Tests\Factory\BandSpace\FinanceEntrySplitFactory;
 use App\Tests\Factory\BandSpace\FinanceRecurrenceFactory;
 use App\Tests\Factory\User\UserFactory;
+use App\Validator\BandSpace\PersonalScopeWithoutSplitsValidator;
 use App\Validator\BandSpace\RecurrenceEndDateValidator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -750,6 +752,69 @@ class FinanceRecurrenceUpdateTest extends ApiTestCase
             $this->assertSame(FinanceEntryScope::Personal, $entry->scope);
             $this->assertSame($ownerMembershipId, (string) $entry->member->id, $entry->date->format('Y-m-d'));
         }
+    }
+
+    /**
+     * The second way into the state #858 is about: the entry PATCH refuses the flip while splits exist,
+     * and this one propagates the recurrence's scope onto its future forecasts, splits included. Refused
+     * whole rather than per entry, because the recurrence and the forecasts it owns must not disagree.
+     */
+    public function test_turning_a_recurrence_personal_is_refused_while_a_forecast_carries_splits(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+        $otherMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other])->create();
+
+        $category = $this->createCategory($bandSpace);
+        $recurrence = $this->createRecurrence($category, self::monthStart(-1), self::monthStart(3));
+        $forecast = $this->createEntry($category, $recurrence, self::monthStart(2), FinanceEntryStatus::Planned);
+        FinanceEntrySplitFactory::new(['entry' => $forecast, 'member' => $otherMembership, 'amount' => 15000])->create();
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->patchRecurrence($owner, $bandSpace, $recurrenceId, ['scope' => 'personal']);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . PersonalScopeWithoutSplitsValidator::ERROR_CODE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'scope',
+                    'message' => 'Supprimez d\'abord la répartition des échéances de cette récurrence pour la passer en personnelle.',
+                    'code' => PersonalScopeWithoutSplitsValidator::ERROR_CODE,
+                ],
+            ],
+            'detail' => 'scope: Supprimez d\'abord la répartition des échéances de cette récurrence pour la passer en personnelle.',
+            'description' => 'scope: Supprimez d\'abord la répartition des échéances de cette récurrence pour la passer en personnelle.',
+            'type' => '/validation_errors/' . PersonalScopeWithoutSplitsValidator::ERROR_CODE,
+            'title' => 'An error occurred',
+        ]);
+
+        $this->assertSame(FinanceEntryScope::Band, $this->reloadRecurrence($recurrenceId)->scope);
+        $this->assertSame(FinanceEntryScope::Band, $this->remainingEntries($recurrenceId)[0]->scope);
+    }
+
+    /** A forecast without splits is nobody else's business, so the series may still go personal. */
+    public function test_turning_a_recurrence_personal_is_allowed_without_splits(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+
+        $category = $this->createCategory($bandSpace);
+        $recurrence = $this->createRecurrence($category, self::monthStart(-1), self::monthStart(3));
+        $this->createEntry($category, $recurrence, self::monthStart(2), FinanceEntryStatus::Planned);
+        $recurrenceId = (string) $recurrence->id;
+
+        $this->patchRecurrence($owner, $bandSpace, $recurrenceId, ['scope' => 'personal']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(FinanceEntryScope::Personal, $this->reloadRecurrence($recurrenceId)->scope);
+        $this->assertSame(FinanceEntryScope::Personal, $this->remainingEntries($recurrenceId)[0]->scope);
     }
 
     /** The PATCH carried no constraint on the amount, so a recurrence could be repriced to a debt. */


### PR DESCRIPTION
Closes #858.

A Band entry can carry `FinanceEntrySplit` rows naming other members and their shares. Flipping it to Personal turned shared accounting into one member's private row while the splits stayed behind, pointing at people who could no longer see the entry they belong to.

Reproduced before the fix: `PATCH {"scope":"personal"}` on a Band entry carrying one split returned 200, and the split survived.

The decision was to refuse rather than cascade delete. Dropping splits as part of a scope change silently rewrites shared accounting history, and the user can always delete the répartition first if that is what they meant.

## There are two doors, not one

The issue describes `FinanceEntryUpdateProcessor`. `FinanceRecurrenceUpdateProcessor::syncFutureForecasts()` pushes the recurrence's scope onto every planned future forecast it owns, and splits are legal on a planned band forecast, so PATCHing a recurrence to personal strands them exactly the same way without ever touching the entry endpoint. Also reproduced with a 200 before the fix. Both are now guarded.

## What changed

A `PersonalScopeWithoutSplits` class constraint on `FinanceEntryResource` and `FinanceRecurrenceResource`, matching the existing `FinanceAmountRange` and `RecurrenceEndDate` shape, which is how this codebase validates a merge PATCH against the post-write state and gets a real `ConstraintViolation` body with a code. No processor changed: the diff is additive.

The recurrence check reads exactly `findPlannedByRecurrenceAfter()`, the same set `syncFutureForecasts()` rewrites, so a split on an occurrence the edit leaves alone does not block the edit.

The frontend resets the Portée select back to « Groupe » on that error code before showing the message. That part is load bearing rather than cosmetic: `SplitManager` is `v-if="form.scope === 'band'"`, so a drawer left on « Personnel » would tell the user to delete a répartition whose UI had just unmounted. Only `form.scope` is touched, so other unsaved fields survive the 422.

## The guard watches the transition, not the scope

An entry stranded before this rule existed still carries splits, and the drawer sends `scope` on every save. Guarding the personal scope itself rather than the change into it would leave those entries permanently uneditable with no way out, since the split UI is hidden on a personal entry so the user cannot clear what blocks them. There is a test pinning that, because the early return responsible for it reads as redundant at a glance.

## Consequences 1 and 2 become unreachable, not fixed

The issue hangs two consequences off the precondition: split read endpoints not checking parent visibility, and `getMemberContributions` counting splits of an entry that became personal. Both need a personal entry that carries splits, which the API can no longer produce:

- Split creation already refuses a personal parent via `#[SplitNotPersonal]`, with a test pinning it.
- `new FinanceEntrySplit()` exists in exactly one place, and splits have only Create and Delete operations, so none can be re-parented.

## Worth an audit before merging

Rows written before this fix are not migrated, so a pre-existing stranded split would still be read by `getMemberContributions` and, per the issue's own item 1, still be readable band wide through the split collection endpoint.

The exposure window is narrow. Personal entries were visible band wide until #812 merged on 2026-08-09, so before that date there was nothing to strand. It needs an entry that already had splits, flipped to personal, in the week since.

Suggested check: finance entries with `scope = personal` that have a matching `finance_entry_split` row, touched on or after 2026-08-09. If anything turns up, items 1 and 2 want a follow-up issue regardless.

## Not included

Consequence 3, a file attached to a personal entry still being downloadable band wide, is untouched. The issue's own reasoning holds: the file lives in the band file browser under its own permissions and the finance entry is only one of its attachment points.

## Testing

7 tests. Both 422 bodies asserted in full inline, plus post-state showing the entry and the forecast are still Band. The allowed directions are covered too: personal to band, band to personal without splits, a band entry with splits edited without a scope change, and a legacy personal entry with splits staying editable.

Reversing the `src/ApiResource/` hunks fails the two refusal tests with 200s.

`tests/Api/BandSpace/Finance/` 157 green, full suite green, PHPStan level 8 clean, biome clean, build and JS tests green.
