### PR TITLE
fix(M-877): read all-day agenda dates as written so they hold west of UTC

### DIFF
--- a/assets/js/components/BandSpace/Agenda/AgendaEntryDrawer.vue
+++ b/assets/js/components/BandSpace/Agenda/AgendaEntryDrawer.vue
@@ -309,7 +309,7 @@
 </template>
 
 <script setup>
-import { differenceInCalendarDays, format, parseISO } from 'date-fns'
+import { differenceInCalendarDays, format } from 'date-fns'
 import { fr } from 'date-fns/locale'
 import Button from 'primevue/button'
 import Checkbox from 'primevue/checkbox'
@@ -325,6 +325,7 @@ import Textarea from 'primevue/textarea'
 import { useConfirm } from 'primevue/useconfirm'
 import { computed, nextTick, reactive, ref, watch } from 'vue'
 import { useBandAgendaStore } from '../../../store/bandSpace/bandSpaceAgenda.js'
+import { toAgendaDate } from '../../../utils/agendaDate.js'
 import {
   agendaSeriesSubmission,
   SERIES_IMPACT_NONE,
@@ -421,22 +422,14 @@ const isEditMode = computed(() => props.agendaItem !== null && props.agendaItem.
 const isSeriesOccurrence = computed(
   () => isEditMode.value && props.agendaItem.metadata?.is_recurring_occurrence === true
 )
-const seriesAnchorStart = computed(() => toDate(props.agendaItem?.metadata?.series_start_datetime))
-const occurrenceStart = computed(() => toDate(props.agendaItem?.datetime))
+const isAllDayEntry = computed(() => props.agendaItem?.is_all_day === true)
+const seriesAnchorStart = computed(() =>
+  toAgendaDate(props.agendaItem?.metadata?.series_start_datetime, isAllDayEntry.value)
+)
+const occurrenceStart = computed(() =>
+  toAgendaDate(props.agendaItem?.datetime, isAllDayEntry.value)
+)
 const seriesStartLabel = computed(() => formatEventMoment(seriesAnchorStart.value))
-
-/**
- * An all day entry is pinned to UTC midnight whatever offset it was created with, so reading it back
- * as an instant lands on the previous day west of UTC: Guadeloupe and Martinique are UTC-4, which
- * makes that a real French user shown the wrong day and weekday for the series start. The date
- * portion is taken as written instead, the way the agenda range helper already does it.
- */
-function toDate(isoString) {
-  if (!isoString) return null
-  if (props.agendaItem?.is_all_day === true) return parseISO(isoString.slice(0, 10))
-
-  return new Date(isoString)
-}
 
 function formatEventMoment(date) {
   if (!date) return ''
@@ -520,10 +513,11 @@ watch(isVisible, (visible) => {
   skipShiftEnd = true
   if (props.agendaItem && props.agendaItem.source === 'manual') {
     form.title = props.agendaItem.title ?? ''
-    form.eventDatetime = props.agendaItem.datetime ? new Date(props.agendaItem.datetime) : null
-    form.endDatetime = props.agendaItem.end_datetime
-      ? new Date(props.agendaItem.end_datetime)
-      : null
+    // The pickers are filled with the day as written, not with the instant: serializeDatetime
+    // writes an all day entry back with local getters, so seeding them from the UTC midnight pin
+    // would move the entry one day earlier on every save west of UTC.
+    form.eventDatetime = toAgendaDate(props.agendaItem.datetime, isAllDayEntry.value)
+    form.endDatetime = toAgendaDate(props.agendaItem.end_datetime, isAllDayEntry.value)
     form.isAllDay = !!props.agendaItem.is_all_day
     form.location = props.agendaItem.metadata?.location ?? ''
     form.description = props.agendaItem.description ?? ''

--- a/assets/js/components/BandSpace/Dashboard/AgendaWidget.vue
+++ b/assets/js/components/BandSpace/Dashboard/AgendaWidget.vue
@@ -21,7 +21,7 @@
         <div class="flex-1 min-w-0">
           <p class="font-medium text-surface-900 dark:text-surface-0 truncate">{{ item.title }}</p>
           <p class="text-xs text-surface-500 dark:text-surface-400 mt-0.5">
-            {{ formatDayLabel(item.datetime) }}<template v-if="!isAllDayItem(item)"> - {{ formatTime(item.datetime) }}</template>
+            {{ formatDayLabel(item) }}<template v-if="!isAllDayItem(item)"> - {{ formatTime(item.datetime) }}</template>
           </p>
         </div>
       </li>
@@ -35,6 +35,7 @@ import { fr } from 'date-fns/locale'
 import { onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import bandSpaceAgendaApi from '../../../api/bandSpace/band-space-agenda.js'
+import { toAgendaDate } from '../../../utils/agendaDate.js'
 import { isAllDayItem } from '../../../utils/agendaItem.js'
 import DashboardWidget from './DashboardWidget.vue'
 
@@ -63,8 +64,9 @@ onMounted(async () => {
   }
 })
 
-function formatDayLabel(datetimeStr) {
-  const date = parseISO(datetimeStr)
+function formatDayLabel(item) {
+  const date = toAgendaDate(item.datetime, isAllDayItem(item))
+  if (date === null) return ''
   if (isToday(date)) return "Aujourd'hui"
   if (isTomorrow(date)) return 'Demain'
   return format(date, 'EEEE d MMMM', { locale: fr })

--- a/assets/js/components/Notification/NotificationItem.vue
+++ b/assets/js/components/Notification/NotificationItem.vue
@@ -71,6 +71,7 @@ import bandSpaceSettingsApi from '../../api/bandSpace/band-space-settings.js'
 import { BAND_SPACE_ROUTES } from '../../constants/bandSpace.js'
 import relativeDate from '../../helper/date/relative-date.js'
 import { useUserNotificationStore } from '../../store/notification/userNotification.js'
+import { withoutAllDayPin } from '../../utils/agendaDate.js'
 import { formatDateLong } from '../../utils/date.js'
 
 const props = defineProps({
@@ -92,6 +93,14 @@ const isUnread = computed(() => props.notification.read_datetime === null)
 function publicationTarget(payload) {
   const name = payload.is_course ? 'app_course_show' : 'app_publication_show'
   return { name, params: { slug: payload.publication_slug } }
+}
+
+// An all day event covers a written day rather than an instant, and reading it as one shows the
+// previous day to anyone west of UTC. The payload says which it is; a notification stored before
+// that flag existed carries no key and reads as timed, which is what it was stored as, and the
+// enricher puts the real flag back on any entry that still exists.
+function agendaEventDay(payload) {
+  return formatDateLong(withoutAllDayPin(payload.event_datetime, payload.is_all_day === true))
 }
 
 // type -> row rendering. Each future producer adds its branch here.
@@ -225,7 +234,7 @@ const TYPE_CONFIG = {
     icon: 'pi pi-calendar-plus',
     avatarClass: 'bg-sky-100 text-sky-600 dark:bg-sky-500/20 dark:text-sky-300',
     title: payload.actor_username,
-    preview: `a ajouté l'événement « ${payload.entry_title} » le ${formatDateLong(payload.event_datetime)}`,
+    preview: `a ajouté l'événement « ${payload.entry_title} » le ${agendaEventDay(payload)}`,
     actions: null,
     target: { name: BAND_SPACE_ROUTES.AGENDA, params: { id: payload.band_space_id } }
   }),

--- a/assets/js/utils/agendaDate.js
+++ b/assets/js/utils/agendaDate.js
@@ -1,0 +1,107 @@
+import { addDays, format, parseISO } from 'date-fns'
+import { isAllDayItem } from './agendaItem.js'
+
+/**
+ * How an agenda datetime has to be read so it lands on the day it was written for.
+ *
+ * An all day entry carries no instant: the API pins it to midnight UTC, and finance and task due
+ * dates are date only columns the aggregator pads the same way. Reading any of those back as an
+ * instant and then applying local getters lands on the previous day for anyone west of UTC, and
+ * Guadeloupe and Martinique are UTC-4 all year, so that is a real French user rather than a
+ * hypothetical one. The pin is dropped instead: a bare `yyyy-MM-dd` string has no offset to
+ * convert, so it holds under any timezone.
+ *
+ * A timed event is the opposite case. It is a real instant and has to keep it, so it shows at the
+ * hour and on the local day the reader actually lives it. Nothing here may unpin one.
+ *
+ * This lives outside the components because the agenda grid, the agenda list, the year overview
+ * dots, the save toast, the dashboard widget, the entry drawer and the notification feed all have
+ * to answer it the same way, and they did not: this bug class has come back three times. It is
+ * pure date arithmetic, so it is unit tested without a browser and in several timezones (npm test).
+ */
+
+/**
+ * The datetime to hand a formatter: the date portion for something that covers a day, the instant
+ * untouched for something that happens at a moment.
+ */
+export function withoutAllDayPin(value, isAllDay) {
+  return isAllDay && typeof value === 'string' ? value.slice(0, 10) : value
+}
+
+/**
+ * The Date an agenda datetime points at: local midnight of the written day when it covers a day,
+ * the instant itself when it happens at a moment. Anything unusable reads as null, so callers fall
+ * back instead of throwing.
+ */
+export function toAgendaDate(value, isAllDay) {
+  if (!value) return null
+  const unpinned = withoutAllDayPin(value, isAllDay)
+  const date = typeof unpinned === 'string' ? parseISO(unpinned) : unpinned
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null
+
+  return date
+}
+
+/** The `yyyy-MM-dd` day an agenda datetime belongs to, or null when there is no usable date. */
+function agendaDayKey(value, isAllDay) {
+  const date = toAgendaDate(value, isAllDay)
+
+  return date === null ? null : format(date, 'yyyy-MM-dd')
+}
+
+/**
+ * The days an agenda item occupies, as `yyyy-MM-dd` keys, for the list grouping and the year
+ * overview dots. Takes the API shape of an agenda item, so snake_case properties.
+ *
+ * Only an all day event spans several days. A timed multi day event would repeat its start day
+ * time range on every intermediate day, which reads as several separate events.
+ *
+ * Whether the item covers a day is the derived rule, the same one agendaCalendarEventDates asks,
+ * and not the raw `is_all_day` flag. Reading the flag here would agree with the calendar only for
+ * as long as the aggregated sources keep sending a null end alongside their false flag: the day a
+ * task or a finance due date grows a real end, the list and the grid would disagree about how many
+ * days it covers, and nothing would say so.
+ */
+export function agendaItemDayKeys(item) {
+  const isAllDay = isAllDayItem(item)
+  const startKey = agendaDayKey(item?.datetime, isAllDay)
+  if (startKey === null) return []
+  if (!isAllDay || !item.end_datetime) return [startKey]
+
+  const endKey = agendaDayKey(item.end_datetime, isAllDay)
+  if (endKey === null || endKey <= startKey) return [startKey]
+
+  const keys = []
+  let cursor = parseISO(startKey)
+  const end = parseISO(endKey)
+  while (cursor <= end) {
+    keys.push(format(cursor, 'yyyy-MM-dd'))
+    cursor = addDays(cursor, 1)
+  }
+
+  return keys
+}
+
+/**
+ * The `start` and `end` an agenda item is fed to FullCalendar with.
+ *
+ * The calendar's timezone is left at its default `local`, and for that setting DateEnv turns a
+ * start carrying an offset into local wall clock and re-tags it as UTC before the day cell is
+ * picked. An all day event pinned to midnight UTC is therefore drawn in the previous day's cell
+ * west of UTC, on the month, week, day and year views alike, which is a wrong grid and not just a
+ * wrong label. A bare date has no offset to convert, so it is taken as written. A timed event keeps
+ * its instant, because that conversion is exactly what puts it at the right hour.
+ */
+export function agendaCalendarEventDates(item) {
+  if (!isAllDayItem(item)) {
+    return { start: item?.datetime, end: item?.end_datetime ?? undefined }
+  }
+
+  const lastDay = item?.end_datetime ? agendaDayKey(item.end_datetime, true) : null
+
+  return {
+    start: agendaDayKey(item?.datetime, true),
+    // FullCalendar reads an all day end as exclusive, so the last day is bumped to the day after.
+    end: lastDay === null ? undefined : format(addDays(parseISO(lastDay), 1), 'yyyy-MM-dd')
+  }
+}

--- a/assets/js/utils/agendaDate.test.js
+++ b/assets/js/utils/agendaDate.test.js
@@ -1,0 +1,269 @@
+import assert from 'node:assert/strict'
+import { after, before, describe, it } from 'node:test'
+import { format } from 'date-fns'
+import {
+  agendaCalendarEventDates,
+  agendaItemDayKeys,
+  toAgendaDate,
+  withoutAllDayPin
+} from './agendaDate.js'
+
+/**
+ * Reading an agenda datetime on the day it was written for.
+ *
+ * Every assertion here runs twice, once east of UTC and once west of it, because that is the only
+ * way this bug shows up: an all day event pinned to midnight UTC reads back as the previous day
+ * for a reader in Guadeloupe or Martinique and looks perfectly fine in Paris. Node applies a
+ * `process.env.TZ` reassignment to every later Date, so a suite can move the runner's timezone
+ * itself rather than relying on whoever launched it.
+ *
+ * Run with `npm test`, and with `TZ=America/Martinique npm test` to prove the runner's own
+ * timezone is not what is holding the assertions up.
+ */
+
+/** Paris in summer, UTC+2: everything already worked here, which is why this took so long to find. */
+const EAST_OF_UTC = 'Europe/Paris'
+/** Martinique, UTC-4 all year: a French user for whom an instant reading lands a day early. */
+const WEST_OF_UTC = 'America/Martinique'
+
+/** An agenda item as the aggregator returns it. */
+function item(fields) {
+  return {
+    id: 'agenda-1',
+    source: 'manual',
+    is_all_day: false,
+    datetime: '2026-08-12T20:30:00+02:00',
+    end_datetime: null,
+    ...fields
+  }
+}
+
+const ALL_DAY = item({ is_all_day: true, datetime: '2026-08-12T00:00:00+00:00' })
+const TIMED = item({})
+// The aggregator sends is_all_day false on a finance due date and pads its date only column to
+// midnight UTC, so the flag alone is not enough to spot one.
+const FINANCE_DUE = item({ source: 'finance', datetime: '2026-08-12T00:00:00+00:00' })
+
+/**
+ * Runs a block in a fixed timezone. Written as a describe wrapper rather than a helper taking a
+ * timezone so a failure names the timezone it failed in.
+ */
+function describeInTimeZone(timeZone, defineTests) {
+  describe(`in ${timeZone}`, () => {
+    const original = process.env.TZ
+    before(() => {
+      process.env.TZ = timeZone
+    })
+    after(() => {
+      process.env.TZ = original
+    })
+
+    defineTests()
+  })
+}
+
+for (const timeZone of [EAST_OF_UTC, WEST_OF_UTC]) {
+  describeInTimeZone(timeZone, () => {
+    describe('toAgendaDate', () => {
+      it('reads an all day entry on the day it was written for', () => {
+        const date = toAgendaDate(ALL_DAY.datetime, true)
+
+        assert.equal(date.getFullYear(), 2026)
+        assert.equal(date.getMonth(), 7)
+        assert.equal(date.getDate(), 12)
+      })
+
+      it('keeps the instant of a timed entry', () => {
+        assert.equal(toAgendaDate(TIMED.datetime, false).toISOString(), '2026-08-12T18:30:00.000Z')
+      })
+
+      it('leaves a Date alone whatever the entry is', () => {
+        const noon = new Date(2026, 7, 12, 12, 0)
+
+        assert.equal(toAgendaDate(noon, true), noon)
+        assert.equal(toAgendaDate(noon, false), noon)
+      })
+
+      it('reads anything unusable as null instead of throwing', () => {
+        assert.equal(toAgendaDate(null, true), null)
+        assert.equal(toAgendaDate('', false), null)
+        assert.equal(toAgendaDate('pas une date', false), null)
+      })
+    })
+
+    describe('agendaItemDayKeys', () => {
+      it('groups an all day entry under the day it was written for', () => {
+        assert.deepEqual(agendaItemDayKeys(ALL_DAY), ['2026-08-12'])
+      })
+
+      it('groups a finance due date under its own day despite its is_all_day being false', () => {
+        assert.deepEqual(agendaItemDayKeys(FINANCE_DUE), ['2026-08-12'])
+      })
+
+      it('groups a timed entry under the local day the reader lives it', () => {
+        // 20:30+02:00 is 14:30 in Martinique and 20:30 in Paris, so the 12th either way. The
+        // instant is what moves here, and it has to.
+        assert.deepEqual(agendaItemDayKeys(TIMED), ['2026-08-12'])
+      })
+
+      it('gives a late timed entry to the local day it falls on', () => {
+        const lateGig = item({ datetime: '2026-08-13T01:30:00+02:00' })
+
+        assert.deepEqual(agendaItemDayKeys(lateGig), [
+          timeZone === EAST_OF_UTC ? '2026-08-13' : '2026-08-12'
+        ])
+      })
+
+      it('spreads a multi day all day entry over every day it covers, ends included', () => {
+        const festival = item({
+          is_all_day: true,
+          datetime: '2026-08-12T00:00:00+00:00',
+          end_datetime: '2026-08-14T00:00:00+00:00'
+        })
+
+        assert.deepEqual(agendaItemDayKeys(festival), ['2026-08-12', '2026-08-13', '2026-08-14'])
+      })
+
+      it('keeps a one day all day entry on its one day when its end names that same day', () => {
+        // The drawer's end picker allows the start day itself, so this shape reaches the list.
+        const openDay = item({
+          is_all_day: true,
+          datetime: '2026-08-12T00:00:00+00:00',
+          end_datetime: '2026-08-12T00:00:00+00:00'
+        })
+
+        assert.deepEqual(agendaItemDayKeys(openDay), ['2026-08-12'])
+      })
+
+      it('keeps a timed entry on its start day even when it has an end', () => {
+        const rehearsal = item({
+          datetime: '2026-08-12T20:30:00+02:00',
+          end_datetime: '2026-08-12T23:00:00+02:00'
+        })
+
+        assert.deepEqual(agendaItemDayKeys(rehearsal), ['2026-08-12'])
+      })
+
+      it('gives back no day at all rather than throwing on a missing datetime', () => {
+        assert.deepEqual(agendaItemDayKeys(item({ datetime: '' })), [])
+        assert.deepEqual(agendaItemDayKeys(null), [])
+      })
+    })
+
+    describe('agendaCalendarEventDates', () => {
+      // The one that decides which day cell FullCalendar draws the event in. Its timeZone is left
+      // at the default 'local', and for that setting a start carrying an offset is rewritten as
+      // local wall clock before the cell is picked, so a bare date is the only stable input.
+      it('hands an all day entry a bare date FullCalendar cannot shift', () => {
+        assert.deepEqual(agendaCalendarEventDates(ALL_DAY), {
+          start: '2026-08-12',
+          end: undefined
+        })
+      })
+
+      it('hands a finance due date a bare date too', () => {
+        assert.deepEqual(agendaCalendarEventDates(FINANCE_DUE), {
+          start: '2026-08-12',
+          end: undefined
+        })
+      })
+
+      it('hands a timed entry its instant untouched, offset included', () => {
+        assert.deepEqual(agendaCalendarEventDates(TIMED), {
+          start: '2026-08-12T20:30:00+02:00',
+          end: undefined
+        })
+      })
+
+      it('hands a timed entry its own end untouched', () => {
+        const rehearsal = item({ end_datetime: '2026-08-12T23:00:00+02:00' })
+
+        assert.deepEqual(agendaCalendarEventDates(rehearsal), {
+          start: '2026-08-12T20:30:00+02:00',
+          end: '2026-08-12T23:00:00+02:00'
+        })
+      })
+
+      it('bumps a one day all day end to the day after so the entry still fills its own cell', () => {
+        const openDay = item({
+          is_all_day: true,
+          datetime: '2026-08-12T00:00:00+00:00',
+          end_datetime: '2026-08-12T00:00:00+00:00'
+        })
+
+        assert.deepEqual(agendaCalendarEventDates(openDay), {
+          start: '2026-08-12',
+          end: '2026-08-13'
+        })
+      })
+
+      it('bumps a multi day all day end to the day after, which FullCalendar reads as exclusive', () => {
+        const festival = item({
+          is_all_day: true,
+          datetime: '2026-08-12T00:00:00+00:00',
+          end_datetime: '2026-08-14T00:00:00+00:00'
+        })
+
+        assert.deepEqual(agendaCalendarEventDates(festival), {
+          start: '2026-08-12',
+          end: '2026-08-15'
+        })
+      })
+    })
+
+    // The entry drawer fills its date pickers with toAgendaDate and writes them back with local
+    // getters, so opening an entry and saving it untouched has to give the same day back. Seeding
+    // the pickers from the instant moved an all day entry one day earlier on every single save.
+    describe('the entry drawer load and save round trip', () => {
+      it('gives an all day entry back on the day it was loaded from', () => {
+        const loaded = toAgendaDate(ALL_DAY.datetime, true)
+
+        assert.equal(format(loaded, 'yyyy-MM-dd'), '2026-08-12')
+      })
+
+      it('gives a timed entry back at the local hour the reader lives it', () => {
+        const loaded = toAgendaDate(TIMED.datetime, false)
+
+        assert.equal(format(loaded, 'HH:mm'), timeZone === EAST_OF_UTC ? '20:30' : '14:30')
+      })
+    })
+
+    describe('withoutAllDayPin', () => {
+      it('gives a label the written date of an all day entry, which no offset can move', () => {
+        assert.equal(withoutAllDayPin(ALL_DAY.datetime, true), '2026-08-12')
+      })
+
+      it('gives a label the untouched instant of a timed entry', () => {
+        assert.equal(withoutAllDayPin(TIMED.datetime, false), '2026-08-12T20:30:00+02:00')
+      })
+
+      it('leaves anything that is not a datetime string alone', () => {
+        assert.equal(withoutAllDayPin(null, true), null)
+        assert.equal(withoutAllDayPin(undefined, true), undefined)
+      })
+    })
+
+    // The list groups an item under a day and the calendar draws it in a cell, from the same item.
+    // They only ever agreed because the aggregated sources happen to send a null end date, so the
+    // agreement is pinned rather than left to that.
+    describe('the list grouping and the calendar grid agreeing', () => {
+      it('covers the same days when the source, not the flag, is what makes an item all day', () => {
+        // buildTask and buildFinance hardcode a null end today. The day either of them carries a
+        // real one while still sending is_all_day false, the two views have to keep agreeing.
+        const financeSpan = item({
+          source: 'finance',
+          datetime: '2026-08-12T00:00:00+00:00',
+          end_datetime: '2026-08-14T00:00:00+00:00'
+        })
+        const dayKeys = agendaItemDayKeys(financeSpan)
+
+        assert.deepEqual(dayKeys, ['2026-08-12', '2026-08-13', '2026-08-14'])
+        assert.deepEqual(agendaCalendarEventDates(financeSpan), {
+          start: dayKeys[0],
+          // The calendar's all day end is exclusive, so it names the day after the last one grouped.
+          end: '2026-08-15'
+        })
+      })
+    })
+  })
+}

--- a/assets/js/utils/agendaRange.js
+++ b/assets/js/utils/agendaRange.js
@@ -1,4 +1,5 @@
-import { endOfMonth, format, parseISO, startOfMonth } from 'date-fns'
+import { endOfMonth, format, startOfMonth } from 'date-fns'
+import { toAgendaDate } from './agendaDate.js'
 
 /**
  * Which period the band space agenda has to show once an entry has been saved.
@@ -9,32 +10,9 @@ import { endOfMonth, format, parseISO, startOfMonth } from 'date-fns'
  * unit tested without a browser (npm test).
  */
 
-/** Anything that is not a usable date reads as null, so callers fall back instead of throwing. */
-function toDate(value) {
-  if (!value) return null
-  const date = typeof value === 'string' ? parseISO(value) : value
-  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null
-
-  return date
-}
-
 /** Local calendar day: the period is day granular, its bounds are 00:00:00 and 23:59:59. */
 function dayKey(date) {
   return format(date, 'yyyy-MM-dd')
-}
-
-/**
- * An all day entry is stored as UTC midnight whatever offset it was created with, so reading it
- * back as an instant lands on the previous day for anyone west of UTC: Guadeloupe and Martinique
- * are UTC-4, which makes that a real French user rather than a hypothetical one. The date portion
- * is taken as written instead, the way a date only field like the recurrence horizon already is.
- */
-function toCalendarDate(value, isAllDay) {
-  if (isAllDay && typeof value === 'string') {
-    return toDate(value.slice(0, 10))
-  }
-
-  return toDate(value)
 }
 
 /**
@@ -43,15 +21,16 @@ function toCalendarDate(value, isAllDay) {
  */
 function entrySpan(entry) {
   const isAllDay = entry?.is_all_day === true
-  const start = toCalendarDate(entry?.event_datetime, isAllDay)
+  const start = toAgendaDate(entry?.event_datetime, isAllDay)
   if (!start) return null
 
-  const ownEnd = toCalendarDate(entry?.end_datetime, isAllDay) ?? start
+  const ownEnd = toAgendaDate(entry?.end_datetime, isAllDay) ?? start
 
   // Every occurrence keeps the duration of the first one, so a series runs past its horizon by
   // however long a single occurrence lasts. Taking the horizon as the end would cut that tail off
   // and report a Monday to Wednesday weekly event as gone two days before it actually is.
-  const horizon = toDate(entry?.recurrence_until_date)
+  // The horizon is a date only field already, so it is read as written whatever the entry is.
+  const horizon = toAgendaDate(entry?.recurrence_until_date, false)
   const lastEnd = horizon
     ? new Date(horizon.getTime() + (ownEnd.getTime() - start.getTime()))
     : ownEnd
@@ -66,8 +45,8 @@ function entrySpan(entry) {
  */
 export function isEntryVisibleInRange(entry, from, to) {
   const span = entrySpan(entry)
-  const rangeStart = toDate(from)
-  const rangeEnd = toDate(to)
+  const rangeStart = toAgendaDate(from, false)
+  const rangeEnd = toAgendaDate(to, false)
   if (!span || !rangeStart || !rangeEnd) return false
 
   return dayKey(span.start) <= dayKey(rangeEnd) && dayKey(span.end) >= dayKey(rangeStart)

--- a/assets/js/views/BandSpace/Agenda.vue
+++ b/assets/js/views/BandSpace/Agenda.vue
@@ -240,6 +240,11 @@ import AgendaEntryDrawer from '../../components/BandSpace/Agenda/AgendaEntryDraw
 import AgendaEventChip from '../../components/BandSpace/Agenda/AgendaEventChip.vue'
 import Avatar from '../../components/User/Avatar.vue'
 import { useBandAgendaStore } from '../../store/bandSpace/bandSpaceAgenda.js'
+import {
+  agendaCalendarEventDates,
+  agendaItemDayKeys,
+  withoutAllDayPin
+} from '../../utils/agendaDate.js'
 import { isAllDayItem } from '../../utils/agendaItem.js'
 import { agendaViewForSavedEntry } from '../../utils/agendaRange.js'
 import { formatDateCompactWithYear, formatDateLong } from '../../utils/date.js'
@@ -382,7 +387,7 @@ const isRefreshing = computed(() => agendaStore.isRefreshing && !agendaStore.isL
 const groupedItems = computed(() => {
   const groups = new Map()
   for (const item of filteredItems.value) {
-    for (const date of itemDateKeys(item)) {
+    for (const date of agendaItemDayKeys(item)) {
       if (!groups.has(date)) {
         groups.set(date, [])
       }
@@ -402,30 +407,13 @@ const groupedItems = computed(() => {
   }))
 })
 
-function itemDateKeys(item) {
-  const startKey = format(parseISO(item.datetime), 'yyyy-MM-dd')
-  // Only all-day events expand across days — a timed multi-day event would mislead with
-  // its start-day time range showing on every intermediate day.
-  if (!item.is_all_day || !item.end_datetime) return [startKey]
-  const endKey = format(parseISO(item.end_datetime), 'yyyy-MM-dd')
-  if (endKey === startKey) return [startKey]
-  const keys = []
-  let cursor = parseISO(item.datetime)
-  const end = parseISO(item.end_datetime)
-  while (cursor <= end) {
-    keys.push(format(cursor, 'yyyy-MM-dd'))
-    cursor = addDays(cursor, 1)
-  }
-  return keys
-}
-
 // One entry per event on each day (the same source repeats when a day has several events of
 // that kind), for the year overview's dots. Built from filteredItems so the source chips
 // filter the dots too.
 const dayEventSourcesByDate = computed(() => {
   const map = new Map()
   for (const item of filteredItems.value) {
-    for (const key of itemDateKeys(item)) {
+    for (const key of agendaItemDayKeys(item)) {
       if (!map.has(key)) map.set(key, [])
       map.get(key).push(item.source)
     }
@@ -435,9 +423,9 @@ const dayEventSourcesByDate = computed(() => {
 
 function dayEventSources(date) {
   // FullCalendar's default timeZone is 'local', so the cell date passed here is local midnight
-  // of the day shown; format it with the same local getters as itemDateKeys so the dot lookup
-  // lines up with how events are keyed. (Do NOT switch to UTC getters: east of UTC that reads
-  // the previous calendar day and shifts every dot one day forward.)
+  // of the day shown; format it with the same local getters as agendaItemDayKeys so the dot
+  // lookup lines up with how events are keyed. (Do NOT switch to UTC getters: east of UTC that
+  // reads the previous calendar day and shifts every dot one day forward.)
   return dayEventSourcesByDate.value.get(format(date, 'yyyy-MM-dd')) ?? []
 }
 
@@ -450,8 +438,7 @@ const calendarEvents = computed(() =>
   filteredItems.value.map((item) => ({
     id: item.id,
     title: item.title,
-    start: item.datetime,
-    end: calendarEnd(item),
+    ...agendaCalendarEventDates(item),
     allDay: isAllDayItem(item),
     color: SOURCE_COLORS[item.source] ?? '#94a3b8',
     contrastColor: '#fff',
@@ -526,10 +513,11 @@ function handleEntrySaved(savedEntry) {
   focusDate.value = nextView.focusDate
   fetchWithCurrentRange()
 
+  const savedDay = withoutAllDayPin(savedEntry.event_datetime, savedEntry.is_all_day === true)
   toast.add({
     severity: 'success',
     summary: 'Événement enregistré',
-    detail: `Il a lieu le ${formatDateLong(savedEntry.event_datetime)} : l'agenda affiche maintenant cette période.`,
+    detail: `Il a lieu le ${formatDateLong(savedDay)} : l'agenda affiche maintenant cette période.`,
     life: 5000
   })
 }
@@ -638,13 +626,6 @@ function formatDateLabel(dateString) {
 
 function formatTime(datetimeString) {
   return format(parseISO(datetimeString), 'HH:mm')
-}
-
-function calendarEnd(item) {
-  if (!item.end_datetime) return undefined
-  if (!item.is_all_day) return item.end_datetime
-  // FullCalendar all-day events use exclusive end: bump last-day-inclusive to the day after.
-  return format(addDays(parseISO(item.end_datetime), 1), 'yyyy-MM-dd')
 }
 
 function sourceLabel(source) {

--- a/src/EventSubscriber/BandSpaceAgendaEntryCreatedListener.php
+++ b/src/EventSubscriber/BandSpaceAgendaEntryCreatedListener.php
@@ -19,8 +19,8 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
  * whole body - including the member-resolution query - is wrapped in try/catch so it can never roll
  * back or 500 the creation. The creator is excluded; createForRecipients dedupes by user id.
  *
- * No per-task-style note here, but see AgendaEntryNotificationEnricher: entry_title + event_datetime
- * are refreshed at feed-read because the agenda has no per-entry deep-link.
+ * No per-task-style note here, but see AgendaEntryNotificationEnricher: entry_title, event_datetime
+ * and is_all_day are refreshed at feed-read because the agenda has no per-entry deep-link.
  */
 #[AsEventListener]
 readonly class BandSpaceAgendaEntryCreatedListener
@@ -55,6 +55,10 @@ readonly class BandSpaceAgendaEntryCreatedListener
                 'agenda_entry_id' => (string) $entry->id,
                 'entry_title' => $entry->title,
                 'event_datetime' => $entry->eventDatetime->format(\DateTimeInterface::ATOM),
+                // An all-day entry is stored pinned to UTC midnight, so the datetime alone cannot say
+                // whether it is a day or a moment. The feed needs to know: read as an instant, an
+                // all-day entry shows the previous day to anyone west of UTC (#877).
+                'is_all_day' => $entry->isAllDay,
                 'actor_id' => $actorId,
                 'actor_username' => $actor->username,
             ]);

--- a/src/Service/Notification/Enricher/AgendaEntryNotificationEnricher.php
+++ b/src/Service/Notification/Enricher/AgendaEntryNotificationEnricher.php
@@ -9,10 +9,14 @@ use App\Repository\BandSpace\AgendaEntryRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
 
 /**
- * Refreshes a band-space agenda-entry notification's `entry_title` + `event_datetime` at feed-read
- * (#722), so it stays accurate after the entry is renamed or rescheduled. The agenda has no
- * per-entry/per-date deep-link, so both fields are load-bearing. Batched: two queries for the whole
- * page. A deleted entry keeps its last-known stored values (graceful staleness).
+ * Refreshes a band-space agenda-entry notification's `entry_title`, `event_datetime` and
+ * `is_all_day` at feed-read (#722), so it stays accurate after the entry is renamed, rescheduled or
+ * switched between a day and a moment. The agenda has no per-entry/per-date deep-link, so all three
+ * are load-bearing: `is_all_day` is what tells the feed to read the datetime as a written day rather
+ * than an instant, which is the whole difference west of UTC (#877). Batched: two queries for the
+ * whole page. A deleted entry keeps its last-known stored values (graceful staleness), and a
+ * notification written before `is_all_day` existed carries no such value: the feed reads a missing
+ * flag as false, which is how those datetimes were being read when they were stored.
  *
  * Like the task-title refresh, it follows the reader's current access (#817): a recipient who has
  * left the band space keeps the title and date as they stood when they were told, rather than a live
@@ -77,6 +81,7 @@ readonly class AgendaEntryNotificationEnricher implements NotificationEnricherIn
                 $entry = $entriesById[$entryId];
                 $notification->payload['entry_title'] = $entry->title;
                 $notification->payload['event_datetime'] = $entry->eventDatetime->format(\DateTimeInterface::ATOM);
+                $notification->payload['is_all_day'] = $entry->isAllDay;
             }
         }
     }

--- a/tests/Api/BandSpace/AgendaEntry/AgendaEntryNotificationTest.php
+++ b/tests/Api/BandSpace/AgendaEntry/AgendaEntryNotificationTest.php
@@ -78,6 +78,7 @@ class AgendaEntryNotificationTest extends ApiTestCase
             'agenda_entry_id' => (string) $entry->id,
             'entry_title' => 'Répétition générale',
             'event_datetime' => '2026-06-15T20:00:00+00:00',
+            'is_all_day' => false,
             'actor_id' => $creatorId,
             'actor_username' => $creatorUsername,
         ];
@@ -91,6 +92,66 @@ class AgendaEntryNotificationTest extends ApiTestCase
 
         // The creator is never notified of their own entry.
         $this->assertCount(0, $notificationRepository->findForRecipient($creator, 10, 0));
+    }
+
+    public function test_creating_an_all_day_entry_says_so_in_the_notification(): void
+    {
+        $creator = UserFactory::new()->asBaseUser()->create();
+        $alice = UserFactory::new()->create(['username' => 'alice', 'email' => 'alice@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'The Rockers']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $creator])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $alice])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $creatorId = (string) $creator->id;
+        $creatorUsername = $creator->username;
+
+        $this->client->loginUser($creator);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/agenda-entries',
+            ['title' => 'Festival', 'eventDatetime' => '2026-06-15', 'isAllDay' => true],
+            self::HEADERS
+        );
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $entry = self::getContainer()->get(AgendaEntryRepository::class)->findByBandSpace($bandSpace)[0];
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpaceId . '/agenda-entries/' . $entry->id,
+            '@type' => 'AgendaEntry',
+            'id' => $entry->id,
+            'band_space_id' => $bandSpaceId,
+            'title' => 'Festival',
+            'description' => null,
+            'location' => null,
+            'event_datetime' => '2026-06-15T00:00:00+00:00',
+            'end_datetime' => null,
+            'is_all_day' => true,
+            'recurrence_frequency' => null,
+            'recurrence_until_date' => null,
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $creator->id,
+            'creator_username' => $creatorUsername,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        // The entry is pinned to UTC midnight, which reads as the day before for a member in
+        // Martinique unless the payload says the datetime is a written day (#877).
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+        $notifications = $notificationRepository->findForRecipient($alice, 10, 0);
+        $this->assertCount(1, $notifications);
+        $this->assertSame(NotificationType::BandSpaceAgendaEntryCreated, $notifications[0]->type);
+        $this->assertSame([
+            'band_space_id' => $bandSpaceId,
+            'band_space_name' => 'The Rockers',
+            'agenda_entry_id' => (string) $entry->id,
+            'entry_title' => 'Festival',
+            'event_datetime' => '2026-06-15T00:00:00+00:00',
+            'is_all_day' => true,
+            'actor_id' => $creatorId,
+            'actor_username' => $creatorUsername,
+        ], $notifications[0]->payload);
     }
 
     public function test_creating_an_entry_in_a_solo_band_space_notifies_no_one(): void

--- a/tests/Api/Notification/UserNotificationTest.php
+++ b/tests/Api/Notification/UserNotificationTest.php
@@ -773,6 +773,69 @@ class UserNotificationTest extends ApiTestCase
                         'agenda_entry_id' => (string) $entry->id,
                         'entry_title' => 'Titre actuel',
                         'event_datetime' => '2026-08-15T20:00:00+00:00',
+                        'is_all_day' => false,
+                        'actor_id' => 'actor-1',
+                        'actor_username' => 'creator',
+                    ],
+                    'read_datetime' => null,
+                    'creation_datetime' => $notification->creationDatetime->format(\DATE_ATOM),
+                ],
+            ],
+        ]);
+    }
+
+    public function test_agenda_entry_notification_recovers_an_all_day_flag_its_payload_never_carried(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Festival',
+            'eventDatetime' => new \DateTimeImmutable('2026-08-15T00:00:00+00:00'),
+            'isAllDay' => true,
+        ])->create();
+        // Written before the payload said whether an entry covers a day: the key is simply absent.
+        $notification = NotificationFactory::new([
+            'recipient' => $user,
+            'type' => NotificationType::BandSpaceAgendaEntryCreated,
+            'payload' => [
+                'band_space_id' => (string) $bandSpace->id,
+                'band_space_name' => 'The Rockers',
+                'agenda_entry_id' => (string) $entry->id,
+                'entry_title' => 'Festival',
+                'event_datetime' => '2026-08-15T00:00:00+00:00',
+                'actor_id' => 'actor-1',
+                'actor_username' => 'creator',
+            ],
+            'creationDatetime' => new \DateTimeImmutable('2026-05-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/user/notifications', [], ['HTTP_ACCEPT' => 'application/ld+json']);
+
+        // The entry still exists, so the flag comes back from it and the feed stops having to guess
+        // an all-day datetime from its shape (#877).
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/UserNotification',
+            '@id' => '/api/user/notifications',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/user/notifications/' . $notification->id,
+                    '@type' => 'UserNotification',
+                    'id' => (string) $notification->id,
+                    'type' => 'band_space_agenda_entry_created',
+                    'payload' => [
+                        'band_space_id' => (string) $bandSpace->id,
+                        'band_space_name' => 'The Rockers',
+                        'agenda_entry_id' => (string) $entry->id,
+                        'entry_title' => 'Festival',
+                        'event_datetime' => '2026-08-15T00:00:00+00:00',
+                        'is_all_day' => true,
                         'actor_id' => 'actor-1',
                         'actor_username' => 'creator',
                     ],
@@ -880,7 +943,9 @@ class UserNotificationTest extends ApiTestCase
         $this->client->jsonRequest('GET', '/api/user/notifications', [], ['HTTP_ACCEPT' => 'application/ld+json']);
 
         // Neither the title nor the date is refreshed: where and when the band rehearses now is no
-        // longer their business.
+        // longer their business. Nothing is added either, so a payload stored before `is_all_day`
+        // existed keeps no such key, and the feed reads a missing flag as false: the datetime is
+        // shown as the instant it was already being shown as.
         $this->assertResponseIsSuccessful();
         $this->assertJsonEquals([
             '@context' => '/api/contexts/UserNotification',


### PR DESCRIPTION
Closes #877.

France has real users west of UTC: Guadeloupe and Martinique are UTC-4. All-day agenda entries are normalised to `T00:00:00+00:00` and finance items forced to midnight UTC, so anything reading that instant with local getters lands them a day early.

Confirmed against the real installed FullCalendar v7 engine rather than by reading. `DateEnv.timestampToMarker()` for `timeZone: 'local'` is `arrayToUtcDate(dateToLocalArray(new Date(ms)))`, which rewrites the instant to local wall clock and re-tags it as UTC before the calendar picks a day cell. Same input `2026-08-12T00:00:00+00:00`, before the fix:

| Site | Europe/Paris | America/Martinique |
|---|---|---|
| FullCalendar day cell | 2026-08-12 | **2026-08-11** |
| Finance due date cell | 2026-08-12 | **2026-08-11** |
| Dashboard widget label | mercredi 12 août | **mardi 11 août** |
| Agenda list grouping | 2026-08-12 | **2026-08-11** |
| Notification sentence | 12 août 2026 | **11 août 2026** |
| Timed 20:30+02:00 | 2026-08-12 | 2026-08-12 |

## A fifth site the issue does not list, and this one corrupts data

`AgendaEntryDrawer.vue` seeded its pickers with `new Date(item.datetime)` while `serializeDatetime` wrote back with local `format(date, 'yyyy-MM-dd')`. Under Martinique, opening an existing all-day entry and pressing Sauvegarder **without changing anything** rewrote `2026-08-12` to `2026-08-11`, and it compounded on every edit.

This has been live on master, so entries edited by a user in Guadeloupe or Martinique may already have drifted. Worth deciding whether an audit is warranted, in the spirit of M-889's own skipped-window report.

## What changed

`assets/js/utils/agendaDate.js` holds the whole rule: a bare `yyyy-MM-dd` string with no time and no offset skips the conversion and stays correct under any TZ. That is what `agendaRange.js` and the drawer already did for their own date handling, so the two existing copies now import the module instead of there being five implementations.

Fixed: the FullCalendar `start` / `end` feed, the list grouping and year-overview dots, the post-save toast, the dashboard widget label, the notification sentence, and the drawer picker seeding.

**Timed events keep their real instant.** The all-day flag is an explicit parameter everywhere rather than inferred, so a timed evening gig still lands on the right local day. Verified at UTC+14 as well: a `20:30+02:00` gig correctly moves to the 13th in Kiritimati while every all-day item stays on the 12th. The load-bearing "do NOT switch to UTC getters" comment in `dayEventSources()` is preserved, since that guards the inverse bug.

## The notification payload now carries the flag

An earlier revision guessed all-day by matching the `T00:00:00+00:00` shape, because the notification payload had no flag. That guess is reachably wrong: `serializeDatetime` calls `toISOString()` unconditionally, so a real gig at 1am winter or 2am summer Paris time serializes to exactly that shape. Nothing was lost, since the sentence is date-only, but the day froze to one value instead of varying per reader, which is the opposite of the point of this change.

So the listener and the enricher now send `is_all_day` and the frontend reads it. A payload predating the change reads as `false` at the single consumer, and the enricher refreshes the flag from the live entity, so existing notifications recover on read. The former-member path keeps its deliberately frozen payload.

## Also

`agendaItemDayKeys` and `agendaCalendarEventDates` gated multi-day expansion on two different conditions that agree only because `AgendaAggregator::buildTask()` and `buildFinance()` both hardcode a null end. Both now use the same derived check, with a test pinning that the list and the grid agree, so a producer growing a real end date cannot make them diverge silently.

## Testing

`agendaDate.test.js` runs every assertion twice through a `describeInTimeZone` wrapper that moves `process.env.TZ`, so CI catches this class without anyone remembering to set TZ. This bug has now appeared three times in this project.

Suite 284 to 332, green under the host zone, `America/Martinique`, `Europe/Paris` and `Pacific/Kiritimati`.

Removing the date-only reading fails **13 tests: 1 in the Paris block and 12 in the Martinique block**. Every timed-entry assertion still passes in both, which is the scoping guarantee. Reverting only the gate alignment fails the 2 agreement tests and nothing else.

PHP: agenda entry 63 green, notification 32 green, full suite 2305 green, PHPStan level 8 clean. Biome clean, build succeeds.
