### PR TITLE
fix(M-915): keep the destination when an unauthenticated visitor is sent to the login form

### DIFF
--- a/assets/js/App.vue
+++ b/assets/js/App.vue
@@ -9,6 +9,7 @@ import ConfirmDialog from 'primevue/confirmdialog'
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useUserSecurityStore } from './store/user/security.js'
+import { resolveUnauthenticatedRedirect } from './utils/unauthenticatedRedirect.js'
 
 const userSecurityStore = useUserSecurityStore()
 const router = useRouter()
@@ -18,10 +19,14 @@ onMounted(async () => {
   const { isAuthenticated, isSuperAdmin } = storeToRefs(userSecurityStore)
 
   router.beforeResolve((to) => {
-    // A route may name where a visitor without an account should land instead of the login form,
-    // so a shared link to a gated module explains itself rather than presenting a bare password box.
+    // Where an unauthenticated visitor lands, and whether the destination is told where they were
+    // going. Extracted so the two carve-outs it encodes are pinned by tests.
+    //
+    // Following a return_url is gated separately by whoever consumes it: the store checks
+    // isSafeReturnUrl before touching window.location, and the OAuth start route is validated
+    // server side. This guard only ever produces a same-origin path from the router itself.
     if (to.meta.isAuthRequired && !isAuthenticated.value) {
-      return { name: to.meta.unauthenticatedRedirect ?? 'app_login' }
+      return resolveUnauthenticatedRedirect(to)
     }
     if (to.meta.isGuestOnly && isAuthenticated.value) {
       return { name: 'app_home' }

--- a/assets/js/utils/returnUrl.test.js
+++ b/assets/js/utils/returnUrl.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { isSafeReturnUrl } from './returnUrl.js'
+
+// This is the app's open-redirect gate: security.js checks it before handing a value to
+// window.location.href. It had no tests, and the guard change in #915 makes it the safety net on the
+// most common unauthenticated path rather than a rarely reached manual-URL edge case.
+describe('isSafeReturnUrl', () => {
+  it('accepts a same-origin relative path', () => {
+    assert.equal(isSafeReturnUrl('/'), true)
+    assert.equal(isSafeReturnUrl('/messages'), true)
+    assert.equal(isSafeReturnUrl('/band/invitation/abc123'), true)
+    assert.equal(isSafeReturnUrl('/band/1/tech-riders?rider=42#top'), true)
+  })
+
+  it('refuses an absolute URL', () => {
+    assert.equal(isSafeReturnUrl('https://evil.example'), false)
+    assert.equal(isSafeReturnUrl('http://evil.example/path'), false)
+  })
+
+  it('refuses a protocol relative URL, which would leave the origin', () => {
+    assert.equal(isSafeReturnUrl('//evil.example'), false)
+  })
+
+  // Browsers normalise a backslash to a slash on a special scheme, so "/\evil.example" resolves
+  // exactly like "//evil.example" while still reading as an internal path.
+  it('refuses a backslash standing in for the second slash', () => {
+    assert.equal(isSafeReturnUrl('/\\evil.example'), false)
+  })
+
+  it('refuses a scheme that is not http', () => {
+    assert.equal(isSafeReturnUrl('javascript:alert(1)'), false)
+    assert.equal(isSafeReturnUrl('data:text/html,<script>'), false)
+    assert.equal(isSafeReturnUrl('mailto:someone@example.com'), false)
+  })
+
+  it('refuses anything that is not a non-empty string', () => {
+    assert.equal(isSafeReturnUrl(''), false)
+    assert.equal(isSafeReturnUrl(null), false)
+    assert.equal(isSafeReturnUrl(undefined), false)
+    assert.equal(isSafeReturnUrl(42), false)
+    assert.equal(isSafeReturnUrl(['/messages']), false)
+    assert.equal(isSafeReturnUrl({ toString: () => '/messages' }), false)
+  })
+})

--- a/assets/js/utils/unauthenticatedRedirect.js
+++ b/assets/js/utils/unauthenticatedRedirect.js
@@ -1,0 +1,26 @@
+/**
+ * Where to send a visitor who is not signed in, for a route that requires it.
+ *
+ * A route may name its own landing place through `meta.unauthenticatedRedirect`, so a shared link to
+ * a gated module can explain itself instead of presenting a bare password box. Anything without one
+ * goes to the login form.
+ *
+ * Only the login form receives `return_url`. It is the one destination that knows how to resume the
+ * journey, and without it an invitation link is a dead end: its token lives in the path, so the
+ * redirect discards it. A destination that is a page rather than a form has nothing to resume with.
+ *
+ * Extracted from the guard in App.vue because this branch carries two deliberate carve-outs now, the
+ * marketing landing page and this one, and it is the kind of conditional a third change gets wrong.
+ *
+ * @param {{meta?: {unauthenticatedRedirect?: string}, fullPath?: string}} to a resolved route
+ * @returns {{name: string, query?: {return_url: string}}}
+ */
+export function resolveUnauthenticatedRedirect(to) {
+  const destination = to?.meta?.unauthenticatedRedirect ?? 'app_login'
+
+  if (destination !== 'app_login' || !to?.fullPath) {
+    return { name: destination }
+  }
+
+  return { name: destination, query: { return_url: to.fullPath } }
+}

--- a/assets/js/utils/unauthenticatedRedirect.test.js
+++ b/assets/js/utils/unauthenticatedRedirect.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { resolveUnauthenticatedRedirect } from './unauthenticatedRedirect.js'
+
+describe('resolveUnauthenticatedRedirect', () => {
+  it('sends a route with no preference to the login form, carrying the destination', () => {
+    assert.deepEqual(resolveUnauthenticatedRedirect({ meta: {}, fullPath: '/messages' }), {
+      name: 'app_login',
+      query: { return_url: '/messages' }
+    })
+  })
+
+  // The whole point of #915: the token lives in the path, so losing it strands the visitor.
+  it('keeps an invitation token', () => {
+    const result = resolveUnauthenticatedRedirect({
+      meta: { unauthenticatedRedirect: 'app_login' },
+      fullPath: '/band/invitation/abc123'
+    })
+    assert.equal(result.query.return_url, '/band/invitation/abc123')
+  })
+
+  it('keeps the query string, not just the path', () => {
+    const result = resolveUnauthenticatedRedirect({
+      meta: {},
+      fullPath: '/band/1/tech-riders?rider=42'
+    })
+    assert.equal(result.query.return_url, '/band/1/tech-riders?rider=42')
+  })
+
+  // A landing page has no form to resume from, so a return_url there would be dead weight.
+  it('does not attach a destination when the route names a page instead of the login form', () => {
+    assert.deepEqual(
+      resolveUnauthenticatedRedirect({
+        meta: { unauthenticatedRedirect: 'app_band_space_presentation' },
+        fullPath: '/band/1/agenda'
+      }),
+      { name: 'app_band_space_presentation' }
+    )
+  })
+
+  it('omits the query rather than sending an empty one when there is no path', () => {
+    assert.deepEqual(resolveUnauthenticatedRedirect({ meta: {} }), { name: 'app_login' })
+  })
+
+  it('tolerates a route with no meta at all', () => {
+    assert.deepEqual(resolveUnauthenticatedRedirect({ fullPath: '/x' }), {
+      name: 'app_login',
+      query: { return_url: '/x' }
+    })
+    assert.deepEqual(resolveUnauthenticatedRedirect(undefined), { name: 'app_login' })
+  })
+})

--- a/assets/js/views/User/Register.vue
+++ b/assets/js/views/User/Register.vue
@@ -526,6 +526,11 @@ async function handleSubmit() {
 }
 
 function goToLogin() {
-  router.push({ name: 'app_login' })
+  // Carries the destination on, or an invited visitor who registered here still loses the
+  // invitation at the last hop. The link at the top of this page already does the same.
+  router.push({
+    name: 'app_login',
+    query: returnUrl.value ? { return_url: returnUrl.value } : {}
+  })
 }
 </script>


### PR DESCRIPTION
Closes #915.

An invitation mail links to `/band/invitation/{token}`. That route is `isAuthRequired`, so the guard in `App.vue` redirected an unauthenticated visitor to `app_login` with nothing attached. The token lives in the path, so it was discarded and the visitor ended up on the home page after signing in with no way back. Most invitations go to people who are not currently signed in, so this was closer to the default path than an edge case.

## The fix

No new mechanism. `return_url` already existed and was wired end to end: `Login.vue` reads it, forwards it to Register and to the Google OAuth start URL, and hands it to the store, which follows it only after `isSafeReturnUrl()`. The guard was the one place that dropped it.

It now attaches `return_url: to.fullPath` when the destination is the login form, and deliberately does not when the destination is a page rather than a form, so #911's marketing redirect is unchanged.

`to.fullPath` rather than `to.path` so a query string survives, which matters for links like the tech rider page's `?rider=`.

## Also fixed, same journey one hop later

`Register.vue`'s `goToLogin()`, the button on the "Email vérifié !" panel shown after OTP verification, pushed `app_login` with no query. So an invited visitor without an account still lost the invitation at the last step: guard forwards it, the "Créer un compte" link forwards it, registration completes, and then this button threw it away. It now forwards it like the sibling link at the top of the same page already did.

## Tests

The guard branch is extracted to `resolveUnauthenticatedRedirect()` in `assets/js/utils/`, following the pure-function convention the other utils use, since this one conditional now carries two deliberate carve-outs and is the sort of thing a third change gets wrong.

Also added the missing tests for `isSafeReturnUrl()`. That function is the app's open-redirect gate and had none, and this change promotes it from a rarely reached manual-URL case to the safety net on the most common unauthenticated path. Covers absolute URLs, protocol relative, the backslash form that browsers normalise to `//`, non-http schemes, and non-string input.

JS suite goes from 422 to 434.

## Verified

In a browser, logged out:

- `/band/invitation/testtoken123` lands on `/login?return_url=/band/invitation/testtoken123`, and the "Créer un compte" link resolves to `/register?return_url=/band/invitation/testtoken123`
- `/band/<id>/agenda` still lands on `/band-space` with no `return_url`

Both re-checked after the extraction, not only before it.

## Noted, not addressed here

The backend's `AbstractOAuthController::isValidReturnUrl()` only tests `str_starts_with($url, '/')`, so it accepts `//evil.com` and `/\evil.com` where the frontend's `isSafeReturnUrl()` rejects both. Not exploitable today: every branch concatenates onto `$this->frontendUrl` first, which anchors the authority. Worth tightening as defence in depth, separately from this fix.
