### PR TITLE
feat(M-865): record note authorship and restrict deletion to author or admin

### DIFF
--- a/assets/js/components/BandSpace/Notes/NoteEditor.vue
+++ b/assets/js/components/BandSpace/Notes/NoteEditor.vue
@@ -43,6 +43,12 @@
           </template>
         </span>
       </div>
+      <p
+        v-if="note.created_by"
+        class="mt-1 ml-10 pl-2 text-xs text-surface-500 dark:text-surface-400"
+      >
+        Créée par {{ note.created_by.username }}
+      </p>
     </div>
 
     <!-- Conflict notice: stays until the member acts on it, autosave is over for this editor -->

--- a/migrations/2026/08/Version20260819133622.php
+++ b/migrations/2026/08/Version20260819133622.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Purely additive, so the generated SQL is kept as is.
+ *
+ * Nullable, and ON DELETE SET NULL rather than CASCADE, for the two cases the column has to survive:
+ * a note written before this migration has nobody recorded, and a member closing their account must
+ * not take the band's pages with them. Both read back as NULL, and NoteOwnerChecker treats that as
+ * "admins only".
+ *
+ * This migration writes no data of its own. A one-shot command, deleted once it had run, filled what
+ * the activity feed answers exactly, from the note_created row carrying both the note id and its
+ * author, and left the rest NULL: notes older than that feed have nothing to read, and guessing from
+ * any other activity type would have handed delete rights to whoever it named.
+ */
+final class Version20260819133622 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the author of a Band Space note';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space_note ADD created_by_id CHAR(36) DEFAULT NULL');
+        $this->addSql('ALTER TABLE band_space_note ADD CONSTRAINT FK_5FFFD959B03A8386 FOREIGN KEY (created_by_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_5FFFD959B03A8386 ON band_space_note (created_by_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space_note DROP FOREIGN KEY FK_5FFFD959B03A8386');
+        $this->addSql('DROP INDEX IDX_5FFFD959B03A8386 ON band_space_note');
+        $this->addSql('ALTER TABLE band_space_note DROP created_by_id');
+    }
+}

--- a/src/ApiResource/BandSpace/BandSpaceNote.php
+++ b/src/ApiResource/BandSpace/BandSpaceNote.php
@@ -102,6 +102,11 @@ class BandSpaceNote
     #[ApiProperty(readable: false)]
     public ?int $expectedContentVersion = null;
     public bool $hasChildren = false;
+
+    /** @var array{id: string, username: string}|null */
+    #[ApiProperty(writable: false)]
+    public ?array $createdBy = null;
+
     public \DateTimeInterface $creationDatetime;
     public ?\DateTimeInterface $updateDatetime = null;
 }

--- a/src/Command/BandSpace/BackfillNoteCreatedByCommand.php
+++ b/src/Command/BandSpace/BackfillNoteCreatedByCommand.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceActivity;
+use App\Entity\BandSpace\BandSpaceNote;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceNoteActivityType;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Fills band_space_note.created_by_id for the notes that predate the column, from the activity feed.
+ *
+ * The value is not inferred. BandSpaceNoteCreateProcessor records a note_created activity carrying the
+ * new note's id and the member who asked for it, so the feed already holds the answer exactly, and
+ * only that one type is read. The first member to rename or edit a note is not necessarily whoever
+ * wrote it, and this column decides who may delete the note, so a plausible guess is worse than NULL.
+ *
+ * Notes created between 2026-03-07, when the module shipped, and 2026-05-08, when #648 wired the
+ * recorder into the note processors, have no such row and keep nobody recorded. NoteOwnerChecker
+ * leaves those admin-only, which is the intended outcome rather than a shortfall, so the counts below
+ * report that remainder instead of trying to shrink it.
+ *
+ * Filling the column widens who may delete a note, from admins alone to its author as well. That is
+ * the point of the backfill, and it is sound only because the source is authoritative.
+ *
+ * Safe to re-run: it considers only notes whose author is NULL, so it can never overwrite one, and a
+ * second run over a filled database writes nothing.
+ *
+ * One-shot, and deliberately self-contained: both lookups go through Doctrine's own findBy, so this
+ * file and its test are the whole feature. Delete the two of them once it has run in production and
+ * nothing is left behind. That is also why neither query lives in a repository, the usual home for
+ * them: a repository method would outlive the only caller and become dead code the day this goes.
+ */
+#[AsCommand(
+    name: 'app:band-space:notes:backfill-created-by',
+    description: 'Fill the author of band space notes written before the column existed, from their note_created activity',
+)]
+class BackfillNoteCreatedByCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would be filled without writing anything');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $isDryRun = (bool) $input->getOption('dry-run');
+        if ($isDryRun) {
+            $io->writeln('<comment>Dry run: nothing will be written</comment>');
+        }
+
+        $notes = $this->entityManager->getRepository(BandSpaceNote::class)->findBy(['createdBy' => null]);
+        $withoutAuthor = count($notes);
+        if ($withoutAuthor === 0) {
+            $io->success('Every note already records who wrote it.');
+
+            return Command::SUCCESS;
+        }
+
+        $actorsByNoteId = $this->findCreationActorsByNoteId($notes);
+
+        $filled = 0;
+        foreach ($notes as $note) {
+            $actor = $actorsByNoteId[(string) $note->id] ?? null;
+            if (!$actor instanceof User) {
+                continue;
+            }
+
+            if (!$isDryRun) {
+                $note->createdBy = $actor;
+            }
+            $filled++;
+        }
+
+        if (!$isDryRun) {
+            $this->entityManager->flush();
+        }
+
+        $io->writeln(sprintf('Notes with nobody recorded: %d', $withoutAuthor));
+        $io->writeln(sprintf('Recovered from a note_created activity: %d', $filled));
+        $io->writeln(sprintf('Older than the activity feed, left as they are: %d', $withoutAuthor - $filled));
+
+        $io->success(sprintf(
+            '%s%d note(s) now record their author.',
+            $isDryRun ? '[DRY-RUN] ' : '',
+            $filled,
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Who created each of the given notes, keyed by note id.
+     *
+     * Scoped to the ids handed in, so the query costs what is left to repair rather than growing with
+     * every note ever created. band_space_activity.resource_id carries no foreign key, the feed being
+     * generic over every module, so the pairing happens here rather than as a join.
+     *
+     * Ordered oldest first and first-write-wins, so a note somehow holding several note_created rows
+     * resolves to the earliest. A row whose actor is NULL recovers nothing and is skipped.
+     *
+     * @param BandSpaceNote[] $notes
+     *
+     * @return array<string, User>
+     */
+    private function findCreationActorsByNoteId(array $notes): array
+    {
+        $noteIds = array_map(
+            static fn(BandSpaceNote $note): UuidInterface => Uuid::fromString((string) $note->id),
+            $notes,
+        );
+
+        $creationActivities = $this->entityManager->getRepository(BandSpaceActivity::class)->findBy(
+            [
+                'module' => BandSpaceModule::Notes,
+                'type' => BandSpaceNoteActivityType::Created->value,
+                'resourceId' => $noteIds,
+            ],
+            ['creationDatetime' => 'ASC'],
+        );
+
+        $actorsByNoteId = [];
+        foreach ($creationActivities as $activity) {
+            $noteId = (string) $activity->resourceId;
+            if (isset($actorsByNoteId[$noteId]) || !$activity->actor instanceof User) {
+                continue;
+            }
+
+            $actorsByNoteId[$noteId] = $activity->actor;
+        }
+
+        return $actorsByNoteId;
+    }
+}

--- a/src/Entity/BandSpace/BandSpaceNote.php
+++ b/src/Entity/BandSpace/BandSpaceNote.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity\BandSpace;
 
+use App\Entity\User;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
 use DateTime;
 use DateTimeInterface;
@@ -29,6 +30,10 @@ class BandSpaceNote
     #[ORM\ManyToOne(targetEntity: BandSpace::class)]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     public BandSpace $bandSpace;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    public ?User $createdBy = null;
 
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[ORM\JoinColumn(onDelete: 'CASCADE')]

--- a/src/Repository/BandSpace/BandSpaceNoteRepository.php
+++ b/src/Repository/BandSpace/BandSpaceNoteRepository.php
@@ -18,11 +18,16 @@ class BandSpaceNoteRepository extends ServiceEntityRepository
     }
 
     /**
+     * The author is fetch joined because every note in the tree carries one in its payload, and a lazy
+     * association would be one query per note.
+     *
      * @return BandSpaceNote[]
      */
     public function findByBandSpace(BandSpace $bandSpace): array
     {
         return $this->createQueryBuilder('n')
+            ->leftJoin('n.createdBy', 'author')
+            ->addSelect('author')
             ->where('n.bandSpace = :bandSpace')
             ->setParameter('bandSpace', $bandSpace)
             ->orderBy('n.position', 'ASC')
@@ -33,6 +38,8 @@ class BandSpaceNoteRepository extends ServiceEntityRepository
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?BandSpaceNote
     {
         return $this->createQueryBuilder('n')
+            ->leftJoin('n.createdBy', 'author')
+            ->addSelect('author')
             ->where('n.id = :id')
             ->andWhere('n.bandSpace = :bandSpace')
             ->setParameter('id', $id)

--- a/src/Security/BandSpace/NoteOwnerChecker.php
+++ b/src/Security/BandSpace/NoteOwnerChecker.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\BandSpace\BandSpaceNote;
+use App\Entity\User;
+use App\Enum\BandSpace\Role;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Deleting a note is owner or admin, the same rule the file and folder endpoints have always applied.
+ *
+ * It used to check membership alone, and a note deletion is a cascade: band_space_note.parent_id is
+ * ON DELETE CASCADE, so any member could take a whole subtree of somebody else's pages behind a single
+ * confirm dialog, with nothing but the activity feed left to say what had been there.
+ *
+ * An authorless note is admin only, exactly as an authorless file is. Both halves of that matter: a
+ * note older than the createdBy column, or one whose author has closed their account, must not become
+ * undeletable, and it must not become deletable by anyone who happens to be in the space either. That
+ * is deliberately the opposite reading from FinanceRecurrenceOwnerChecker, which treats an ownerless
+ * recurrence as claimable: a recurrence with no entries left protects nobody, whereas an old note is
+ * still somebody's writing and the missing name is the only thing that is gone.
+ */
+readonly class NoteOwnerChecker
+{
+    public function checkCanDelete(BandSpaceNote $note, BandSpaceMembership $membership): void
+    {
+        if ($membership->role === Role::Admin) {
+            return;
+        }
+
+        if ($note->createdBy instanceof User && $note->createdBy->id === $membership->user->id) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut supprimer cette note');
+    }
+}

--- a/src/Service/Builder/BandSpace/BandSpaceNoteBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceNoteBuilder.php
@@ -53,6 +53,17 @@ readonly class BandSpaceNoteBuilder
         $dto->content = null;
         $dto->contentVersion = $entity->contentVersion;
         $dto->hasChildren = !$entity->children->isEmpty();
+
+        // isDeleted, not just a null check: closing an account anonymises the row in place and keeps its
+        // primary key, so the FK never breaks and the author reads back as the deleted_<uuid> handle.
+        // Without this the byline would say "Créée par deleted_c7c9f2e1-...", which names nobody.
+        if ($entity->createdBy instanceof \App\Entity\User && !$entity->createdBy->isDeleted()) {
+            $dto->createdBy = [
+                'id' => $entity->createdBy->id,
+                'username' => $entity->createdBy->username,
+            ];
+        }
+
         $dto->creationDatetime = $entity->creationDatetime;
         $dto->updateDatetime = $entity->updateDatetime;
 

--- a/src/State/Processor/BandSpace/BandSpaceNoteCreateProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceNoteCreateProcessor.php
@@ -53,6 +53,7 @@ readonly class BandSpaceNoteCreateProcessor implements ProcessorInterface
 
         $note = new BandSpaceNote();
         $note->bandSpace = $bandSpace;
+        $note->createdBy = $user;
         $note->title = $data->title;
         $note->parent = $parent;
         $note->position = $this->bandSpaceNoteRepository->getNextPosition($bandSpace, $parent);

--- a/src/State/Processor/BandSpace/BandSpaceNoteDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceNoteDeleteProcessor.php
@@ -10,6 +10,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceNoteActivityType;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\NoteOwnerChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\File\BandSpaceFileSourceDetacher;
 use Doctrine\ORM\EntityManagerInterface;
@@ -24,6 +25,7 @@ readonly class BandSpaceNoteDeleteProcessor implements ProcessorInterface
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
+        private NoteOwnerChecker $noteOwnerChecker,
         private BandSpaceNoteRepository $bandSpaceNoteRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private BandSpaceFileSourceDetacher $fileSourceDetacher,
@@ -39,12 +41,15 @@ readonly class BandSpaceNoteDeleteProcessor implements ProcessorInterface
         /** @var User $user */
         $user = $this->security->getUser();
 
-        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+        [$bandSpace, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
         $note = $this->bandSpaceNoteRepository->findOneByIdAndBandSpace($data->id, $bandSpace);
         if (!$note instanceof \App\Entity\BandSpace\BandSpaceNote) {
             throw new NotFoundHttpException('Note not found');
         }
+
+        // After the lookup on purpose: a member has no business learning from a 403 which note ids exist.
+        $this->noteOwnerChecker->checkCanDelete($note, $membership);
 
         $this->bandSpaceActivityRecorder->record(
             bandSpace: $bandSpace,

--- a/tests/Api/BandSpace/BandSpaceNoteCreateTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteCreateTest.php
@@ -44,6 +44,8 @@ class BandSpaceNoteCreateTest extends ApiTestCase
         $this->assertCount(1, $notes);
 
         $note = $notes[0];
+        // Asserted on the row and not only in the payload: this column is what NoteOwnerChecker reads.
+        $this->assertSame($user->id, $note->createdBy?->id);
         $this->assertJsonEquals([
             '@context' => '/api/contexts/BandSpaceNote',
             '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
@@ -56,6 +58,7 @@ class BandSpaceNoteCreateTest extends ApiTestCase
             'content' => null,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => ['id' => $user->id, 'username' => 'base_admin'],
             'emoji' => null,
             'creation_datetime' => $note->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => null,
@@ -105,6 +108,7 @@ class BandSpaceNoteCreateTest extends ApiTestCase
             'content' => null,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => ['id' => $user->id, 'username' => 'base_admin'],
             'emoji' => null,
             'creation_datetime' => $created->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => null,
@@ -147,6 +151,7 @@ class BandSpaceNoteCreateTest extends ApiTestCase
             'content' => null,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => ['id' => $user->id, 'username' => 'base_admin'],
             'emoji' => null,
             'creation_datetime' => $created->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => null,

--- a/tests/Api/BandSpace/BandSpaceNoteDeleteTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteDeleteTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Api\BandSpace;
 
 use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
@@ -29,7 +30,7 @@ class BandSpaceNoteDeleteTest extends ApiTestCase
 {
     use ApiTestAssertionsTrait;
 
-    public function test_delete_note(): void
+    public function test_delete_note_as_its_author(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
@@ -38,6 +39,7 @@ class BandSpaceNoteDeleteTest extends ApiTestCase
         $note = BandSpaceNoteFactory::new([
             'bandSpace' => $bandSpace,
             'title' => 'To Delete',
+            'createdBy' => $user,
         ])->create();
         $noteId = (string) $note->id;
 
@@ -67,6 +69,7 @@ class BandSpaceNoteDeleteTest extends ApiTestCase
         $parentNote = BandSpaceNoteFactory::new([
             'bandSpace' => $bandSpace,
             'title' => 'Parent',
+            'createdBy' => $user,
         ])->create();
 
         $childNote = BandSpaceNoteFactory::new([
@@ -94,7 +97,7 @@ class BandSpaceNoteDeleteTest extends ApiTestCase
         $bandSpace = BandSpaceFactory::new()->create();
         BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
-        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Répétition'])->create();
+        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Répétition', 'createdBy' => $user])->create();
         $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
         $attachment = BandSpaceFileAttachmentFactory::createOne([
             'bandSpaceFile' => $file,
@@ -144,7 +147,7 @@ class BandSpaceNoteDeleteTest extends ApiTestCase
         $bandSpace = BandSpaceFactory::new()->create();
         BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
-        $parent = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Tournée'])->create();
+        $parent = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Tournée', 'createdBy' => $user])->create();
         $child = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Paris', 'parent' => $parent])->create();
         $grandChild = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace, 'title' => 'Backline', 'parent' => $child])->create();
 
@@ -188,6 +191,143 @@ class BandSpaceNoteDeleteTest extends ApiTestCase
             'source_id' => $grandChildId,
             'source_label' => 'Backline',
         ], $activities[0]->payload);
+    }
+
+    public function test_delete_note_written_by_another_member_as_admin(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $author = UserFactory::new()->create(['username' => 'author', 'email' => 'author@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $admin,
+            'role' => Role::Admin,
+        ])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Écrite par un autre',
+            'createdBy' => $author,
+        ])->create();
+        $noteId = (string) $note->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $noteId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $this->assertNull(self::getContainer()->get(BandSpaceNoteRepository::class)->find($noteId));
+    }
+
+    /**
+     * The hole this endpoint had. Deletion cascades through band_space_note.parent_id, so a member who
+     * wrote none of it could take a whole subtree of somebody else's pages behind one confirm dialog.
+     */
+    public function test_delete_note_written_by_another_member_is_refused(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $author = UserFactory::new()->create(['username' => 'author', 'email' => 'author@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Tournée',
+            'createdBy' => $author,
+        ])->create();
+        $child = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Paris',
+            'parent' => $note,
+            'createdBy' => $author,
+        ])->create();
+        $noteId = (string) $note->id;
+        $childId = (string) $child->id;
+
+        $this->client->loginUser($member);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $noteId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Seul le créateur ou un administrateur peut supprimer cette note',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Seul le créateur ou un administrateur peut supprimer cette note',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $this->assertNotNull($noteRepository->find($noteId));
+        $this->assertNotNull($noteRepository->find($childId));
+    }
+
+    /**
+     * A note older than the createdBy column, or one whose author has closed their account, records
+     * nobody. It is admin only rather than open to whoever is in the space: the name is what is
+     * missing, not the fact that somebody wrote it.
+     */
+    public function test_delete_note_without_an_author_is_refused_for_a_plain_member(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Note héritée',
+        ])->create();
+        $noteId = (string) $note->id;
+
+        $this->client->loginUser($member);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $noteId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Seul le créateur ou un administrateur peut supprimer cette note',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Seul le créateur ou un administrateur peut supprimer cette note',
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $this->assertNotNull(self::getContainer()->get(BandSpaceNoteRepository::class)->find($noteId));
+    }
+
+    /** The other half of the rule above: an authorless note must not become undeletable. */
+    public function test_delete_note_without_an_author_as_admin(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $admin,
+            'role' => Role::Admin,
+        ])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Note héritée',
+        ])->create();
+        $noteId = (string) $note->id;
+
+        $this->client->loginUser($admin);
+        $this->client->request('DELETE', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $noteId);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $this->assertNull(self::getContainer()->get(BandSpaceNoteRepository::class)->find($noteId));
     }
 
     public function test_delete_not_found(): void

--- a/tests/Api/BandSpace/BandSpaceNoteGetCollectionTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteGetCollectionTest.php
@@ -26,10 +26,13 @@ class BandSpaceNoteGetCollectionTest extends ApiTestCase
         $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
         BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
+        // One authored and one not, so the tree payload is asserted on both shapes: notes predating the
+        // author column, and notes whose author has closed their account, both come back with none.
         $note1 = BandSpaceNoteFactory::new([
             'bandSpace' => $bandSpace,
             'title' => 'First Note',
             'position' => 0,
+            'createdBy' => $user,
             'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
         ])->create();
         $note2 = BandSpaceNoteFactory::new([
@@ -59,6 +62,7 @@ class BandSpaceNoteGetCollectionTest extends ApiTestCase
                     'content' => null,
                     'content_version' => 1,
                     'has_children' => false,
+                    'created_by' => ['id' => $user->id, 'username' => 'base_admin'],
                     'emoji' => null,
                     'creation_datetime' => '2024-01-01T10:00:00+00:00',
                     'update_datetime' => null,
@@ -74,6 +78,7 @@ class BandSpaceNoteGetCollectionTest extends ApiTestCase
                     'content' => null,
                     'content_version' => 1,
                     'has_children' => false,
+                    'created_by' => null,
                     'emoji' => null,
                     'creation_datetime' => '2024-01-02T10:00:00+00:00',
                     'update_datetime' => null,
@@ -184,6 +189,7 @@ class BandSpaceNoteGetCollectionTest extends ApiTestCase
                     'content' => null,
                     'content_version' => 1,
                     'has_children' => false,
+                    'created_by' => null,
                     'emoji' => null,
                     'creation_datetime' => '2024-01-01T10:00:00+00:00',
                     'update_datetime' => null,

--- a/tests/Api/BandSpace/BandSpaceNoteGetTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteGetTest.php
@@ -32,6 +32,7 @@ class BandSpaceNoteGetTest extends ApiTestCase
             'title' => 'My Note',
             'content' => $content,
             'position' => 0,
+            'createdBy' => $user,
             'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
         ])->create();
 
@@ -51,6 +52,97 @@ class BandSpaceNoteGetTest extends ApiTestCase
             'content' => $content,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => ['id' => $user->id, 'username' => 'base_admin'],
+            'emoji' => null,
+            'creation_datetime' => '2024-01-01T10:00:00+00:00',
+            'update_datetime' => null,
+        ]);
+    }
+
+    /**
+     * A note written before the author column existed reports no author rather than a placeholder. The
+     * header hides its byline on exactly this shape. A closed account is the other way in, and it is a
+     * separate case with a separate mechanism, so it gets its own test below.
+     */
+    public function test_get_item_without_an_author_reports_none(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Note héritée',
+            'position' => 0,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => $note->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Note héritée',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => null,
+            'content_version' => 1,
+            'has_children' => false,
+            'created_by' => null,
+            'emoji' => null,
+            'creation_datetime' => '2024-01-01T10:00:00+00:00',
+            'update_datetime' => null,
+        ]);
+    }
+
+    /**
+     * Closing an account does not null this FK. DeleteAccountProcedure anonymises the fos_user row in
+     * place and keeps its primary key, so ON DELETE SET NULL never fires and the author still resolves,
+     * to a deleted_<uuid> handle. The byline has to be suppressed on the read side instead, or it would
+     * name a handle nobody recognises.
+     */
+    public function test_get_item_hides_the_byline_of_a_closed_account(): void
+    {
+        $reader = UserFactory::new()->asBaseUser()->create();
+        // Its own email, because asBaseUser pins a fixed one and the column is unique.
+        $departed = UserFactory::new()->asBaseUser()->create([
+            'username' => 'deleted_c7c9f2e1',
+            'email' => 'deleted_c7c9f2e1@email.com',
+            'deletionDatetime' => new \DateTimeImmutable('2024-06-01 09:00:00'),
+        ]);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $reader])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Note orpheline',
+            'position' => 0,
+            'createdBy' => $departed,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($reader);
+        $this->client->request('GET', '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => $note->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Note orpheline',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => null,
+            'content_version' => 1,
+            'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => '2024-01-01T10:00:00+00:00',
             'update_datetime' => null,
@@ -112,6 +204,7 @@ class BandSpaceNoteGetTest extends ApiTestCase
             'content' => $content,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => '2024-01-01T10:00:00+00:00',
             'update_datetime' => null,
@@ -174,6 +267,7 @@ class BandSpaceNoteGetTest extends ApiTestCase
             ],
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => '2024-01-01T10:00:00+00:00',
             'update_datetime' => null,

--- a/tests/Api/BandSpace/BandSpaceNoteUpdateTest.php
+++ b/tests/Api/BandSpace/BandSpaceNoteUpdateTest.php
@@ -23,6 +23,60 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
 {
     use ApiTestAssertionsTrait;
 
+    /**
+     * The author is server owned, so a payload naming somebody else is ignored rather than applied.
+     * It is what NoteOwnerChecker reads, so a writable field here would let any member hand themselves
+     * the right to delete anyone's note by renaming its author first.
+     */
+    public function test_update_cannot_reassign_the_author(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $author = UserFactory::new()->create(['username' => 'author', 'email' => 'author@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $author])->create();
+
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Tournée',
+            'position' => 0,
+            'createdBy' => $author,
+            'creationDatetime' => new \DateTime('2024-01-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($member);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            ['title' => 'Tournée 2026', 'created_by' => ['id' => $member->id, 'username' => 'base_admin']],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $noteRepository = self::getContainer()->get(BandSpaceNoteRepository::class);
+        $refreshed = $noteRepository->find($note->id);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceNote',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/notes/' . $note->id,
+            '@type' => 'BandSpaceNote',
+            'id' => (string) $note->id,
+            'band_space_id' => (string) $bandSpace->id,
+            'title' => 'Tournée 2026',
+            'parent_id' => null,
+            'position' => 0,
+            'content' => null,
+            'content_version' => 1,
+            'has_children' => false,
+            'created_by' => ['id' => $author->id, 'username' => 'author'],
+            'emoji' => null,
+            'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
+            'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        $this->assertSame($author->id, $refreshed->createdBy?->id);
+    }
+
     public function test_update_title(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();
@@ -60,6 +114,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => null,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -111,6 +166,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => $content,
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -159,6 +215,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => null,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -205,6 +262,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => null,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => '🎵',
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -256,6 +314,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => null,
             'content_version' => 1,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -302,6 +361,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => null,
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -460,6 +520,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => $content,
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -519,6 +580,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => $content,
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -579,6 +641,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => $content,
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -629,6 +692,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => $content,
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -701,6 +765,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             ],
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -762,6 +827,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             ],
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -833,6 +899,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             ],
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -892,6 +959,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             ],
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -961,6 +1029,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => $content,
             'content_version' => 2,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -1249,6 +1318,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => $secondContent,
             'content_version' => 3,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -1293,6 +1363,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => null,
             'content_version' => 3,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),
@@ -1339,6 +1410,7 @@ class BandSpaceNoteUpdateTest extends ApiTestCase
             'content' => $content,
             'content_version' => 3,
             'has_children' => false,
+            'created_by' => null,
             'emoji' => null,
             'creation_datetime' => $refreshed->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $refreshed->updateDatetime->format(\DateTimeInterface::ATOM),

--- a/tests/Integration/Command/BandSpace/BackfillNoteCreatedByCommandTest.php
+++ b/tests/Integration/Command/BandSpace/BackfillNoteCreatedByCommandTest.php
@@ -1,0 +1,227 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Integration\Command\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceNote;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\BandSpaceNoteActivityType;
+use App\Repository\BandSpace\BandSpaceNoteRepository;
+use App\Tests\Factory\BandSpace\BandSpaceActivityFactory;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceNoteFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BackfillNoteCreatedByCommandTest extends KernelTestCase
+{
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        parent::setUp();
+
+        $application = new Application(self::$kernel);
+        $command = $application->find('app:band-space:notes:backfill-created-by');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function test_fills_the_author_from_the_note_created_activity(): void
+    {
+        $author = $this->createMember('note_author');
+        $bandSpace = BandSpaceFactory::new()->create();
+        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace])->create();
+        $this->recordCreation($bandSpace, $note, $author);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Notes with nobody recorded: 1', $output);
+        $this->assertStringContainsString('Recovered from a note_created activity: 1', $output);
+        $this->assertStringContainsString('Older than the activity feed, left as they are: 0', $output);
+        $this->assertStringContainsString('1 note(s) now record their author.', $output);
+
+        $this->assertSame((string) $author->id, (string) $this->reload($note)->createdBy?->id);
+    }
+
+    public function test_leaves_a_note_whose_only_activity_is_a_later_edit_alone(): void
+    {
+        $editor = $this->createMember('note_editor');
+        $bandSpace = BandSpaceFactory::new()->create();
+        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace])->create();
+
+        // The member who edited or renamed a note is not necessarily the one who wrote it, so neither
+        // type may stand in for note_created.
+        BandSpaceActivityFactory::createOne([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Notes,
+            'type' => BandSpaceNoteActivityType::ContentUpdated->value,
+            'resourceId' => Uuid::fromString((string) $note->id),
+            'actor' => $editor,
+        ]);
+        BandSpaceActivityFactory::createOne([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Notes,
+            'type' => BandSpaceNoteActivityType::Renamed->value,
+            'resourceId' => Uuid::fromString((string) $note->id),
+            'actor' => $editor,
+        ]);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Recovered from a note_created activity: 0', $output);
+        $this->assertStringContainsString('Older than the activity feed, left as they are: 1', $output);
+
+        $this->assertNull($this->reload($note)->createdBy);
+    }
+
+    public function test_never_overwrites_an_author_already_recorded(): void
+    {
+        $recordedAuthor = $this->createMember('recorded_author');
+        $otherMember = $this->createMember('other_member');
+        $bandSpace = BandSpaceFactory::new()->create();
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $recordedAuthor,
+        ])->create();
+        $this->recordCreation($bandSpace, $note, $otherMember);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Every note already records who wrote it.', $this->commandTester->getDisplay());
+
+        $this->assertSame((string) $recordedAuthor->id, (string) $this->reload($note)->createdBy?->id);
+    }
+
+    public function test_ignores_an_activity_of_another_module_on_the_same_resource_id(): void
+    {
+        $member = $this->createMember('note_member');
+        $bandSpace = BandSpaceFactory::new()->create();
+        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace])->create();
+
+        // resource_id has no foreign key, so the same uuid can legitimately appear under another module.
+        BandSpaceActivityFactory::createOne([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Task,
+            'type' => BandSpaceNoteActivityType::Created->value,
+            'resourceId' => Uuid::fromString((string) $note->id),
+            'actor' => $member,
+        ]);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Recovered from a note_created activity: 0', $this->commandTester->getDisplay());
+
+        $this->assertNull($this->reload($note)->createdBy);
+    }
+
+    public function test_leaves_a_note_whose_creation_row_has_no_actor_alone(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace])->create();
+
+        // band_space_activity.actor is nullable, so a creation row can name nobody. It recovers nothing
+        // and must not be mistaken for an answer, since this column decides who may delete the note.
+        BandSpaceActivityFactory::createOne([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Notes,
+            'type' => BandSpaceNoteActivityType::Created->value,
+            'resourceId' => Uuid::fromString((string) $note->id),
+            'actor' => null,
+        ]);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Recovered from a note_created activity: 0', $output);
+        $this->assertStringContainsString('Older than the activity feed, left as they are: 1', $output);
+
+        $this->assertNull($this->reload($note)->createdBy);
+    }
+
+    public function test_keeps_the_earliest_actor_when_several_creation_rows_exist(): void
+    {
+        $firstActor = $this->createMember('first_actor');
+        $laterActor = $this->createMember('later_actor');
+        $bandSpace = BandSpaceFactory::new()->create();
+        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace])->create();
+
+        $this->recordCreation($bandSpace, $note, $laterActor, new \DateTime('2026-06-02 10:00:00'));
+        $this->recordCreation($bandSpace, $note, $firstActor, new \DateTime('2026-06-01 10:00:00'));
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Recovered from a note_created activity: 1', $this->commandTester->getDisplay());
+
+        $this->assertSame((string) $firstActor->id, (string) $this->reload($note)->createdBy?->id);
+    }
+
+    public function test_dry_run_reports_without_writing_and_the_run_is_repeatable(): void
+    {
+        $author = $this->createMember('note_author');
+        $bandSpace = BandSpaceFactory::new()->create();
+        $note = BandSpaceNoteFactory::new(['bandSpace' => $bandSpace])->create();
+        $this->recordCreation($bandSpace, $note, $author);
+
+        $this->commandTester->execute(['--dry-run' => true]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('[DRY-RUN] 1 note(s) now record their author.', $this->commandTester->getDisplay());
+        $this->assertNull($this->reload($note)->createdBy);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('1 note(s) now record their author.', $this->commandTester->getDisplay());
+        $this->assertSame((string) $author->id, (string) $this->reload($note)->createdBy?->id);
+
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Every note already records who wrote it.', $this->commandTester->getDisplay());
+    }
+
+    private function createMember(string $username): User
+    {
+        return UserFactory::new()->create([
+            'username' => $username,
+            'email' => $username . '@email.com',
+        ]);
+    }
+
+    private function recordCreation(
+        BandSpace $bandSpace,
+        BandSpaceNote $note,
+        User $actor,
+        ?\DateTime $at = null,
+    ): void {
+        BandSpaceActivityFactory::createOne([
+            'bandSpace' => $bandSpace,
+            'module' => BandSpaceModule::Notes,
+            'type' => BandSpaceNoteActivityType::Created->value,
+            'resourceId' => Uuid::fromString((string) $note->id),
+            'actor' => $actor,
+            'creationDatetime' => $at ?? new \DateTime('2026-06-01 10:00:00'),
+        ]);
+    }
+
+    private function reload(BandSpaceNote $note): BandSpaceNote
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->clear();
+
+        $reloaded = self::getContainer()->get(BandSpaceNoteRepository::class)->find((string) $note->id);
+        $this->assertInstanceOf(BandSpaceNote::class, $reloaded);
+
+        return $reloaded;
+    }
+}


### PR DESCRIPTION
Closes #865.

`BandSpaceNote` had no `createdBy`, so "who wrote this" was only recoverable from the activity feed. Separately, the delete check verified membership only, unlike files which require owner or admin, so any member could cascade-delete a whole subtree behind a single confirm.

## What changed

`createdBy` on the entity, the DTO and the note header, matching the shape `BandSpaceFile` and `BandSpaceFolder` already use. The create processor sets it from the authenticated user, and the DTO field is `writable: false`, so it cannot be supplied or reassigned through the API.

Deletion is now owner or admin, expressed in `NoteOwnerChecker` under `src/Security/` following the existing entity-scoped checker pattern rather than a voter. The membership check runs before the note lookup, so a 403 never reveals which note ids exist.

The repository fetch-joins the author with a left join, so listing a tree costs no extra query per note and notes without an author are still returned.

## A legacy note with no author is admin-deletable, not member-deletable

Notes written before the column existed read back null. They are never undeletable, since admins can always delete them, and never open to everyone in the space. No backfill from the activity feed: a wrong guess would hand delete rights to whoever it named.

## A bug found in review

The entity, the migration and a test all claimed that a member closing their account leaves their notes with a null author, via `ON DELETE SET NULL`. That is false. `DeleteAccountProcedure` never issues a real delete on `fos_user`: it anonymises the row in place and keeps the primary key, so the FK never breaks and the author still resolves. The byline would have read "Créée par deleted_c7c9f2e1-...".

The telling part is that the test asserting this was named for the case and its docblock described it, but its body only seeded a legacy null-author note, so the acceptance criterion was never actually exercised.

Fixed on the read side with `User::isDeleted()` in the builder, which is the pattern the project already documents for read-side providers. The two cases are now separate tests, and the closed-account one was checked to fail with the guard removed and pass with it restored, so it proves the fix rather than passing incidentally. The entity docblock now records that the database does not cover this case and why.

## Migration

`up()` adds the column, the FK to `fos_user` with `ON DELETE SET NULL` and the index; `down()` drops the FK, then the index, then the column. Validated on the migration database: the full 86-migration chain builds from zero, this migration applies, rolls back through `down()` and re-applies through `up()`, and the schema drift against the Doctrine mapping stays at exactly the four statements master already has, so it adds none.

## Follow-up worth its own issue

Owner-or-admin narrows the hole without closing the subtree case: the author of a root note can still cascade-delete children written by other members, because the rule checks only the note named in the URL. Review proved this by execution. The folder module answers the same problem by requiring admin for a cascade. This issue asked for root-level owner-or-admin, so that second tier is not invented here.

## Verification

68 note tests green, covering author deletes, admin deletes another member's, a plain member refused, a legacy null-author note refused for a member and allowed for an admin, and a forged `created_by` in a merge-patch being ignored. Full suite 2334 green, PHPStan level 8 clean, biome clean, build succeeds.
