### PR TITLE
feat(M-831): accept mm:ss durations and unify the setlist total format

### DIFF
--- a/assets/js/components/BandSpace/Setlist/AddSetlistItemDialog.vue
+++ b/assets/js/components/BandSpace/Setlist/AddSetlistItemDialog.vue
@@ -117,16 +117,16 @@
               <small v-if="labelError" class="text-red-500">{{ labelError }}</small>
             </div>
             <div>
-              <label class="block text-sm font-medium mb-1">Durée (s, optionnel)</label>
-              <InputNumber
+              <label class="block text-sm font-medium mb-1">Durée (mm:ss, optionnel)</label>
+              <InputText
                 v-model="otherDuration"
-                :min="1"
-                :max="86400"
-                :useGrouping="false"
+                placeholder="3:47"
                 class="w-full"
-                inputClass="w-full"
-                aria-label="Durée (s, optionnel)"
+                :invalid="!!otherDurationError"
+                aria-label="Durée au format mm:ss, optionnel"
               />
+              <small v-if="otherDurationError" class="text-red-500">{{ otherDurationError }}</small>
+              <small v-else class="text-surface-500">Minutes et secondes, par exemple 3:47.</small>
             </div>
             <div class="flex justify-end gap-2 pt-2">
               <Button label="Annuler" severity="secondary" text @click="visible = false" />
@@ -145,7 +145,6 @@ import Checkbox from 'primevue/checkbox'
 import Dialog from 'primevue/dialog'
 import IconField from 'primevue/iconfield'
 import InputIcon from 'primevue/inputicon'
-import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
 import SelectButton from 'primevue/selectbutton'
 import Tab from 'primevue/tab'
@@ -157,6 +156,7 @@ import { useToast } from 'primevue/usetoast'
 import { computed, ref, watch } from 'vue'
 import { useBandSetlistsStore } from '../../../store/bandSpace/bandSpaceSetlists.js'
 import { useBandSongsStore } from '../../../store/bandSpace/bandSpaceSongs.js'
+import { formatDuration, parseDurationInput } from '../../../utils/setlistDuration.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -179,7 +179,9 @@ const query = ref('')
 
 const otherType = ref('talk')
 const otherLabel = ref('')
-const otherDuration = ref(null)
+// Text, converted to seconds once on submit. Empty stays empty: the duration is optional here.
+const otherDuration = ref('')
+const otherDurationError = ref(null)
 const labelError = ref(null)
 
 const otherTypeOptions = [
@@ -230,12 +232,6 @@ function toggle(songId, checked) {
   selectedIds.value = next
 }
 
-function formatDuration(seconds) {
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${m}′${String(s).padStart(2, '0')}″`
-}
-
 watch(visible, (isOpen) => {
   if (isOpen) reset()
 })
@@ -247,7 +243,8 @@ function reset() {
   query.value = ''
   otherType.value = 'talk'
   otherLabel.value = ''
-  otherDuration.value = null
+  otherDuration.value = ''
+  otherDurationError.value = null
   labelError.value = null
 }
 
@@ -300,12 +297,16 @@ async function submitOther() {
     labelError.value = 'Veuillez spécifier un libellé'
     return
   }
+  const duration = parseDurationInput(otherDuration.value)
+  otherDurationError.value = duration.error
+  if (duration.error) return
+
   isSubmitting.value = true
   try {
     await setlistsStore.addItem(props.bandSpaceId, props.setlistId, {
       type: otherType.value,
       label: trimmed,
-      duration_override: otherDuration.value ?? null
+      duration_override: duration.seconds
     })
     toast.add({ severity: 'success', summary: 'Élément ajouté', life: 3000 })
     emit('added')

--- a/assets/js/components/BandSpace/Setlist/RepertoireView.vue
+++ b/assets/js/components/BandSpace/Setlist/RepertoireView.vue
@@ -47,7 +47,7 @@
             <td class="px-4 py-3 hidden md:table-cell text-surface-600 dark:text-surface-300">{{ song.tonality || '—' }}</td>
             <td class="px-4 py-3 hidden md:table-cell text-right tabular-nums text-surface-600 dark:text-surface-300">{{ song.tempo || '—' }}</td>
             <td class="px-4 py-3 hidden lg:table-cell text-right tabular-nums text-surface-600 dark:text-surface-300">
-              {{ formatDuration(song.reference_duration) }}
+              {{ formatDuration(song.reference_duration) || '—' }}
             </td>
             <td class="px-4 py-3 text-right">
               <Button
@@ -95,6 +95,7 @@ import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref, watch } from 'vue'
 import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
 import { useBandSongsStore } from '../../../store/bandSpace/bandSpaceSongs.js'
+import { formatDuration } from '../../../utils/setlistDuration.js'
 import SongDetailDrawer from './SongDetailDrawer.vue'
 import SongFormDialog from './SongFormDialog.vue'
 
@@ -170,13 +171,6 @@ const menuItems = computed(() => [
     command: () => confirmArchive(menuTargetSong.value)
   }
 ])
-
-function formatDuration(seconds) {
-  if (!seconds) return '—'
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${m}′${String(s).padStart(2, '0')}″`
-}
 
 function openCreateDialog() {
   editingSong.value = null

--- a/assets/js/components/BandSpace/Setlist/SetlistEditor.vue
+++ b/assets/js/components/BandSpace/Setlist/SetlistEditor.vue
@@ -136,6 +136,7 @@ import { computed, ref, watch } from 'vue'
 import { VueDraggable } from 'vue-draggable-plus'
 import { useRouter } from 'vue-router'
 import { useBandSetlistsStore } from '../../../store/bandSpace/bandSpaceSetlists.js'
+import { formatDuration } from '../../../utils/setlistDuration.js'
 import AddSetlistItemDialog from './AddSetlistItemDialog.vue'
 import PdfExportPopover from './PdfExportPopover.vue'
 import SetlistFileDrawer from './SetlistFileDrawer.vue'
@@ -195,13 +196,7 @@ const totalDurationSeconds = computed(() =>
   )
 )
 
-const formattedTotalDuration = computed(() => {
-  const total = totalDurationSeconds.value
-  const h = Math.floor(total / 3600)
-  const m = Math.floor((total % 3600) / 60)
-  const s = total % 60
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-})
+const formattedTotalDuration = computed(() => formatDuration(totalDurationSeconds.value))
 
 // Inline rename
 const editingName = ref(false)

--- a/assets/js/components/BandSpace/Setlist/SetlistItemCard.vue
+++ b/assets/js/components/BandSpace/Setlist/SetlistItemCard.vue
@@ -33,7 +33,7 @@
       <div
         v-if="hasOverride"
         class="text-[10px] text-amber-600 uppercase tracking-wide"
-        v-tooltip.top="`Durée surchargée (référence : ${formatSeconds(item.song?.reference_duration)})`"
+        v-tooltip.top="`Durée surchargée (référence : ${formatDuration(item.song?.reference_duration) || '—'})`"
       >
         surch.
       </div>
@@ -56,6 +56,7 @@
 <script setup>
 import Button from 'primevue/button'
 import { computed } from 'vue'
+import { formatDuration } from '../../../utils/setlistDuration.js'
 
 const props = defineProps({
   item: { type: Object, required: true },
@@ -100,12 +101,5 @@ const hasOverride = computed(
   () => props.item.duration_override !== null && props.item.duration_override !== undefined
 )
 
-function formatSeconds(seconds) {
-  if (!seconds) return '—'
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${m}′${String(s).padStart(2, '0')}″`
-}
-
-const formattedDuration = computed(() => formatSeconds(effectiveDuration.value))
+const formattedDuration = computed(() => formatDuration(effectiveDuration.value))
 </script>

--- a/assets/js/components/BandSpace/Setlist/SetlistItemEditDrawer.vue
+++ b/assets/js/components/BandSpace/Setlist/SetlistItemEditDrawer.vue
@@ -16,19 +16,20 @@
       </div>
 
       <div>
-        <label class="block text-sm font-medium mb-1">Durée surchargée (s)</label>
-        <InputNumber
-          v-model="form.duration_override"
-          :min="1"
-          :max="86400"
-          :useGrouping="false"
-          placeholder="Vide = utiliser la durée de référence"
+        <label class="block text-sm font-medium mb-1">Durée surchargée (mm:ss)</label>
+        <InputText
+          v-model="durationInput"
+          placeholder="3:47"
           class="w-full"
-          inputClass="w-full"
-          aria-label="Durée surchargée (s)"
+          :invalid="!!durationError"
+          aria-label="Durée surchargée au format mm:ss"
         />
-        <small v-if="referenceDuration" class="text-surface-500 block mt-1">
-          Référence&nbsp;: {{ formatSeconds(referenceDuration) }}
+        <small v-if="durationError" class="text-red-500 block mt-1">{{ durationError }}</small>
+        <small v-else class="text-surface-500 block mt-1">
+          Minutes et secondes.
+          <template v-if="referenceDuration">
+            Vide&nbsp;: la durée de référence ({{ formatDuration(referenceDuration) }}) est utilisée.
+          </template>
         </small>
       </div>
 
@@ -61,13 +62,13 @@
 <script setup>
 import Button from 'primevue/button'
 import Drawer from 'primevue/drawer'
-import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref, watch } from 'vue'
 import { useBandSetlistsStore } from '../../../store/bandSpace/bandSpaceSetlists.js'
+import { formatDuration, parseDurationInput } from '../../../utils/setlistDuration.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -82,7 +83,11 @@ const setlistsStore = useBandSetlistsStore()
 const confirm = useConfirm()
 const toast = useToast()
 
-const form = ref({ label: '', duration_override: null, transition: '', note: '' })
+const form = ref({ label: '', transition: '', note: '' })
+// The override is held as text and converted once, on save: seconds stay the stored unit, they are
+// just no longer what a member has to type.
+const durationInput = ref('')
+const durationError = ref(null)
 const isSubmitting = ref(false)
 
 const typeLabel = computed(() => {
@@ -102,35 +107,36 @@ const typeLabel = computed(() => {
 
 const referenceDuration = computed(() => props.item?.song?.reference_duration ?? null)
 
+// Reopening the drawer reseeds it, not only switching item: closing on a refused duration and
+// coming back to the same card must not show the refusal again.
 watch(
-  () => props.item,
-  (item) => {
-    if (item) {
+  [visible, () => props.item],
+  ([isVisible, item]) => {
+    if (isVisible && item) {
       form.value = {
         label: item.label ?? '',
-        duration_override: item.duration_override ?? null,
         transition: item.transition ?? '',
         note: item.note ?? ''
       }
+      durationInput.value = formatDuration(item.duration_override)
+      durationError.value = null
     }
   },
   { immediate: true }
 )
 
-function formatSeconds(seconds) {
-  if (!seconds) return '—'
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${m}′${String(s).padStart(2, '0')}″`
-}
-
 async function handleSave() {
   if (!props.item) return
+
+  const duration = parseDurationInput(durationInput.value)
+  durationError.value = duration.error
+  if (duration.error) return
+
   isSubmitting.value = true
   try {
     await setlistsStore.updateItem(props.bandSpaceId, props.setlistId, props.item.id, {
       label: form.value.label?.trim() || null,
-      duration_override: form.value.duration_override ?? null,
+      duration_override: duration.seconds,
       transition: form.value.transition?.trim() || null,
       note: form.value.note?.trim() || null
     })

--- a/assets/js/components/BandSpace/Setlist/SongDetailDrawer.vue
+++ b/assets/js/components/BandSpace/Setlist/SongDetailDrawer.vue
@@ -17,7 +17,7 @@
         </div>
         <div>
           <div class="text-xs uppercase text-surface-500 mb-1">Durée</div>
-          <div>{{ formatDuration(song.reference_duration) }}</div>
+          <div>{{ formatDuration(song.reference_duration) || '—' }}</div>
         </div>
       </div>
 
@@ -101,6 +101,7 @@ import { useToast } from 'primevue/usetoast'
 import { ref, watch } from 'vue'
 import bandSpaceSongsApi from '../../../api/bandSpace/band-space-songs.js'
 import { useBandSongsStore } from '../../../store/bandSpace/bandSpaceSongs.js'
+import { formatDuration } from '../../../utils/setlistDuration.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -118,13 +119,6 @@ const fileInput = ref(null)
 const isUploading = ref(false)
 const files = ref([])
 const isLoadingFiles = ref(false)
-
-function formatDuration(seconds) {
-  if (!seconds) return '—'
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${m}′${String(s).padStart(2, '0')}″`
-}
 
 function formatBytes(bytes) {
   if (!bytes) return ''

--- a/assets/js/components/BandSpace/Setlist/SongFormDialog.vue
+++ b/assets/js/components/BandSpace/Setlist/SongFormDialog.vue
@@ -36,18 +36,17 @@
       </div>
 
       <div>
-        <label class="block text-sm font-medium mb-1">Durée de référence (secondes)</label>
-        <InputNumber
-          v-model="form.reference_duration"
-          :min="1"
-          :max="86400"
-          :useGrouping="false"
+        <label class="block text-sm font-medium mb-1">Durée de référence (mm:ss)</label>
+        <InputText
+          v-model="durationInput"
+          placeholder="3:47"
           class="w-full"
-          inputClass="w-full"
-          :invalid="!!violationFor('reference_duration')"
-          aria-label="Durée de référence (secondes)"
+          :invalid="!!durationError || !!violationFor('reference_duration')"
+          aria-label="Durée de référence au format mm:ss"
         />
-        <small v-if="violationFor('reference_duration')" class="text-red-500">{{ violationFor('reference_duration') }}</small>
+        <small v-if="durationError" class="text-red-500">{{ durationError }}</small>
+        <small v-else-if="violationFor('reference_duration')" class="text-red-500">{{ violationFor('reference_duration') }}</small>
+        <small v-else class="text-surface-500">Minutes et secondes, par exemple 3:47.</small>
       </div>
 
       <div>
@@ -72,6 +71,7 @@ import Textarea from 'primevue/textarea'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref, watch } from 'vue'
 import { useBandSongsStore } from '../../../store/bandSpace/bandSpaceSongs.js'
+import { formatDuration, parseDurationInput } from '../../../utils/setlistDuration.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -84,7 +84,11 @@ const visible = defineModel('visible', { type: Boolean, default: false })
 const songsStore = useBandSongsStore()
 const toast = useToast()
 
-const form = ref({ title: '', tonality: null, tempo: null, reference_duration: null, notes: null })
+const form = ref({ title: '', tonality: null, tempo: null, notes: null })
+// Held as text, not as seconds: the field is a duration a member reads and types, and the
+// conversion to the stored unit happens once, on submit.
+const durationInput = ref('')
+const durationError = ref(null)
 const isSubmitting = ref(false)
 const violations = ref({})
 
@@ -99,10 +103,11 @@ watch(
             title: song.title,
             tonality: song.tonality,
             tempo: song.tempo,
-            reference_duration: song.reference_duration,
             notes: song.notes
           }
-        : { title: '', tonality: null, tempo: null, reference_duration: null, notes: null }
+        : { title: '', tonality: null, tempo: null, notes: null }
+      durationInput.value = song ? formatDuration(song.reference_duration) : ''
+      durationError.value = null
       violations.value = {}
     }
   },
@@ -114,11 +119,17 @@ function violationFor(field) {
 }
 
 function resetForm() {
-  form.value = { title: '', tonality: null, tempo: null, reference_duration: null, notes: null }
+  form.value = { title: '', tonality: null, tempo: null, notes: null }
+  durationInput.value = ''
+  durationError.value = null
   violations.value = {}
 }
 
 async function handleSubmit() {
+  const duration = parseDurationInput(durationInput.value)
+  durationError.value = duration.error
+  if (duration.error) return
+
   isSubmitting.value = true
   violations.value = {}
   try {
@@ -126,7 +137,7 @@ async function handleSubmit() {
       title: form.value.title?.trim() ?? '',
       tonality: form.value.tonality?.trim() || null,
       tempo: form.value.tempo ?? null,
-      reference_duration: form.value.reference_duration ?? null,
+      reference_duration: duration.seconds,
       notes: form.value.notes?.trim() || null
     }
     if (isEdit.value) {

--- a/assets/js/utils/setlistDuration.js
+++ b/assets/js/utils/setlistDuration.js
@@ -1,0 +1,127 @@
+/**
+ * The one way a duration is written and read in the setlist module.
+ *
+ * Seconds stay the stored unit: the API takes and returns an integer number of seconds, and nothing
+ * here changes that. What changes is that a human never has to do the arithmetic. Seeding a 40 song
+ * repertoire, the module's very first task, used to mean converting every "3:47" into 227 by hand,
+ * while every screen downstream already displayed minutes and seconds.
+ *
+ * Display used three formats for the same number: HH:MM:SS in the editor header, "97 min 30 s" in
+ * the PDF header, which never rolled over to hours, and minutes with primes in the PDF total row.
+ * There is now one, and it is deliberately the same notation the inputs accept, so a duration can
+ * be read off a card and typed straight back into a field.
+ *
+ * Pure on purpose, so the rules are tested without a component. The PHP side of the same format
+ * lives in src/Twig/DurationExtension.php for the PDF templates: the two must stay in step.
+ *
+ * See setlistDuration.test.js.
+ */
+
+/** The API's own range for a duration (Assert\Range on SongCreate and SetlistItemCreate). */
+export const MIN_DURATION_SECONDS = 1
+export const MAX_DURATION_SECONDS = 86400
+
+export const DURATION_FORMAT_MESSAGE = 'Durée invalide. Utilisez le format mm:ss, par exemple 3:47.'
+export const DURATION_RANGE_MESSAGE =
+  'La durée doit être comprise entre 1 seconde et 24 heures (24:00:00).'
+
+/**
+ * Minutes are uncapped so a long break can be written 90:00, seconds are a real clock reading.
+ * A single digit is allowed, 3:7 is unambiguous, but 3:75 is not a time at all and is refused
+ * rather than quietly read as 4:15: a field whose point is that you can read it back must not
+ * reinterpret what you typed.
+ */
+const MINUTES_SECONDS_PATTERN = /^(\d+):([0-5]?\d)$/
+
+/**
+ * Whatever formatDuration writes, this reads back, so a total displayed as 1:37:30 can be typed
+ * into a field. Both trailing fields are two digits here, which is what keeps 3:7:9 out: a third
+ * field is only a duration when it is written as a clock.
+ */
+const HOURS_MINUTES_SECONDS_PATTERN = /^(\d+):([0-5]\d):([0-5]\d)$/
+
+/** A bare number is still read as seconds, which is what the field used to take. */
+const BARE_SECONDS_PATTERN = /^\d+$/
+
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 3600
+
+function pad(value) {
+  return String(value).padStart(2, '0')
+}
+
+/**
+ * A duration for reading: `3:47`, `37:30`, `1:37:30`. Hours appear only once there are any, which
+ * is the whole point of going through here instead of hardcoding HH:MM:SS or minutes only.
+ *
+ * An absent duration formats as an empty string, never as `0:00`, so a call site substitutes its own
+ * placeholder when the string comes back empty. A real zero, the total of an empty setlist, does
+ * format as `0:00`.
+ *
+ * That split only holds for a total. A per-item duration of exactly zero would render `0:00` where
+ * the old per-component formatters rendered a placeholder, and it would seed an edit field with
+ * `0:00` that then refuses to save, since zero is below MIN_DURATION_SECONDS. It never surfaces
+ * because `Assert\Range(min: 1)` on SongCreate, SongResource, SetlistItemCreate and
+ * SetlistItemResource stops a zero being persisted in the first place. Relax any of those bounds and
+ * the per-item call sites have to start distinguishing zero from absent themselves.
+ *
+ * @param {number|null|undefined} seconds
+ * @returns {string}
+ */
+export function formatDuration(seconds) {
+  if (seconds === null || seconds === undefined || seconds === '') return ''
+
+  const total = Math.round(Number(seconds))
+  if (!Number.isFinite(total) || total < 0) return ''
+
+  const hours = Math.floor(total / SECONDS_PER_HOUR)
+  const minutes = Math.floor((total % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)
+  const remainingSeconds = total % SECONDS_PER_MINUTE
+
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(remainingSeconds)}`
+    : `${minutes}:${pad(remainingSeconds)}`
+}
+
+/**
+ * Reads what a member typed into a duration field.
+ *
+ * An empty field is not an error: it is how a duration is cleared, and how an optional one is left
+ * unset, so it gives back null seconds and no message. Anything unreadable gives back null seconds
+ * and the message to show, so a caller can refuse to submit without inventing a value.
+ *
+ * @param {string|number|null|undefined} value
+ * @returns {{seconds: number|null, error: string|null}}
+ */
+export function parseDurationInput(value) {
+  const raw = String(value ?? '').trim()
+  if (raw === '') return { seconds: null, error: null }
+
+  const longClock = raw.match(HOURS_MINUTES_SECONDS_PATTERN)
+  if (longClock) {
+    return withinRange(
+      Number(longClock[1]) * SECONDS_PER_HOUR +
+        Number(longClock[2]) * SECONDS_PER_MINUTE +
+        Number(longClock[3])
+    )
+  }
+
+  const clock = raw.match(MINUTES_SECONDS_PATTERN)
+  if (clock) {
+    return withinRange(Number(clock[1]) * SECONDS_PER_MINUTE + Number(clock[2]))
+  }
+  if (BARE_SECONDS_PATTERN.test(raw)) {
+    return withinRange(Number(raw))
+  }
+
+  return { seconds: null, error: DURATION_FORMAT_MESSAGE }
+}
+
+/** Refuses what the API would refuse anyway, so a zero never travels as a duration. */
+function withinRange(seconds) {
+  if (seconds < MIN_DURATION_SECONDS || seconds > MAX_DURATION_SECONDS) {
+    return { seconds: null, error: DURATION_RANGE_MESSAGE }
+  }
+
+  return { seconds, error: null }
+}

--- a/assets/js/utils/setlistDuration.test.js
+++ b/assets/js/utils/setlistDuration.test.js
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  DURATION_FORMAT_MESSAGE,
+  DURATION_RANGE_MESSAGE,
+  formatDuration,
+  MAX_DURATION_SECONDS,
+  parseDurationInput
+} from './setlistDuration.js'
+
+/**
+ * These pin the two halves of the contract that lets a member type "3:47" into a field the API
+ * still stores as 227 seconds.
+ *
+ * The parsing side matters most on the seeding path: a 40 song repertoire is entered in one sitting,
+ * so a slip has to be refused with a message rather than silently reinterpreted. 3:75 is the case
+ * worth reading twice, it is refused, because reading it as 4:15 would mean the field gave back
+ * something other than what was typed.
+ *
+ * The formatting side matters because the same number used to be rendered three different ways for
+ * the same setlist. There is one format now, and the round trip tests at the bottom are what keep it
+ * honest: whatever this displays has to parse back to the number it came from.
+ *
+ * Run with `npm test`.
+ */
+
+describe('formatDuration', () => {
+  it('writes a duration under a minute with an explicit zero minute', () => {
+    assert.equal(formatDuration(47), '0:47')
+    assert.equal(formatDuration(7), '0:07')
+  })
+
+  it('writes minutes and seconds with the seconds always on two digits', () => {
+    assert.equal(formatDuration(227), '3:47')
+    assert.equal(formatDuration(187), '3:07')
+    assert.equal(formatDuration(600), '10:00')
+  })
+
+  it('rolls over to hours, which the PDF header used to refuse to do', () => {
+    // 5850s is the "97 min 30 s" the old header printed for a full set.
+    assert.equal(formatDuration(5850), '1:37:30')
+    assert.equal(formatDuration(3600), '1:00:00')
+    assert.equal(formatDuration(3661), '1:01:01')
+    assert.equal(formatDuration(MAX_DURATION_SECONDS), '24:00:00')
+  })
+
+  it('writes a real zero as a zero, because an empty setlist still has a total', () => {
+    assert.equal(formatDuration(0), '0:00')
+  })
+
+  it('writes an absent duration as nothing, leaving the placeholder to the caller', () => {
+    assert.equal(formatDuration(null), '')
+    assert.equal(formatDuration(undefined), '')
+    assert.equal(formatDuration(''), '')
+  })
+
+  it('writes anything unusable as nothing rather than NaN', () => {
+    assert.equal(formatDuration('abc'), '')
+    assert.equal(formatDuration(Number.NaN), '')
+    assert.equal(formatDuration(-1), '')
+  })
+})
+
+describe('parseDurationInput', () => {
+  it('reads mm:ss as minutes and seconds', () => {
+    assert.deepEqual(parseDurationInput('3:47'), { seconds: 227, error: null })
+    assert.deepEqual(parseDurationInput('03:47'), { seconds: 227, error: null })
+    assert.deepEqual(parseDurationInput('0:59'), { seconds: 59, error: null })
+  })
+
+  it('reads a single digit of seconds, since 3:7 says only one thing', () => {
+    assert.deepEqual(parseDurationInput('3:7'), { seconds: 187, error: null })
+  })
+
+  it('leaves the minutes uncapped so a long break can be written 90:00', () => {
+    assert.deepEqual(parseDurationInput('90:00'), { seconds: 5400, error: null })
+    assert.deepEqual(parseDurationInput('97:30'), { seconds: 5850, error: null })
+  })
+
+  it('still reads a bare number as a number of seconds', () => {
+    assert.deepEqual(parseDurationInput('227'), { seconds: 227, error: null })
+    assert.deepEqual(parseDurationInput(227), { seconds: 227, error: null })
+    assert.deepEqual(parseDurationInput(String(MAX_DURATION_SECONDS)), {
+      seconds: MAX_DURATION_SECONDS,
+      error: null
+    })
+  })
+
+  it('ignores whitespace around what was typed', () => {
+    assert.deepEqual(parseDurationInput('  3:47  '), { seconds: 227, error: null })
+  })
+
+  it('reads an empty field as no duration, which is how one is cleared', () => {
+    assert.deepEqual(parseDurationInput(''), { seconds: null, error: null })
+    assert.deepEqual(parseDurationInput('   '), { seconds: null, error: null })
+    assert.deepEqual(parseDurationInput(null), { seconds: null, error: null })
+    assert.deepEqual(parseDurationInput(undefined), { seconds: null, error: null })
+  })
+
+  it('refuses seconds over 59 instead of quietly carrying them into the minutes', () => {
+    // 3:75 is a slip, not a time. Reading it as 4:15 would give back something else than typed.
+    assert.deepEqual(parseDurationInput('3:75'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+    assert.deepEqual(parseDurationInput('3:60'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+  })
+
+  it('refuses a half written clock', () => {
+    assert.deepEqual(parseDurationInput('3:'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+    assert.deepEqual(parseDurationInput(':47'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+    assert.deepEqual(parseDurationInput(':'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+  })
+
+  it('reads a full clock, so a total read off the header can be typed back', () => {
+    assert.deepEqual(parseDurationInput('1:37:30'), { seconds: 5850, error: null })
+    assert.deepEqual(parseDurationInput('1:00:00'), { seconds: 3600, error: null })
+    assert.deepEqual(parseDurationInput('24:00:00'), {
+      seconds: MAX_DURATION_SECONDS,
+      error: null
+    })
+  })
+
+  it('refuses a third field that is not written as a clock, so 3:7:9 is never guessed at', () => {
+    // Both trailing fields have to be two digits. 3:7:9 could be 3h07m09s or three of anything,
+    // and a duration field is not the place to pick.
+    assert.deepEqual(parseDurationInput('3:7:9'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+    assert.deepEqual(parseDurationInput('1:7:30'), {
+      seconds: null,
+      error: DURATION_FORMAT_MESSAGE
+    })
+    assert.deepEqual(parseDurationInput('1:60:00'), {
+      seconds: null,
+      error: DURATION_FORMAT_MESSAGE
+    })
+    assert.deepEqual(parseDurationInput('1:30:75'), {
+      seconds: null,
+      error: DURATION_FORMAT_MESSAGE
+    })
+    assert.deepEqual(parseDurationInput('1:2:3:4'), {
+      seconds: null,
+      error: DURATION_FORMAT_MESSAGE
+    })
+  })
+
+  it('refuses anything that is not a duration', () => {
+    assert.deepEqual(parseDurationInput('abc'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+    assert.deepEqual(parseDurationInput('3,47'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+    assert.deepEqual(parseDurationInput('3.47'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+    assert.deepEqual(parseDurationInput('-5'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+    assert.deepEqual(parseDurationInput('3m47'), { seconds: null, error: DURATION_FORMAT_MESSAGE })
+  })
+
+  it('refuses a zero, which the API would refuse too', () => {
+    // Assert\Range(min: 1) on both SongCreate and SetlistItemCreate. A duration of zero is either a
+    // mistake or a clear, and a clear is an empty field.
+    assert.deepEqual(parseDurationInput('0'), { seconds: null, error: DURATION_RANGE_MESSAGE })
+    assert.deepEqual(parseDurationInput('0:00'), { seconds: null, error: DURATION_RANGE_MESSAGE })
+  })
+
+  it('refuses more than the API ceiling of 24 hours', () => {
+    assert.deepEqual(parseDurationInput(String(MAX_DURATION_SECONDS + 1)), {
+      seconds: null,
+      error: DURATION_RANGE_MESSAGE
+    })
+    assert.deepEqual(parseDurationInput('1441:00'), {
+      seconds: null,
+      error: DURATION_RANGE_MESSAGE
+    })
+  })
+})
+
+describe('the field round trip', () => {
+  // A field is seeded with formatDuration and read back with parseDurationInput, so opening an item
+  // and saving it untouched has to store the very same number of seconds.
+  it('gives back the seconds it was seeded with, hours included', () => {
+    const values = [1, 47, 187, 227, 258, 600, 3599, 3600, 3661, 5850, MAX_DURATION_SECONDS]
+
+    for (const seconds of values) {
+      const displayed = formatDuration(seconds)
+      assert.deepEqual(
+        parseDurationInput(displayed),
+        { seconds, error: null },
+        `${seconds}s displayed as "${displayed}" must parse back to ${seconds}`
+      )
+    }
+  })
+
+  it('accepts the same duration written either way', () => {
+    // 61 minutes and 1 hour 1 minute are the same thing, and the field takes both.
+    assert.deepEqual(parseDurationInput('61:00'), { seconds: 3660, error: null })
+    assert.deepEqual(parseDurationInput('1:01:00'), { seconds: 3660, error: null })
+    assert.equal(formatDuration(3660), '1:01:00')
+  })
+})

--- a/assets/js/views/BandSpace/SetlistLive.vue
+++ b/assets/js/views/BandSpace/SetlistLive.vue
@@ -133,6 +133,7 @@ import Drawer from 'primevue/drawer'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useBandSetlistsStore } from '../../store/bandSpace/bandSpaceSetlists.js'
+import { formatDuration } from '../../utils/setlistDuration.js'
 import {
   openLivePositionStorage,
   readLivePosition,
@@ -187,11 +188,7 @@ function titleFor(item) {
 }
 
 function durationFor(item) {
-  const duration = item?.duration_override ?? item?.song?.reference_duration ?? null
-  if (!duration) return ''
-  const m = Math.floor(duration / 60)
-  const s = duration % 60
-  return `${m}′${String(s).padStart(2, '0')}″`
+  return formatDuration(item?.duration_override ?? item?.song?.reference_duration ?? null)
 }
 
 const currentTypeIcon = computed(() => iconFor(current.value))
@@ -207,11 +204,9 @@ const currentMeta = computed(() => {
   if (item.type === 'song' && item.song?.tempo) {
     meta.push({ key: 'tempo', label: `${item.song.tempo} BPM` })
   }
-  const duration = item.duration_override ?? item.song?.reference_duration ?? null
+  const duration = durationFor(item)
   if (duration) {
-    const m = Math.floor(duration / 60)
-    const s = duration % 60
-    meta.push({ key: 'duration', label: `${m}′${String(s).padStart(2, '0')}″` })
+    meta.push({ key: 'duration', label: duration })
   }
   return meta
 })

--- a/src/Twig/DurationExtension.php
+++ b/src/Twig/DurationExtension.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace App\Twig;
+
+use Twig\Attribute\AsTwigFilter;
+
+/**
+ * The PDF half of the setlist duration format. Mirrors formatDuration() in
+ * assets/js/utils/setlistDuration.js, and the two have to stay in step: the point of the filter is
+ * that a total printed on a sheet reads exactly like the same total in the editor.
+ *
+ * A filter rather than a pre-formatted string in the render context, because the large layout needs
+ * the format in three places (header total, per item cell, footer total row) and the arithmetic
+ * cannot be inlined in Twig without the hour rollover being forgotten again, which is precisely how
+ * the header came to print "97 min 30 s".
+ *
+ * Static, so the class is never instantiated as a Twig runtime.
+ */
+final class DurationExtension
+{
+    private const int SECONDS_PER_MINUTE = 60;
+    private const int SECONDS_PER_HOUR = 3600;
+
+    /**
+     * Hours appear only once there are any: 3:47, 37:30, 1:37:30. An absent duration formats as an
+     * empty string so the template picks its own placeholder; a real zero formats as 0:00.
+     */
+    #[AsTwigFilter('duration_format')]
+    public static function format(?int $seconds): string
+    {
+        if ($seconds === null || $seconds < 0) {
+            return '';
+        }
+
+        $hours = intdiv($seconds, self::SECONDS_PER_HOUR);
+        $minutes = intdiv($seconds % self::SECONDS_PER_HOUR, self::SECONDS_PER_MINUTE);
+        $remainingSeconds = $seconds % self::SECONDS_PER_MINUTE;
+
+        return $hours > 0
+            ? sprintf('%d:%02d:%02d', $hours, $minutes, $remainingSeconds)
+            : sprintf('%d:%02d', $minutes, $remainingSeconds);
+    }
+}

--- a/templates/pdf/setlist/setlist_large.html.twig
+++ b/templates/pdf/setlist/setlist_large.html.twig
@@ -119,7 +119,7 @@
                 <div>{{ setlist.items|length }} {{ setlist.items|length > 1 ? 'titres' : 'titre' }}</div>
                 {% if total_duration_seconds > 0 %}
                     <div class="total">
-                        {{ (total_duration_seconds // 60) }} min {{ (total_duration_seconds % 60) }} s
+                        {{ total_duration_seconds|duration_format }}
                     </div>
                 {% endif %}
                 {% if missing_duration_items > 0 %}
@@ -185,7 +185,7 @@
                     {% endif %}
                     {% if options.showDurations %}
                         <td class="numeric {{ duration ? '' : 'muted' }}">
-                            {{ duration ? ((duration // 60) ~ '′' ~ ('%02d'|format(duration % 60)) ~ '″') : '—' }}
+                            {{ duration ? duration|duration_format : '—' }}
                         </td>
                     {% endif %}
                 </tr>
@@ -196,7 +196,7 @@
                 <tr class="total-row">
                     <td colspan="{{ visible_cols - 1 }}">Total</td>
                     <td class="numeric">
-                        {{ (total_duration_seconds // 60) }}′{{ '%02d'|format(total_duration_seconds % 60) }}″
+                        {{ total_duration_seconds|duration_format }}
                     </td>
                 </tr>
             </tfoot>

--- a/tests/Api/BandSpace/Setlist/SetlistPdfExportTest.php
+++ b/tests/Api/BandSpace/Setlist/SetlistPdfExportTest.php
@@ -580,10 +580,42 @@ class SetlistPdfExportTest extends ApiTestCase
         ]);
 
         $this->assertStringContainsString('1 titre sans durée', $html);
-        $this->assertStringContainsString('3 min 0 s', $html);
+        // The header total, the item cell and the footer total row all read the same way now: 3:00,
+        // not "3 min 0 s" in one place and 3′00″ in the next.
+        $this->assertSame(3, substr_count($html, '3:00'));
         // Total row in the table footer
         $this->assertStringContainsString('total-row', $html);
         $this->assertStringContainsString('Total', $html);
+    }
+
+    public function test_large_template_rolls_a_total_over_one_hour_into_hours(): void
+    {
+        // Regression (#831): the header printed the total in minutes only, so a normal set came out
+        // as "97 min 30 s" while the editor showed 01:37:30 for the very same number.
+        $bandSpace = BandSpaceFactory::new()->create();
+        $setlist = SetlistFactory::new(['bandSpace' => $bandSpace])->create();
+        $song = SongFactory::new(['bandSpace' => $bandSpace, 'referenceDuration' => 5850])->create();
+        SetlistItemFactory::new([
+            'setlist' => $setlist,
+            'type' => SetlistItemType::Song,
+            'song' => $song,
+            'durationOverride' => null,
+            'position' => 0,
+        ])->create();
+
+        $entity = self::getContainer()->get(SetlistRepository::class)->find((string) $setlist->id);
+        $html = self::getContainer()->get(Environment::class)->render('pdf/setlist/setlist_large.html.twig', [
+            'setlist' => $entity,
+            'options' => new SetlistPdfOptions(layout: SetlistPdfLayout::Large, showDurations: true),
+            'total_duration_seconds' => 5850,
+            'missing_duration_items' => 0,
+            'font' => SetlistPdfFont::Inter,
+        ]);
+
+        // Header total, item cell, footer total row.
+        $this->assertSame(3, substr_count($html, '1:37:30'));
+        $this->assertStringNotContainsString('97 min', $html);
+        $this->assertStringNotContainsString('97:30', $html);
     }
 
     public function test_compact_template_omits_per_field_data_even_if_options_say_otherwise(): void

--- a/tests/Unit/Twig/DurationExtensionTest.php
+++ b/tests/Unit/Twig/DurationExtensionTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Twig;
+
+use App\Twig\DurationExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The format table the PDF prints. It has to agree, value for value, with formatDuration() in
+ * assets/js/utils/setlistDuration.js: the point of having one format is that the total on a printed
+ * sheet reads exactly like the total in the editor.
+ */
+class DurationExtensionTest extends TestCase
+{
+    /** @return iterable<string, array{int|null, string}> */
+    public static function durationProvider(): iterable
+    {
+        yield 'under a minute keeps an explicit zero minute' => [47, '0:47'];
+        yield 'seconds are always two digits' => [7, '0:07'];
+        yield 'a song reads as minutes and seconds' => [227, '3:47'];
+        yield 'a padded second is not lost' => [187, '3:07'];
+        yield 'a whole minute' => [600, '10:00'];
+        // The set total the header used to print as "97 min 30 s".
+        yield 'a full set rolls over to hours' => [5850, '1:37:30'];
+        yield 'exactly one hour' => [3600, '1:00:00'];
+        yield 'one hour and change pads both fields' => [3661, '1:01:01'];
+        yield 'the API ceiling of 24 hours' => [86400, '24:00:00'];
+        yield 'a real zero still reads as a duration' => [0, '0:00'];
+        yield 'an absent duration reads as nothing' => [null, ''];
+        yield 'a negative duration reads as nothing rather than a minus sign' => [-1, ''];
+    }
+
+    #[DataProvider('durationProvider')]
+    public function test_format(?int $seconds, string $expected): void
+    {
+        $this->assertSame($expected, DurationExtension::format($seconds));
+    }
+}


### PR DESCRIPTION
Closes #831.

Two related problems. All three duration inputs took raw seconds, so seeding a 40-song repertoire, the module's very first task, meant hand-converting every "3:47" into 227 while everything downstream already rendered minutes and seconds. And the total was formatted three different ways for the same number: HH:MM:SS in the editor header, "97 min 30 s" in the PDF header, which never rolled over to hours, and minutes and seconds again in the PDF total row.

## What changed

`assets/js/utils/setlistDuration.js` holds the parsing and formatting, and `src/Twig/DurationExtension.php` mirrors it as a `duration_format` filter so the PDF and the screen cannot drift. No duration arithmetic is left in Twig, which is where the missing hour rollover came from.

**Seconds remain the stored unit.** No entity, DTO, validator or migration changed. This is a presentation change.

The single format is `m:ss`, growing to `h:mm:ss` only when there are hours: `3:47`, `37:30`, `1:37:30`, and `0:00` for an empty setlist. It is the notation the inputs now accept, so what a member reads off a card is what they can type back, it rolls over to hours, and it stays compact in the PDF total cell. Applied to per-item durations too, since leaving items at `3'47"` while totals read `1:37:30` would only have moved the inconsistency, and the prime notation is untypeable.

`3:75` is refused rather than normalised to `4:15`. It is a slip, not a clock reading, and a field whose whole point is that you can read a value back must not hand back something other than what was typed. Accepted leniencies: single-digit seconds, uncapped minutes, a bare integer as seconds, and a full `h:mm:ss` clock, so anything the app displays parses back. Empty input clears rather than erroring, and the range refusal matches the existing `Assert\Range(min: 1, max: 86400)`.

## Deduplication

Five more copy-pasted formatter bodies were deleted across `SetlistItemCard`, `RepertoireView`, `SongDetailDrawer` and `SetlistLive`, leaving one implementation instead of eight. Review compared each deleted body against the shared helper over the values those components actually pass and confirmed the rendered output is unchanged, apart from the intended notation change and the hour rollover four of them never had.

## One latent inconsistency, documented rather than restructured

The old per-component formatters treated a literal `0` as absent and rendered a placeholder; the shared helper renders `0:00`, which is correct for a total. Review proved this is currently unreachable, because `Assert\Range(min: 1)` on all four DTOs stops a zero being persisted, so the distinction never surfaces. The coupling is now written down in the helper, including that relaxing any of those bounds means the per-item call sites have to start distinguishing zero from absent themselves.

## Verification

21 new unit tests on the helper, run through `node --test`, covering valid input, boundaries, and every malformed shape. The PHP filter and the JS helper were run over the same input table and produce byte-identical strings at 0, 59, 60, 61, 3599, 3600, 3601, 86400 and null. A new PDF test pins the hour rollover that was broken. Full suite 2341 green, JS suite 399 green, PHPStan level 8 clean, biome clean, build succeeds.
