### PR TITLE
fix(M-904): refuse an oversize upload in the browser and distrust a 200 response

### DIFF
--- a/assets/js/api/bandSpace/band-space-files.js
+++ b/assets/js/api/bandSpace/band-space-files.js
@@ -1,6 +1,7 @@
 /** global: Routing */
 
 import axios from 'axios'
+import { assertUploadedFile } from '../../utils/fileUploadQueue.js'
 import { handleApiError } from '../utils/handleApiError.js'
 
 export default {
@@ -167,7 +168,7 @@ export default {
         }
       })
       .then((resp) => ({
-        file: resp.data,
+        file: assertUploadedFile(resp.data),
         quotaApproaching: resp.headers['x-quota-approaching'] === 'true'
       }))
       .catch(handleApiError)
@@ -232,7 +233,7 @@ export default {
         }
       )
       .then((resp) => ({
-        version: resp.data,
+        version: assertUploadedFile(resp.data),
         quotaApproaching: resp.headers['x-quota-approaching'] === 'true'
       }))
       .catch(handleApiError)
@@ -291,7 +292,7 @@ export default {
         }
       })
       .then((resp) => ({
-        file: resp.data,
+        file: assertUploadedFile(resp.data),
         quotaApproaching: resp.headers['x-quota-approaching'] === 'true'
       }))
       .catch(handleApiError)

--- a/assets/js/components/BandSpace/Files/FileNewVersionDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileNewVersionDialog.vue
@@ -88,6 +88,7 @@ import Message from 'primevue/message'
 import ProgressBar from 'primevue/progressbar'
 import { computed, reactive, ref } from 'vue'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
+import { uploadRejectionReason } from '../../../utils/fileUploadQueue.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -120,11 +121,28 @@ function triggerFilePicker() {
   fileInput.value?.click()
 }
 
+/**
+ * Both ways of choosing a file go through here, so an oversize one is refused once rather than in two
+ * places that could drift. It is refused at selection because the alternative is uploading it first.
+ */
+function selectFile(file) {
+  const rejection = uploadRejectionReason(file, filesStore.maxUploadSizeBytes)
+  if (rejection !== null) {
+    selectedFile.value = null
+    fieldErrors.uploadedFile = rejection
+    if (fileInput.value) fileInput.value.value = ''
+
+    return
+  }
+
+  selectedFile.value = file
+  fieldErrors.uploadedFile = null
+}
+
 function handleFileChange(event) {
   const file = event.target.files?.[0]
   if (file) {
-    selectedFile.value = file
-    fieldErrors.uploadedFile = null
+    selectFile(file)
   }
 }
 
@@ -132,8 +150,7 @@ function handleDrop(event) {
   isDragging.value = false
   const file = event.dataTransfer?.files?.[0]
   if (file) {
-    selectedFile.value = file
-    fieldErrors.uploadedFile = null
+    selectFile(file)
   }
 }
 

--- a/assets/js/components/BandSpace/Files/FileUploadDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileUploadDialog.vue
@@ -144,7 +144,7 @@
 
       <Message
         v-if="summary.isFinished && !isUploading"
-        :severity="summary.unsent > 0 ? 'warn' : 'success'"
+        :severity="summary.hasFailures ? 'warn' : 'success'"
         :closable="false"
       >
         {{ summary.label }}
@@ -320,7 +320,9 @@ function handleDrop(event) {
 
 function addFiles(files) {
   if (!files || files.length === 0) return
-  queue.value = appendToQueue(queue.value, files)
+  // The limit is passed in rather than read inside the queue module so the module stays pure and
+  // testable. An oversize file lands in the list already failed and is never sent.
+  queue.value = appendToQueue(queue.value, files, filesStore.maxUploadSizeBytes)
   batchNotice.value = null
 }
 
@@ -534,7 +536,8 @@ const STATUS_ICONS = {
   [UPLOAD_STATUS.Uploaded]: 'pi pi-check-circle text-green-600',
   [UPLOAD_STATUS.Failed]: 'pi pi-times-circle text-red-600',
   [UPLOAD_STATUS.Skipped]: 'pi pi-ban text-amber-600',
-  [UPLOAD_STATUS.Cancelled]: 'pi pi-ban text-surface-400'
+  [UPLOAD_STATUS.Cancelled]: 'pi pi-ban text-surface-400',
+  [UPLOAD_STATUS.Rejected]: 'pi pi-ban text-red-600'
 }
 
 const STATUS_LABELS = {
@@ -543,7 +546,8 @@ const STATUS_LABELS = {
   [UPLOAD_STATUS.Uploaded]: 'Importé',
   [UPLOAD_STATUS.Failed]: 'Échec',
   [UPLOAD_STATUS.Skipped]: 'Non envoyé',
-  [UPLOAD_STATUS.Cancelled]: 'Interrompu'
+  [UPLOAD_STATUS.Cancelled]: 'Interrompu',
+  [UPLOAD_STATUS.Rejected]: 'Refusé'
 }
 
 function statusIconClass(status) {

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -74,6 +74,12 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   // Served by the quota endpoint so the interface quotes the same window the purge enforces.
   const trashRetentionDays = computed(() => quota.value?.trash_retention_days ?? 30)
 
+  // Same reason, for the per-file upload limit: the dialog refuses an oversize file before sending it,
+  // and it has to refuse against the server's real number. The fallback only covers the window before
+  // the quota has loaded, and it is deliberately the value the server ships today rather than a
+  // rounder guess, so a mismatch shows up as a refusal the server then disagrees with.
+  const maxUploadSizeBytes = computed(() => quota.value?.max_upload_size_bytes ?? 500 * 1024 * 1024)
+
   const hasMoreFiles = computed(() => hasMoreToLoad(files.value.length, totalFiles.value))
   const filesCountLabel = computed(() => fileCountLabel(files.value.length, totalFiles.value))
 
@@ -523,6 +529,7 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     filesCountLabel,
     archivedCount: readonly(archivedCount),
     trashRetentionDays,
+    maxUploadSizeBytes,
     folders: readonly(folders),
     virtualFolders: readonly(virtualFolders),
     tags: readonly(tags),

--- a/assets/js/utils/fileUploadQueue.js
+++ b/assets/js/utils/fileUploadQueue.js
@@ -20,6 +20,8 @@
  * Pure on purpose, so the rules are tested without a browser. See fileUploadQueue.test.js.
  */
 
+import { formatBytes } from './formatBytes.js'
+
 /**
  * What the API accepts per user.
  *
@@ -47,14 +49,20 @@ export const UPLOAD_STATUS = Object.freeze({
   Failed: 'failed',
   /** Never sent, because something upstream made sending pointless. Retryable. */
   Skipped: 'skipped',
-  Cancelled: 'cancelled'
+  Cancelled: 'cancelled',
+  /**
+   * Refused here, before anything was sent, on grounds that cannot change by trying again: the file
+   * is simply too large. Deliberately not retryable, because a retry would re-queue it with its error
+   * cleared and then actually upload it, which is the whole thing the check exists to prevent.
+   */
+  Rejected: 'rejected'
 })
 
 /** Statuses a retry can put back in the queue. */
 const RETRYABLE_STATUSES = [UPLOAD_STATUS.Failed, UPLOAD_STATUS.Skipped, UPLOAD_STATUS.Cancelled]
 
 /** Statuses nothing more is going to happen to. */
-const TERMINAL_STATUSES = [UPLOAD_STATUS.Uploaded, ...RETRYABLE_STATUSES]
+const TERMINAL_STATUSES = [UPLOAD_STATUS.Uploaded, UPLOAD_STATUS.Rejected, ...RETRYABLE_STATUSES]
 
 const QUOTA_REACHED_MESSAGE = 'Quota de stockage atteint, fichier non envoyé'
 const QUOTA_BATCH_NOTICE =
@@ -66,28 +74,77 @@ const CANCELLED_MESSAGE = 'Import interrompu'
 const CANCELLED_BATCH_NOTICE = "Import interrompu. Les fichiers restants n'ont pas été envoyés."
 
 /**
+ * A 2xx upload response that is not actually a file resource is a failure, and has to be turned into
+ * one here because nothing downstream will.
+ *
+ * A request whose body exceeds PHP's post_max_size dies before the controller runs, and under
+ * FrankenPHP's worker mode that surfaces as HTTP 200 carrying an HTML fatal error page, not as a 4xx.
+ * Axios resolves on a 200, so handleApiError never runs, applyUploadFailure never runs, and the batch
+ * counted the file as uploaded while nothing was stored. Checking the shape is what turns that silent
+ * false success into a visible failure.
+ *
+ * @param {unknown} data
+ * @returns {Object} the file resource, unchanged, when it is one
+ */
+export function assertUploadedFile(data) {
+  if (data !== null && typeof data === 'object' && typeof data.id === 'string') {
+    return data
+  }
+
+  throw new Error("Le serveur a renvoyé une réponse inattendue, le fichier n'a pas été enregistré.")
+}
+
+/**
+ * Why a file is refused before it is sent, or null when it is acceptable.
+ *
+ * Size is the only thing the browser can judge on its own: the mime allowlist and the storage quota
+ * both need the server. Checking it here is not a security boundary, the endpoint validates the size
+ * again, it is about not spending minutes of someone's upstream on a file that cannot be accepted.
+ *
+ * @param {{size: number}} file
+ * @param {number|null} maxSizeBytes the server's own limit, or null when it is not known yet
+ * @returns {string|null}
+ */
+export function uploadRejectionReason(file, maxSizeBytes) {
+  if (!maxSizeBytes || !Number.isFinite(file?.size)) return null
+  if (file.size <= maxSizeBytes) return null
+
+  return `Fichier trop volumineux (${formatBytes(file.size)}). La taille maximale est de ${formatBytes(maxSizeBytes)}.`
+}
+
+/**
  * Adds files to the end of the queue, keeping whatever is already there.
  *
  * Two files sharing a name both stay, with their own id: see the note at the top of this file.
  *
+ * A file over the limit is added as already Rejected rather than dropped, so the member sees which
+ * file was refused and why instead of watching it silently not appear. It never reaches Queued, so the
+ * upload loop never picks it up and not one byte of it goes over the wire. Rejected rather than Failed
+ * because Failed is retryable, and retrying would clear the error and send it after all.
+ *
  * @param {{id: number}[]} queue
  * @param {Iterable<{name: string, size: number}>} files a FileList or an array of File
+ * @param {number|null} [maxSizeBytes] the server's per-file limit, when the quota has been loaded
  * @returns {Object[]} a new queue
  */
-export function appendToQueue(queue, files) {
+export function appendToQueue(queue, files, maxSizeBytes = null) {
   let nextId = queue.reduce((max, item) => Math.max(max, item.id), 0) + 1
 
-  const added = Array.from(files ?? []).map((file) => ({
-    id: nextId++,
-    file,
-    name: file.name,
-    size: file.size,
-    status: UPLOAD_STATUS.Queued,
-    progress: 0,
-    error: null,
-    /** How many times the rate limiter has pushed this file back. */
-    attempts: 0
-  }))
+  const added = Array.from(files ?? []).map((file) => {
+    const rejection = uploadRejectionReason(file, maxSizeBytes)
+
+    return {
+      id: nextId++,
+      file,
+      name: file.name,
+      size: file.size,
+      status: rejection === null ? UPLOAD_STATUS.Queued : UPLOAD_STATUS.Rejected,
+      progress: 0,
+      error: rejection,
+      /** How many times the rate limiter has pushed this file back. */
+      attempts: 0
+    }
+  })
 
   return [...queue, ...added]
 }
@@ -406,7 +463,10 @@ export function summarizeQueue(queue) {
   const total = queue.length
   const uploaded = countByStatus(queue, UPLOAD_STATUS.Uploaded)
   const unsent = queue.filter((item) => RETRYABLE_STATUSES.includes(item.status)).length
-  const done = uploaded + unsent
+  // Counted apart from unsent because the retry button is driven by unsent, and offering to retry a
+  // file that is too large would be offering something that cannot work.
+  const rejected = countByStatus(queue, UPLOAD_STATUS.Rejected)
+  const done = uploaded + unsent + rejected
 
   const percent =
     total === 0
@@ -422,12 +482,20 @@ export function summarizeQueue(queue) {
     total,
     uploaded,
     unsent,
+    rejected,
     done,
     /** Which file the batch is on, one based, for « Fichier 3 sur 20 ». */
     position: Math.min(total, done + 1),
     isFinished: total > 0 && done === total,
+    /**
+     * Whether anything went wrong, so the closing banner is not styled as a success. Decided here
+     * rather than in the dialog because it has to account for every way a file can end up unimported,
+     * and this module is the one that is tested: reading only `unsent` painted "Aucun fichier importé,
+     * 1 refusé" green.
+     */
+    hasFailures: unsent > 0 || rejected > 0,
     percent,
-    label: outcomeLabel(uploaded, unsent)
+    label: outcomeLabel(uploaded, unsent, rejected)
   }
 }
 
@@ -446,15 +514,17 @@ function countByStatus(queue, status) {
  * @param {number} unsent
  * @returns {string}
  */
-function outcomeLabel(uploaded, unsent) {
+function outcomeLabel(uploaded, unsent, rejected = 0) {
   const importedPart =
     uploaded === 0
       ? 'Aucun fichier importé'
       : `${uploaded} fichier${uploaded > 1 ? 's' : ''} importé${uploaded > 1 ? 's' : ''}`
 
-  if (unsent === 0) {
-    return importedPart
-  }
+  // "non envoyé" says the batch stopped before reaching it, which invites a retry. A refused file was
+  // reached and turned down, and no retry will change that, so it gets its own word.
+  const parts = []
+  if (unsent > 0) parts.push(`${unsent} non ${unsent > 1 ? 'envoyés' : 'envoyé'}`)
+  if (rejected > 0) parts.push(`${rejected} refusé${rejected > 1 ? 's' : ''}`)
 
-  return `${importedPart}, ${unsent} non ${unsent > 1 ? 'envoyés' : 'envoyé'}`
+  return parts.length === 0 ? importedPart : `${importedPart}, ${parts.join(', ')}`
 }

--- a/assets/js/utils/fileUploadQueue.test.js
+++ b/assets/js/utils/fileUploadQueue.test.js
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test'
 import {
   appendToQueue,
   applyUploadFailure,
+  assertUploadedFile,
   cancelPendingUploads,
   classifyUploadFailure,
   hasUnsentItems,
@@ -20,8 +21,12 @@ import {
   UPLOAD_RATE_LIMIT,
   UPLOAD_RATE_WINDOW_MS,
   UPLOAD_STATUS,
+  uploadRejectionReason,
   withQueueItem
 } from './fileUploadQueue.js'
+
+/** The per-file limit the server ships, 500 MiB, which the quota endpoint now reports. */
+const LIMIT = 500 * 1024 * 1024
 
 /**
  * The rules a batch of file uploads follows.
@@ -100,6 +105,118 @@ describe('appendToQueue', () => {
 
     assert.equal(appendToQueue([], [file])[0].file, file)
     assert.equal(appendToQueue([], [file])[0].size, 4096)
+  })
+
+  it('adds an oversize file already rejected, so it is shown but never sent', () => {
+    const queue = appendToQueue([], [fakeFile('film.mov', LIMIT + 1)], LIMIT)
+
+    assert.equal(queue.length, 1, 'the file stays in the list rather than vanishing')
+    assert.equal(queue[0].status, UPLOAD_STATUS.Rejected)
+    assert.match(queue[0].error, /trop volumineux/)
+    assert.equal(nextQueuedItem(queue), null, 'the upload loop must never pick it up')
+  })
+
+  it('does not offer to retry an oversize file, and a retry cannot resurrect it', () => {
+    // Rejected has to stay out of the retryable set. As Failed, the retry button appeared, and
+    // requeueUnsentItems put the file back as Queued with its error cleared, so pressing retry
+    // uploaded the very file the check had just refused.
+    const queue = appendToQueue([], [fakeFile('film.mov', LIMIT * 4)], LIMIT)
+
+    assert.equal(hasUnsentItems(queue), false, 'no retry button for a file that cannot be accepted')
+
+    const retried = requeueUnsentItems(queue)
+    assert.equal(retried[0].status, UPLOAD_STATUS.Rejected, 'still rejected after a retry')
+    assert.match(retried[0].error, /trop volumineux/, 'and it keeps saying why')
+    assert.equal(nextQueuedItem(retried), null, 'so it is still never sent')
+  })
+
+  it('still offers to retry a genuinely unsent file alongside a rejected one', () => {
+    const queue = withQueueItem(
+      appendToQueue([], [fakeFile('petit.jpg', 1024), fakeFile('film.mov', LIMIT * 4)], LIMIT),
+      1,
+      { status: UPLOAD_STATUS.Skipped, error: 'Quota de stockage atteint, fichier non envoyé' }
+    )
+
+    assert.equal(hasUnsentItems(queue), true)
+
+    const retried = requeueUnsentItems(queue)
+    assert.equal(retried[0].status, UPLOAD_STATUS.Queued, 'the skipped file goes back in the queue')
+    assert.equal(retried[1].status, UPLOAD_STATUS.Rejected, 'the oversize one does not')
+  })
+
+  it('keeps a file exactly on the limit, since the server accepts it', () => {
+    const queue = appendToQueue([], [fakeFile('juste.zip', LIMIT)], LIMIT)
+
+    assert.equal(queue[0].status, UPLOAD_STATUS.Queued)
+    assert.equal(queue[0].error, null)
+  })
+
+  it('refuses only the oversize files in a mixed selection', () => {
+    const queue = appendToQueue(
+      [],
+      [fakeFile('petit.jpg', 1024), fakeFile('enorme.mov', LIMIT * 3), fakeFile('moyen.pdf', 2048)],
+      LIMIT
+    )
+
+    assert.deepEqual(
+      queue.map((item) => item.status),
+      [UPLOAD_STATUS.Queued, UPLOAD_STATUS.Rejected, UPLOAD_STATUS.Queued]
+    )
+    // The first still-queued file is picked up, so one refusal does not stall the batch.
+    assert.equal(nextQueuedItem(queue).name, 'petit.jpg')
+  })
+
+  it('queues everything when the limit is not known yet', () => {
+    // The quota endpoint has not answered, so there is nothing to check against and the server
+    // stays the one that decides. Guessing a limit here would refuse files it would have accepted.
+    for (const unknown of [null, undefined, 0]) {
+      const queue = appendToQueue([], [fakeFile('film.mov', LIMIT * 5)], unknown)
+
+      assert.equal(queue[0].status, UPLOAD_STATUS.Queued)
+      assert.equal(queue[0].error, null)
+    }
+  })
+})
+
+describe('assertUploadedFile', () => {
+  it('passes a real file resource straight through', () => {
+    const resource = { id: '16bca0e5-8202-402d-9444-7e111692cd61', original_name: 'demo.mp3' }
+
+    assert.equal(assertUploadedFile(resource), resource)
+  })
+
+  it('refuses the HTML fatal error a body over post_max_size returns with a 200', () => {
+    // The real observed body: PHP warns that Content-Length exceeds post_max_size, the warning becomes
+    // an uncaught ErrorException in the FrankenPHP worker, and the status stays 200. Without this the
+    // batch reported the file as uploaded.
+    const fatal = '<br />\n<b>Fatal error</b>:  Uncaught ErrorException: Warning: ...'
+
+    assert.throws(() => assertUploadedFile(fatal), /réponse inattendue/)
+  })
+
+  it('refuses anything else a 200 might carry instead of a resource', () => {
+    for (const body of [null, undefined, '', 0, [], {}, { id: 42 }]) {
+      assert.throws(() => assertUploadedFile(body), /réponse inattendue/)
+    }
+  })
+})
+
+describe('uploadRejectionReason', () => {
+  it('names both the file size and the limit, in French units', () => {
+    const reason = uploadRejectionReason({ size: 2299496872 }, LIMIT)
+
+    assert.equal(reason, 'Fichier trop volumineux (2.14 Go). La taille maximale est de 500.0 Mo.')
+  })
+
+  it('accepts anything at or under the limit', () => {
+    assert.equal(uploadRejectionReason({ size: LIMIT }, LIMIT), null)
+    assert.equal(uploadRejectionReason({ size: 0 }, LIMIT), null)
+  })
+
+  it('does not refuse when the size is unusable', () => {
+    assert.equal(uploadRejectionReason({}, LIMIT), null)
+    assert.equal(uploadRejectionReason({ size: Number.NaN }, LIMIT), null)
+    assert.equal(uploadRejectionReason(null, LIMIT), null)
   })
 })
 
@@ -382,6 +499,22 @@ describe('cancelPendingUploads', () => {
     assert.equal(cancelled.queue[0].error, quotaError.message)
     assert.equal(cancelled.queue[1].status, UPLOAD_STATUS.Skipped)
   })
+
+  it('does not relabel a rejected file as interrupted', () => {
+    // Rejected is terminal, so cancelling has to leave it saying why it was refused rather than
+    // overwriting that with "Import interrompu", which would lose the only explanation there is.
+    const queue = appendToQueue(
+      [],
+      [fakeFile('petit.jpg', 1024), fakeFile('film.mov', LIMIT * 4)],
+      LIMIT
+    )
+
+    const cancelled = cancelPendingUploads(queue)
+
+    assert.equal(cancelled.queue[0].status, UPLOAD_STATUS.Cancelled, 'the queued file is abandoned')
+    assert.equal(cancelled.queue[1].status, UPLOAD_STATUS.Rejected, 'the refused one is untouched')
+    assert.match(cancelled.queue[1].error, /trop volumineux/)
+  })
 })
 
 describe('hasUploadInFlight', () => {
@@ -532,5 +665,35 @@ describe('summarizeQueue', () => {
     const queue = applyUploadFailure(queueOf('un.jpg'), 1, quotaError).queue
 
     assert.equal(summarizeQueue(queue).label, 'Aucun fichier importé, 1 non envoyé')
+  })
+
+  it('calls a file refused before sending refused, not unsent', () => {
+    const queue = appendToQueue([], [fakeFile('film.mov', LIMIT * 4)], LIMIT)
+    const summary = summarizeQueue(queue)
+
+    assert.equal(summary.rejected, 1)
+    assert.equal(summary.unsent, 0, 'it is not waiting to be sent, it will not be sent')
+    assert.equal(summary.label, 'Aucun fichier importé, 1 refusé')
+    assert.equal(summary.isFinished, true, 'the batch is over, not stalled on it')
+    // Reading only `unsent` painted this banner green while it said nothing had been imported.
+    assert.equal(summary.hasFailures, true, 'so the closing banner is not styled as a success')
+  })
+
+  it('reports no failures when every file went up', () => {
+    const queue = withQueueItem(appendToQueue([], [fakeFile('un.jpg')], LIMIT), 1, {
+      status: UPLOAD_STATUS.Uploaded
+    })
+
+    assert.equal(summarizeQueue(queue).hasFailures, false)
+  })
+
+  it('words the two kinds of failure separately when both happened', () => {
+    const queue = withQueueItem(
+      appendToQueue([], [fakeFile('petit.jpg', 1024), fakeFile('film.mov', LIMIT * 4)], LIMIT),
+      1,
+      { status: UPLOAD_STATUS.Skipped }
+    )
+
+    assert.equal(summarizeQueue(queue).label, 'Aucun fichier importé, 1 non envoyé, 1 refusé')
   })
 })

--- a/src/ApiResource/BandSpace/File/BandSpaceFileQuotaResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileQuotaResource.php
@@ -41,6 +41,14 @@ class BandSpaceFileQuotaResource
      */
     public int $trashRetentionDays;
 
+    /**
+     * The largest a single file may be, as opposed to quotaBytes which is the whole space. Served for
+     * the same reason as trashRetentionDays: the browser has to refuse an oversize file before it
+     * spends minutes uploading it, and the only way it can do that against the real limit rather than
+     * a copy is to be told what the limit is.
+     */
+    public int $maxUploadSizeBytes;
+
     /** @var array<int, array{source: string, bytes: int}> */
     public array $breakdownBySource = [];
 }

--- a/src/Service/BandSpace/File/BandSpaceFileMimeAllowlist.php
+++ b/src/Service/BandSpace/File/BandSpaceFileMimeAllowlist.php
@@ -4,6 +4,13 @@ namespace App\Service\BandSpace\File;
 
 final class BandSpaceFileMimeAllowlist
 {
+    /**
+     * Served to the browser by BandSpaceFileQuotaProvider so the upload dialog can refuse an oversize
+     * file before spending minutes sending it. `assets/js/store/bandSpace/bandSpaceFiles.js` also hand
+     * copies this number as the fallback used before the quota endpoint has answered: change one and
+     * change the other. A drift there only makes the browser refuse too eagerly or too late, never
+     * bypasses anything, because Assert\File still validates on the way in.
+     */
     public const int MAX_UPLOAD_SIZE_BYTES = 500 * 1024 * 1024;
 
     /**

--- a/src/State/Provider/BandSpace/File/BandSpaceFileQuotaProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFileQuotaProvider.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use App\ApiResource\BandSpace\File\BandSpaceFileQuotaResource;
 use App\Entity\User;
 use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\File\BandSpaceFileMimeAllowlist;
 use App\Service\BandSpace\File\BandSpaceFileQuotaService;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -47,6 +48,7 @@ readonly class BandSpaceFileQuotaProvider implements ProviderInterface
             && $usedBytes / $quotaBytes >= BandSpaceFileQuotaService::APPROACHING_LIMIT_RATIO;
         $dto->breakdownBySource = $this->quotaService->getUsageBreakdown($bandSpace);
         $dto->trashRetentionDays = $this->retentionDays;
+        $dto->maxUploadSizeBytes = BandSpaceFileMimeAllowlist::MAX_UPLOAD_SIZE_BYTES;
 
         return $dto;
     }

--- a/tests/Api/BandSpace/File/BandSpaceFileQuotaTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileQuotaTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Api\BandSpace\File;
 
+use App\Service\BandSpace\File\BandSpaceFileMimeAllowlist;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
@@ -51,6 +52,9 @@ class BandSpaceFileQuotaTest extends ApiTestCase
             'trash_retention_days' => 30,
             'is_approaching_limit' => false,
             'breakdown_by_source' => [],
+            // The browser refuses an oversize file before sending it, and this is where it learns the
+            // number to refuse against, so the endpoint has to keep reporting it.
+            'max_upload_size_bytes' => BandSpaceFileMimeAllowlist::MAX_UPLOAD_SIZE_BYTES,
         ]);
     }
 


### PR DESCRIPTION
Closes #904.

Uploading a 2.14 GB file appeared to do nothing: no error, and no file. The description in the issue guessed at the mechanism and was wrong, so the [reproduction comment](https://github.com/Cryde/musicall/issues/904#issuecomment-5366537345) has the real one. In short, it was not a missing error, it was a **false success**.

## What actually happened

A request body over `post_max_size` (553,648,128) dies before the controller runs, and under FrankenPHP worker mode PHP's warning becomes an uncaught `ErrorException` in the worker. The response is **HTTP 200 carrying an HTML fatal error page**. Axios resolves on a 200, so `handleApiError` never ran, `applyUploadFailure` never ran, and the batch counted the file as uploaded while nothing was stored.

Verified against the dev environment: 24 bytes gives 201, 526,000,000 gives a proper 422 from `Assert\File`, and both 560,000,000 and the original 2.14 GB give a 200 with the fatal error page. So the validator works fine, it just never gets to run once `post_max_size` is exceeded.

## Three changes

**The browser now refuses an oversize file at selection, before a byte is sent.** The guard lives in `appendToQueue`, the single choke point both the file picker and drag-and-drop go through. The file is added already refused, so the member sees which file was rejected and why rather than watching it silently not appear, and the upload loop never picks it up.

**The limit comes from the server.** `BandSpaceFileQuotaResource` gained `maxUploadSizeBytes`, fed from `BandSpaceFileMimeAllowlist::MAX_UPLOAD_SIZE_BYTES`, following the `trashRetentionDays` precedent of serving a configured limit alongside live state. The store's pre-load fallback hand copies the constant, and both sides now carry a comment saying so; a drift there can only make the browser refuse too eagerly or too late, never bypass anything, because `Assert\File` still validates.

**A 2xx that is not a file resource is treated as a failure.** `assertUploadedFile` guards all three multipart upload paths in `band-space-files.js`. It lives in `fileUploadQueue.js` rather than the api module so it could be unit tested, including against the exact fatal-error HTML the issue captured.

## A non-retryable status, which is the subtle part

The first version marked an oversize file `Failed`. `Failed` is in `RETRYABLE_STATUSES`, and `requeueUnsentItems` puts a retryable item back as `Queued` **with its error cleared**, so the "Réessayer les fichiers non envoyés" button would have uploaded the very file the check had just refused.

Hence a new `UPLOAD_STATUS.Rejected`: terminal, so the batch reports finished and cancelling does not relabel it, but deliberately **not** retryable, so no path can resurrect it. The summary counts it apart from `unsent` and the wording says "refusé" rather than "non envoyé", because "non envoyé" implies the batch stopped short and invites a retry.

## From review

Three findings, all fixed here:

- **`uploadVersion` was still unguarded.** There are three multipart upload paths in that module, not two, and the version one has a different response shape so it was missed. It sat behind `FileVersionPanel.vue`, which shows an unconditional "Nouvelle version téléversée" success toast, so the false success was fully live there. Now guarded, and confirmed by a census of all three `FormData` sites.
- **The closing banner rendered green** for a batch that imported nothing, because the severity read only `summary.unsent`. `summarizeQueue` now returns `hasFailures`, putting the decision in the tested module rather than inline in the template.
- **The new status had no icon or label**, so it rendered `<i class="undefined">` with no accessible name. Added `pi pi-ban text-red-600` and "Refusé".

## Verification

Full PHP suite 2354 green, PHPStan level 8 clean, 415 JS tests, Biome clean, build clean.

Checked in a real browser with the reported 2.14 GB file, reading the rendered DOM rather than trusting the tests: banner `p-message-warn` reading "Aucun fichier importé, 1 refusé", status icon `pi pi-ban text-red-600` with `aria-label="Refusé"`, no retry button, Importer disabled, and no network request for the refused file.

## Not in scope

The **HTTP 200 carrying a fatal error** is not fixed. It affects any request whose body exceeds `post_max_size`, so it defeats client-side error handling across the whole app rather than only uploads, and it deserves its own issue. This branch makes uploads survive it; it does not make the worker answer a correct status.

Also worth a separate look: `deploy.php` runs no cache clearing for the API Platform metadata pools, which are Redis backed. Adding a property to a shipped `#[ApiResource]` DTO, as this does, may therefore not appear in production until `php-web` restarts or those pools are flushed.
