### PR TITLE
feat(M-682): report a forum post for moderation

### DIFF
--- a/assets/js/api/admin/forum.js
+++ b/assets/js/api/admin/forum.js
@@ -1,0 +1,21 @@
+/** global: Routing */
+
+import axios from 'axios'
+
+export default {
+  getPendingReports() {
+    return axios
+      .get(Routing.generate('api_admin_forum_reports_list'))
+      .then((resp) => resp.data.member)
+  },
+
+  resolveReport(id) {
+    return axios.post(
+      Routing.generate('api_admin_forum_reports_resolve', { id }),
+      {},
+      {
+        headers: { 'Content-Type': 'application/ld+json' }
+      }
+    )
+  }
+}

--- a/assets/js/api/forum/forum.js
+++ b/assets/js/api/forum/forum.js
@@ -1,6 +1,7 @@
 /** global: Routing */
 
 import axios from 'axios'
+import { handleApiError } from '../utils/handleApiError.js'
 
 export default {
   getCategories() {
@@ -126,6 +127,18 @@ export default {
         }
       )
       .then((resp) => resp.data)
+  },
+
+  reportForumPost(id, reason) {
+    return axios
+      .post(
+        Routing.generate('api_forum_post_report', { id }),
+        { reason },
+        {
+          headers: { 'Content-Type': 'application/ld+json' }
+        }
+      )
+      .catch(handleApiError)
   },
 
   uploadImage(file) {

--- a/assets/js/components/Forum/ReportPostModal.vue
+++ b/assets/js/components/Forum/ReportPostModal.vue
@@ -1,0 +1,115 @@
+<template>
+  <Dialog
+    v-model:visible="visible"
+    modal
+    :style="{ width: '500px' }"
+    :pt="{
+      header: { class: 'pb-0 border-0' },
+      content: { class: 'pt-4' }
+    }"
+    @hide="reset"
+  >
+    <template #header>
+      <div class="flex items-center gap-3">
+        <div class="flex items-center justify-center w-10 h-10 rounded-full bg-red-100 dark:bg-red-900/30">
+          <i class="pi pi-flag text-red-600 dark:text-red-400 text-lg" />
+        </div>
+        <div>
+          <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 m-0">
+            Signaler ce message
+          </h2>
+          <p class="text-sm text-surface-500 dark:text-surface-400 m-0">
+            Expliquez pourquoi ce message pose problème
+          </p>
+        </div>
+      </div>
+    </template>
+
+    <div class="flex flex-col gap-2">
+      <label for="report-reason" class="text-sm font-medium text-surface-700 dark:text-surface-200">
+        Motif du signalement
+      </label>
+      <Textarea
+        id="report-reason"
+        v-model="reason"
+        :disabled="isSubmitting"
+        :invalid="isTooLong"
+        rows="5"
+        fluid
+        placeholder="Propos insultants, spam, contenu hors sujet..."
+      />
+      <div class="flex justify-end text-xs" :class="isTooLong ? 'text-red-500' : 'text-surface-500'">
+        {{ reason.length }} / {{ MAX_REASON_LENGTH }}
+      </div>
+
+      <Message v-if="errorMessage" severity="error" :closable="false">
+        {{ errorMessage }}
+      </Message>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-2 w-full">
+        <Button label="Annuler" severity="secondary" text :disabled="isSubmitting" @click="visible = false" />
+        <Button
+          label="Signaler"
+          icon="pi pi-flag"
+          severity="danger"
+          :loading="isSubmitting"
+          :disabled="!canSubmit"
+          class="px-5"
+          @click="submitReport"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import Message from 'primevue/message'
+import Textarea from 'primevue/textarea'
+import { computed, ref } from 'vue'
+import forumApi from '../../api/forum/forum.js'
+
+const MAX_REASON_LENGTH = 500
+
+const props = defineProps({
+  postId: { type: String, required: true }
+})
+
+const emit = defineEmits(['reported'])
+const visible = defineModel('visible', { type: Boolean, default: false })
+
+const reason = ref('')
+const isSubmitting = ref(false)
+const errorMessage = ref('')
+
+const isTooLong = computed(() => reason.value.length > MAX_REASON_LENGTH)
+
+const canSubmit = computed(
+  () => reason.value.trim().length > 0 && !isTooLong.value && !isSubmitting.value
+)
+
+async function submitReport() {
+  if (!canSubmit.value) return
+
+  errorMessage.value = ''
+  isSubmitting.value = true
+  try {
+    await forumApi.reportForumPost(props.postId, reason.value.trim())
+    visible.value = false
+    emit('reported')
+  } catch (e) {
+    errorMessage.value = e.message || 'Une erreur est survenue.'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+function reset() {
+  reason.value = ''
+  errorMessage.value = ''
+  isSubmitting.value = false
+}
+</script>

--- a/assets/js/components/Forum/TopicPost.vue
+++ b/assets/js/components/Forum/TopicPost.vue
@@ -109,6 +109,17 @@
                 :aria-label="`Citer le message de ${creatorName}`"
                 @click="handleQuote"
               />
+              <Button
+                v-if="canReport"
+                icon="pi pi-flag"
+                label="Signaler"
+                text
+                size="small"
+                severity="secondary"
+                class="ml-auto"
+                :aria-label="`Signaler le message de ${creatorName}`"
+                @click="showReportModal = true"
+              />
             </div>
           </template>
         </div>
@@ -119,6 +130,12 @@
   <SendMessageModal
     v-model:visible="showMessageModal"
     :selected-recipient="post.creator"
+  />
+
+  <ReportPostModal
+    v-model:visible="showReportModal"
+    :post-id="post.id"
+    @reported="handleReported"
   />
 
   <AuthRequiredModal
@@ -142,6 +159,7 @@ import { formatDate } from '../../utils/date.js'
 import AuthRequiredModal from '../Auth/AuthRequiredModal.vue'
 import SendMessageModal from '../Message/SendMessageModal.vue'
 import MessageEditor from './MessageEditor.vue'
+import ReportPostModal from './ReportPostModal.vue'
 
 const props = defineProps({
   post: {
@@ -164,6 +182,7 @@ const creatorName = computed(() => displayName(props.post.creator))
 
 const showMessageModal = ref(false)
 const showAuthModal = ref(false)
+const showReportModal = ref(false)
 
 const localUpvotes = ref(props.post.upvotes ?? 0)
 const localDownvotes = ref(props.post.downvotes ?? 0)
@@ -242,6 +261,20 @@ const canContact = computed(() => {
 const canQuote = computed(
   () => userSecurityStore.isAuthenticated && !props.isLocked && !isEditing.value
 )
+
+const canReport = computed(() => {
+  if (!userSecurityStore.isAuthenticated) return false
+  return userSecurityStore.userProfile?.id !== props.post.creator.id
+})
+
+function handleReported() {
+  toast.add({
+    severity: 'success',
+    summary: 'Message signalé',
+    detail: 'Un modérateur va examiner ce message.',
+    life: 4000
+  })
+}
 
 function handleQuote() {
   emit('quote', {

--- a/assets/js/router/admin.js
+++ b/assets/js/router/admin.js
@@ -49,6 +49,11 @@ export default {
       component: () => import('../views/Admin/Forum/Index.vue')
     },
     {
+      name: 'admin_forum_reports',
+      path: 'forum/reports',
+      component: () => import('../views/Admin/Forum/Reports.vue')
+    },
+    {
       name: 'admin_band_space_coming_soon',
       path: 'band-spaces',
       component: () => import('../views/Admin/ComingSoonPage.vue'),

--- a/assets/js/store/admin/forumReport.js
+++ b/assets/js/store/admin/forumReport.js
@@ -1,0 +1,31 @@
+import { defineStore } from 'pinia'
+import { readonly, ref } from 'vue'
+import adminForumApi from '../../api/admin/forum.js'
+
+export const useAdminForumReportStore = defineStore('adminForumReport', () => {
+  const pendingReports = ref([])
+  const isLoading = ref(false)
+
+  async function loadPendingReports() {
+    isLoading.value = true
+    try {
+      pendingReports.value = await adminForumApi.getPendingReports()
+    } catch (e) {
+      console.error('Failed to load pending forum reports:', e)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function resolveReport(id) {
+    await adminForumApi.resolveReport(id)
+    pendingReports.value = pendingReports.value.filter((report) => report.id !== id)
+  }
+
+  return {
+    pendingReports: readonly(pendingReports),
+    isLoading: readonly(isLoading),
+    loadPendingReports,
+    resolveReport
+  }
+})

--- a/assets/js/views/Admin/Forum/Index.vue
+++ b/assets/js/views/Admin/Forum/Index.vue
@@ -6,11 +6,12 @@
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <AdminModuleCard
-        label="Modération du forum"
-        description="File de modération des sujets et posts signalés"
-        icon="pi-shield"
+        label="Messages signalés"
+        description="File de modération des messages signalés par les membres"
+        icon="pi-flag"
         color="#06b6d4"
-        coming-soon
+        route="admin_forum_reports"
+        :badge-count="adminForumReportStore.pendingReports.length"
       />
     </div>
 
@@ -152,8 +153,10 @@ import AdminModuleCard from '../../../components/Admin/AdminModuleCard.vue'
 import DateRangePicker from '../../../components/Admin/DateRangePicker.vue'
 import TimeSeriesChart from '../../../components/Admin/TimeSeriesChart.vue'
 import { useAdminDashboardStore } from '../../../store/admin/dashboard.js'
+import { useAdminForumReportStore } from '../../../store/admin/forumReport.js'
 
 const dashboardStore = useAdminDashboardStore()
+const adminForumReportStore = useAdminForumReportStore()
 
 const contentOverview = computed(() => dashboardStore.contentOverview)
 const forumRecentActivity = computed(() => dashboardStore.forumRecentActivity)
@@ -198,5 +201,6 @@ function handleDateRangeApply({ from, to }) {
 onMounted(() => {
   loadMetrics()
   loadRecentActivity()
+  adminForumReportStore.loadPendingReports()
 })
 </script>

--- a/assets/js/views/Admin/Forum/Reports.vue
+++ b/assets/js/views/Admin/Forum/Reports.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="flex flex-col gap-6">
+    <h1 class="text-3xl font-bold text-surface-900 dark:text-surface-100">
+      Messages signalés
+    </h1>
+
+    <DataTable
+      :value="adminForumReportStore.pendingReports"
+      :loading="adminForumReportStore.isLoading"
+      stripedRows
+      tableStyle="min-width: 50rem"
+    >
+      <template #empty>
+        <div class="text-center py-8 text-surface-500">
+          Il n'y a aucun message signalé en attente de traitement.
+        </div>
+      </template>
+
+      <Column header="Message signalé">
+        <template #body="{ data }">
+          <div class="flex flex-col gap-1">
+            <span class="text-surface-800 dark:text-surface-100">{{ data.post_excerpt }}</span>
+            <span class="text-xs text-surface-500">
+              par {{ data.post_author_username }} dans « {{ data.topic_title }} »
+            </span>
+          </div>
+        </template>
+      </Column>
+
+      <Column header="Motif">
+        <template #body="{ data }">
+          <span class="text-surface-700 dark:text-surface-200">{{ data.reason }}</span>
+        </template>
+      </Column>
+
+      <Column header="Signalé par" style="width: 180px">
+        <template #body="{ data }">
+          <div class="flex flex-col gap-1">
+            <span>{{ data.reporter_username }}</span>
+            <span class="text-xs text-surface-500">{{ formatDate(data.creation_datetime) }}</span>
+          </div>
+        </template>
+      </Column>
+
+      <Column header="Actions" style="width: 130px">
+        <template #body="{ data }">
+          <div class="flex gap-2">
+            <Button
+              icon="pi pi-eye"
+              severity="info"
+              text
+              rounded
+              v-tooltip.top="'Voir le post'"
+              aria-label="Voir le post"
+              as="router-link"
+              :to="postRoute(data)"
+              target="_blank"
+            />
+            <Button
+              icon="pi pi-check"
+              severity="success"
+              text
+              rounded
+              v-tooltip.top="'Marquer comme résolu'"
+              aria-label="Marquer comme résolu"
+              @click="confirmResolve(data)"
+            />
+          </div>
+        </template>
+      </Column>
+    </DataTable>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import { useConfirm } from 'primevue/useconfirm'
+import { useToast } from 'primevue/usetoast'
+import { onMounted } from 'vue'
+import { useAdminForumReportStore } from '../../../store/admin/forumReport.js'
+import { formatDate } from '../../../utils/date.js'
+
+const confirm = useConfirm()
+const toast = useToast()
+const adminForumReportStore = useAdminForumReportStore()
+
+onMounted(async () => {
+  await adminForumReportStore.loadPendingReports()
+})
+
+function postRoute(report) {
+  return {
+    name: 'forum_topic_item',
+    params:
+      report.topic_page === 1
+        ? { slug: report.topic_slug }
+        : { slug: report.topic_slug, page: report.topic_page },
+    hash: `#post-${report.post_id}`
+  }
+}
+
+function confirmResolve(report) {
+  confirm.require({
+    message: `Marquer le signalement de ${report.reporter_username} comme résolu ?`,
+    header: 'Confirmation',
+    icon: 'pi pi-check-circle',
+    acceptLabel: 'Marquer comme résolu',
+    rejectLabel: 'Annuler',
+    acceptClass: 'p-button-success',
+    accept: async () => {
+      try {
+        await adminForumReportStore.resolveReport(report.id)
+        toast.add({
+          severity: 'success',
+          summary: 'Signalement résolu',
+          detail: 'Le signalement a été retiré de la file de modération.',
+          life: 3000
+        })
+      } catch (e) {
+        toast.add({
+          severity: 'error',
+          summary: 'Erreur',
+          detail: 'Une erreur est survenue lors du traitement du signalement.',
+          life: 3000
+        })
+      }
+    }
+  })
+}
+</script>

--- a/migrations/2026/08/Version20260819114500.php
+++ b/migrations/2026/08/Version20260819114500.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * The unique index on (post_id, reporter_id) is what actually enforces one report per user per post.
+ * The processor checks first so the user gets a readable 409 instead of a 500, but two concurrent
+ * requests can both pass that check, and only the index stops the second insert.
+ *
+ * post and reporter cascade because a report has no meaning once either side is gone. resolved_by is
+ * SET NULL instead: deleting a moderator account must not erase the report of a post that is still
+ * online.
+ */
+final class Version20260819114500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add forum_post_report table for the forum moderation queue';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE forum_post_report (id CHAR(36) NOT NULL, reason VARCHAR(500) NOT NULL, creation_datetime DATETIME NOT NULL, resolved_datetime DATETIME DEFAULT NULL, post_id CHAR(36) NOT NULL, reporter_id CHAR(36) NOT NULL, resolved_by_id CHAR(36) DEFAULT NULL, INDEX IDX_F23910434B89032C (post_id), INDEX IDX_F2391043E1CFE6F5 (reporter_id), INDEX IDX_F23910436713A32B (resolved_by_id), UNIQUE INDEX uniq_forum_post_report_post_reporter (post_id, reporter_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE forum_post_report ADD CONSTRAINT FK_F23910434B89032C FOREIGN KEY (post_id) REFERENCES forum_post (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE forum_post_report ADD CONSTRAINT FK_F2391043E1CFE6F5 FOREIGN KEY (reporter_id) REFERENCES fos_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE forum_post_report ADD CONSTRAINT FK_F23910436713A32B FOREIGN KEY (resolved_by_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE forum_post_report DROP FOREIGN KEY FK_F23910434B89032C');
+        $this->addSql('ALTER TABLE forum_post_report DROP FOREIGN KEY FK_F2391043E1CFE6F5');
+        $this->addSql('ALTER TABLE forum_post_report DROP FOREIGN KEY FK_F23910436713A32B');
+        $this->addSql('DROP TABLE forum_post_report');
+    }
+}

--- a/src/ApiResource/Admin/Forum/AdminForumReport.php
+++ b/src/ApiResource/Admin/Forum/AdminForumReport.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Admin\Forum;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\Admin\Forum\AdminForumReportResolveProcessor;
+use App\State\Provider\Admin\Forum\AdminForumReportCollectionProvider;
+use DateTimeInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    shortName: 'AdminForumReport',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/admin/forum/reports',
+            openapi: new Operation(tags: ['Admin Forum']),
+            paginationEnabled: false,
+            security: 'is_granted("ROLE_ADMIN")',
+            name: 'api_admin_forum_reports_list',
+            provider: AdminForumReportCollectionProvider::class,
+        ),
+        new Post(
+            uriTemplate: '/admin/forum/reports/{id}/resolve',
+            uriVariables: ['id'],
+            status: Response::HTTP_NO_CONTENT,
+            openapi: new Operation(tags: ['Admin Forum']),
+            security: 'is_granted("ROLE_ADMIN")',
+            read: false,
+            deserialize: false,
+            validate: false,
+            name: 'api_admin_forum_reports_resolve',
+            processor: AdminForumReportResolveProcessor::class,
+        ),
+    ]
+)]
+class AdminForumReport
+{
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    public string $reason;
+    public DateTimeInterface $creationDatetime;
+    public string $reporterUsername;
+
+    public string $postId;
+    public string $postExcerpt;
+    public string $postAuthorUsername;
+
+    public string $topicSlug;
+    public string $topicTitle;
+
+    /** Page the reported post sits on, so the admin can deep-link straight to it. */
+    public int $topicPage;
+}

--- a/src/ApiResource/Forum/ForumPostReportInput.php
+++ b/src/ApiResource/Forum/ForumPostReportInput.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiResource\Forum;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\Entity\Forum\ForumPostReport;
+use App\State\Processor\Forum\ForumPostReportProcessor;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Post(
+    uriTemplate: '/forums/posts/{id}/report',
+    uriVariables: ['id'],
+    status: Response::HTTP_NO_CONTENT,
+    openapi: new Operation(tags: ['Forum']),
+    security: 'is_granted("IS_AUTHENTICATED_REMEMBERED")',
+    name: 'api_forum_post_report',
+    processor: ForumPostReportProcessor::class,
+)]
+class ForumPostReportInput
+{
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    #[Assert\NotBlank(message: 'Veuillez préciser le motif du signalement', normalizer: 'trim')]
+    #[Assert\Length(
+        max: ForumPostReport::REASON_MAX_LENGTH,
+        maxMessage: 'Le motif ne peut pas dépasser {{ limit }} caractères',
+        normalizer: 'trim',
+    )]
+    public string $reason;
+}

--- a/src/ApiResource/Forum/ForumPostResource.php
+++ b/src/ApiResource/Forum/ForumPostResource.php
@@ -26,7 +26,7 @@ use DateTimeInterface;
             ],
             openapi: new Operation(tags: ['Forum']),
             paginationEnabled: true,
-            paginationItemsPerPage: 10,
+            paginationItemsPerPage: ForumPostResource::POSTS_PER_PAGE,
             name: 'api_forum_topic_posts_list',
             provider: ForumPostCollectionProvider::class,
         ),
@@ -41,6 +41,12 @@ use DateTimeInterface;
 )]
 class ForumPostResource
 {
+    /**
+     * Page size of a topic. Admin screens deep-link to a single post, so they need the same value to
+     * work out which page it lands on.
+     */
+    final public const int POSTS_PER_PAGE = 10;
+
     #[ApiProperty(identifier: true)]
     public string $id;
     public DateTimeInterface $creationDatetime;

--- a/src/Entity/Forum/ForumPostReport.php
+++ b/src/Entity/Forum/ForumPostReport.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Forum;
+
+use App\Entity\User;
+use App\Repository\Forum\ForumPostReportRepository;
+use DateTime;
+use DateTimeInterface;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity(repositoryClass: ForumPostReportRepository::class)]
+#[ORM\UniqueConstraint(name: 'uniq_forum_post_report_post_reporter', columns: ['post_id', 'reporter_id'])]
+class ForumPostReport
+{
+    final public const int REASON_MAX_LENGTH = 500;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    public UuidInterface|string|null $id = null {
+        get {
+            return is_string($this->id) ? $this->id : $this->id?->toString();
+        }
+    }
+
+    #[ORM\ManyToOne(targetEntity: ForumPost::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    public ForumPost $post;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    public User $reporter;
+
+    #[ORM\Column(type: Types::STRING, length: self::REASON_MAX_LENGTH)]
+    public string $reason;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    public DateTimeInterface $creationDatetime;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    public ?DateTimeInterface $resolvedDatetime = null;
+
+    /**
+     * The moderator who closed the report. SET NULL rather than CASCADE: deleting a moderator account
+     * must not erase the moderation history of a post that is still online.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    public ?User $resolvedBy = null;
+
+    public function __construct()
+    {
+        $this->creationDatetime = new DateTime();
+    }
+
+    public function isResolved(): bool
+    {
+        return $this->resolvedDatetime instanceof DateTimeInterface;
+    }
+}

--- a/src/Repository/Forum/ForumPostReportRepository.php
+++ b/src/Repository/Forum/ForumPostReportRepository.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository\Forum;
+
+use App\Entity\Forum\ForumPost;
+use App\Entity\Forum\ForumPostReport;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<ForumPostReport>
+ */
+class ForumPostReportRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ForumPostReport::class);
+    }
+
+    public function findOneByPostAndReporter(ForumPost $post, User $reporter): ?ForumPostReport
+    {
+        return $this->findOneBy(['post' => $post, 'reporter' => $reporter]);
+    }
+
+    /**
+     * The id comes straight off the URL, so it is not necessarily a uuid at all. find() would hand a
+     * malformed string to the uuid type and throw before the caller could turn a miss into a 404, which
+     * answers garbage with a 500. Reject it here instead and let the caller treat it as not found.
+     */
+    public function findOneById(string $id): ?ForumPostReport
+    {
+        if (!Uuid::isValid($id)) {
+            return null;
+        }
+
+        return $this->find($id);
+    }
+
+    /**
+     * Oldest first: the moderation queue is worked front to back.
+     *
+     * @return ForumPostReport[]
+     */
+    public function findPending(): array
+    {
+        return $this->createQueryBuilder('r')
+            ->innerJoin('r.post', 'p')
+            ->innerJoin('p.topic', 't')
+            ->innerJoin('p.creator', 'c')
+            ->innerJoin('r.reporter', 'reporter')
+            ->addSelect('p', 't', 'c', 'reporter')
+            ->where('r.resolvedDatetime IS NULL')
+            ->orderBy('r.creationDatetime', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Repository/Forum/ForumPostRepository.php
+++ b/src/Repository/Forum/ForumPostRepository.php
@@ -6,6 +6,7 @@ use App\Entity\Forum\ForumPost;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @extends ServiceEntityRepository<ForumPost>
@@ -15,6 +16,24 @@ class ForumPostRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ForumPost::class);
+    }
+
+    /**
+     * The id comes straight off the URL, so it is not necessarily a uuid at all. find() would hand a
+     * malformed string to the uuid type and throw before the caller could turn a miss into a 404, which
+     * answers garbage with a 500. Reject it here instead and let the caller treat it as not found.
+     *
+     * The older sibling call sites (ForumPostItemProvider, ForumPostVoteProcessor, ForumPostEditProcessor)
+     * still call find() directly and still answer 500 on a malformed id. They want the same treatment,
+     * but changing their behaviour is not in the scope of the reporting feature.
+     */
+    public function findOneById(string $id): ?ForumPost
+    {
+        if (!Uuid::isValid($id)) {
+            return null;
+        }
+
+        return $this->find($id);
     }
 
     public function createQueryBuilderByTopicSlug(string $topicSlug): QueryBuilder

--- a/src/Service/Forum/ForumPostExcerpt.php
+++ b/src/Service/Forum/ForumPostExcerpt.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Forum;
+
+/**
+ * Plain-text preview of a forum post, for the admin screens that list posts without rendering their
+ * HTML (the moderation queue and the recent-activity panel).
+ */
+readonly class ForumPostExcerpt
+{
+    private const int MAX_LENGTH = 120;
+
+    public function create(string $content): string
+    {
+        $plain = trim(preg_replace('/\s+/', ' ', strip_tags($content)) ?? '');
+        if (mb_strlen($plain) <= self::MAX_LENGTH) {
+            return $plain;
+        }
+
+        return mb_substr($plain, 0, self::MAX_LENGTH - 1) . '…';
+    }
+}

--- a/src/State/Processor/Admin/Forum/AdminForumReportResolveProcessor.php
+++ b/src/State/Processor/Admin/Forum/AdminForumReportResolveProcessor.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Processor\Admin\Forum;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Forum\ForumPostReport;
+use App\Entity\User;
+use App\Repository\Forum\ForumPostReportRepository;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * @implements ProcessorInterface<mixed, null>
+ */
+readonly class AdminForumReportResolveProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private ForumPostReportRepository $forumPostReportRepository,
+        private EntityManagerInterface $entityManager,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): null
+    {
+        $report = $this->forumPostReportRepository->findOneById((string) $uriVariables['id']);
+        if (!$report instanceof ForumPostReport) {
+            throw new NotFoundHttpException('Signalement inexistant');
+        }
+
+        if ($report->isResolved()) {
+            throw new ConflictHttpException('Ce signalement est déjà résolu');
+        }
+
+        $moderator = $this->security->getUser();
+        if (!$moderator instanceof User) {
+            throw new AccessDeniedException('Vous n\'êtes pas connecté.');
+        }
+
+        $report->resolvedDatetime = new DateTime();
+        $report->resolvedBy = $moderator;
+
+        $this->entityManager->flush();
+
+        return null;
+    }
+}

--- a/src/State/Processor/Forum/ForumPostReportProcessor.php
+++ b/src/State/Processor/Forum/ForumPostReportProcessor.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Processor\Forum;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Forum\ForumPostReportInput;
+use App\Entity\Forum\ForumPost;
+use App\Entity\Forum\ForumPostReport;
+use App\Entity\User;
+use App\Repository\Forum\ForumPostReportRepository;
+use App\Repository\Forum\ForumPostRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * @implements ProcessorInterface<ForumPostReportInput, null>
+ */
+readonly class ForumPostReportProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private ForumPostRepository $forumPostRepository,
+        private ForumPostReportRepository $forumPostReportRepository,
+        private EntityManagerInterface $entityManager,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): null
+    {
+        $post = $this->forumPostRepository->findOneById((string) $uriVariables['id']);
+        if (!$post instanceof ForumPost) {
+            throw new NotFoundHttpException('Message de forum inexistant');
+        }
+
+        $reporter = $this->security->getUser();
+        if (!$reporter instanceof User) {
+            throw new AccessDeniedException('Vous n\'êtes pas connecté.');
+        }
+
+        if ($this->forumPostReportRepository->findOneByPostAndReporter($post, $reporter) instanceof ForumPostReport) {
+            throw new ConflictHttpException('Vous avez déjà signalé ce message');
+        }
+
+        $report = new ForumPostReport();
+        $report->post = $post;
+        $report->reporter = $reporter;
+        $report->reason = trim($data->reason);
+
+        $this->entityManager->persist($report);
+
+        // The check above is what produces a readable error; this is what makes the rule true. Two
+        // concurrent reports both pass that check, and only the unique index stops the second insert.
+        // Uncaught, the violation is not in api_platform.yaml's exception_to_status and surfaces as a
+        // 500, so a double-clicked button answers with a crash instead of the conflict it already knows
+        // how to describe.
+        try {
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException) {
+            throw new ConflictHttpException('Vous avez déjà signalé ce message');
+        }
+
+        return null;
+    }
+}

--- a/src/State/Provider/Admin/Forum/AdminForumReportCollectionProvider.php
+++ b/src/State/Provider/Admin/Forum/AdminForumReportCollectionProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Provider\Admin\Forum;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Admin\Forum\AdminForumReport;
+use App\ApiResource\Forum\ForumPostResource;
+use App\Entity\Forum\ForumPostReport;
+use App\Repository\Forum\ForumPostReportRepository;
+use App\Repository\Forum\ForumPostRepository;
+use App\Service\Forum\ForumPostExcerpt;
+
+/**
+ * @implements ProviderInterface<AdminForumReport>
+ */
+readonly class AdminForumReportCollectionProvider implements ProviderInterface
+{
+    public function __construct(
+        private ForumPostReportRepository $forumPostReportRepository,
+        private ForumPostRepository $forumPostRepository,
+        private ForumPostExcerpt $forumPostExcerpt,
+    ) {
+    }
+
+    /**
+     * @return AdminForumReport[]
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    {
+        return array_map(
+            $this->buildResource(...),
+            $this->forumPostReportRepository->findPending(),
+        );
+    }
+
+    private function buildResource(ForumPostReport $report): AdminForumReport
+    {
+        $post = $report->post;
+
+        $resource = new AdminForumReport();
+        $resource->id = (string) $report->id;
+        $resource->reason = $report->reason;
+        $resource->creationDatetime = $report->creationDatetime;
+        $resource->reporterUsername = $report->reporter->username;
+        $resource->postId = (string) $post->id;
+        $resource->postExcerpt = $this->forumPostExcerpt->create($post->content);
+        $resource->postAuthorUsername = $post->creator->username;
+        $resource->topicSlug = $post->topic->slug;
+        $resource->topicTitle = $post->topic->title;
+        $resource->topicPage = (int) ceil(
+            $this->forumPostRepository->findPositionInTopic($post) / ForumPostResource::POSTS_PER_PAGE
+        );
+
+        return $resource;
+    }
+}

--- a/src/State/Provider/Admin/Forum/RecentActivityProvider.php
+++ b/src/State/Provider/Admin/Forum/RecentActivityProvider.php
@@ -5,10 +5,12 @@ namespace App\State\Provider\Admin\Forum;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\Admin\Forum\RecentActivity;
+use App\ApiResource\Forum\ForumPostResource;
 use App\Entity\Forum\ForumPost;
 use App\Entity\Forum\ForumTopic;
 use App\Repository\Forum\ForumPostRepository;
 use App\Repository\Forum\ForumTopicRepository;
+use App\Service\Forum\ForumPostExcerpt;
 
 /**
  * @implements ProviderInterface<RecentActivity>
@@ -16,12 +18,11 @@ use App\Repository\Forum\ForumTopicRepository;
 readonly class RecentActivityProvider implements ProviderInterface
 {
     private const LIMIT = 10;
-    private const EXCERPT_MAX_LENGTH = 120;
-    private const POSTS_PER_PAGE = 10;
 
     public function __construct(
         private ForumTopicRepository $forumTopicRepository,
         private ForumPostRepository $forumPostRepository,
+        private ForumPostExcerpt $forumPostExcerpt,
     ) {
     }
 
@@ -45,8 +46,8 @@ readonly class RecentActivityProvider implements ProviderInterface
                 'id' => (string) $post->id,
                 'topic_slug' => $post->topic->slug,
                 'topic_title' => $post->topic->title,
-                'topic_page' => (int) ceil($this->forumPostRepository->findPositionInTopic($post) / self::POSTS_PER_PAGE),
-                'content_excerpt' => $this->buildExcerpt($post->content),
+                'topic_page' => (int) ceil($this->forumPostRepository->findPositionInTopic($post) / ForumPostResource::POSTS_PER_PAGE),
+                'content_excerpt' => $this->forumPostExcerpt->create($post->content),
                 'creation_datetime' => $post->creationDatetime->format(\DateTimeInterface::ATOM),
                 'creator_username' => $post->creator->username,
             ],
@@ -54,15 +55,5 @@ readonly class RecentActivityProvider implements ProviderInterface
         );
 
         return $result;
-    }
-
-    private function buildExcerpt(string $content): string
-    {
-        $plain = trim(preg_replace('/\s+/', ' ', strip_tags($content)) ?? '');
-        if (mb_strlen($plain) <= self::EXCERPT_MAX_LENGTH) {
-            return $plain;
-        }
-
-        return mb_substr($plain, 0, self::EXCERPT_MAX_LENGTH - 1) . '…';
     }
 }

--- a/tests/Api/Admin/Forum/AdminForumReportTest.php
+++ b/tests/Api/Admin/Forum/AdminForumReportTest.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Admin\Forum;
+
+use App\Entity\Forum\ForumPost;
+use App\Repository\Forum\ForumPostReportRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\Forum\ForumCategoryFactory;
+use App\Tests\Factory\Forum\ForumFactory;
+use App\Tests\Factory\Forum\ForumPostFactory;
+use App\Tests\Factory\Forum\ForumPostReportFactory;
+use App\Tests\Factory\Forum\ForumTopicFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class AdminForumReportTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array SERVER_PARAMS = [
+        'CONTENT_TYPE' => 'application/ld+json',
+        'HTTP_ACCEPT' => 'application/ld+json',
+    ];
+
+    public function test_list_unauthenticated_returns_401(): void
+    {
+        $this->client->jsonRequest('GET', '/api/admin/forum/reports', [], self::SERVER_PARAMS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function test_list_as_base_user_returns_403(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/admin/forum/reports', [], self::SERVER_PARAMS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+            'description' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+            'status' => 403,
+            'type' => '/errors/403',
+        ]);
+    }
+
+    public function test_list_returns_empty_collection_when_nothing_is_pending(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('GET', '/api/admin/forum/reports', [], self::SERVER_PARAMS);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminForumReport',
+            '@id' => '/api/admin/forum/reports',
+            '@type' => 'Collection',
+            'member' => [],
+            'totalItems' => 0,
+        ]);
+    }
+
+    public function test_list_returns_pending_reports_oldest_first(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $post = $this->createPost('<p>Un message <strong>problématique</strong></p>');
+        $firstReporter = UserFactory::new()->create(['username' => 'first_reporter', 'email' => 'first@email.com']);
+        $secondReporter = UserFactory::new()->create(['username' => 'second_reporter', 'email' => 'second@email.com']);
+
+        $older = ForumPostReportFactory::new([
+            'post' => $post,
+            'reporter' => $firstReporter,
+            'reason' => 'Propos insultants',
+            'creationDatetime' => new \DateTime('2026-08-01T10:00:00+00:00'),
+        ])->create();
+        $newer = ForumPostReportFactory::new([
+            'post' => $post,
+            'reporter' => $secondReporter,
+            'reason' => 'Spam publicitaire',
+            'creationDatetime' => new \DateTime('2026-08-02T11:30:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('GET', '/api/admin/forum/reports', [], self::SERVER_PARAMS);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminForumReport',
+            '@id' => '/api/admin/forum/reports',
+            '@type' => 'Collection',
+            'member' => [
+                [
+                    '@id' => '/api/admin_forum_reports/' . $older->id,
+                    '@type' => 'AdminForumReport',
+                    'id' => (string) $older->id,
+                    'reason' => 'Propos insultants',
+                    'creation_datetime' => '2026-08-01T10:00:00+00:00',
+                    'reporter_username' => 'first_reporter',
+                    'post_id' => (string) $post->id,
+                    'post_excerpt' => 'Un message problématique',
+                    'post_author_username' => 'post_author',
+                    'topic_slug' => 'test-topic',
+                    'topic_title' => 'Test Topic',
+                    'topic_page' => 1,
+                ],
+                [
+                    '@id' => '/api/admin_forum_reports/' . $newer->id,
+                    '@type' => 'AdminForumReport',
+                    'id' => (string) $newer->id,
+                    'reason' => 'Spam publicitaire',
+                    'creation_datetime' => '2026-08-02T11:30:00+00:00',
+                    'reporter_username' => 'second_reporter',
+                    'post_id' => (string) $post->id,
+                    'post_excerpt' => 'Un message problématique',
+                    'post_author_username' => 'post_author',
+                    'topic_slug' => 'test-topic',
+                    'topic_title' => 'Test Topic',
+                    'topic_page' => 1,
+                ],
+            ],
+            'totalItems' => 2,
+        ]);
+    }
+
+    public function test_list_excludes_resolved_reports(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $post = $this->createPost('Un message signalé deux fois');
+        $pendingReporter = UserFactory::new()->create(['username' => 'pending_reporter', 'email' => 'pending@email.com']);
+        $doneReporter = UserFactory::new()->create(['username' => 'done_reporter', 'email' => 'done@email.com']);
+
+        $pending = ForumPostReportFactory::new([
+            'post' => $post,
+            'reporter' => $pendingReporter,
+            'reason' => 'Toujours en attente',
+            'creationDatetime' => new \DateTime('2026-08-03T09:00:00+00:00'),
+        ])->create();
+        ForumPostReportFactory::new([
+            'post' => $post,
+            'reporter' => $doneReporter,
+            'reason' => 'Déjà traité',
+            'creationDatetime' => new \DateTime('2026-08-01T09:00:00+00:00'),
+            'resolvedDatetime' => new \DateTime('2026-08-02T09:00:00+00:00'),
+            'resolvedBy' => $admin,
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('GET', '/api/admin/forum/reports', [], self::SERVER_PARAMS);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminForumReport',
+            '@id' => '/api/admin/forum/reports',
+            '@type' => 'Collection',
+            'member' => [
+                [
+                    '@id' => '/api/admin_forum_reports/' . $pending->id,
+                    '@type' => 'AdminForumReport',
+                    'id' => (string) $pending->id,
+                    'reason' => 'Toujours en attente',
+                    'creation_datetime' => '2026-08-03T09:00:00+00:00',
+                    'reporter_username' => 'pending_reporter',
+                    'post_id' => (string) $post->id,
+                    'post_excerpt' => 'Un message signalé deux fois',
+                    'post_author_username' => 'post_author',
+                    'topic_slug' => 'test-topic',
+                    'topic_title' => 'Test Topic',
+                    'topic_page' => 1,
+                ],
+            ],
+            'totalItems' => 1,
+        ]);
+    }
+
+    public function test_list_reports_the_page_the_post_sits_on(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $post = $this->createPost('Le vingt-cinquième message');
+        for ($i = 1; $i <= 24; $i++) {
+            ForumPostFactory::new([
+                'topic' => $post->topic,
+                'creator' => $post->creator,
+                'content' => 'Message ' . $i,
+                'creationDatetime' => new \DateTime(sprintf('2026-08-01T10:%02d:00+00:00', $i)),
+                'updateDatetime' => null,
+            ])->create();
+        }
+
+        $report = ForumPostReportFactory::new([
+            'post' => $post,
+            'reporter' => UserFactory::new(['username' => 'page_reporter', 'email' => 'page@email.com']),
+            'reason' => 'Hors sujet',
+            'creationDatetime' => new \DateTime('2026-08-04T09:00:00+00:00'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('GET', '/api/admin/forum/reports', [], self::SERVER_PARAMS);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminForumReport',
+            '@id' => '/api/admin/forum/reports',
+            '@type' => 'Collection',
+            'member' => [
+                [
+                    '@id' => '/api/admin_forum_reports/' . $report->id,
+                    '@type' => 'AdminForumReport',
+                    'id' => (string) $report->id,
+                    'reason' => 'Hors sujet',
+                    'creation_datetime' => '2026-08-04T09:00:00+00:00',
+                    'reporter_username' => 'page_reporter',
+                    'post_id' => (string) $post->id,
+                    'post_excerpt' => 'Le vingt-cinquième message',
+                    'post_author_username' => 'post_author',
+                    'topic_slug' => 'test-topic',
+                    'topic_title' => 'Test Topic',
+                    'topic_page' => 3,
+                ],
+            ],
+            'totalItems' => 1,
+        ]);
+    }
+
+    public function test_resolve_unauthenticated_returns_401(): void
+    {
+        $report = $this->createReport();
+
+        $this->client->jsonRequest('POST', '/api/admin/forum/reports/' . $report->id . '/resolve', [], self::SERVER_PARAMS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+        $this->assertNull($this->reportRepository()->find($report->id)->resolvedDatetime);
+    }
+
+    public function test_resolve_as_base_user_returns_403(): void
+    {
+        $report = $this->createReport();
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', '/api/admin/forum/reports/' . $report->id . '/resolve', [], self::SERVER_PARAMS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+            'description' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+            'status' => 403,
+            'type' => '/errors/403',
+        ]);
+        $this->assertNull($this->reportRepository()->find($report->id)->resolvedDatetime);
+    }
+
+    public function test_resolve_unknown_report_returns_404(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/admin/forum/reports/00000000-0000-0000-0000-000000000000/resolve',
+            [],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Signalement inexistant',
+            'description' => 'Signalement inexistant',
+            'status' => 404,
+            'type' => '/errors/404',
+        ]);
+    }
+
+    /**
+     * A malformed id is not a missing row, it is a string the uuid type cannot convert at all. Handing it
+     * to find() throws before the 404 above can be reached, so garbage in the URL would answer 500.
+     */
+    public function test_resolve_with_a_malformed_report_id_returns_404(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/admin/forum/reports/not-a-uuid-at-all/resolve',
+            [],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Signalement inexistant',
+            'description' => 'Signalement inexistant',
+            'status' => 404,
+            'type' => '/errors/404',
+        ]);
+    }
+
+    public function test_resolve_marks_the_report_resolved_and_records_the_moderator(): void
+    {
+        $report = $this->createReport();
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/forum/reports/' . $report->id . '/resolve', [], self::SERVER_PARAMS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $resolved = $this->reportRepository()->find($report->id);
+        $this->assertTrue($resolved->isResolved());
+        $this->assertNotNull($resolved->resolvedDatetime);
+        $this->assertSame($admin->id, $resolved->resolvedBy->id);
+    }
+
+    public function test_resolve_an_already_resolved_report_returns_409(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $report = ForumPostReportFactory::new([
+            'post' => $this->createPost('Un message signalé'),
+            'reporter' => UserFactory::new(['username' => 'reporter', 'email' => 'reporter@email.com']),
+            'reason' => 'Déjà traité',
+            'resolvedDatetime' => new \DateTime('2026-08-02T09:00:00+00:00'),
+            'resolvedBy' => $admin,
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/forum/reports/' . $report->id . '/resolve', [], self::SERVER_PARAMS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Ce signalement est déjà résolu',
+            'description' => 'Ce signalement est déjà résolu',
+            'status' => 409,
+            'type' => '/errors/409',
+        ]);
+        $this->assertSame(
+            '2026-08-02T09:00:00+00:00',
+            $this->reportRepository()->find($report->id)->resolvedDatetime->format('c')
+        );
+    }
+
+    private function reportRepository(): ForumPostReportRepository
+    {
+        /** @var ForumPostReportRepository $repository */
+        $repository = static::getContainer()->get(ForumPostReportRepository::class);
+
+        return $repository;
+    }
+
+    private function createReport(): \App\Entity\Forum\ForumPostReport
+    {
+        return ForumPostReportFactory::new([
+            'post' => $this->createPost('Un message signalé'),
+            'reporter' => UserFactory::new(['username' => 'reporter', 'email' => 'reporter@email.com']),
+            'reason' => 'Propos insultants',
+            'creationDatetime' => new \DateTime('2026-08-01T10:00:00+00:00'),
+        ])->create();
+    }
+
+    private function createPost(string $content): ForumPost
+    {
+        $forumCategory = ForumCategoryFactory::new(['position' => 1])->create();
+        $forum = ForumFactory::new(['forumCategory' => $forumCategory])->create();
+        $author = UserFactory::new(['username' => 'post_author', 'email' => 'post_author@email.com'])->create();
+        $topic = ForumTopicFactory::new([
+            'forum' => $forum,
+            'title' => 'Test Topic',
+            'slug' => 'test-topic',
+            'author' => $author,
+        ])->create();
+
+        return ForumPostFactory::new([
+            'topic' => $topic,
+            'creator' => $author,
+            'content' => $content,
+            'creationDatetime' => new \DateTime('2026-08-01T12:00:00+00:00'),
+            'updateDatetime' => null,
+        ])->create();
+    }
+}

--- a/tests/Api/Forum/ForumPostReportTest.php
+++ b/tests/Api/Forum/ForumPostReportTest.php
@@ -1,0 +1,366 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Forum;
+
+use App\Entity\Forum\ForumPost;
+use App\Repository\Forum\ForumPostReportRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\Forum\ForumCategoryFactory;
+use App\Tests\Factory\Forum\ForumFactory;
+use App\Tests\Factory\Forum\ForumPostFactory;
+use App\Tests\Factory\Forum\ForumPostReportFactory;
+use App\Tests\Factory\Forum\ForumTopicFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class ForumPostReportTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array SERVER_PARAMS = [
+        'CONTENT_TYPE' => 'application/ld+json',
+        'HTTP_ACCEPT' => 'application/ld+json',
+    ];
+
+    public function test_report_unauthenticated_returns_401(): void
+    {
+        $post = $this->createPost();
+
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => 'Ce message est insultant'],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+        $this->assertSame(0, $this->reportRepository()->count([]));
+    }
+
+    public function test_report_unknown_post_returns_404(): void
+    {
+        $reporter = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/00000000-0000-0000-0000-000000000000/report',
+            ['reason' => 'Ce message est insultant'],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Message de forum inexistant',
+            'description' => 'Message de forum inexistant',
+            'status' => 404,
+            'type' => '/errors/404',
+        ]);
+    }
+
+    /**
+     * A malformed id is not a missing row, it is a string the uuid type cannot convert at all. Handing it
+     * to find() throws before the 404 above can be reached, so garbage in the URL would answer 500.
+     */
+    public function test_report_with_a_malformed_post_id_returns_404(): void
+    {
+        $reporter = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/not-a-uuid-at-all/report',
+            ['reason' => 'Ce message est insultant'],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Message de forum inexistant',
+            'description' => 'Message de forum inexistant',
+            'status' => 404,
+            'type' => '/errors/404',
+        ]);
+    }
+
+    public function test_report_with_empty_reason_returns_422(): void
+    {
+        $post = $this->createPost();
+        $reporter = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => ''],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'reason',
+                    'message' => 'Veuillez préciser le motif du signalement',
+                    'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                ],
+            ],
+            'detail' => 'reason: Veuillez préciser le motif du signalement',
+            'type' => '/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            'title' => 'An error occurred',
+            'description' => 'reason: Veuillez préciser le motif du signalement',
+        ]);
+        $this->assertSame(0, $this->reportRepository()->count([]));
+    }
+
+    public function test_report_with_whitespace_only_reason_returns_422(): void
+    {
+        $post = $this->createPost();
+        $reporter = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => '     '],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'reason',
+                    'message' => 'Veuillez préciser le motif du signalement',
+                    'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                ],
+            ],
+            'detail' => 'reason: Veuillez préciser le motif du signalement',
+            'type' => '/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            'title' => 'An error occurred',
+            'description' => 'reason: Veuillez préciser le motif du signalement',
+        ]);
+        $this->assertSame(0, $this->reportRepository()->count([]));
+    }
+
+    public function test_report_with_reason_over_500_characters_returns_422(): void
+    {
+        $post = $this->createPost();
+        $reporter = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => str_repeat('a', 501)],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'reason',
+                    'message' => 'Le motif ne peut pas dépasser 500 caractères',
+                    'code' => 'd94b19cc-114f-4f44-9cc4-4138e80a87b9',
+                ],
+            ],
+            'detail' => 'reason: Le motif ne peut pas dépasser 500 caractères',
+            'type' => '/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            'title' => 'An error occurred',
+            'description' => 'reason: Le motif ne peut pas dépasser 500 caractères',
+        ]);
+        $this->assertSame(0, $this->reportRepository()->count([]));
+    }
+
+    public function test_report_with_reason_of_exactly_500_characters_succeeds(): void
+    {
+        $post = $this->createPost();
+        $reporter = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => str_repeat('a', 500)],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $report = $this->reportRepository()->findOneBy([]);
+        $this->assertNotNull($report);
+        $this->assertSame(str_repeat('a', 500), $report->reason);
+    }
+
+    public function test_report_by_authenticated_user_persists_the_report(): void
+    {
+        $post = $this->createPost();
+        $reporter = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => '  Ce message est insultant  '],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $report = $this->reportRepository()->findOneBy([]);
+        $this->assertNotNull($report);
+        $this->assertSame('Ce message est insultant', $report->reason);
+        $this->assertSame((string) $post->id, (string) $report->post->id);
+        $this->assertSame($reporter->id, $report->reporter->id);
+        $this->assertNull($report->resolvedDatetime);
+        $this->assertNull($report->resolvedBy);
+        $this->assertFalse($report->isResolved());
+    }
+
+    public function test_report_same_post_twice_returns_409(): void
+    {
+        $post = $this->createPost();
+        $reporter = UserFactory::new()->asBaseUser()->create();
+        ForumPostReportFactory::new([
+            'post' => $post,
+            'reporter' => $reporter,
+            'reason' => 'Premier signalement',
+        ])->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => 'Second signalement'],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous avez déjà signalé ce message',
+            'description' => 'Vous avez déjà signalé ce message',
+            'status' => 409,
+            'type' => '/errors/409',
+        ]);
+        $this->assertSame(1, $this->reportRepository()->count([]));
+        $this->assertSame('Premier signalement', $this->reportRepository()->findOneBy([])->reason);
+    }
+
+    public function test_report_already_resolved_post_by_same_user_still_returns_409(): void
+    {
+        $post = $this->createPost();
+        $reporter = UserFactory::new()->asBaseUser()->create();
+        ForumPostReportFactory::new([
+            'post' => $post,
+            'reporter' => $reporter,
+            'reason' => 'Signalement traité',
+            'resolvedDatetime' => new \DateTime('-1 day'),
+        ])->create();
+
+        $this->client->loginUser($reporter);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => 'Encore un signalement'],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous avez déjà signalé ce message',
+            'description' => 'Vous avez déjà signalé ce message',
+            'status' => 409,
+            'type' => '/errors/409',
+        ]);
+        $this->assertSame(1, $this->reportRepository()->count([]));
+    }
+
+    public function test_two_different_users_can_report_the_same_post(): void
+    {
+        $post = $this->createPost();
+        $first = UserFactory::new()->create(['username' => 'first_reporter', 'email' => 'first@email.com']);
+        $second = UserFactory::new()->asBaseUser()->create();
+        ForumPostReportFactory::new([
+            'post' => $post,
+            'reporter' => $first,
+            'reason' => 'Signalement du premier',
+        ])->create();
+
+        $this->client->loginUser($second);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/forums/posts/' . $post->id . '/report',
+            ['reason' => 'Signalement du second'],
+            self::SERVER_PARAMS
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertSame(2, $this->reportRepository()->count([]));
+        $this->assertNotNull($this->reportRepository()->findOneByPostAndReporter($post, $second));
+    }
+
+    private function reportRepository(): ForumPostReportRepository
+    {
+        /** @var ForumPostReportRepository $repository */
+        $repository = static::getContainer()->get(ForumPostReportRepository::class);
+
+        return $repository;
+    }
+
+    private function createPost(): ForumPost
+    {
+        $forumCategory = ForumCategoryFactory::new(['position' => 1])->create();
+        $forum = ForumFactory::new(['forumCategory' => $forumCategory])->create();
+        $author = UserFactory::new(['username' => 'post_author', 'email' => 'post_author@email.com'])->create();
+        $topic = ForumTopicFactory::new([
+            'forum' => $forum,
+            'title' => 'Test Topic',
+            'slug' => 'test-topic',
+            'author' => $author,
+        ])->create();
+
+        return ForumPostFactory::new([
+            'topic' => $topic,
+            'creator' => $author,
+            'content' => 'original content here',
+            'updateDatetime' => null,
+        ])->create();
+    }
+}

--- a/tests/Factory/Forum/ForumPostReportFactory.php
+++ b/tests/Factory/Forum/ForumPostReportFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Factory\Forum;
+
+use App\Entity\Forum\ForumPostReport;
+use App\Tests\Factory\User\UserFactory;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+
+/**
+ * @extends PersistentObjectFactory<ForumPostReport>
+ */
+final class ForumPostReportFactory extends PersistentObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [
+            'creationDatetime' => new \DateTime(),
+            'post' => ForumPostFactory::new(),
+            'reason' => self::faker()->text(200),
+            'reporter' => UserFactory::new(),
+            'resolvedBy' => null,
+            'resolvedDatetime' => null,
+        ];
+    }
+
+    public static function class(): string
+    {
+        return ForumPostReport::class;
+    }
+}


### PR DESCRIPTION
Closes #682.

Logged-in users can flag a forum post as inappropriate, and admins work the flagged posts from a queue in the forum admin.

## What changed

`ForumPostReport` with a `(post_id, reporter_id)` unique constraint, `POST /api/forums/posts/{id}/report` behind `IS_AUTHENTICATED_REMEMBERED`, and two admin endpoints behind `ROLE_ADMIN`: the pending queue and a resolve action. Frontend gets a "Signaler" button on each post with a reason dialog and a 500-character counter, and the forum admin dashboard's placeholder moderation card becomes a live "Messages signalés" card with a pending count.

`reason` is `VARCHAR(500)` rather than TEXT, so the database enforces the bound rather than trusting the validator alone, and the validator trims before measuring.

The queue links straight to the reported post, computing which page of the topic it sits on, since forum posts are paginated.

## The no-double-report rule is enforced twice, deliberately

The unique index is the guarantee. The runtime check exists only so the user gets a readable 409 instead of a constraint violation. A resolved report still blocks the same user from re-reporting, otherwise resolving would reopen the spam vector.

## A blocker found in review

The runtime check plus an unguarded `flush()` meant the concurrent case was a 500, not a 409. Two requests can both pass the pre-check, and `UniqueConstraintViolationException` is not in `api_platform.yaml`'s `exception_to_status`, so it surfaced as a bare crash. Reachable by a double-click before the button disables, two tabs, or a client retry after a slow response. The `flush()` is now wrapped, following the same shape `BandSpaceInvitationAcceptProcessor` already uses for exactly this situation. Note that catch is untested here, as it is at that precedent, because forcing a genuine race in a test would mean faking the pre-check.

Review also found that a malformed id in the URL answered 500 rather than 404 on both new endpoints: the uuid type throws on conversion before the not-found branch can be reached. Both now go through a guarded repository lookup that rejects a non-uuid and lets the caller answer 404, following the `Uuid::isValid()` pattern already used in `TechRiderItemRepository` and `BandSpaceActivityRepository`, with a test on each endpoint.

The three older sibling call sites, `ForumPostItemProvider`, `ForumPostVoteProcessor` and `ForumPostEditProcessor`, still call `find()` directly and still answer 500 on a malformed id. That is recorded in the repository method but not changed here, since it is pre-existing behaviour outside this feature.

## Shared code touched

`ForumPostExcerpt` and `ForumPostResource::POSTS_PER_PAGE` were extracted out of `RecentActivityProvider`, which had its own private copy of both. Review confirmed the admin recent-activity output and forum pagination are unchanged by running the full pre-existing forum and forum-admin suites.

## Not done

No server-side block on reporting your own post. The button is hidden in the UI, and the API would accept it; the worst case is a self-report an admin dismisses. Not asked for by the issue.

## Migration

Validated on the migration database: the full 86-migration chain builds from zero, this migration applies, rolls back and re-applies, and the schema drift against the Doctrine mapping stays at exactly the four statements master already has.

## Verification

121 forum and forum-admin tests green, of which 23 are new. Every non-204 response gets a full-body `assertJsonEquals`; the three 204 paths use status plus database-state assertions, following `ForumTopicLockTest`, because an empty body cannot be compared to an expected array. Full suite 2349 green, PHPStan level 8 clean over 1145 files, biome clean, build succeeds.

One incidental finding worth acting on separately: `loginUser()` cannot authenticate a second request in the same test method. Calling it again returns 401 on the next call, verified three ways. No test in the repo relies on it, and the project notes describing the workaround were wrong.
