### PR TITLE
feat(M-833): notify the remaining admins when a member leaves a band space

### DIFF
--- a/assets/js/components/Notification/NotificationItem.vue
+++ b/assets/js/components/Notification/NotificationItem.vue
@@ -214,6 +214,21 @@ const TYPE_CONFIG = {
     actions: null,
     target: null
   }),
+  // Sent to the remaining admins, so it deep-links to the roster they will want to look at. A
+  // different icon and colour from band_space_member_removed on purpose: quitting and being removed
+  // sit side by side in the same feed and must not read as the same event.
+  band_space_member_left: (payload) => ({
+    icon: 'pi pi-sign-out',
+    avatarClass: 'bg-orange-100 text-orange-600 dark:bg-orange-500/20 dark:text-orange-300',
+    title: payload.actor_username,
+    preview: `a quitté « ${payload.band_space_name} »`,
+    actions: null,
+    target: {
+      name: BAND_SPACE_ROUTES.PARAMETERS,
+      params: { id: payload.band_space_id },
+      query: { section: 'members' }
+    }
+  }),
   task_mention: (payload) => ({
     icon: 'pi pi-at',
     avatarClass: 'bg-amber-100 text-amber-600 dark:bg-amber-500/20 dark:text-amber-300',

--- a/src/Enum/Notification/NotificationType.php
+++ b/src/Enum/Notification/NotificationType.php
@@ -21,6 +21,7 @@ enum NotificationType: string
     case GalleryRejected = 'gallery_rejected';
     case BandSpaceRoleChanged = 'band_space_role_changed';
     case BandSpaceMemberRemoved = 'band_space_member_removed';
+    case BandSpaceMemberLeft = 'band_space_member_left';
     case BandSpaceAgendaEntryCreated = 'band_space_agenda_entry_created';
     case BandSpaceFinanceSplitAssigned = 'band_space_finance_split_assigned';
     case BandSpaceDeletionScheduled = 'band_space_deletion_scheduled';

--- a/src/Event/BandSpaceMemberLeftEvent.php
+++ b/src/Event/BandSpaceMemberLeftEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * A member quit a band space of their own accord.
+ *
+ * No separate actor, unlike {@see BandSpaceMemberRemovedEvent}: the member who left is the actor, so
+ * the membership carries both. The membership is already flagged as left when this is dispatched.
+ */
+class BandSpaceMemberLeftEvent extends Event
+{
+    public function __construct(
+        public readonly BandSpaceMembership $membership,
+    ) {
+    }
+}

--- a/src/EventSubscriber/BandSpaceMemberLeftListener.php
+++ b/src/EventSubscriber/BandSpaceMemberLeftListener.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\User;
+use App\Enum\Notification\NotificationType;
+use App\Event\BandSpaceMemberLeftEvent;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Service\Notification\NotificationCreator;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * Notifies the remaining admins when a member quits a band space (#833). Departing deactivates that
+ * member's finance recurrences and drops their planned entries, so an admin who is not told has a
+ * budget that moved under them and nothing but the activity log to explain it.
+ *
+ * Admins only, not the whole roster: the departure leaves book-keeping for whoever can act on it.
+ * Best-effort per the epic #689 resilience contract: dispatched after the commit, and the whole body
+ * (including the admin-resolution query) is wrapped so it can never roll back or 500 the departure.
+ *
+ * No enricher: band_space_name and the username are point-in-time labels, and a membership that no
+ * longer exists has no page of its own to deep-link to.
+ */
+#[AsEventListener]
+readonly class BandSpaceMemberLeftListener
+{
+    public function __construct(
+        private NotificationCreator $notificationCreator,
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(BandSpaceMemberLeftEvent $event): void
+    {
+        $membership = $event->membership;
+        $actorId = (string) $membership->user->id;
+
+        try {
+            $bandSpace = $membership->bandSpace;
+            // The departure is committed by now, so the leaver's own membership is no longer active and
+            // the query cannot return it. Filtered anyway, for symmetry with the sibling listeners and
+            // so an admin who quits is never told about their own departure.
+            $recipients = array_filter(
+                array_map(
+                    static fn (BandSpaceMembership $adminMembership): User => $adminMembership->user,
+                    $this->bandSpaceMembershipRepository->findActiveAdmins($bandSpace),
+                ),
+                static fn (User $admin): bool => (string) $admin->id !== $actorId,
+            );
+            if ($recipients === []) {
+                return;
+            }
+
+            $this->notificationCreator->createForRecipients($recipients, NotificationType::BandSpaceMemberLeft, [
+                'band_space_id' => (string) $bandSpace->id,
+                'band_space_name' => $bandSpace->name,
+                'actor_id' => $actorId,
+                'actor_username' => $membership->user->username,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to create band space member left notifications', [
+                'membership_id' => (string) $membership->id,
+                'exception' => $e,
+            ]);
+        }
+    }
+}

--- a/src/Repository/BandSpace/BandSpaceMembershipRepository.php
+++ b/src/Repository/BandSpace/BandSpaceMembershipRepository.php
@@ -100,6 +100,27 @@ class BandSpaceMembershipRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
+    /**
+     * The active admins of a band space. The user comes along because the caller notifies them, and
+     * leaving it lazy would cost one query per admin.
+     *
+     * @return BandSpaceMembership[]
+     */
+    public function findActiveAdmins(BandSpace $bandSpace): array
+    {
+        return $this->createQueryBuilder('m')
+            ->innerJoin('m.user', 'u')
+            ->addSelect('u')
+            ->where('m.bandSpace = :bandSpace')
+            ->andWhere('m.role = :role')
+            ->andWhere('m.status = :status')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('role', Role::Admin)
+            ->setParameter('status', MembershipStatus::Active)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function countActiveMembers(BandSpace $bandSpace): int
     {
         return (int) $this->createQueryBuilder('m')

--- a/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
+++ b/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
@@ -48,6 +48,14 @@ use DateTime;
  * departing member and that account is gone; neither is BandSpaceDeletionStateChangedEvent, since the
  * space only gets scheduled when nobody is left to read it. The departure itself lands in the settings
  * activity feed, which is where the band looks for who came and went.
+ *
+ * BandSpaceMemberLeftEvent is not dispatched either, and that one is an open question rather than a
+ * settled call. The manual Quitter button does dispatch it, on the argument that the activity feed is
+ * not where admins notice a departure that silently deactivated the leaver's finance recurrences. The
+ * same consequence happens here. The reason it is still not dispatched is that the handle is already
+ * anonymized by this point, so admins would be told that deleted_<uuid> left, which carries the fact
+ * but not the person. Deciding to send it anyway is a behaviour change on the account-deletion path,
+ * so it belongs in its own issue rather than riding along with the one that added the event.
  */
 readonly class WithdrawUserFromBandSpacesProcedure
 {

--- a/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
@@ -9,6 +9,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceSettingsActivityType;
 use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\BandSpace\Role;
+use App\Event\BandSpaceMemberLeftEvent;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
@@ -20,6 +21,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @implements ProcessorInterface<mixed, void>
@@ -34,6 +36,7 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
         private TaskAssignmentRevoker $taskAssignmentRevoker,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -79,5 +82,8 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
                 ],
             );
         });
+
+        // Best-effort notification dispatched after the commit (epic #689 contract).
+        $this->eventDispatcher->dispatch(new BandSpaceMemberLeftEvent($membership));
     }
 }

--- a/tests/Api/BandSpace/BandSpaceMembershipNotificationTest.php
+++ b/tests/Api/BandSpace/BandSpaceMembershipNotificationTest.php
@@ -179,6 +179,113 @@ class BandSpaceMembershipNotificationTest extends ApiTestCase
         $this->assertCount(0, self::getContainer()->get(NotificationRepository::class)->findForRecipient($admin, 10, 0));
     }
 
+    public function test_leaving_notifies_the_remaining_admins_only(): void
+    {
+        $admin1 = UserFactory::new()->asBaseUser()->create();
+        $admin2 = UserFactory::new()->create(['username' => 'admin2', 'email' => 'admin2@test.com']);
+        $plainMember = UserFactory::new()->create(['username' => 'plain_member', 'email' => 'plain@test.com']);
+        $leaver = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin1, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin2, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $plainMember, 'role' => Role::User])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $leaver, 'role' => Role::User])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $leaverId = (string) $leaver->id;
+
+        $this->client->loginUser($leaver);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/leave',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $expectedPayload = [
+            'band_space_id' => $bandSpaceId,
+            'band_space_name' => 'Mon groupe',
+            'actor_id' => $leaverId,
+            'actor_username' => 'member_user',
+        ];
+
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+        foreach ([$admin1, $admin2] as $admin) {
+            $notifications = $notificationRepository->findForRecipient($admin, 10, 0);
+            $this->assertCount(1, $notifications);
+            $this->assertSame(NotificationType::BandSpaceMemberLeft, $notifications[0]->type);
+            $this->assertSame($expectedPayload, $notifications[0]->payload);
+        }
+
+        // A departure is book-keeping for whoever can act on it, so plain members are left out.
+        $this->assertCount(0, $notificationRepository->findForRecipient($plainMember, 10, 0));
+        // The member who quit is their own actor and is never notified.
+        $this->assertCount(0, $notificationRepository->findForRecipient($leaver, 10, 0));
+    }
+
+    public function test_an_admin_leaving_does_not_notify_themselves(): void
+    {
+        $admin1 = UserFactory::new()->asBaseUser()->create();
+        $admin2 = UserFactory::new()->create(['username' => 'admin2', 'email' => 'admin2@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin1, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin2, 'role' => Role::Admin])->create();
+
+        $bandSpaceId = (string) $bandSpace->id;
+        $admin2Id = (string) $admin2->id;
+
+        $this->client->loginUser($admin2);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/' . $bandSpaceId . '/leave',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $notificationRepository = self::getContainer()->get(NotificationRepository::class);
+        $notifications = $notificationRepository->findForRecipient($admin1, 10, 0);
+        $this->assertCount(1, $notifications);
+        $this->assertSame(NotificationType::BandSpaceMemberLeft, $notifications[0]->type);
+        $this->assertSame([
+            'band_space_id' => $bandSpaceId,
+            'band_space_name' => 'Mon groupe',
+            'actor_id' => $admin2Id,
+            'actor_username' => 'admin2',
+        ], $notifications[0]->payload);
+
+        $this->assertCount(0, $notificationRepository->findForRecipient($admin2, 10, 0));
+    }
+
+    public function test_notification_failure_does_not_break_the_departure(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'member_user', 'email' => 'member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Mon groupe']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $memberMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member, 'role' => Role::User])->create();
+        $memberMembershipId = $memberMembership->id;
+
+        self::getContainer()->set(NotificationCreator::class, $this->throwingNotificationCreator());
+
+        $this->client->loginUser($member);
+        $this->client->request(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/leave',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $left = self::getContainer()->get(BandSpaceMembershipRepository::class)->find($memberMembershipId);
+        $this->assertSame(MembershipStatus::Left, $left->status);
+        $this->assertCount(0, self::getContainer()->get(NotificationRepository::class)->findForRecipient($admin, 10, 0));
+    }
+
     public function test_self_demote_does_not_notify(): void
     {
         $admin1 = UserFactory::new()->asBaseUser()->create();


### PR DESCRIPTION
Closes #833.

`BandSpaceLeaveProcessor` recorded the departure in the activity feed and dispatched nothing, unlike every sibling action: a kick dispatches `BandSpaceMemberRemovedEvent`, a role change dispatches `BandSpaceMemberRoleChangedEvent`. So a member could quit, have their finance recurrences deactivated and their planned entries deleted, and the admins would only find out by scrolling the activity log.

## What changed

`BandSpaceMemberLeftEvent` plus `BandSpaceMemberLeftListener`, following the established notification shape: one event, one listener with a single `__invoke`, the whole body in try/catch with a log so it can never roll back or 500 the departure. Recipients are the remaining active admins, excluding the actor. Dispatched after `wrapInTransaction` commits, so a failed flush cannot announce a departure that did not happen.

Admins only rather than the whole roster, because the departure leaves book-keeping only an admin can act on. The payload matches the `band_space_member_removed` shape exactly (`band_space_id`, `band_space_name`, `actor_id`, `actor_username`), and the feed gets a distinct icon and colour from a kick, since quitting and being removed sit side by side in the same list.

`BandSpaceMembershipRepository::findActiveAdmins()` filters on both `role = Admin` and `status = Active`, so a departed or removed admin is never notified.

## Review

Confirmed by execution rather than by reading: the post-commit dispatch, the admin-query filtering, the fault isolation, and that the frontend branch reads exactly the keys the listener writes.

It also confirmed a gap the implementation had already disclosed: `WithdrawUserFromBandSpacesProcedure` performs the identical `status = Left` transition on the account-deletion path and does not dispatch this event. That is left as is deliberately, and the reasoning is now recorded in that class rather than left implicit. Worth knowing the original justification was wrong: the concern was scattering fresh copies of a deleted member's username, but `DeleteAccountProcedure` anonymises first and withdraws second, so a notification there would carry the anonymised handle. The real reason not to send it is that admins would be told `deleted_<uuid>` left, which carries the fact but not the person, and changing that is a behaviour change on the deletion path that belongs in its own issue.

## Verification

Full suite 2331 green, PHPStan level 8 clean, biome clean, build succeeds. New tests cover the notify-admins-only path with a full-body payload assertion, an admin leaving not notifying themselves, and a fault-isolation case proving a throwing notification path still returns 204 with the membership marked `Left`.
