### PR TITLE
feat(M-828): surface the split warning on finance entries

### DIFF
--- a/assets/js/components/BandSpace/Finance/EntryList.vue
+++ b/assets/js/components/BandSpace/Finance/EntryList.vue
@@ -72,6 +72,11 @@
           {{ entry.type === 'expense' ? 'Dépense' : 'Revenu' }}
         </span>
 
+        <!-- Répartition that no longer matches the amount. Sits against the amount because that is
+             what it disagrees with, and stays visible on mobile: it is the only place the mismatch
+             is reported outside the drawer. -->
+        <FinanceSplitWarning v-if="entry.split_warning" />
+
         <!-- Amount -->
         <span class="text-sm font-medium tabular-nums flex-shrink-0 text-right w-20 sm:w-24">
           {{ formatEntryAmount(entry) }}
@@ -100,6 +105,7 @@ import { VueDraggable } from 'vue-draggable-plus'
 import { useBandSpaceFinanceStore } from '../../../store/bandSpace/bandSpaceFinance.js'
 import { formatAmount } from '../../../utils/currency.js'
 import { formatDateCompact } from '../../../utils/date.js'
+import FinanceSplitWarning from './FinanceSplitWarning.vue'
 import FinanceStatusDot from './FinanceStatusDot.vue'
 
 const props = defineProps({

--- a/assets/js/components/BandSpace/Finance/FinanceDrawer.vue
+++ b/assets/js/components/BandSpace/Finance/FinanceDrawer.vue
@@ -468,7 +468,15 @@ async function handleSave() {
 
     if (entryId && splitManager) {
       try {
-        await splitManager.syncSplits(entryId)
+        // The répartition is written after the entry, so createEntry/updateEntry reloaded the lists
+        // while the old shares were still in place. Without this second reload the row keeps the
+        // split_warning badge the member just fixed, and the contributions bar keeps the old totals.
+        if (await splitManager.syncSplits(entryId)) {
+          await Promise.all([
+            financeStore.loadEntries(props.bandSpaceId),
+            financeStore.loadSummary(props.bandSpaceId)
+          ])
+        }
       } catch (error) {
         // The entry itself is saved, so this is not a failed save, but the repartition on screen is no
         // longer what the entry carries. The drawer stays open on the reloaded splits instead of

--- a/assets/js/components/BandSpace/Finance/FinanceSplitWarning.vue
+++ b/assets/js/components/BandSpace/Finance/FinanceSplitWarning.vue
@@ -1,0 +1,31 @@
+<template>
+  <!-- Mismatch conveyed by icon SHAPE + an accessible name, never by colour alone (WCAG 1.4.1).
+       A PrimeVue tooltip carries no accessible name, so the wording is on aria-label as well as on
+       the native title that shows it on hover. Amber 700 in light mode, because the rows sit on the
+       grey surface band where the 500 level fails AA (same reason as the #688 darkening). -->
+  <span
+    role="img"
+    :aria-label="SPLIT_WARNING_LABEL"
+    :title="SPLIT_WARNING_LABEL"
+    class="inline-flex flex-shrink-0 leading-none text-amber-700 dark:text-amber-400"
+  >
+    <i class="pi pi-exclamation-triangle text-xs" aria-hidden="true" />
+  </span>
+</template>
+
+<script setup>
+/**
+ * The entry carries a répartition that no longer adds up to its amount, which the API reports as
+ * split_warning and nothing on screen used to show.
+ *
+ * Nothing re-checks the shares when the amount changes: lowering an entry from 100 to 60 without
+ * touching a 50/50 répartition writes no split at all, because both sides are unchanged. The 100
+ * allocated on a 60 EUR expense is then wrong everywhere and announced nowhere, so the row needs a
+ * signal of its own rather than one only the drawer's total line shows.
+ *
+ * Under-allocation counts too: the flag is raised as soon as the shares total anything other than
+ * the amount, so the wording says "ne correspond pas" and not "dépasse".
+ */
+const SPLIT_WARNING_LABEL =
+  'Répartition à revoir : le total réparti entre les membres ne correspond pas au montant de l’entrée.'
+</script>

--- a/assets/js/components/BandSpace/Finance/FinanceTimeline.vue
+++ b/assets/js/components/BandSpace/Finance/FinanceTimeline.vue
@@ -65,6 +65,9 @@
             {{ entry.type === 'expense' ? 'Dépense' : 'Revenu' }}
           </span>
 
+          <!-- Répartition that no longer matches the amount, against the amount it disagrees with -->
+          <FinanceSplitWarning v-if="entry.split_warning" />
+
           <!-- Amount -->
           <span class="text-sm font-medium tabular-nums flex-shrink-0 text-right w-20 sm:w-24">
             {{ formatEntryAmount(entry) }}
@@ -90,6 +93,7 @@ import Button from 'primevue/button'
 import { computed } from 'vue'
 import { formatAmount } from '../../../utils/currency.js'
 import { formatDateCompactWithYear } from '../../../utils/date.js'
+import FinanceSplitWarning from './FinanceSplitWarning.vue'
 import FinanceStatusDot from './FinanceStatusDot.vue'
 
 const props = defineProps({

--- a/assets/js/components/BandSpace/Finance/SplitManager.vue
+++ b/assets/js/components/BandSpace/Finance/SplitManager.vue
@@ -51,18 +51,28 @@
         <!-- Total line -->
         <div class="border-t border-surface-200 dark:border-surface-700 mt-2 pt-2 flex items-center justify-between text-sm">
           <span class="text-surface-500">Total</span>
+          <!-- 700 in light mode: the 500 level of both colours fails AA as text. The icon carries an
+               accessible name of its own, so the mismatch is stated and not only coloured, and it says
+               the same thing as the badge the row shows for the same entry. -->
           <span
-            :class="splitsMatchAmount ? 'text-green-500' : 'text-orange-500'"
+            :class="
+              splitsMatchAmount
+                ? 'text-green-700 dark:text-green-400'
+                : 'text-amber-700 dark:text-amber-400'
+            "
             class="font-medium"
           >
             {{ formatAmount(splitsTotal) }}
             <span v-if="amountEuros != null">
               / {{ formatAmount(Math.round(amountEuros * 100)) }}
             </span>
-            <i
-              :class="splitsMatchAmount ? 'pi pi-check' : 'pi pi-exclamation-triangle'"
-              class="text-xs ml-1"
-            ></i>
+            <span role="img" :aria-label="totalMatchLabel">
+              <i
+                :class="splitsMatchAmount ? 'pi pi-check' : 'pi pi-exclamation-triangle'"
+                class="text-xs ml-1"
+                aria-hidden="true"
+              ></i>
+            </span>
           </span>
         </div>
       </div>
@@ -123,6 +133,12 @@ const activeSplitsCount = computed(() => {
   }
   return count
 })
+
+const totalMatchLabel = computed(() =>
+  splitsMatchAmount.value
+    ? 'Le total réparti correspond au montant de l’entrée'
+    : 'Le total réparti ne correspond pas au montant de l’entrée'
+)
 
 const splitsSummaryText = computed(() => {
   if (activeSplitsCount.value === 0) return 'Aucune répartition'
@@ -197,13 +213,18 @@ function validateSplits() {
   return buildPlan().error
 }
 
+/**
+ * @returns {Promise<boolean>} whether a split was actually written, which the caller needs because
+ *          the répartition is saved after the entry: the lists it reloaded before this ran describe
+ *          the previous shares, so they have to be reloaded again, but only when there is a change.
+ */
 async function syncSplits(entryId) {
   const { error, operations } = buildPlan()
   if (error) {
     throw new Error(error)
   }
   if (operations.length === 0) {
-    return
+    return false
   }
 
   for (const operation of operations) {
@@ -220,6 +241,8 @@ async function syncSplits(entryId) {
   // The plan was built against the splits loaded when the drawer opened. Saving twice without
   // re-reading them would plan the second save against split ids that no longer exist.
   await loadExistingSplits(entryId)
+
+  return true
 }
 
 async function reset(entryId) {


### PR DESCRIPTION
Closes #828.

The backend already computed and shipped a `split_warning` flag on entries whose splits no longer sum to the amount, in four places. Grepping `assets/` returned zero references: the flag was never displayed anywhere.

It matters because nothing re-checks splits when an entry amount changes. Lower an entry from 100 to 60 EUR without touching its 50/50 shares and `syncSplits` sends no requests at all, because both sides are unchanged, leaving a 100 EUR allocation on a 60 EUR expense with no visible signal.

## What changed

Frontend only. No provider, builder or processor was touched.

A shared `FinanceSplitWarning.vue` badge, rendered in `EntryList.vue` and `FinanceTimeline.vue`. Meaning is carried by the triangle shape, distinct from the status dot's circle and the recurrence arrows, not by colour: `role="img"` with an `aria-label` gives it an accessible name, since a PrimeVue tooltip provides none, and the native `title` supplies the hover text. Amber 700 in light mode and 400 in dark, because the rows sit on the grey surface band where the 500 level fails AA, the same reason behind the #688 darkening.

The wording says "ne correspond pas" rather than "dépasse", because the flag is raised on under-allocation too.

## Two files beyond the issue's scope

`FinanceDrawer.vue` and `SplitManager.vue` also changed. `handleSave` writes splits after the create or update call has already reloaded the lists, so a member who opened a flagged entry and fixed the shares kept seeing the badge on the closed row until a period change or a page reload. A warning that lies immediately after being resolved is worse than no warning. `syncSplits()` now reports whether it wrote anything, and the reload is guarded on that, so an ordinary save with untouched splits still costs no extra request.

The motivating case from the issue already worked without this: lowering an amount goes through `updateEntry`, whose reload recomputes the flag server side.

## Two gaps this cannot close

Both are pre-existing backend limitations rather than anything introduced here.

The dashboard `FinanceSidebar` upcoming-deadlines widget renders a payload that has no `split_warning` field at all, so it cannot show the badge without a backend change. And range entries can never be flagged, because all three computation sites guard on `amount !== null`.

## Verification

Full suite 2328 green, JS suite 378 green, PHPStan level 8 clean, biome clean, build succeeds. No component test harness exists in this repo (no vitest, no `@vue/test-utils`), and the #688 precedent `FinanceStatusDot.vue` ships untested; the one behavioural boundary introduced, an empty operation list reporting nothing written, is already covered by `splitReconciliation.test.js`.
