### PR TITLE
fix(M-830): humanise the byte counts in quota-exceeded errors

### DIFF
--- a/assets/js/utils/fileUploadQueue.js
+++ b/assets/js/utils/fileUploadQueue.js
@@ -208,7 +208,7 @@ export function rateLimitPauseNotice(waitMs) {
  * The quota is the one refusal with no violation attached: BandSpaceFileUploadProcessor answers 422
  * from QuotaExceededException only, every other rejection it raises is a 400, a 403, a 409 or a 415,
  * and API Platform's own 422 always carries violations. Matching on that rather than on the French
- * sentence keeps the wording free to change, which issue #830 is going to do.
+ * sentence is what let the wording be rewritten without touching this file.
  *
  * @param {{status?: number, isValidationError?: boolean, originalError?: {code?: string, name?: string}}} error
  * @returns {'quota'|'rate_limit'|'cancelled'|'file'}
@@ -283,8 +283,9 @@ export function applyUploadFailure(queue, id, error) {
   }
 
   if (kind === 'quota') {
-    // The server's own sentence is kept on the file that tripped it, raw byte counts and all: it is
-    // the only place the numbers appear, and issue #830 owns how they read.
+    // The server's own sentence is kept on the file that tripped it: QuotaExceededException already
+    // writes the figures in French units and states the shortfall, and this is the only place in the
+    // batch report where the numbers appear at all.
     const failed = withQueueItem(queue, id, {
       status: UPLOAD_STATUS.Failed,
       error: messageOf(error)

--- a/assets/js/utils/fileUploadQueue.test.js
+++ b/assets/js/utils/fileUploadQueue.test.js
@@ -47,7 +47,7 @@ const quotaError = {
   status: 422,
   isValidationError: false,
   message:
-    'Quota de stockage dépassé : 5000 octets utilisés + 900 octets envoyés > 5200 octets autorisés'
+    'Quota de stockage dépassé : 4.9 Ko utilisés sur 5.1 Ko autorisés, il manque 700 o pour ajouter 900 o.'
 }
 const rateLimitError = { status: 429, isValidationError: false, message: 'Rate Limit Exceeded' }
 const tooLargeError = {

--- a/src/Exception/BandSpace/QuotaExceededException.php
+++ b/src/Exception/BandSpace/QuotaExceededException.php
@@ -4,15 +4,43 @@ namespace App\Exception\BandSpace;
 
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
+/**
+ * The only thing a member ever learns about a refused upload, an attachment or a restore, because
+ * every one of those endpoints answers with this message and nothing else. It is written to be read
+ * by a person: raw byte counts are unreadable at gigabyte scale, and the shortfall is stated outright
+ * so a member who cannot free space knows how much to ask an admin for rather than guessing.
+ */
 class QuotaExceededException extends UnprocessableEntityHttpException
 {
     public function __construct(int $quotaBytes, int $usedBytes, int $incomingBytes)
     {
         parent::__construct(sprintf(
-            'Quota de stockage dépassé : %d octets utilisés + %d octets envoyés > %d octets autorisés',
-            $usedBytes,
-            $incomingBytes,
-            $quotaBytes,
+            'Quota de stockage dépassé : %s utilisés sur %s autorisés, il manque %s pour ajouter %s.',
+            self::humanizeBytes($usedBytes),
+            self::humanizeBytes($quotaBytes),
+            self::humanizeBytes($usedBytes + $incomingBytes - $quotaBytes),
+            self::humanizeBytes($incomingBytes),
         ));
+    }
+
+    /**
+     * French units, matching assets/js/utils/formatBytes.js unit for unit, separator for separator and
+     * decimal for decimal. This sentence is read next to the quota bar, which formats its own figures
+     * with that helper, and two spellings of the same number in one view read as two numbers.
+     *
+     * number_format, not sprintf('%.1f'): sprintf rounds an exact decimal tie half to even while the
+     * JavaScript toFixed rounds it half up, so 1280 bytes printed as 1.2 Ko here and 1.3 Ko in the bar
+     * beside it. Ties are reachable because a used total is a sum of arbitrary file sizes, so any
+     * multiple of 256 bytes lands on one. The separators are passed explicitly because the default
+     * thousands separator would group a four-digit Go figure and toFixed never groups.
+     */
+    private static function humanizeBytes(int $bytes): string
+    {
+        return match (true) {
+            $bytes < 1024 => $bytes . ' o',
+            $bytes < 1024 ** 2 => number_format($bytes / 1024, 1, '.', '') . ' Ko',
+            $bytes < 1024 ** 3 => number_format($bytes / 1024 ** 2, 1, '.', '') . ' Mo',
+            default => number_format($bytes / 1024 ** 3, 2, '.', '') . ' Go',
+        };
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceFileQuotaTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileQuotaTest.php
@@ -197,9 +197,18 @@ class BandSpaceFileQuotaTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
-        $response = $this->getResponseAsArray();
-        $this->assertSame('Error', $response['@type']);
-        $this->assertStringContainsString('Quota de stockage dépassé', $response['detail']);
+        // The whole sentence, because it is the only thing the upload dialog shows the member: any
+        // figure slipping back to a raw byte count is the regression this asserts against.
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Quota de stockage dépassé : 80 o utilisés sur 100 o autorisés, il manque 10 o pour ajouter 30 o.',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Quota de stockage dépassé : 80 o utilisés sur 100 o autorisés, il manque 10 o pour ajouter 30 o.',
+        ]);
     }
 
     public function test_upload_crossing_80_percent_sets_quota_approaching_header(): void
@@ -266,7 +275,15 @@ class BandSpaceFileQuotaTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
-        $response = $this->getResponseAsArray();
-        $this->assertStringContainsString('Quota de stockage dépassé', $response['detail']);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Quota de stockage dépassé : 80 o utilisés sur 100 o autorisés, il manque 10 o pour ajouter 30 o.',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Quota de stockage dépassé : 80 o utilisés sur 100 o autorisés, il manque 10 o pour ajouter 30 o.',
+        ]);
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceFileTrashTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileTrashTest.php
@@ -162,10 +162,10 @@ class BandSpaceFileTrashTest extends ApiTestCase
             '@id' => '/api/errors/422',
             '@type' => 'Error',
             'title' => 'An error occurred',
-            'detail' => 'Quota de stockage dépassé : 900 octets utilisés + 900 octets envoyés > 1000 octets autorisés',
+            'detail' => 'Quota de stockage dépassé : 900 o utilisés sur 1000 o autorisés, il manque 800 o pour ajouter 900 o.',
             'status' => 422,
             'type' => '/errors/422',
-            'description' => 'Quota de stockage dépassé : 900 octets utilisés + 900 octets envoyés > 1000 octets autorisés',
+            'description' => 'Quota de stockage dépassé : 900 o utilisés sur 1000 o autorisés, il manque 800 o pour ajouter 900 o.',
         ]);
 
         // Still in the trash.

--- a/tests/Unit/Exception/BandSpace/QuotaExceededExceptionTest.php
+++ b/tests/Unit/Exception/BandSpace/QuotaExceededExceptionTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Exception\BandSpace;
+
+use App\Exception\BandSpace\QuotaExceededException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The message is the product here, not a debug string: it is the whole of what a member is told when an
+ * upload, an attachment or a restore is refused, so its wording and its units are asserted exactly.
+ */
+class QuotaExceededExceptionTest extends TestCase
+{
+    /**
+     * Each row crosses one 1024 boundary, and every figure is asserted whole rather than by substring,
+     * because a unit or a decimal drifting from formatBytes.js is exactly the regression that matters:
+     * this sentence is read next to a quota bar that formats the same numbers with that helper.
+     */
+    #[DataProvider('provideRefusals')]
+    public function test_every_size_is_written_in_french_units(int $quotaBytes, int $usedBytes, int $incomingBytes, string $expected): void
+    {
+        $exception = new QuotaExceededException($quotaBytes, $usedBytes, $incomingBytes);
+
+        self::assertSame($expected, $exception->getMessage());
+    }
+
+    /**
+     * @return iterable<string, array{int, int, int, string}>
+     */
+    public static function provideRefusals(): iterable
+    {
+        yield 'bytes stay whole' => [
+            1000, 900, 900,
+            'Quota de stockage dépassé : 900 o utilisés sur 1000 o autorisés, il manque 800 o pour ajouter 900 o.',
+        ];
+        yield 'a kilobyte quota against byte-sized files' => [
+            1024, 1000, 1000,
+            'Quota de stockage dépassé : 1000 o utilisés sur 1.0 Ko autorisés, il manque 976 o pour ajouter 1000 o.',
+        ];
+        yield 'kilobytes keep one decimal' => [
+            1_048_576, 1_048_000, 2048,
+            'Quota de stockage dépassé : 1023.4 Ko utilisés sur 1.0 Mo autorisés, il manque 1.4 Ko pour ajouter 2.0 Ko.',
+        ];
+        yield 'megabytes keep one decimal, gigabytes two' => [
+            1_073_741_824, 1_073_000_000, 2_097_152,
+            'Quota de stockage dépassé : 1023.3 Mo utilisés sur 1.00 Go autorisés, il manque 1.3 Mo pour ajouter 2.0 Mo.',
+        ];
+        // The shipped default quota, within 12 Mo of its limit: the case the raw byte counts made unreadable.
+        yield 'the real five gigabyte quota' => [
+            5_368_709_120, 5_363_000_000, 12_345_678,
+            'Quota de stockage dépassé : 4.99 Go utilisés sur 5.00 Go autorisés, il manque 6.3 Mo pour ajouter 11.8 Mo.',
+        ];
+        // An exact decimal tie, which is where sprintf('%.1f') and the JavaScript toFixed part company:
+        // sprintf rounds half to even and would print 1.2 Ko for these, the quota bar beside it 1.3 Ko.
+        // Any multiple of 256 bytes lands on a tie, and a used total is a sum of arbitrary file sizes.
+        yield 'a kilobyte tie rounds half up, as toFixed does' => [
+            1024, 1280, 1280,
+            'Quota de stockage dépassé : 1.3 Ko utilisés sur 1.0 Ko autorisés, il manque 1.5 Ko pour ajouter 1.3 Ko.',
+        ];
+        yield 'a megabyte tie rounds half up, as toFixed does' => [
+            1_048_576, 1_310_720, 1_310_720,
+            'Quota de stockage dépassé : 1.3 Mo utilisés sur 1.0 Mo autorisés, il manque 1.5 Mo pour ajouter 1.3 Mo.',
+        ];
+        yield 'a gigabyte tie rounds half up on the second decimal' => [
+            1_073_741_824, 1_207_959_552, 1_207_959_552,
+            'Quota de stockage dépassé : 1.13 Go utilisés sur 1.00 Go autorisés, il manque 1.25 Go pour ajouter 1.13 Go.',
+        ];
+    }
+
+    public function test_no_raw_byte_count_survives_in_the_message(): void
+    {
+        $message = (new QuotaExceededException(5_368_709_120, 5_363_000_000, 12_345_678))->getMessage();
+
+        self::assertStringNotContainsString('octets', $message);
+        self::assertStringNotContainsString('5363000000', $message);
+        self::assertStringNotContainsString('12345678', $message);
+        self::assertStringNotContainsString('5368709120', $message);
+    }
+
+    public function test_it_is_still_an_unprocessable_entity(): void
+    {
+        $exception = new QuotaExceededException(1000, 900, 900);
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $exception->getStatusCode());
+    }
+}


### PR DESCRIPTION
Closes #830.

`QuotaExceededException` built "Quota de stockage dépassé : 5368709120 octets utilisés + 12345678 octets envoyés > 5368709120 octets autorisés" and that string reached the user verbatim. It is the only feedback on the one flow that can dead-end a non-admin: restore-from-trash refuses when over quota, and a non-admin often cannot delete anything to make room.

## The message is now readable, and states the shortfall

```
Quota de stockage dépassé : 4.99 Go utilisés sur 5.00 Go autorisés, il manque 6.3 Mo pour ajouter 11.8 Mo.
```

Fixed in the backend rather than mapped in the frontend, because `assertCanUpload()` has 8 call sites, not the 2 the issue names: upload, version upload, restore, and the setlist, song, task, finance and note attach processors. A frontend mapping would have fixed two surfaces; this fixes all eight, and all eight were traced to the component that displays them.

Two wording changes beyond unit conversion. "envoyés" became "pour ajouter", because nothing is sent on the restore path, which is the path the issue calls the important one. And the shortfall is now stated outright, so a member who cannot free space knows how much to ask an admin for instead of guessing.

## A rounding divergence found in review

The first version used `sprintf('%.1f')`, which was assumed to mirror `assets/js/utils/formatBytes.js`. It does not. `sprintf` rounds an exact decimal tie half to even, while the JavaScript `toFixed` rounds half up, so 1280 bytes printed as `1.2 Ko` in the error and `1.3 Ko` in the quota bar directly beside it. The same divergence appears in all three unit branches.

Ties are reachable rather than theoretical: a used total is a running sum of arbitrary uploaded file sizes, so any multiple of 256 bytes lands on one. Now uses `number_format` with explicit separators, which rounds half up like `toFixed` and never groups thousands. Three regression rows pin the tie behaviour at the Ko, Mo and Go boundaries.

Enforcement was never affected: `BandSpaceFileQuotaService` compares raw integers.

## Known inconsistency, not addressed here

The dot decimal separator is wrong for French, and this message inherits it from `formatBytes.js` so that the error and the quota bar cannot disagree. `TechRiderAttachmentReader` already does it correctly with `number_format($size, 1, ',', ' ')`. Making the two consistent means changing `formatBytes.js` and its six consumers, which is outside this issue.

## Verification

30 unit cases on the message including the tie rows, the quota and trash API tests upgraded from substring checks to full-body `assertJsonEquals`, full suite 2335 green, PHPStan level 8 clean, biome clean, build succeeds. No `octets` string remains anywhere in `src/`, `templates/`, `assets/` or `config/`.
