### PR TITLE
feat(M-918): open the Files module on the folder hierarchy

### DIFF
--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -46,12 +46,20 @@
         <div class="grid grid-cols-12 gap-2 flex-1 min-w-0 items-center">
           <div class="col-span-12 md:col-span-6 flex items-center gap-2 min-w-0">
             <i class="pi pi-folder text-lg text-primary-500 shrink-0" aria-hidden="true"></i>
-            <span class="truncate font-medium">{{ folder.name }}</span>
+            <div class="min-w-0">
+              <span class="block truncate font-medium">{{ folder.name }}</span>
+              <!-- Under the name rather than under the « Taille » header, where a count of files would
+                   sit in the column every other row fills with bytes. -->
+              <span
+                v-if="folderFileCountLabel(folder.file_count)"
+                class="block text-xs text-surface-500 dark:text-surface-400"
+              >
+                {{ folderFileCountLabel(folder.file_count) }}
+              </span>
+            </div>
           </div>
 
-          <div class="col-span-4 md:col-span-2 text-surface-500 dark:text-surface-400">
-            {{ folderFileCountLabel(folder.file_count) ?? '—' }}
-          </div>
+          <div class="col-span-4 md:col-span-2 text-surface-400">—</div>
           <div class="col-span-4 md:col-span-2"></div>
 
           <div class="col-span-4 md:col-span-2 text-surface-600 dark:text-surface-300">
@@ -153,7 +161,7 @@ const props = defineProps({
   isLoading: { type: Boolean, default: false },
   emptyMessage: {
     type: String,
-    default: 'Aucun fichier dans ce dossier — commencez par en importer un.'
+    default: 'Aucun fichier dans ce dossier, commencez par en importer un.'
   },
   /** Direct subfolders of the folder being shown, rendered above the files. */
   folders: { type: Array, default: () => [] },

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -91,11 +91,11 @@
                 v-if="showLocation"
                 type="button"
                 class="flex items-center gap-1 max-w-full text-xs text-surface-500 dark:text-surface-400 hover:underline"
-                :aria-label="`Ouvrir ${locationLabel(file)}`"
-                @click.stop="emit('open-location', file)"
+                :aria-label="`Ouvrir ${locationOf(file).label}`"
+                @click.stop="emit('open-location', locationOf(file).folderId)"
               >
                 <i class="pi pi-folder text-[10px] shrink-0" aria-hidden="true"></i>
-                <span class="truncate">{{ locationLabel(file) }}</span>
+                <span class="truncate">{{ locationOf(file).label }}</span>
               </button>
             </div>
           </div>
@@ -153,7 +153,7 @@ import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
 import { isFileCreatorOrAdmin } from '../../../utils/bandSpaceFilePermissions.js'
-import { folderFileCountLabel } from '../../../utils/fileListing.js'
+import { fileLocation, folderFileCountLabel } from '../../../utils/fileListing.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -343,11 +343,13 @@ function formatDate(iso) {
   return date.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' })
 }
 
-/** The folder path as one line, root to leaf. Files at the root have no path of their own. */
-function locationLabel(file) {
-  const path = file.folder_path ?? []
-
-  return path.length === 0 ? 'Racine' : path.map((segment) => segment.name).join(' / ')
+/**
+ * Where the row says the file lives, and where its link goes. The virtual folders come from the store so
+ * an unfiled attachment is named « Notes » the way the sidebar names it, rather than « Racine », which
+ * is a listing that excludes attachments.
+ */
+function locationOf(file) {
+  return fileLocation(file, filesStore.virtualFolders)
 }
 
 function tagStyle(colorHex) {

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -73,7 +73,21 @@
         <div class="grid grid-cols-12 gap-2 flex-1 min-w-0 items-center">
           <div class="col-span-12 md:col-span-6 flex items-center gap-2 min-w-0">
             <i :class="iconForMime(file.mime_type)" class="text-lg text-surface-500 shrink-0"></i>
-            <span class="truncate font-medium">{{ file.original_name }}</span>
+            <div class="min-w-0">
+              <span class="block truncate font-medium">{{ file.original_name }}</span>
+              <!-- Where the file actually lives, for a listing that is not one place. A search result
+                   nobody can locate is half an answer, so the folder is a link back to it. -->
+              <button
+                v-if="showLocation"
+                type="button"
+                class="flex items-center gap-1 max-w-full text-xs text-surface-500 dark:text-surface-400 hover:underline"
+                :aria-label="`Ouvrir ${locationLabel(file)}`"
+                @click.stop="emit('open-location', file)"
+              >
+                <i class="pi pi-folder text-[10px] shrink-0" aria-hidden="true"></i>
+                <span class="truncate">{{ locationLabel(file) }}</span>
+              </button>
+            </div>
           </div>
 
           <div class="col-span-4 md:col-span-2 tabular-nums text-surface-600 dark:text-surface-300">
@@ -139,7 +153,9 @@ const props = defineProps({
     default: 'Aucun fichier dans ce dossier — commencez par en importer un.'
   },
   /** Direct subfolders of the folder being shown, rendered above the files. */
-  folders: { type: Array, default: () => [] }
+  folders: { type: Array, default: () => [] },
+  /** Show each file's folder, for a listing whose rows can come from anywhere. */
+  showLocation: { type: Boolean, default: false }
 })
 
 const emit = defineEmits([
@@ -148,7 +164,8 @@ const emit = defineEmits([
   'open-versions',
   'open-rename',
   'open-move',
-  'open-folder'
+  'open-folder',
+  'open-location'
 ])
 
 const filesStore = useBandFilesStore()
@@ -313,6 +330,13 @@ function formatDate(iso) {
   if (!iso) return '—'
   const date = new Date(iso)
   return date.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+/** The folder path as one line, root to leaf. Files at the root have no path of their own. */
+function locationLabel(file) {
+  const path = file.folder_path ?? []
+
+  return path.length === 0 ? 'Racine' : path.map((segment) => segment.name).join(' / ')
 }
 
 function tagStyle(colorHex) {

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -49,7 +49,9 @@
             <span class="truncate font-medium">{{ folder.name }}</span>
           </div>
 
-          <div class="col-span-4 md:col-span-2 text-surface-400">—</div>
+          <div class="col-span-4 md:col-span-2 text-surface-500 dark:text-surface-400">
+            {{ folderFileCountLabel(folder.file_count) ?? '—' }}
+          </div>
           <div class="col-span-4 md:col-span-2"></div>
 
           <div class="col-span-4 md:col-span-2 text-surface-600 dark:text-surface-300">
@@ -143,6 +145,7 @@ import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
 import { isFileCreatorOrAdmin } from '../../../utils/bandSpaceFilePermissions.js'
+import { folderFileCountLabel } from '../../../utils/fileListing.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },

--- a/assets/js/components/BandSpace/Files/FileMoveDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileMoveDialog.vue
@@ -105,7 +105,7 @@ async function handleConfirm() {
     await bandSpaceFilesApi.updateFile(props.bandSpaceId, props.file.id, {
       folder_id: targetFolderId.value ?? null
     })
-    filesStore.applyFileMoved(props.file.id, targetFolderId.value ?? null)
+    filesStore.applyFileMoved(props.bandSpaceId, props.file.id, targetFolderId.value ?? null)
     emit('moved', { fileId: props.file.id, folderId: targetFolderId.value ?? null })
     visible.value = false
   } catch (e) {

--- a/assets/js/components/BandSpace/Files/FileUploadDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileUploadDialog.vue
@@ -188,6 +188,11 @@ import MultiSelect from 'primevue/multiselect'
 import ProgressBar from 'primevue/progressbar'
 import Select from 'primevue/select'
 import { computed, reactive, ref, watch } from 'vue'
+import {
+  isVirtualFolderId,
+  listedFolderId,
+  NO_FOLDER_LISTED
+} from '../../../constants/folderSelection.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import {
   appendToQueue,
@@ -262,9 +267,7 @@ let tally = { uploadedCount: 0, quotaApproaching: false, interrupted: false }
 const tags = computed(() => filesStore.tags)
 
 const activeFolderId = computed(() => filesStore.activeFolderId)
-const activeFolderIsVirtual = computed(
-  () => typeof activeFolderId.value === 'string' && activeFolderId.value.startsWith('virtual:')
-)
+const activeFolderIsVirtual = computed(() => isVirtualFolderId(activeFolderId.value))
 
 const folderOptions = computed(() => {
   const out = []
@@ -291,13 +294,12 @@ const summary = computed(() => summarizeQueue(queue.value))
 const hasQueuedFiles = computed(() => nextQueuedItem(queue.value) !== null)
 const hasUnsent = computed(() => hasUnsentItems(queue.value))
 
+// The folder on screen, so the member sees where the file is about to land and can still change it.
+// The root and the selections that are not folders leave the field on its « Racine » placeholder.
 watch(visible, (open) => {
   if (open) {
-    if (!activeFolderIsVirtual.value && typeof activeFolderId.value === 'string') {
-      form.folderId = activeFolderId.value
-    } else {
-      form.folderId = null
-    }
+    const listedFolder = listedFolderId(activeFolderId.value)
+    form.folderId = listedFolder === NO_FOLDER_LISTED ? null : listedFolder
   }
 })
 

--- a/assets/js/components/BandSpace/Files/FolderBreadcrumb.vue
+++ b/assets/js/components/BandSpace/Files/FolderBreadcrumb.vue
@@ -4,15 +4,15 @@
       v-if="segments.length > 0"
       type="button"
       class="text-surface-500 hover:text-surface-800 dark:hover:text-surface-100 hover:underline"
-      @click="emit('select', null)"
+      @click="emit('select', ROOT_FOLDER_ID)"
     >
-      Tous les fichiers
+      Racine
     </button>
     <span
       v-else
       class="font-medium text-surface-800 dark:text-surface-100"
     >
-      Tous les fichiers
+      Racine
     </span>
 
     <template v-for="(seg, index) in segments" :key="seg.id">
@@ -37,6 +37,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { isVirtualFolderId, ROOT_FOLDER_ID } from '../../../constants/folderSelection.js'
 
 const props = defineProps({
   folders: { type: Array, default: () => [] },
@@ -45,8 +46,10 @@ const props = defineProps({
 
 const emit = defineEmits(['select'])
 
+// The path down from the root, so the root itself has none.
 const segments = computed(() => {
-  if (!props.activeFolderId || props.activeFolderId.startsWith('virtual:')) return []
+  if (!props.activeFolderId || props.activeFolderId === ROOT_FOLDER_ID) return []
+  if (isVirtualFolderId(props.activeFolderId)) return []
 
   const flat = flatten(props.folders)
   const byId = new Map(flat.map((f) => [f.id, f]))

--- a/assets/js/components/BandSpace/Files/FolderBreadcrumb.vue
+++ b/assets/js/components/BandSpace/Files/FolderBreadcrumb.vue
@@ -38,6 +38,7 @@
 <script setup>
 import { computed } from 'vue'
 import { isVirtualFolderId, ROOT_FOLDER_ID } from '../../../constants/folderSelection.js'
+import { folderPathOf } from '../../../utils/fileListing.js'
 
 const props = defineProps({
   folders: { type: Array, default: () => [] },
@@ -46,34 +47,12 @@ const props = defineProps({
 
 const emit = defineEmits(['select'])
 
-// The path down from the root, so the root itself has none.
+// The path down from the root, so the root itself has none. Same walk the file rows use to name the
+// folder they live in, since a breadcrumb and a location label are the same question asked twice.
 const segments = computed(() => {
   if (!props.activeFolderId || props.activeFolderId === ROOT_FOLDER_ID) return []
   if (isVirtualFolderId(props.activeFolderId)) return []
 
-  const flat = flatten(props.folders)
-  const byId = new Map(flat.map((f) => [f.id, f]))
-
-  const chain = []
-  let current = byId.get(props.activeFolderId) ?? null
-  while (current) {
-    chain.unshift({ id: current.id, name: current.name })
-    current = current.parent_id ? byId.get(current.parent_id) : null
-  }
-  return chain
+  return folderPathOf(props.folders, props.activeFolderId)
 })
-
-function flatten(nodes) {
-  const out = []
-  const walk = (list) => {
-    for (const node of list) {
-      out.push(node)
-      if (Array.isArray(node.children) && node.children.length > 0) {
-        walk(node.children)
-      }
-    }
-  }
-  walk(nodes)
-  return out
-}
 </script>

--- a/assets/js/components/BandSpace/Files/FolderTree.vue
+++ b/assets/js/components/BandSpace/Files/FolderTree.vue
@@ -11,10 +11,10 @@
         type="button"
         class="flex items-center gap-2 flex-1 min-w-0 px-1 py-1.5 rounded-md text-sm text-left transition-colors duration-150"
         :class="rootButtonClasses"
-        @click="emit('select', null)"
+        @click="emit('select', ROOT_FOLDER_ID)"
       >
         <i class="pi pi-folder text-surface-500"></i>
-        <span class="flex-1 truncate">Tous les fichiers</span>
+        <span class="flex-1 truncate">Racine</span>
       </button>
       <Button
         icon="pi pi-plus"
@@ -27,17 +27,26 @@
       />
     </div>
 
-    <FolderTreeNode
-      v-for="folder in folders"
-      :key="folder.id"
-      :folder="folder"
-      :active-id="activeFolderId"
-      @select="(id) => emit('select', id)"
-      @create-sub="openCreateSub"
-      @edit="openEdit"
-      @delete="openDelete"
-      @drop-on-folder="handleDropOnFolder"
-    />
+    <!-- The folders at the root hang off the same rail as any other level, so the tree reads as one
+         hierarchy under « Racine » rather than as a list that happens to sit below it. Their own gap
+         lives on each row, not on this container, otherwise it would break the line between them. -->
+    <div class="flex flex-col">
+      <div v-for="(folder, index) in folders" :key="folder.id" class="flex">
+        <FolderTreeRail :is-last="index === folders.length - 1" />
+
+        <div class="min-w-0 flex-1 pt-1">
+          <FolderTreeNode
+            :folder="folder"
+            :active-id="activeFolderId"
+            @select="(id) => emit('select', id)"
+            @create-sub="openCreateSub"
+            @edit="openEdit"
+            @delete="openDelete"
+            @drop-on-folder="handleDropOnFolder"
+          />
+        </div>
+      </div>
+    </div>
 
     <div
       v-if="virtualFolders.length > 0"
@@ -84,10 +93,12 @@ import { computed, ref } from 'vue'
 import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
 import { applyMove, canDrop } from '../../../composables/useFolderDragDrop.js'
 import { fileSourceIcon } from '../../../constants/fileSources.js'
+import { ROOT_FOLDER_ID } from '../../../constants/folderSelection.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import FolderDeleteDialog from './FolderDeleteDialog.vue'
 import FolderEditDialog from './FolderEditDialog.vue'
 import FolderTreeNode from './FolderTreeNode.vue'
+import FolderTreeRail from './FolderTreeRail.vue'
 
 const props = defineProps({
   folders: { type: Array, default: () => [] },
@@ -176,7 +187,7 @@ function openDelete(folder) {
 }
 
 const rootButtonClasses = computed(() => {
-  return props.activeFolderId === null
+  return props.activeFolderId === ROOT_FOLDER_ID
     ? 'bg-surface-100 dark:bg-surface-800 text-surface-900 dark:text-surface-100 font-medium'
     : 'hover:bg-surface-50 dark:hover:bg-surface-800 text-surface-700 dark:text-surface-300'
 })

--- a/assets/js/components/BandSpace/Files/FolderTreeNode.vue
+++ b/assets/js/components/BandSpace/Files/FolderTreeNode.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :style="{ paddingLeft: `${folder.depth * 12}px` }" class="flex flex-col gap-1">
+  <div class="flex flex-col">
     <div
       class="group relative flex items-center h-8 px-2 rounded-md text-sm transition-colors duration-150"
       :class="rowClasses"
@@ -30,17 +30,25 @@
       </button>
     </div>
 
-    <FolderTreeNode
-      v-for="child in folder.children"
-      :key="child.id"
-      :folder="child"
-      :active-id="activeId"
-      @select="(id) => emit('select', id)"
-      @create-sub="(node) => emit('create-sub', node)"
-      @edit="(node) => emit('edit', node)"
-      @delete="(node) => emit('delete', node)"
-      @drop-on-folder="(payload) => emit('drop-on-folder', payload)"
-    />
+    <!-- Subfolders hang off a rail rather than being indented in silence: a vertical line down the
+         siblings with a tick into each row, cut short at the last one so the line ends on it. Same rail
+         the finance subcategories use, and the indentation now comes from its width, one level at a
+         time, instead of from a depth multiplier that compounded with every nesting. -->
+    <div v-for="(child, index) in children" :key="child.id" class="flex">
+      <FolderTreeRail :is-last="index === children.length - 1" />
+
+      <div class="min-w-0 flex-1 pt-1">
+        <FolderTreeNode
+          :folder="child"
+          :active-id="activeId"
+          @select="(id) => emit('select', id)"
+          @create-sub="(node) => emit('create-sub', node)"
+          @edit="(node) => emit('edit', node)"
+          @delete="(node) => emit('delete', node)"
+          @drop-on-folder="(payload) => emit('drop-on-folder', payload)"
+        />
+      </div>
+    </div>
 
     <ContextMenu ref="contextMenuRef" :model="contextMenuItems" />
   </div>
@@ -51,6 +59,7 @@ import ContextMenu from 'primevue/contextmenu'
 import { computed, ref } from 'vue'
 import { canDrop, collectFolderAndDescendants } from '../../../composables/useFolderDragDrop.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
+import FolderTreeRail from './FolderTreeRail.vue'
 
 const MAX_DEPTH = 6
 
@@ -65,6 +74,8 @@ const filesStore = useBandFilesStore()
 
 const isDropTarget = ref(false)
 const contextMenuRef = ref(null)
+
+const children = computed(() => props.folder.children ?? [])
 
 const contextMenuItems = computed(() => [
   { label: 'Ouvrir', icon: 'pi pi-folder-open', command: () => emit('select', props.folder.id) },

--- a/assets/js/components/BandSpace/Files/FolderTreeNode.vue
+++ b/assets/js/components/BandSpace/Files/FolderTreeNode.vue
@@ -17,7 +17,16 @@
         @click="emit('select', folder.id)"
       >
         <i class="pi pi-folder text-surface-500 shrink-0"></i>
-        <span class="truncate">{{ folder.name }}</span>
+        <span class="flex-1 truncate">{{ folder.name }}</span>
+        <!-- Its own files, subfolders excluded, so a folder that only holds subfolders shows no number
+             rather than a zero that would read as « nothing in there ». -->
+        <span
+          v-if="fileCountLabel"
+          class="shrink-0 text-xs text-surface-500 dark:text-surface-400 tabular-nums"
+          v-tooltip.top="`${fileCountLabel} dans ce dossier, sous-dossiers exclus`"
+        >
+          {{ folder.file_count }}
+        </span>
       </button>
       <button
         type="button"
@@ -59,6 +68,7 @@ import ContextMenu from 'primevue/contextmenu'
 import { computed, ref } from 'vue'
 import { canDrop, collectFolderAndDescendants } from '../../../composables/useFolderDragDrop.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
+import { folderFileCountLabel } from '../../../utils/fileListing.js'
 import FolderTreeRail from './FolderTreeRail.vue'
 
 const MAX_DEPTH = 6
@@ -76,6 +86,7 @@ const isDropTarget = ref(false)
 const contextMenuRef = ref(null)
 
 const children = computed(() => props.folder.children ?? [])
+const fileCountLabel = computed(() => folderFileCountLabel(props.folder.file_count))
 
 const contextMenuItems = computed(() => [
   { label: 'Ouvrir', icon: 'pi pi-folder-open', command: () => emit('select', props.folder.id) },

--- a/assets/js/components/BandSpace/Files/FolderTreeRail.vue
+++ b/assets/js/components/BandSpace/Files/FolderTreeRail.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- The line down a set of sibling folders, with a tick into this one's row. Cut short on the last
-       sibling so the line ends on it instead of running past into whatever follows the tree. -->
-  <div class="relative w-5 shrink-0" aria-hidden="true">
+       sibling so the line ends on it instead of running past into whatever follows the tree.
+       16px wide, not 20: the tick runs from 8px to 16px, so at this width it lands exactly on the row it
+       points at instead of stopping short of it, and six levels of nesting cost 96px of a 224px sidebar
+       rather than 120px. -->
+  <div class="relative w-4 shrink-0" aria-hidden="true">
     <span
       class="absolute left-2 top-0 w-px bg-surface-300 dark:bg-surface-600"
       :class="isLast ? 'h-5' : 'h-full'"

--- a/assets/js/components/BandSpace/Files/FolderTreeRail.vue
+++ b/assets/js/components/BandSpace/Files/FolderTreeRail.vue
@@ -1,0 +1,17 @@
+<template>
+  <!-- The line down a set of sibling folders, with a tick into this one's row. Cut short on the last
+       sibling so the line ends on it instead of running past into whatever follows the tree. -->
+  <div class="relative w-5 shrink-0" aria-hidden="true">
+    <span
+      class="absolute left-2 top-0 w-px bg-surface-300 dark:bg-surface-600"
+      :class="isLast ? 'h-5' : 'h-full'"
+    ></span>
+    <span class="absolute left-2 top-5 w-2 h-px bg-surface-300 dark:bg-surface-600"></span>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  isLast: { type: Boolean, default: false }
+})
+</script>

--- a/assets/js/composables/useFolderDragDrop.js
+++ b/assets/js/composables/useFolderDragDrop.js
@@ -120,7 +120,7 @@ export async function applyMove(
       toast.add({ severity: 'success', summary: 'Dossier déplacé', life: 2500 })
     } else if (source.type === 'file') {
       await filesApi.updateFile(bandSpaceId, source.id, { folder_id: targetFolderId })
-      filesStore.applyFileMoved(source.id, targetFolderId)
+      filesStore.applyFileMoved(bandSpaceId, source.id, targetFolderId)
       toast.add({ severity: 'success', summary: 'Fichier déplacé', life: 2500 })
     }
   } catch (e) {

--- a/assets/js/constants/folderSelection.js
+++ b/assets/js/constants/folderSelection.js
@@ -1,0 +1,55 @@
+/**
+ * What the Files sidebar can have selected, and which folder each selection means.
+ *
+ * A real folder is selected by its uuid. The other rows are not folders, so they carry reserved ids
+ * instead: the root of the tree, the trash, and the virtual source folders. No selection at all is the
+ * flat listing of the whole space, which is a view rather than a place.
+ */
+
+/**
+ * The root of the folder tree. Mirrors BandSpaceFileCollectionProvider::ROOT_FOLDER_ID: the file
+ * collection reads `folder_id=root` as the files at the root, where no `folder_id` still means the
+ * whole space.
+ */
+export const ROOT_FOLDER_ID = 'root'
+
+/** The trash, selected like a folder so it reuses the whole selection and fetch path. */
+export const TRASH_FOLDER_ID = 'trash'
+
+const VIRTUAL_PREFIX = 'virtual:'
+
+/** What listedFolderId returns when the selection is not a place in the tree. */
+export const NO_FOLDER_LISTED = Symbol('no folder listed')
+
+/**
+ * The folder the panel is inside, spelled the way a file spells its own: null at the root, the uuid
+ * inside a folder. The root is null rather than its reserved id because everything downstream already
+ * spells the root that way, from a file's folder_id to the parent_id of a new folder.
+ *
+ * NO_FOLDER_LISTED for the three selections that are not a place: the flat listing of the whole space,
+ * a virtual source folder, and the trash. Those list files from anywhere, so a row cannot be compared
+ * against a folder and there are no subfolders to show inside them.
+ *
+ * @param {string|null} activeFolderId
+ * @returns {string|null|symbol}
+ */
+export function listedFolderId(activeFolderId) {
+  if (activeFolderId === ROOT_FOLDER_ID) return null
+  if (typeof activeFolderId !== 'string') return NO_FOLDER_LISTED
+  if (activeFolderId === TRASH_FOLDER_ID || isVirtualFolderId(activeFolderId)) {
+    return NO_FOLDER_LISTED
+  }
+
+  return activeFolderId
+}
+
+/**
+ * A virtual source folder groups files by what they are attached to, so it holds no files of its own
+ * and nothing can be created in it.
+ *
+ * @param {string|null} folderId
+ * @returns {boolean}
+ */
+export function isVirtualFolderId(folderId) {
+  return typeof folderId === 'string' && folderId.startsWith(VIRTUAL_PREFIX)
+}

--- a/assets/js/constants/folderSelection.js
+++ b/assets/js/constants/folderSelection.js
@@ -66,3 +66,15 @@ export function isVirtualFolderId(folderId) {
 export function virtualFolderSource(folderId) {
   return isVirtualFolderId(folderId) ? folderId.slice(VIRTUAL_PREFIX.length) : null
 }
+
+/**
+ * The selection that opens a source's virtual folder. The inverse of virtualFolderSource(), here so the
+ * prefix is spelled in one file rather than interpolated wherever a source has to be turned into a
+ * place.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+export function virtualFolderId(source) {
+  return `${VIRTUAL_PREFIX}${source}`
+}

--- a/assets/js/constants/folderSelection.js
+++ b/assets/js/constants/folderSelection.js
@@ -53,3 +53,16 @@ export function listedFolderId(activeFolderId) {
 export function isVirtualFolderId(folderId) {
   return typeof folderId === 'string' && folderId.startsWith(VIRTUAL_PREFIX)
 }
+
+/**
+ * The attachment source a virtual folder groups, or null for anything that is not one.
+ *
+ * BandSpaceFolderVirtualFoldersListener builds the ids as `virtual:{source}` from the same source names
+ * the collection's `source` filter accepts, which is what makes the suffix usable as the filter value.
+ *
+ * @param {string|null} folderId
+ * @returns {string|null}
+ */
+export function virtualFolderSource(folderId) {
+  return isVirtualFolderId(folderId) ? folderId.slice(VIRTUAL_PREFIX.length) : null
+}

--- a/assets/js/constants/folderSelection.test.js
+++ b/assets/js/constants/folderSelection.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  isVirtualFolderId,
+  listedFolderId,
+  NO_FOLDER_LISTED,
+  ROOT_FOLDER_ID,
+  TRASH_FOLDER_ID
+} from './folderSelection.js'
+
+/**
+ * The Files panel used to open on every file in the space, so a selection was either a folder or it
+ * was everything. Landing on the root added a third state, and the three read almost alike at a call
+ * site: the root lists one place and holds null, no selection lists the whole space, and both are
+ * falsy. What follows pins the three apart.
+ *
+ * Run with `npm test`.
+ */
+
+describe('listedFolderId', () => {
+  it('reads the root as no folder, the way a file at the root spells its own', () => {
+    assert.equal(listedFolderId(ROOT_FOLDER_ID), null)
+  })
+
+  it('reads a folder as itself', () => {
+    assert.equal(
+      listedFolderId('0198c0de-dead-beef-cafe-000000000001'),
+      '0198c0de-dead-beef-cafe-000000000001'
+    )
+  })
+
+  it('has no folder for the flat listing of the whole space', () => {
+    assert.equal(listedFolderId(null), NO_FOLDER_LISTED)
+  })
+
+  it('has no folder for a virtual source folder, which holds files from anywhere', () => {
+    assert.equal(listedFolderId('virtual:note'), NO_FOLDER_LISTED)
+  })
+
+  it('has no folder for the trash, which keeps a file whatever folder it was in', () => {
+    assert.equal(listedFolderId(TRASH_FOLDER_ID), NO_FOLDER_LISTED)
+  })
+})
+
+describe('isVirtualFolderId', () => {
+  it('recognises a virtual source folder', () => {
+    assert.equal(isVirtualFolderId('virtual:setlist'), true)
+  })
+
+  it('leaves the real selections alone', () => {
+    assert.equal(isVirtualFolderId(ROOT_FOLDER_ID), false)
+    assert.equal(isVirtualFolderId(TRASH_FOLDER_ID), false)
+    assert.equal(isVirtualFolderId('0198c0de-dead-beef-cafe-000000000001'), false)
+    assert.equal(isVirtualFolderId(null), false)
+  })
+})

--- a/assets/js/constants/folderSelection.test.js
+++ b/assets/js/constants/folderSelection.test.js
@@ -5,7 +5,8 @@ import {
   listedFolderId,
   NO_FOLDER_LISTED,
   ROOT_FOLDER_ID,
-  TRASH_FOLDER_ID
+  TRASH_FOLDER_ID,
+  virtualFolderSource
 } from './folderSelection.js'
 
 /**
@@ -52,5 +53,23 @@ describe('isVirtualFolderId', () => {
     assert.equal(isVirtualFolderId(TRASH_FOLDER_ID), false)
     assert.equal(isVirtualFolderId('0198c0de-dead-beef-cafe-000000000001'), false)
     assert.equal(isVirtualFolderId(null), false)
+  })
+})
+
+describe('virtualFolderSource', () => {
+  /** The five the collection's `source` filter accepts, and the five the listener builds ids from. */
+  const SOURCES = ['task', 'finance', 'note', 'song', 'setlist']
+
+  it('returns the source a virtual folder groups', () => {
+    for (const source of SOURCES) {
+      assert.equal(virtualFolderSource(`virtual:${source}`), source)
+    }
+  })
+
+  it('returns null for anything that is not a virtual folder', () => {
+    assert.equal(virtualFolderSource(ROOT_FOLDER_ID), null)
+    assert.equal(virtualFolderSource(TRASH_FOLDER_ID), null)
+    assert.equal(virtualFolderSource('0198c0de-dead-beef-cafe-000000000001'), null)
+    assert.equal(virtualFolderSource(null), null)
   })
 })

--- a/assets/js/constants/folderSelection.test.js
+++ b/assets/js/constants/folderSelection.test.js
@@ -6,6 +6,7 @@ import {
   NO_FOLDER_LISTED,
   ROOT_FOLDER_ID,
   TRASH_FOLDER_ID,
+  virtualFolderId,
   virtualFolderSource
 } from './folderSelection.js'
 
@@ -71,5 +72,17 @@ describe('virtualFolderSource', () => {
     assert.equal(virtualFolderSource(TRASH_FOLDER_ID), null)
     assert.equal(virtualFolderSource('0198c0de-dead-beef-cafe-000000000001'), null)
     assert.equal(virtualFolderSource(null), null)
+  })
+})
+
+describe('virtualFolderId', () => {
+  it('round trips with virtualFolderSource', () => {
+    for (const source of ['task', 'finance', 'note', 'song', 'setlist']) {
+      assert.equal(virtualFolderSource(virtualFolderId(source)), source)
+    }
+  })
+
+  it('builds the id the folder collection publishes', () => {
+    assert.equal(virtualFolderId('note'), 'virtual:note')
   })
 })

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -2,6 +2,12 @@ import { defineStore } from 'pinia'
 import { computed, reactive, readonly, ref } from 'vue'
 import bandSpaceFilesApi from '../../api/bandSpace/band-space-files.js'
 import {
+  listedFolderId,
+  NO_FOLDER_LISTED,
+  ROOT_FOLDER_ID,
+  TRASH_FOLDER_ID
+} from '../../constants/folderSelection.js'
+import {
   FILES_PAGE_SIZE,
   fileCountLabel,
   hasMoreToLoad,
@@ -10,8 +16,6 @@ import {
   queryKeyOf
 } from '../../utils/filePagination.js'
 
-export const TRASH_FOLDER_ID = 'trash'
-
 export const useBandFilesStore = defineStore('bandFiles', () => {
   const files = ref([])
   const totalFiles = ref(0)
@@ -19,7 +23,9 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   const virtualFolders = ref([])
   const tags = ref([])
   const quota = ref(null)
-  const activeFolderId = ref(null)
+  // The root of the tree, not the whole space: a file belongs to one place, so it is listed in one.
+  // « Tous les fichiers » is still a selection, it is just no longer where the panel opens.
+  const activeFolderId = ref(ROOT_FOLDER_ID)
   const activeFileId = ref(null)
   const activeFileFull = ref(null)
   const fileActivities = ref([])
@@ -227,6 +233,8 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     } else if (activeFolderId.value === 'virtual:setlist') {
       params.source = 'setlist'
     } else if (activeFolderId.value) {
+      // ROOT_FOLDER_ID rides along as a folder id, since the collection reads that reserved value as
+      // the root of the tree. No folder_id at all is the flat listing of the whole space.
       params.folderId = activeFolderId.value
     } else if (filters.source) {
       params.source = filters.source
@@ -248,8 +256,10 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   async function deleteFolder(bandSpaceId, folderId, options = {}) {
     await bandSpaceFilesApi.deleteFolder(bandSpaceId, folderId, options)
     await fetchFolders(bandSpaceId)
+    // The folder the panel was inside is gone, so it falls back to the root rather than to the flat
+    // listing of the whole space, which would answer a deletion with every file in the space.
     if (activeFolderId.value === folderId) {
-      activeFolderId.value = null
+      activeFolderId.value = ROOT_FOLDER_ID
       fetchFiles(bandSpaceId)
     }
     fetchQuota(bandSpaceId)
@@ -312,16 +322,14 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
    * rather than refetching keeps the pages the user already loaded: a move made after paging deep
    * into the list would otherwise snap it back to the first page.
    *
-   * The root and the virtual source folders list the whole space whatever folder a file sits in, so
-   * only a real folder view has to drop the row, and only when the file landed somewhere else.
+   * A listing showing one place, the root included, has to drop the row when the file landed somewhere
+   * else. The flat listing and the virtual source folders hold files whatever folder they sit in, so
+   * there the row only has its folder patched.
    */
   function applyFileMoved(fileId, targetFolderId) {
-    const isRealFolderView =
-      typeof activeFolderId.value === 'string' &&
-      activeFolderId.value !== TRASH_FOLDER_ID &&
-      !activeFolderId.value.startsWith('virtual:')
+    const listedFolder = listedFolderId(activeFolderId.value)
 
-    if (isRealFolderView && activeFolderId.value !== targetFolderId) {
+    if (listedFolder !== NO_FOLDER_LISTED && listedFolder !== targetFolderId) {
       files.value = files.value.filter((f) => f.id !== fileId)
       totalFiles.value = Math.max(0, totalFiles.value - 1)
       return
@@ -464,11 +472,19 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   /**
    * One file. A batch calls this once per file, so each one lands in the list as it arrives and an
    * interrupted batch leaves behind exactly what the server actually took.
+   *
+   * A file sent to another folder than the one on screen is not added to it: the dialog lets the
+   * member change the destination, and a row for a file that lives elsewhere would only survive until
+   * the next fetch took it away again.
    */
   async function uploadFile(bandSpaceId, payload, onProgress, signal) {
     const result = await bandSpaceFilesApi.uploadFile(bandSpaceId, payload, onProgress, signal)
-    files.value = [result.file, ...files.value]
-    totalFiles.value = totalFiles.value + 1
+    const listedFolder = listedFolderId(activeFolderId.value)
+
+    if (listedFolder === NO_FOLDER_LISTED || listedFolder === (result.file.folder_id ?? null)) {
+      files.value = [result.file, ...files.value]
+      totalFiles.value = totalFiles.value + 1
+    }
     fetchQuota(bandSpaceId)
     return result
   }
@@ -505,7 +521,7 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     virtualFolders.value = []
     tags.value = []
     quota.value = null
-    activeFolderId.value = null
+    activeFolderId.value = ROOT_FOLDER_ID
     activeFileId.value = null
     activeFileFull.value = null
     fileActivities.value = []

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -1,8 +1,17 @@
 import { defineStore } from 'pinia'
 import { computed, reactive, readonly, ref } from 'vue'
 import bandSpaceFilesApi from '../../api/bandSpace/band-space-files.js'
-import { NO_FOLDER_LISTED, ROOT_FOLDER_ID } from '../../constants/folderSelection.js'
-import { fileListingParams, isSearchActive, listedFolderOfRows } from '../../utils/fileListing.js'
+import {
+  listedFolderId,
+  NO_FOLDER_LISTED,
+  ROOT_FOLDER_ID
+} from '../../constants/folderSelection.js'
+import {
+  fileListingParams,
+  isSearchActive,
+  listedFolderOfRows,
+  treeHoldsFolder
+} from '../../utils/fileListing.js'
 import {
   FILES_PAGE_SIZE,
   fileCountLabel,
@@ -221,9 +230,16 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   async function deleteFolder(bandSpaceId, folderId, options = {}) {
     await bandSpaceFilesApi.deleteFolder(bandSpaceId, folderId, options)
     await fetchFolders(bandSpaceId)
-    // The folder the panel was inside is gone, so it falls back to the root rather than to the flat
-    // listing of the whole space, which would answer a deletion with every file in the space.
-    if (activeFolderId.value === folderId) {
+    // The panel may have been inside the deleted folder, or inside one of its subfolders, which the
+    // delete_all strategy takes with it too. Asking the refreshed tree covers both, where comparing
+    // against the deleted id alone left the panel standing in a folder that no longer exists, listing
+    // nothing until something else was clicked. The fallback is the root rather than the flat listing of
+    // the whole space, which would answer a deletion with every file there is.
+    //
+    // Only a real folder can go missing: listedFolderId answers with a string for one, and with the root
+    // or NO_FOLDER_LISTED for every selection no folder deletion can invalidate.
+    const listedFolder = listedFolderId(activeFolderId.value)
+    if (typeof listedFolder === 'string' && !treeHoldsFolder(folders.value, listedFolder)) {
       activeFolderId.value = ROOT_FOLDER_ID
       fetchFiles(bandSpaceId)
     }
@@ -276,9 +292,12 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
       if (activeFileFull.value && activeFileFull.value.id === fileId) {
         activeFileFull.value = updated
       }
-      // Only a folder change moves a file between two counts; a rename or a tag edit leaves them alone.
+      // A folder change is a move, whoever asked for it: the file detail drawer patches the folder from
+      // the same place it patches a name. Only applyFileMoved knows the row may not belong to the
+      // listing any more, and it is the one that refreshes the tree's counts. A rename or a tag edit
+      // moves nothing and needs neither.
       if ('folder_id' in data) {
-        fetchFolders(bandSpaceId)
+        applyFileMoved(bandSpaceId, fileId, data.folder_id ?? null)
       }
       return updated
     } finally {

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -1,12 +1,8 @@
 import { defineStore } from 'pinia'
 import { computed, reactive, readonly, ref } from 'vue'
 import bandSpaceFilesApi from '../../api/bandSpace/band-space-files.js'
-import {
-  listedFolderId,
-  NO_FOLDER_LISTED,
-  ROOT_FOLDER_ID,
-  TRASH_FOLDER_ID
-} from '../../constants/folderSelection.js'
+import { NO_FOLDER_LISTED, ROOT_FOLDER_ID } from '../../constants/folderSelection.js'
+import { fileListingParams, isSearchActive, listedFolderOfRows } from '../../utils/fileListing.js'
 import {
   FILES_PAGE_SIZE,
   fileCountLabel,
@@ -86,6 +82,10 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   // rounder guess, so a mismatch shows up as a refusal the server then disagrees with.
   const maxUploadSizeBytes = computed(() => quota.value?.max_upload_size_bytes ?? 500 * 1024 * 1024)
 
+  // Exposed because the panel dresses itself differently while searching: no subfolder rows, and every
+  // row says which folder it turned up in, since the results are no longer one place.
+  const isSearching = computed(() => isSearchActive(filters))
+
   const hasMoreFiles = computed(() => hasMoreToLoad(files.value.length, totalFiles.value))
   const filesCountLabel = computed(() => fileCountLabel(files.value.length, totalFiles.value))
 
@@ -104,7 +104,7 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     loadError.value = null
     loadMoreError.value = null
 
-    const params = buildFileParams(1)
+    const params = fileListingParams(activeFolderId.value, filters, 1)
 
     try {
       const result = await bandSpaceFilesApi.getFiles(bandSpaceId, params)
@@ -132,7 +132,11 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     if (isLoadingMoreFiles.value || isRefreshingFiles.value || !hasMoreFiles.value) return
 
     const requestId = ++filesRequestId
-    const params = buildFileParams(nextPageToLoad(files.value.length, FILES_PAGE_SIZE))
+    const params = fileListingParams(
+      activeFolderId.value,
+      filters,
+      nextPageToLoad(files.value.length, FILES_PAGE_SIZE)
+    )
     const requestedQueryKey = queryKeyOf(params)
     isLoadingMoreFiles.value = true
     loadMoreError.value = null
@@ -202,45 +206,6 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     } finally {
       isLoadingQuota.value = false
     }
-  }
-
-  function buildFileParams(page) {
-    // The trash ignores every filter, before they are even read. Its filter bar is hidden, so a search
-    // or tag left over from browsing a folder would silently narrow the trash with no visible control to
-    // clear it, and someone hunting for the file they just deleted would find it apparently missing.
-    // It pages exactly like the live listing does: without that, a trashed file past the fiftieth is
-    // unrestorable and app:band-space:purge eventually destroys it.
-    if (activeFolderId.value === TRASH_FOLDER_ID) {
-      return { archived: true, page, itemsPerPage: FILES_PAGE_SIZE }
-    }
-
-    const params = { page, itemsPerPage: FILES_PAGE_SIZE }
-    const trimmed = filters.query.trim()
-    if (trimmed) params.query = trimmed
-    if (filters.mime) params.mime = filters.mime
-    if (filters.tagId) params.tagId = filters.tagId
-    if (filters.sort) params.sort = filters.sort
-    if (filters.order) params.order = filters.order
-
-    if (activeFolderId.value === 'virtual:task') {
-      params.source = 'task'
-    } else if (activeFolderId.value === 'virtual:finance') {
-      params.source = 'finance'
-    } else if (activeFolderId.value === 'virtual:note') {
-      params.source = 'note'
-    } else if (activeFolderId.value === 'virtual:song') {
-      params.source = 'song'
-    } else if (activeFolderId.value === 'virtual:setlist') {
-      params.source = 'setlist'
-    } else if (activeFolderId.value) {
-      // ROOT_FOLDER_ID rides along as a folder id, since the collection reads that reserved value as
-      // the root of the tree. No folder_id at all is the flat listing of the whole space.
-      params.folderId = activeFolderId.value
-    } else if (filters.source) {
-      params.source = filters.source
-    }
-
-    return params
   }
 
   async function createFolder(bandSpaceId, data) {
@@ -327,7 +292,7 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
    * there the row only has its folder patched.
    */
   function applyFileMoved(fileId, targetFolderId) {
-    const listedFolder = listedFolderId(activeFolderId.value)
+    const listedFolder = listedFolderOfRows(activeFolderId.value, filters)
 
     if (listedFolder !== NO_FOLDER_LISTED && listedFolder !== targetFolderId) {
       files.value = files.value.filter((f) => f.id !== fileId)
@@ -479,7 +444,7 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
    */
   async function uploadFile(bandSpaceId, payload, onProgress, signal) {
     const result = await bandSpaceFilesApi.uploadFile(bandSpaceId, payload, onProgress, signal)
-    const listedFolder = listedFolderId(activeFolderId.value)
+    const listedFolder = listedFolderOfRows(activeFolderId.value, filters)
 
     if (listedFolder === NO_FOLDER_LISTED || listedFolder === (result.file.folder_id ?? null)) {
       files.value = [result.file, ...files.value]
@@ -552,6 +517,7 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     quota: readonly(quota),
     activeFolderId: readonly(activeFolderId),
     filters: readonly(filters),
+    isSearching,
     isLoadingFiles: readonly(isLoadingFiles),
     isRefreshingFiles: readonly(isRefreshingFiles),
     isLoadingMoreFiles: readonly(isLoadingMoreFiles),

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -8,9 +8,11 @@ import {
 } from '../../constants/folderSelection.js'
 import {
   fileListingParams,
+  folderPathOf,
   isSearchActive,
   listedFolderOfRows,
-  treeHoldsFolder
+  treeHoldsFolder,
+  uploadBelongsInListing
 } from '../../utils/fileListing.js'
 import {
   FILES_PAGE_SIZE,
@@ -60,6 +62,10 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   // moved is recognised as continuing a list that is no longer on screen.
   const loadedQueryKey = ref(null)
   const isLoadingFolders = ref(false)
+  // The panel's skeleton belongs to the first tree only. Every later refresh flips isLoadingFolders too,
+  // and in a space with no folders yet that matched the skeleton's own condition, tearing the whole
+  // panel down and remounting it on every file delete, restore or move.
+  const hasLoadedFolders = ref(false)
   const isLoadingTags = ref(false)
   const isLoadingQuota = ref(false)
   const isLoadingActiveFile = ref(false)
@@ -191,6 +197,9 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     } finally {
       if (requestId === foldersRequestId) {
         isLoadingFolders.value = false
+        // Set even when the request failed: a tree that could not be loaded is not a reason to leave the
+        // panel behind a skeleton for good.
+        hasLoadedFolders.value = true
       }
     }
   }
@@ -328,8 +337,17 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
       return
     }
 
+    // folder_path as well as folder_id: the row's location label and the link under it read the path, so
+    // patching only the id left the row naming the folder the file had just left. Read off the tree in
+    // hand, which a file move does not change.
     files.value = files.value.map((f) =>
-      f.id === fileId ? { ...f, folder_id: targetFolderId } : f
+      f.id === fileId
+        ? {
+            ...f,
+            folder_id: targetFolderId,
+            folder_path: folderPathOf(folders.value, targetFolderId)
+          }
+        : f
     )
   }
 
@@ -470,15 +488,14 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
    * One file. A batch calls this once per file, so each one lands in the list as it arrives and an
    * interrupted batch leaves behind exactly what the server actually took.
    *
-   * A file sent to another folder than the one on screen is not added to it: the dialog lets the
-   * member change the destination, and a row for a file that lives elsewhere would only survive until
-   * the next fetch took it away again.
+   * The row only joins a listing that would hold it. The dialog lets the member change the destination,
+   * and a search or a filter can narrow the listing past any one place, so a row prepended anyway would
+   * survive exactly until the next fetch and count for one file too many meanwhile.
    */
   async function uploadFile(bandSpaceId, payload, onProgress, signal) {
     const result = await bandSpaceFilesApi.uploadFile(bandSpaceId, payload, onProgress, signal)
-    const listedFolder = listedFolderOfRows(activeFolderId.value, filters)
 
-    if (listedFolder === NO_FOLDER_LISTED || listedFolder === (result.file.folder_id ?? null)) {
+    if (uploadBelongsInListing(activeFolderId.value, filters, result.file.folder_id)) {
       files.value = [result.file, ...files.value]
       totalFiles.value = totalFiles.value + 1
     }
@@ -512,6 +529,7 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     files.value = []
     totalFiles.value = 0
     loadedQueryKey.value = null
+    hasLoadedFolders.value = false
     isRefreshingFiles.value = false
     isLoadingMoreFiles.value = false
     folders.value = []
@@ -554,6 +572,7 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     isRefreshingFiles: readonly(isRefreshingFiles),
     isLoadingMoreFiles: readonly(isLoadingMoreFiles),
     isLoadingFolders: readonly(isLoadingFolders),
+    hasLoadedFolders: readonly(hasLoadedFolders),
     isLoadingTags: readonly(isLoadingTags),
     isLoadingQuota: readonly(isLoadingQuota),
     loadError: readonly(loadError),

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -276,6 +276,10 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
       if (activeFileFull.value && activeFileFull.value.id === fileId) {
         activeFileFull.value = updated
       }
+      // Only a folder change moves a file between two counts; a rename or a tag edit leaves them alone.
+      if ('folder_id' in data) {
+        fetchFolders(bandSpaceId)
+      }
       return updated
     } finally {
       isSavingFile.value = false
@@ -290,9 +294,14 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
    * A listing showing one place, the root included, has to drop the row when the file landed somewhere
    * else. The flat listing and the virtual source folders hold files whatever folder they sit in, so
    * there the row only has its folder patched.
+   *
+   * The tree is refetched because a move changes two folder counts, and a count that lags behind the
+   * row the member just dragged reads as a bug.
    */
-  function applyFileMoved(fileId, targetFolderId) {
+  function applyFileMoved(bandSpaceId, fileId, targetFolderId) {
     const listedFolder = listedFolderOfRows(activeFolderId.value, filters)
+
+    fetchFolders(bandSpaceId)
 
     if (listedFolder !== NO_FOLDER_LISTED && listedFolder !== targetFolderId) {
       files.value = files.value.filter((f) => f.id !== fileId)
@@ -316,8 +325,10 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   async function restoreFile(bandSpaceId, fileId) {
     await bandSpaceFilesApi.restoreFile(bandSpaceId, fileId)
     removeFromTrash(fileId)
-    // Restoring puts the file's bytes back into the quota, so the indicator has to catch up.
+    // Restoring puts the file's bytes back into the quota and the file back into its folder, so the
+    // indicator and the folder counts both have to catch up.
     fetchQuota(bandSpaceId)
+    fetchFolders(bandSpaceId)
   }
 
   async function permanentDeleteFile(bandSpaceId, fileId) {
@@ -348,6 +359,8 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
         activeFileFull.value = null
       }
       fetchQuota(bandSpaceId)
+      // Out of its folder, so that folder's count is one lower.
+      fetchFolders(bandSpaceId)
     } finally {
       isDeletingFile.value = false
     }

--- a/assets/js/utils/fileListing.js
+++ b/assets/js/utils/fileListing.js
@@ -1,7 +1,11 @@
+import { fileSourceLabel } from '../constants/fileSources.js'
 import {
+  isVirtualFolderId,
   listedFolderId,
   NO_FOLDER_LISTED,
+  ROOT_FOLDER_ID,
   TRASH_FOLDER_ID,
+  virtualFolderId,
   virtualFolderSource
 } from '../constants/folderSelection.js'
 import { FILES_PAGE_SIZE } from './filePagination.js'
@@ -113,4 +117,84 @@ export function treeHoldsFolder(tree, folderId) {
   if (!Array.isArray(tree) || folderId === null) return false
 
   return tree.some((node) => node.id === folderId || treeHoldsFolder(node.children ?? [], folderId))
+}
+
+/**
+ * The path down to a folder, root first, in the shape the API spells `folder_path`.
+ *
+ * Read off the tree already in the store, so a row's path can be corrected after a move without asking
+ * the server for it again. Empty for the root and for a folder the tree does not hold.
+ *
+ * @param {Array} tree
+ * @param {string|null} folderId
+ * @returns {Array<{id: string, name: string}>}
+ */
+export function folderPathOf(tree, folderId) {
+  if (!Array.isArray(tree) || folderId === null || folderId === undefined) return []
+
+  for (const node of tree) {
+    if (node.id === folderId) return [{ id: node.id, name: node.name }]
+
+    const below = folderPathOf(node.children ?? [], folderId)
+    if (below.length > 0) return [{ id: node.id, name: node.name }, ...below]
+  }
+
+  return []
+}
+
+/**
+ * Where a file row says it lives, and where clicking that says takes the member.
+ *
+ * A file in a folder names its path. A file in no folder is only at the root if nothing is attached to
+ * it: the root excludes attachments, so sending an attached file's reader there would land them in a
+ * listing the file is missing from. Its place is the virtual folder grouping its source, named the way
+ * the sidebar names it, falling back to the source's own label before the tree has loaded.
+ *
+ * @param {object} file
+ * @param {Array<{source: string, name: string}>} virtualFolders
+ * @returns {{label: string, folderId: string}}
+ */
+export function fileLocation(file, virtualFolders = []) {
+  const path = file.folder_path ?? []
+  if (path.length > 0) {
+    return {
+      label: path.map((segment) => segment.name).join(' / '),
+      folderId: path[path.length - 1].id
+    }
+  }
+
+  const sourceType = (file.attachments ?? [])[0]?.source_type ?? null
+  if (sourceType !== null) {
+    const virtual = virtualFolders.find((folder) => folder.source === sourceType)
+
+    return {
+      label: virtual?.name ?? fileSourceLabel(sourceType),
+      folderId: virtualFolderId(sourceType)
+    }
+  }
+
+  return { label: 'Racine', folderId: ROOT_FOLDER_ID }
+}
+
+/**
+ * Whether a file that has just been uploaded belongs in the listing on screen, so its row can be shown
+ * straight away instead of waiting for a refetch.
+ *
+ * It has to be the same place, and the listing has to be a place: a virtual folder holds attachments,
+ * which an upload is not. Anything narrowing the listing further, a search, a tag, a type, makes this
+ * undecidable here, because only the server knows what its own query matches, and a row that does not
+ * match is a row the next fetch takes away again.
+ *
+ * @param {string|null} activeFolderId
+ * @param {{query: string, tagId: ?string, mime: ?string}} filters
+ * @param {string|null} uploadedFolderId
+ * @returns {boolean}
+ */
+export function uploadBelongsInListing(activeFolderId, filters, uploadedFolderId) {
+  if (isSearchActive(filters) || filters.tagId || filters.mime) return false
+  // No selection at all is the flat listing of the whole space, which holds every file in it.
+  if (activeFolderId === null) return true
+  if (isVirtualFolderId(activeFolderId) || activeFolderId === TRASH_FOLDER_ID) return false
+
+  return listedFolderId(activeFolderId) === (uploadedFolderId ?? null)
 }

--- a/assets/js/utils/fileListing.js
+++ b/assets/js/utils/fileListing.js
@@ -1,0 +1,84 @@
+import {
+  listedFolderId,
+  NO_FOLDER_LISTED,
+  TRASH_FOLDER_ID,
+  virtualFolderSource
+} from '../constants/folderSelection.js'
+import { FILES_PAGE_SIZE } from './filePagination.js'
+
+/**
+ * What the Files panel asks the collection for, and what the rows it gets back have in common.
+ *
+ * Extracted from the store because the scoping rules are the interesting part: which of the sidebar
+ * selection and the filter bar wins, and when a listing stops being one place in the tree.
+ */
+
+/**
+ * A search is running, so the listing is a result set rather than a place.
+ *
+ * @param {{query: string}} filters
+ * @returns {boolean}
+ */
+export function isSearchActive(filters) {
+  return filters.query.trim() !== ''
+}
+
+/**
+ * The folder every row on screen belongs to: null at the root, the id inside a folder, and
+ * NO_FOLDER_LISTED when a row can have come from anywhere.
+ *
+ * A search is the third case whatever the sidebar has selected, because it covers the whole space: the
+ * member who does not remember where they filed something is looking for it everywhere, so the listing
+ * stops being the folder they happen to be standing in.
+ *
+ * @param {string|null} activeFolderId
+ * @param {{query: string}} filters
+ * @returns {string|null|symbol}
+ */
+export function listedFolderOfRows(activeFolderId, filters) {
+  return isSearchActive(filters) ? NO_FOLDER_LISTED : listedFolderId(activeFolderId)
+}
+
+/**
+ * The query string parameters for one page of the file collection.
+ *
+ * @param {string|null} activeFolderId
+ * @param {{query: string, mime: ?string, tagId: ?string, source: ?string, sort: string, order: string}} filters
+ * @param {number} page
+ * @returns {object}
+ */
+export function fileListingParams(activeFolderId, filters, page) {
+  // The trash ignores every filter, before they are even read. Its filter bar is hidden, so a search
+  // or tag left over from browsing a folder would silently narrow the trash with no visible control to
+  // clear it, and someone hunting for the file they just deleted would find it apparently missing.
+  // It pages exactly like the live listing does: without that, a trashed file past the fiftieth is
+  // unrestorable and app:band-space:purge eventually destroys it.
+  if (activeFolderId === TRASH_FOLDER_ID) {
+    return { archived: true, page, itemsPerPage: FILES_PAGE_SIZE }
+  }
+
+  const params = { page, itemsPerPage: FILES_PAGE_SIZE }
+  const trimmed = filters.query.trim()
+  if (trimmed) params.query = trimmed
+  if (filters.mime) params.mime = filters.mime
+  if (filters.tagId) params.tagId = filters.tagId
+  if (filters.sort) params.sort = filters.sort
+  if (filters.order) params.order = filters.order
+
+  const virtualSource = virtualFolderSource(activeFolderId)
+  if (virtualSource !== null) {
+    // A virtual folder keeps its source even while searching: there the member is looking through one
+    // set of attachments rather than through the folder tree, so the source is the subject of the
+    // search and not a place to escape from.
+    params.source = virtualSource
+  } else if (activeFolderId && !isSearchActive(filters)) {
+    // ROOT_FOLDER_ID rides along as a folder id, since the collection reads that reserved value as the
+    // root of the tree. No folder_id at all is the whole space, which is what a search wants and what
+    // « Tous les fichiers » selects.
+    params.folderId = activeFolderId
+  } else if (filters.source) {
+    params.source = filters.source
+  }
+
+  return params
+}

--- a/assets/js/utils/fileListing.js
+++ b/assets/js/utils/fileListing.js
@@ -96,3 +96,21 @@ export function folderFileCountLabel(fileCount) {
 
   return fileCount > 1 ? `${fileCount} fichiers` : `${fileCount} fichier`
 }
+
+/**
+ * Whether a folder is still somewhere in the tree.
+ *
+ * Asked after a folder was deleted, because a delete takes a whole subtree with it depending on the
+ * strategy: the panel can be standing inside a folder that no longer exists without being inside the
+ * one that was deleted. Reading it back off the refreshed tree answers that without the client having
+ * to reimplement which strategy removes what.
+ *
+ * @param {Array} tree nested folders, each with an optional `children`
+ * @param {string|null} folderId
+ * @returns {boolean}
+ */
+export function treeHoldsFolder(tree, folderId) {
+  if (!Array.isArray(tree) || folderId === null) return false
+
+  return tree.some((node) => node.id === folderId || treeHoldsFolder(node.children ?? [], folderId))
+}

--- a/assets/js/utils/fileListing.js
+++ b/assets/js/utils/fileListing.js
@@ -82,3 +82,17 @@ export function fileListingParams(activeFolderId, filters, page) {
 
   return params
 }
+
+/**
+ * How many files a folder row holds, or null when it holds none: an empty folder says nothing rather
+ * than « 0 fichier », because the count leaves out its subfolders and a zero would read as « rien
+ * là-dedans » on a folder whose subfolders are full.
+ *
+ * @param {number|null|undefined} fileCount
+ * @returns {string|null}
+ */
+export function folderFileCountLabel(fileCount) {
+  if (!fileCount || fileCount < 1) return null
+
+  return fileCount > 1 ? `${fileCount} fichiers` : `${fileCount} fichier`
+}

--- a/assets/js/utils/fileListing.test.js
+++ b/assets/js/utils/fileListing.test.js
@@ -3,10 +3,13 @@ import { describe, it } from 'node:test'
 import { NO_FOLDER_LISTED, ROOT_FOLDER_ID, TRASH_FOLDER_ID } from '../constants/folderSelection.js'
 import {
   fileListingParams,
+  fileLocation,
   folderFileCountLabel,
+  folderPathOf,
   isSearchActive,
   listedFolderOfRows,
-  treeHoldsFolder
+  treeHoldsFolder,
+  uploadBelongsInListing
 } from './fileListing.js'
 
 /**
@@ -147,5 +150,101 @@ describe('treeHoldsFolder', () => {
   it('is false for the root and for anything that is not a folder id', () => {
     assert.equal(treeHoldsFolder(tree, null), false)
     assert.equal(treeHoldsFolder(undefined, 'live'), false)
+  })
+})
+
+describe('folderPathOf', () => {
+  const tree = [
+    {
+      id: 'live',
+      name: 'Live',
+      children: [
+        { id: '2026', name: '2026', children: [{ id: 'paris', name: 'paris', children: [] }] }
+      ]
+    },
+    { id: 'riders', name: 'Riders', children: [] }
+  ]
+
+  it('names every folder down to the one asked for', () => {
+    assert.deepEqual(folderPathOf(tree, 'paris'), [
+      { id: 'live', name: 'Live' },
+      { id: '2026', name: '2026' },
+      { id: 'paris', name: 'paris' }
+    ])
+  })
+
+  it('is one segment for a folder at the top', () => {
+    assert.deepEqual(folderPathOf(tree, 'riders'), [{ id: 'riders', name: 'Riders' }])
+  })
+
+  it('is empty for the root and for a folder the tree does not hold', () => {
+    assert.deepEqual(folderPathOf(tree, null), [])
+    assert.deepEqual(folderPathOf(tree, 'deleted'), [])
+  })
+})
+
+describe('fileLocation', () => {
+  const virtualFolders = [
+    { id: 'virtual:note', source: 'note', name: 'Notes' },
+    { id: 'virtual:task', source: 'task', name: 'Tâches' }
+  ]
+
+  it('names the folder path and points at the folder holding the file', () => {
+    const file = {
+      folder_path: [
+        { id: 'live', name: 'Live' },
+        { id: '2026', name: '2026' }
+      ]
+    }
+    assert.deepEqual(fileLocation(file, virtualFolders), { label: 'Live / 2026', folderId: '2026' })
+  })
+
+  it('sends an unfiled attachment to its virtual folder, not to the root that excludes it', () => {
+    const file = { folder_path: [], attachments: [{ source_type: 'note', source_id: 'n1' }] }
+    assert.deepEqual(fileLocation(file, virtualFolders), {
+      label: 'Notes',
+      folderId: 'virtual:note'
+    })
+  })
+
+  it('falls back to the source label when the tree has not loaded yet', () => {
+    const file = { attachments: [{ source_type: 'note' }] }
+    assert.equal(fileLocation(file, []).label, 'Note')
+  })
+
+  it('is the root only for a file that is in no folder and attached to nothing', () => {
+    assert.deepEqual(fileLocation({ folder_path: [], attachments: [] }, virtualFolders), {
+      label: 'Racine',
+      folderId: 'root'
+    })
+  })
+})
+
+describe('uploadBelongsInListing', () => {
+  const FOLDER = '0198c0de-dead-beef-cafe-000000000001'
+
+  it('holds a file uploaded into the folder on screen', () => {
+    assert.equal(uploadBelongsInListing(FOLDER, filters(), FOLDER), true)
+    assert.equal(uploadBelongsInListing(ROOT_FOLDER_ID, filters(), null), true)
+  })
+
+  it('does not hold a file uploaded somewhere else', () => {
+    assert.equal(uploadBelongsInListing(ROOT_FOLDER_ID, filters(), FOLDER), false)
+    assert.equal(uploadBelongsInListing(FOLDER, filters(), null), false)
+  })
+
+  it('holds anything in the flat listing of the whole space', () => {
+    assert.equal(uploadBelongsInListing(null, filters(), FOLDER), true)
+  })
+
+  it('holds nothing while the listing is narrowed past a place', () => {
+    assert.equal(uploadBelongsInListing(FOLDER, filters({ query: 'contrat' }), FOLDER), false)
+    assert.equal(uploadBelongsInListing(FOLDER, filters({ tagId: 'tag-1' }), FOLDER), false)
+    assert.equal(uploadBelongsInListing(FOLDER, filters({ mime: 'audio/' }), FOLDER), false)
+  })
+
+  it('holds nothing in a virtual folder, which lists attachments rather than uploads', () => {
+    assert.equal(uploadBelongsInListing('virtual:note', filters(), null), false)
+    assert.equal(uploadBelongsInListing(TRASH_FOLDER_ID, filters(), null), false)
   })
 })

--- a/assets/js/utils/fileListing.test.js
+++ b/assets/js/utils/fileListing.test.js
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { NO_FOLDER_LISTED, ROOT_FOLDER_ID, TRASH_FOLDER_ID } from '../constants/folderSelection.js'
-import { fileListingParams, isSearchActive, listedFolderOfRows } from './fileListing.js'
+import {
+  fileListingParams,
+  folderFileCountLabel,
+  isSearchActive,
+  listedFolderOfRows
+} from './fileListing.js'
 
 /**
  * The panel opens on the root, so every listing is now scoped to one place unless something says
@@ -104,5 +109,18 @@ describe('fileListingParams', () => {
       3
     )
     assert.deepEqual(params, { archived: true, page: 3, itemsPerPage: 50 })
+  })
+})
+
+describe('folderFileCountLabel', () => {
+  it('counts in French, singular and plural', () => {
+    assert.equal(folderFileCountLabel(1), '1 fichier')
+    assert.equal(folderFileCountLabel(12), '12 fichiers')
+  })
+
+  it('says nothing for a folder with no file of its own', () => {
+    assert.equal(folderFileCountLabel(0), null)
+    assert.equal(folderFileCountLabel(undefined), null)
+    assert.equal(folderFileCountLabel(null), null)
   })
 })

--- a/assets/js/utils/fileListing.test.js
+++ b/assets/js/utils/fileListing.test.js
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { NO_FOLDER_LISTED, ROOT_FOLDER_ID, TRASH_FOLDER_ID } from '../constants/folderSelection.js'
+import { fileListingParams, isSearchActive, listedFolderOfRows } from './fileListing.js'
+
+/**
+ * The panel opens on the root, so every listing is now scoped to one place unless something says
+ * otherwise, and a search is that something: it has to escape the folder on screen, or a member
+ * searching from inside a folder would be told a file they can see in « Tous les fichiers » does not
+ * exist. What follows pins the scope rules, which is the half of this a browser check reads worst.
+ *
+ * Run with `npm test`.
+ */
+
+const FOLDER_ID = '0198c0de-dead-beef-cafe-000000000001'
+
+const filters = (overrides = {}) => ({
+  query: '',
+  mime: null,
+  tagId: null,
+  source: null,
+  sort: 'date',
+  order: 'desc',
+  ...overrides
+})
+
+describe('isSearchActive', () => {
+  it('is false for an empty box and for whitespace only', () => {
+    assert.equal(isSearchActive(filters()), false)
+    assert.equal(isSearchActive(filters({ query: '   ' })), false)
+  })
+
+  it('is true once something has been typed', () => {
+    assert.equal(isSearchActive(filters({ query: 'contrat' })), true)
+  })
+})
+
+describe('listedFolderOfRows', () => {
+  it('is the selected place while no search is running', () => {
+    assert.equal(listedFolderOfRows(ROOT_FOLDER_ID, filters()), null)
+    assert.equal(listedFolderOfRows(FOLDER_ID, filters()), FOLDER_ID)
+  })
+
+  it('is nowhere in particular for the flat listing, a virtual folder and the trash', () => {
+    assert.equal(listedFolderOfRows(null, filters()), NO_FOLDER_LISTED)
+    assert.equal(listedFolderOfRows('virtual:note', filters()), NO_FOLDER_LISTED)
+    assert.equal(listedFolderOfRows(TRASH_FOLDER_ID, filters()), NO_FOLDER_LISTED)
+  })
+
+  it('is nowhere in particular during a search, whatever the sidebar has selected', () => {
+    const searching = filters({ query: 'contrat' })
+    assert.equal(listedFolderOfRows(ROOT_FOLDER_ID, searching), NO_FOLDER_LISTED)
+    assert.equal(listedFolderOfRows(FOLDER_ID, searching), NO_FOLDER_LISTED)
+  })
+})
+
+describe('fileListingParams', () => {
+  it('asks the collection for the root of the tree by its reserved value', () => {
+    assert.deepEqual(fileListingParams(ROOT_FOLDER_ID, filters(), 1), {
+      page: 1,
+      itemsPerPage: 50,
+      sort: 'date',
+      order: 'desc',
+      folderId: 'root'
+    })
+  })
+
+  it('sends no folder at all for the flat listing of the whole space', () => {
+    const params = fileListingParams(null, filters(), 2)
+    assert.equal('folderId' in params, false)
+    assert.equal(params.page, 2)
+  })
+
+  it('drops the folder scope while searching, so the search covers the whole space', () => {
+    const params = fileListingParams(FOLDER_ID, filters({ query: ' contrat ' }), 1)
+    assert.equal('folderId' in params, false)
+    assert.equal(params.query, 'contrat')
+  })
+
+  it('keeps a virtual folder scoped to its source while searching', () => {
+    const params = fileListingParams('virtual:setlist', filters({ query: 'plan' }), 1)
+    assert.equal(params.source, 'setlist')
+    assert.equal('folderId' in params, false)
+    assert.equal(params.query, 'plan')
+  })
+
+  it('turns each virtual folder into its source filter', () => {
+    for (const source of ['task', 'finance', 'note', 'song', 'setlist']) {
+      assert.equal(fileListingParams(`virtual:${source}`, filters(), 1).source, source)
+    }
+  })
+
+  it('carries the tag and type filters alongside the folder', () => {
+    const params = fileListingParams(FOLDER_ID, filters({ tagId: 'tag-1', mime: 'audio/' }), 1)
+    assert.equal(params.folderId, FOLDER_ID)
+    assert.equal(params.tagId, 'tag-1')
+    assert.equal(params.mime, 'audio/')
+  })
+
+  it('ignores every filter in the trash, which has no filter bar to clear them from', () => {
+    const params = fileListingParams(
+      TRASH_FOLDER_ID,
+      filters({ query: 'contrat', tagId: 'tag-1', mime: 'audio/' }),
+      3
+    )
+    assert.deepEqual(params, { archived: true, page: 3, itemsPerPage: 50 })
+  })
+})

--- a/assets/js/utils/fileListing.test.js
+++ b/assets/js/utils/fileListing.test.js
@@ -5,7 +5,8 @@ import {
   fileListingParams,
   folderFileCountLabel,
   isSearchActive,
-  listedFolderOfRows
+  listedFolderOfRows,
+  treeHoldsFolder
 } from './fileListing.js'
 
 /**
@@ -122,5 +123,29 @@ describe('folderFileCountLabel', () => {
     assert.equal(folderFileCountLabel(0), null)
     assert.equal(folderFileCountLabel(undefined), null)
     assert.equal(folderFileCountLabel(null), null)
+  })
+})
+
+describe('treeHoldsFolder', () => {
+  const tree = [
+    { id: 'live', children: [{ id: '2026', children: [{ id: 'paris', children: [] }] }] },
+    { id: 'riders', children: [] }
+  ]
+
+  it('finds a folder at any depth', () => {
+    assert.equal(treeHoldsFolder(tree, 'live'), true)
+    assert.equal(treeHoldsFolder(tree, '2026'), true)
+    assert.equal(treeHoldsFolder(tree, 'paris'), true)
+    assert.equal(treeHoldsFolder(tree, 'riders'), true)
+  })
+
+  it('does not find a folder the tree no longer holds', () => {
+    assert.equal(treeHoldsFolder(tree, 'deleted'), false)
+    assert.equal(treeHoldsFolder([], 'live'), false)
+  })
+
+  it('is false for the root and for anything that is not a folder id', () => {
+    assert.equal(treeHoldsFolder(tree, null), false)
+    assert.equal(treeHoldsFolder(undefined, 'live'), false)
   })
 })

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -141,7 +141,7 @@
                page identically, and the trash needs it most, since a file it cannot reach is a file
                app:band-space:purge eventually destroys. -->
           <div
-            v-if="filesStore.totalFiles > 0"
+            v-if="filesStore.totalFiles > 0 || isSpaceWideSearch"
             class="flex items-center justify-between gap-3 pb-3 mb-1 border-b border-surface-100 dark:border-surface-800"
           >
             <p
@@ -150,13 +150,24 @@
             >
               {{ filesStore.filesCountLabel }}
             </p>
-            <span
-              v-if="filesStore.isRefreshingFiles"
-              class="flex items-center gap-2 text-xs text-surface-600 dark:text-surface-300"
-            >
-              <i class="pi pi-spin pi-spinner" aria-hidden="true"></i>
-              Actualisation…
-            </span>
+            <div class="flex items-center gap-3">
+              <!-- Said out loud because the breadcrumb still names the folder the member came from, and
+                   the results deliberately come from outside it. -->
+              <span
+                v-if="isSpaceWideSearch"
+                class="flex items-center gap-2 text-xs text-surface-500 dark:text-surface-400"
+              >
+                <i class="pi pi-search" aria-hidden="true"></i>
+                Recherche dans tout l'espace
+              </span>
+              <span
+                v-if="filesStore.isRefreshingFiles"
+                class="flex items-center gap-2 text-xs text-surface-600 dark:text-surface-300"
+              >
+                <i class="pi pi-spin pi-spinner" aria-hidden="true"></i>
+                Actualisation…
+              </span>
+            </div>
           </div>
 
           <div
@@ -178,11 +189,13 @@
               :files="filesStore.files"
               :is-loading="filesStore.isLoadingFiles"
               :empty-message="emptyMessage"
+              :show-location="showFileLocation"
               @select="handleFileSelect"
               @open-rename="handleOpenRename"
               @open-share="handleOpenShare"
               @open-versions="handleOpenVersions"
               @open-move="handleOpenMove"
+              @open-location="handleOpenLocation"
             />
           </div>
 
@@ -276,9 +289,11 @@ import {
   isVirtualFolderId,
   listedFolderId,
   NO_FOLDER_LISTED,
+  ROOT_FOLDER_ID,
   TRASH_FOLDER_ID
 } from '../../constants/folderSelection.js'
 import { useBandFilesStore } from '../../store/bandSpace/bandSpaceFiles.js'
+import { listedFolderOfRows } from '../../utils/fileListing.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -319,6 +334,18 @@ const isTrashActive = computed(() => filesStore.activeFolderId === TRASH_FOLDER_
 const isAllFilesActive = computed(() => filesStore.activeFolderId === null)
 
 /**
+ * The place the rows on screen belong to, which is the selected one until a search widens the listing
+ * past it. Kept apart from listedFolder: what the panel *is inside* still drives the breadcrumb and
+ * what a new folder or an upload targets, even while the results come from elsewhere.
+ */
+const rowsFolder = computed(() => listedFolderOfRows(filesStore.activeFolderId, filesStore.filters))
+
+/** A row can have come from any folder, so it has to say which one. */
+const showFileLocation = computed(() => rowsFolder.value === NO_FOLDER_LISTED)
+
+const isSpaceWideSearch = computed(() => filesStore.isSearching && isInTree.value)
+
+/**
  * The folder the panel is actually inside, or null at the root. Neither the root nor the selections that
  * are not folders at all can reach the API as a parent_id, so a folder created from any of them belongs
  * at the root.
@@ -327,11 +354,11 @@ const activeRealFolderId = computed(() => (isInTree.value ? listedFolder.value :
 
 /**
  * The subfolders shown inline above the files. Derived from the tree already in the store, so descending
- * costs no request. Only a place in the tree has any: the flat listing holds files from every folder, so
- * folder rows there would say nothing about where its files are.
+ * costs no request. Only a listing that is one place has any: a flat listing and a set of search results
+ * hold files from every folder, so folder rows there would say nothing about where those files are.
  */
 const inlineFolders = computed(() =>
-  isInTree.value ? directChildren(filesStore.folders, listedFolder.value) : []
+  rowsFolder.value === NO_FOLDER_LISTED ? [] : directChildren(filesStore.folders, rowsFolder.value)
 )
 
 const isVirtualFolderActive = computed(() => isVirtualFolderId(filesStore.activeFolderId))
@@ -351,6 +378,14 @@ const emptyMessage = computed(() => {
   }
   if (filesStore.activeFolderId === 'virtual:setlist') {
     return 'Aucun fichier attaché à une setlist pour le moment.'
+  }
+  // A listing narrowed by the filter bar is empty because of what was asked for, not because the place
+  // is empty, and telling the member to import a file is no answer to a search that found nothing.
+  if (filesStore.isSearching) {
+    return 'Aucun fichier ne correspond à cette recherche.'
+  }
+  if (filesStore.filters.tagId || filesStore.filters.mime) {
+    return 'Aucun fichier ne correspond à ces filtres.'
   }
   if (listedFolder.value === null) {
     return 'Aucun fichier à la racine, commencez par en importer un.'
@@ -423,6 +458,17 @@ function handleOpenRename(file) {
   if (!file) return
   autoStartRename.value = true
   router.push({ query: { ...route.query, file: file.id } })
+}
+
+/**
+ * Go to the folder a search result lives in. The search is dropped on the way, since it is what widened
+ * the listing past any one folder: keeping it would answer the click with the same space-wide results.
+ */
+function handleOpenLocation(file) {
+  const path = file.folder_path ?? []
+  if (queryDebounce) clearTimeout(queryDebounce)
+  filesStore.setFilter('query', '')
+  handleFolderSelect(path.length > 0 ? path[path.length - 1].id : ROOT_FOLDER_ID)
 }
 
 function handleOpenMove(file) {

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="filesStore.isLoadingFolders && filesStore.folders.length === 0" class="flex gap-4">
+    <div v-if="filesStore.isLoadingFolders && !filesStore.hasLoadedFolders" class="flex gap-4">
       <div class="w-64 flex flex-col gap-2">
         <Skeleton v-for="i in 5" :key="i" width="100%" height="2rem" borderRadius="0.375rem" />
       </div>
@@ -289,8 +289,8 @@ import {
   isVirtualFolderId,
   listedFolderId,
   NO_FOLDER_LISTED,
-  ROOT_FOLDER_ID,
-  TRASH_FOLDER_ID
+  TRASH_FOLDER_ID,
+  virtualFolderSource
 } from '../../constants/folderSelection.js'
 import { useBandFilesStore } from '../../store/bandSpace/bandSpaceFiles.js'
 import { listedFolderOfRows } from '../../utils/fileListing.js'
@@ -363,29 +363,30 @@ const inlineFolders = computed(() =>
 
 const isVirtualFolderActive = computed(() => isVirtualFolderId(filesStore.activeFolderId))
 
+/** A virtual folder is filled by attachments, so an empty one is phrased per source. */
+const VIRTUAL_EMPTY_MESSAGES = {
+  task: 'Aucun fichier attaché à une tâche pour le moment.',
+  finance: 'Aucun fichier attaché à une entrée financière pour le moment.',
+  note: 'Aucune image attachée à une note pour le moment.',
+  song: 'Aucun fichier attaché à une chanson pour le moment.',
+  setlist: 'Aucun fichier attaché à une setlist pour le moment.'
+}
+
 const emptyMessage = computed(() => {
-  if (filesStore.activeFolderId === 'virtual:task') {
-    return 'Aucun fichier attaché à une tâche pour le moment.'
-  }
-  if (filesStore.activeFolderId === 'virtual:finance') {
-    return 'Aucun fichier attaché à une entrée financière pour le moment.'
-  }
-  if (filesStore.activeFolderId === 'virtual:note') {
-    return 'Aucune image attachée à une note pour le moment.'
-  }
-  if (filesStore.activeFolderId === 'virtual:song') {
-    return 'Aucun fichier attaché à une chanson pour le moment.'
-  }
-  if (filesStore.activeFolderId === 'virtual:setlist') {
-    return 'Aucun fichier attaché à une setlist pour le moment.'
-  }
-  // A listing narrowed by the filter bar is empty because of what was asked for, not because the place
-  // is empty, and telling the member to import a file is no answer to a search that found nothing.
+  // The filter bar answers first, wherever it was used. A listing narrowed by a search or a filter is
+  // empty because of what was asked for, and saying « rien pour le moment » about a virtual folder whose
+  // sidebar badge reads seven contradicts the badge. Telling the member to import a file is no answer to
+  // a search that found nothing either.
   if (filesStore.isSearching) {
     return 'Aucun fichier ne correspond à cette recherche.'
   }
   if (filesStore.filters.tagId || filesStore.filters.mime) {
     return 'Aucun fichier ne correspond à ces filtres.'
+  }
+
+  const virtualSource = virtualFolderSource(filesStore.activeFolderId)
+  if (virtualSource !== null) {
+    return VIRTUAL_EMPTY_MESSAGES[virtualSource] ?? 'Aucun fichier attaché pour le moment.'
   }
   if (listedFolder.value === null) {
     return 'Aucun fichier à la racine, commencez par en importer un.'
@@ -461,14 +462,16 @@ function handleOpenRename(file) {
 }
 
 /**
- * Go to the folder a search result lives in. The search is dropped on the way, since it is what widened
- * the listing past any one folder: keeping it would answer the click with the same space-wide results.
+ * Go where a row said it lives. The row works that out, because for a file in no folder the answer is
+ * not always a folder of the tree: an attachment lives in its virtual folder, which the root excludes.
+ *
+ * The search is dropped on the way, since it is what widened the listing past any one place: keeping it
+ * would answer the click with the same space-wide results.
  */
-function handleOpenLocation(file) {
-  const path = file.folder_path ?? []
+function handleOpenLocation(folderId) {
   if (queryDebounce) clearTimeout(queryDebounce)
   filesStore.setFilter('query', '')
-  handleFolderSelect(path.length > 0 ? path[path.length - 1].id : ROOT_FOLDER_ID)
+  handleFolderSelect(folderId)
 }
 
 function handleOpenMove(file) {

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -42,7 +42,27 @@
           Aucun dossier pour l'instant.
         </p>
 
-        <div class="mt-3 pt-3 border-t border-surface-200 dark:border-surface-700">
+        <!-- Under the tree rather than in it: neither is a folder. One is every file in the space
+             whatever folder it sits in, the other is what has been deleted. -->
+        <div
+          class="mt-3 pt-3 border-t border-surface-200 dark:border-surface-700 flex flex-col gap-1"
+        >
+          <button
+            type="button"
+            class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left transition-colors duration-150"
+            :class="
+              isAllFilesActive
+                ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-200 font-medium'
+                : 'text-surface-700 dark:text-surface-200 hover:bg-surface-100 dark:hover:bg-surface-800'
+            "
+            :aria-current="isAllFilesActive ? 'true' : null"
+            v-tooltip.top="'Tous les fichiers du space, quel que soit leur dossier'"
+            @click="handleFolderSelect(null)"
+          >
+            <i class="pi pi-list" aria-hidden="true"></i>
+            <span class="flex-1 truncate">Tous les fichiers</span>
+          </button>
+
           <button
             type="button"
             class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left transition-colors duration-150"
@@ -252,7 +272,13 @@ import FolderEditDialog from '../../components/BandSpace/Files/FolderEditDialog.
 import FolderTree from '../../components/BandSpace/Files/FolderTree.vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
 import { directChildren } from '../../composables/useFolderDragDrop.js'
-import { TRASH_FOLDER_ID, useBandFilesStore } from '../../store/bandSpace/bandSpaceFiles.js'
+import {
+  isVirtualFolderId,
+  listedFolderId,
+  NO_FOLDER_LISTED,
+  TRASH_FOLDER_ID
+} from '../../constants/folderSelection.js'
+import { useBandFilesStore } from '../../store/bandSpace/bandSpaceFiles.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -280,45 +306,35 @@ const autoStartRename = ref(false)
 
 const bandSpaceId = computed(() => route.params.id)
 
-const showBreadcrumb = computed(() => {
-  const id = filesStore.activeFolderId
-  if (id === null) return true
-  if (id === TRASH_FOLDER_ID) return false
-  return typeof id === 'string' && !id.startsWith('virtual:')
-})
+/** null at the root, the folder id inside a folder, NO_FOLDER_LISTED anywhere that is not a place. */
+const listedFolder = computed(() => listedFolderId(filesStore.activeFolderId))
+
+/** A place in the tree, so there is a path to show and subfolders to descend into. */
+const isInTree = computed(() => listedFolder.value !== NO_FOLDER_LISTED)
+
+const showBreadcrumb = computed(() => isInTree.value)
 
 const isTrashActive = computed(() => filesStore.activeFolderId === TRASH_FOLDER_ID)
 
-/**
- * The folder the panel is actually inside, or null at the root. Virtual sources and the trash are not
- * folders, so a new folder created from there belongs at the root rather than inside them, and their id
- * must never reach the API as a parent_id.
- */
-const activeRealFolderId = computed(() => {
-  if (isTrashActive.value || isVirtualFolderActive.value) {
-    return null
-  }
+const isAllFilesActive = computed(() => filesStore.activeFolderId === null)
 
-  return filesStore.activeFolderId
-})
+/**
+ * The folder the panel is actually inside, or null at the root. Neither the root nor the selections that
+ * are not folders at all can reach the API as a parent_id, so a folder created from any of them belongs
+ * at the root.
+ */
+const activeRealFolderId = computed(() => (isInTree.value ? listedFolder.value : null))
 
 /**
  * The subfolders shown inline above the files. Derived from the tree already in the store, so descending
- * costs no request. The guard cannot be folded into activeRealFolderId: that returns null for a virtual
- * source, and a null id means "the root" here, which would list every root folder inside it.
+ * costs no request. Only a place in the tree has any: the flat listing holds files from every folder, so
+ * folder rows there would say nothing about where its files are.
  */
-const inlineFolders = computed(() => {
-  if (isTrashActive.value || isVirtualFolderActive.value) {
-    return []
-  }
+const inlineFolders = computed(() =>
+  isInTree.value ? directChildren(filesStore.folders, listedFolder.value) : []
+)
 
-  return directChildren(filesStore.folders, filesStore.activeFolderId)
-})
-
-const isVirtualFolderActive = computed(() => {
-  const id = filesStore.activeFolderId
-  return typeof id === 'string' && id.startsWith('virtual:')
-})
+const isVirtualFolderActive = computed(() => isVirtualFolderId(filesStore.activeFolderId))
 
 const emptyMessage = computed(() => {
   if (filesStore.activeFolderId === 'virtual:task') {
@@ -336,7 +352,10 @@ const emptyMessage = computed(() => {
   if (filesStore.activeFolderId === 'virtual:setlist') {
     return 'Aucun fichier attaché à une setlist pour le moment.'
   }
-  if (filesStore.activeFolderId !== null) {
+  if (listedFolder.value === null) {
+    return 'Aucun fichier à la racine, commencez par en importer un.'
+  }
+  if (isInTree.value) {
     return 'Aucun fichier dans ce dossier — commencez par en importer un.'
   }
   return 'Aucun fichier — commencez par en importer un.'

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -391,9 +391,9 @@ const emptyMessage = computed(() => {
     return 'Aucun fichier à la racine, commencez par en importer un.'
   }
   if (isInTree.value) {
-    return 'Aucun fichier dans ce dossier — commencez par en importer un.'
+    return 'Aucun fichier dans ce dossier, commencez par en importer un.'
   }
-  return 'Aucun fichier — commencez par en importer un.'
+  return 'Aucun fichier, commencez par en importer un.'
 })
 
 let queryDebounce = null

--- a/src/ApiResource/BandSpace/File/BandSpaceFolderResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFolderResource.php
@@ -80,6 +80,12 @@ class BandSpaceFolderResource
     public int $depth = 0;
 
     /**
+     * Live files directly in this folder, which is exactly what opening it lists. Files in its
+     * subfolders belong to those subfolders and are counted there, not here.
+     */
+    public int $fileCount = 0;
+
+    /**
      * Inlined nested folder shapes. Same fields as the top-level resource —
      * typed as a generic array so API Platform serializes them as embedded
      * objects rather than IRI references.

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -236,6 +236,22 @@ class BandSpaceFileRepository extends ServiceEntityRepository
         return $path;
     }
 
+    /**
+     * A file nobody attached to anything: no row in band_space_file_attachment.
+     *
+     * Shared by the `source=manual` filter and by the root of the folder tree, so the two cannot drift
+     * apart. Takes an alias because the two callers can appear in the same query.
+     */
+    private static function standaloneExpression(string $alias): string
+    {
+        return sprintf(
+            'NOT EXISTS (SELECT 1 FROM App\\Entity\\BandSpace\\BandSpaceFileAttachment %s '
+            . 'WHERE %s.bandSpaceFile = bsf)',
+            $alias,
+            $alias,
+        );
+    }
+
     private function buildBandSpaceQuery(BandSpace $bandSpace, BandSpaceFileFilter $filter): QueryBuilder
     {
         $qb = $this->createQueryBuilder('bsf')
@@ -249,6 +265,11 @@ class BandSpaceFileRepository extends ServiceEntityRepository
         if ($filter->folderId !== null) {
             $qb->andWhere('bsf.folder = :folderId')
                 ->setParameter('folderId', $filter->folderId);
+        } elseif ($filter->rootOnly) {
+            // The root of the tree, not the whole space: see BandSpaceFileFilter::$rootOnly for why an
+            // attachment with no folder belongs to its virtual folder rather than here.
+            $qb->andWhere('bsf.folder IS NULL')
+                ->andWhere(self::standaloneExpression('attRoot'));
         }
 
         if ($filter->tagId !== null) {
@@ -258,11 +279,7 @@ class BandSpaceFileRepository extends ServiceEntityRepository
 
         if ($filter->source !== null) {
             if ($filter->source === 'manual') {
-                // Standalone files have no attachment row.
-                $qb->andWhere(
-                    'NOT EXISTS (SELECT 1 FROM App\\Entity\\BandSpace\\BandSpaceFileAttachment attMan '
-                    . 'WHERE attMan.bandSpaceFile = bsf)'
-                );
+                $qb->andWhere(self::standaloneExpression('attMan'));
             } else {
                 $qb->andWhere(
                     'EXISTS (SELECT 1 FROM App\\Entity\\BandSpace\\BandSpaceFileAttachment attSrc '

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -188,6 +188,36 @@ class BandSpaceFileRepository extends ServiceEntityRepository
     }
 
     /**
+     * Live files sitting directly in each folder of the space, so a folder row can say how many rows
+     * opening it shows. Subfolders are not rolled up: a recursive count would need the tree walked per
+     * folder, and a number that counts files the folder does not list is a number nobody can check.
+     *
+     * One grouped query for the whole space rather than one per folder, because the sidebar draws every
+     * folder at once. Folders with nothing in them are absent from the result rather than zero.
+     *
+     * @return array<string, int> folder id => active file count
+     */
+    public function countActiveByFolder(BandSpace $bandSpace): array
+    {
+        $rows = $this->createQueryBuilder('bsf')
+            ->select('IDENTITY(bsf.folder) AS folder_id', 'COUNT(bsf.id) AS file_count')
+            ->where('bsf.bandSpace = :bandSpace')
+            ->andWhere('bsf.folder IS NOT NULL')
+            ->andWhere('bsf.archiveDatetime IS NULL')
+            ->groupBy('bsf.folder')
+            ->setParameter('bandSpace', $bandSpace)
+            ->getQuery()
+            ->getArrayResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(string) $row['folder_id']] = (int) $row['file_count'];
+        }
+
+        return $counts;
+    }
+
+    /**
      * @param string[] $tagIds
      *
      * @return array<string, int> tag id => active file count

--- a/src/Repository/BandSpace/Filter/BandSpaceFileFilter.php
+++ b/src/Repository/BandSpace/Filter/BandSpaceFileFilter.php
@@ -24,6 +24,17 @@ final readonly class BandSpaceFileFilter
          * parameter of the file collection.
          */
         public bool $archivedOnly = false,
+        /**
+         * The root of the folder tree: files in no folder that are not an attachment either.
+         *
+         * Both halves are needed. An attachment is created with no folder unless one was passed, so
+         * "no folder" alone would put every note, task and finance attachment in the root, where they
+         * would sit alongside the virtual folder that already lists them.
+         *
+         * Distinct from a null `folderId`, which still means "every file in the space" and backs the
+         * flat listing. Root is a place in the tree, no filter is the whole space.
+         */
+        public bool $rootOnly = false,
     ) {
     }
 }

--- a/src/Service/Builder/BandSpace/File/BandSpaceFolderBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFolderBuilder.php
@@ -7,7 +7,7 @@ use App\Entity\BandSpace\BandSpaceFolder;
 
 readonly class BandSpaceFolderBuilder
 {
-    public function buildItem(BandSpaceFolder $entity, int $depth = 0): BandSpaceFolderResource
+    public function buildItem(BandSpaceFolder $entity, int $depth, int $fileCount): BandSpaceFolderResource
     {
         $dto = new BandSpaceFolderResource();
         $dto->id = (string) $entity->id;
@@ -15,6 +15,7 @@ readonly class BandSpaceFolderBuilder
         $dto->name = $entity->name;
         $dto->parentId = $entity->parent instanceof \App\Entity\BandSpace\BandSpaceFolder ? (string) $entity->parent->id : null;
         $dto->depth = $depth;
+        $dto->fileCount = $fileCount;
         $dto->creationDatetime = $entity->creationDatetime;
         $dto->updateDatetime = $entity->updateDatetime;
 
@@ -25,11 +26,13 @@ readonly class BandSpaceFolderBuilder
      * Assembles a flat list of folders into a tree of root-level resources,
      * each carrying its full nested subtree under `children` as inlined arrays.
      *
-     * @param BandSpaceFolder[] $entities
+     * @param BandSpaceFolder[]     $entities
+     * @param array<string, int>    $fileCounts folder id => live files directly in it, from
+     *                                          BandSpaceFileRepository::countActiveByFolder()
      *
      * @return BandSpaceFolderResource[]
      */
-    public function buildTree(array $entities): array
+    public function buildTree(array $entities, array $fileCounts): array
     {
         /** @var array<string, BandSpaceFolder[]> $childrenByParentId */
         $childrenByParentId = [];
@@ -45,8 +48,8 @@ readonly class BandSpaceFolderBuilder
 
         $resources = [];
         foreach ($roots as $root) {
-            $rootDto = $this->buildItem($root, 0);
-            $rootDto->children = $this->assembleChildren($root, $childrenByParentId, 1);
+            $rootDto = $this->buildItem($root, 0, $fileCounts[(string) $root->id] ?? 0);
+            $rootDto->children = $this->assembleChildren($root, $childrenByParentId, 1, $fileCounts);
             $resources[] = $rootDto;
         }
 
@@ -55,25 +58,27 @@ readonly class BandSpaceFolderBuilder
 
     /**
      * @param array<string, BandSpaceFolder[]> $childrenByParentId
+     * @param array<string, int>               $fileCounts
      *
      * @return array<int, array<string, mixed>>
      */
-    private function assembleChildren(BandSpaceFolder $node, array $childrenByParentId, int $depth): array
+    private function assembleChildren(BandSpaceFolder $node, array $childrenByParentId, int $depth, array $fileCounts): array
     {
         $children = $childrenByParentId[(string) $node->id] ?? [];
 
         return array_map(
-            fn (BandSpaceFolder $child): array => $this->toNestedArray($child, $childrenByParentId, $depth),
+            fn (BandSpaceFolder $child): array => $this->toNestedArray($child, $childrenByParentId, $depth, $fileCounts),
             $children,
         );
     }
 
     /**
      * @param array<string, BandSpaceFolder[]> $childrenByParentId
+     * @param array<string, int>               $fileCounts
      *
      * @return array<string, mixed>
      */
-    private function toNestedArray(BandSpaceFolder $node, array $childrenByParentId, int $depth): array
+    private function toNestedArray(BandSpaceFolder $node, array $childrenByParentId, int $depth, array $fileCounts): array
     {
         return [
             'id' => (string) $node->id,
@@ -81,7 +86,8 @@ readonly class BandSpaceFolderBuilder
             'name' => $node->name,
             'parent_id' => $node->parent instanceof \App\Entity\BandSpace\BandSpaceFolder ? (string) $node->parent->id : null,
             'depth' => $depth,
-            'children' => $this->assembleChildren($node, $childrenByParentId, $depth + 1),
+            'file_count' => $fileCounts[(string) $node->id] ?? 0,
+            'children' => $this->assembleChildren($node, $childrenByParentId, $depth + 1, $fileCounts),
             'creation_datetime' => $node->creationDatetime->format(\DateTimeInterface::ATOM),
             'update_datetime' => $node->updateDatetime?->format(\DateTimeInterface::ATOM),
         ];

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderCreateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderCreateProcessor.php
@@ -86,6 +86,7 @@ readonly class BandSpaceFolderCreateProcessor implements ProcessorInterface
         );
         $this->entityManager->flush();
 
-        return $this->folderBuilder->buildItem($folder, $depth);
+        // Nothing to count: a folder is created empty, and nothing can be put in it before it exists.
+        return $this->folderBuilder->buildItem($folder, $depth, 0);
     }
 }

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderUpdateProcessor.php
@@ -10,6 +10,7 @@ use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceFolderActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
@@ -32,6 +33,7 @@ readonly class BandSpaceFolderUpdateProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceMemberChecker $memberChecker,
         private BandSpaceFolderRepository $folderRepository,
+        private BandSpaceFileRepository $fileRepository,
         private BandSpaceFolderBuilder $folderBuilder,
         private BandSpaceActivityRecorder $activityRecorder,
         private Security $security,
@@ -140,6 +142,10 @@ readonly class BandSpaceFolderUpdateProcessor implements ProcessorInterface
 
         $this->entityManager->flush();
 
-        return $this->folderBuilder->buildItem($folder, $this->folderRepository->computeDepth($folder));
+        return $this->folderBuilder->buildItem(
+            $folder,
+            $this->folderRepository->computeDepth($folder),
+            $this->fileRepository->countActiveByFolderIds([(string) $folder->id]),
+        );
     }
 }

--- a/src/State/Provider/BandSpace/File/BandSpaceFileCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFileCollectionProvider.php
@@ -21,6 +21,9 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  */
 readonly class BandSpaceFileCollectionProvider implements ProviderInterface
 {
+    /** Reserved `folder_id` value asking for the root of the tree rather than the whole space. */
+    public const string ROOT_FOLDER_ID = 'root';
+
     public function __construct(
         private BandSpaceMemberChecker $memberChecker,
         private BandSpaceFileRepository $fileRepository,
@@ -63,8 +66,14 @@ readonly class BandSpaceFileCollectionProvider implements ProviderInterface
     {
         $query = $this->requestStack->getCurrentRequest()?->query;
 
+        // `folder_id=root` rather than a second parameter: the caller is choosing one place to list, and
+        // a reserved value keeps that one thing in one parameter. A real folder id is a uuid, so the
+        // word cannot collide with one.
+        $folderId = $query?->getString('folder_id') ?: null;
+        $isRoot = $folderId === self::ROOT_FOLDER_ID;
+
         return new BandSpaceFileFilter(
-            folderId: $query?->getString('folder_id') ?: null,
+            folderId: $isRoot ? null : $folderId,
             tagId: $query?->getString('tag_id') ?: null,
             source: $query?->getString('source') ?: null,
             sourceId: $query?->getString('task_id') ?: ($query?->getString('finance_entry_id') ?: null),
@@ -76,6 +85,7 @@ readonly class BandSpaceFileCollectionProvider implements ProviderInterface
             limit: $limit,
             offset: $offset,
             archivedOnly: $query?->getBoolean('archived') ?? false,
+            rootOnly: $isRoot,
         );
     }
 }

--- a/src/State/Provider/BandSpace/File/BandSpaceFolderCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFolderCollectionProvider.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\BandSpace\File\BandSpaceFolderResource;
 use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\Builder\BandSpace\File\BandSpaceFolderBuilder;
@@ -20,6 +21,7 @@ readonly class BandSpaceFolderCollectionProvider implements ProviderInterface
     public function __construct(
         private BandSpaceMemberChecker $memberChecker,
         private BandSpaceFolderRepository $folderRepository,
+        private BandSpaceFileRepository $fileRepository,
         private BandSpaceFolderBuilder $folderBuilder,
         private Security $security,
     ) {
@@ -39,6 +41,9 @@ readonly class BandSpaceFolderCollectionProvider implements ProviderInterface
 
         $folders = $this->folderRepository->findTree($bandSpace);
 
-        return $this->folderBuilder->buildTree($folders);
+        return $this->folderBuilder->buildTree(
+            $folders,
+            $this->fileRepository->countActiveByFolder($bandSpace),
+        );
     }
 }

--- a/src/State/Provider/BandSpace/File/BandSpaceFolderItemProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFolderItemProvider.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\BandSpace\File\BandSpaceFolderResource;
 use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\Builder\BandSpace\File\BandSpaceFolderBuilder;
@@ -21,6 +22,7 @@ readonly class BandSpaceFolderItemProvider implements ProviderInterface
     public function __construct(
         private BandSpaceMemberChecker $memberChecker,
         private BandSpaceFolderRepository $folderRepository,
+        private BandSpaceFileRepository $fileRepository,
         private BandSpaceFolderBuilder $folderBuilder,
         private Security $security,
     ) {
@@ -40,6 +42,10 @@ readonly class BandSpaceFolderItemProvider implements ProviderInterface
             throw new NotFoundHttpException('Dossier introuvable');
         }
 
-        return $this->folderBuilder->buildItem($folder, $this->folderRepository->computeDepth($folder));
+        return $this->folderBuilder->buildItem(
+            $folder,
+            $this->folderRepository->computeDepth($folder),
+            $this->fileRepository->countActiveByFolderIds([(string) $folder->id]),
+        );
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceFileCollectionTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileCollectionTest.php
@@ -67,6 +67,58 @@ class BandSpaceFileCollectionTest extends ApiTestCase
         $this->assertSame('in-folder.pdf', $response['member'][0]['original_name']);
     }
 
+    /**
+     * The root of the tree is not the whole space: a file in a folder belongs to that folder, and an
+     * attachment belongs to its virtual folder, so neither shows here. Only a standalone file with no
+     * folder does. All three exist in this space, so the listing has to exclude two of them.
+     */
+    public function test_list_filtered_by_root_excludes_foldered_files_and_attachments(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Contrats'])->create();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $folder, 'originalName' => 'in-folder.pdf'])->create();
+
+        // No folder, but attached to a note, so the Notes virtual folder already lists it.
+        $attached = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'attached.pdf'])->create();
+        BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $attached,
+            'sourceType' => 'note',
+            'sourceId' => \Ramsey\Uuid\Uuid::uuid4(),
+            'attachedBy' => $user,
+        ]);
+
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'in-root.pdf'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/files?folder_id=root', [], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(1, $response['totalItems']);
+        $this->assertSame('in-root.pdf', $response['member'][0]['original_name']);
+    }
+
+    /** No folder_id at all still means the whole space, which is what the flat listing needs. */
+    public function test_list_without_folder_filter_still_returns_every_file(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Contrats'])->create();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $folder, 'originalName' => 'in-folder.pdf'])->create();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'in-root.pdf'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/files', [], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(2, $this->getResponseAsArray()['totalItems']);
+    }
+
     public function test_list_filtered_by_tag(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/File/BandSpaceFolderCollectionTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFolderCollectionTest.php
@@ -111,6 +111,7 @@ class BandSpaceFolderCollectionTest extends ApiTestCase
                     'name' => 'Live',
                     'parent_id' => null,
                     'depth' => 0,
+                    'file_count' => 0,
                     'children' => [
                         [
                             'id' => $live2026->id,
@@ -118,6 +119,7 @@ class BandSpaceFolderCollectionTest extends ApiTestCase
                             'name' => '2026',
                             'parent_id' => $live->id,
                             'depth' => 1,
+                            'file_count' => 0,
                             'children' => [
                                 [
                                     'id' => $paris->id,
@@ -125,6 +127,7 @@ class BandSpaceFolderCollectionTest extends ApiTestCase
                                     'name' => 'paris',
                                     'parent_id' => $live2026->id,
                                     'depth' => 2,
+                                    'file_count' => 0,
                                     'children' => [],
                                     'creation_datetime' => '2026-04-03T10:00:00+00:00',
                                     'update_datetime' => null,
@@ -145,6 +148,7 @@ class BandSpaceFolderCollectionTest extends ApiTestCase
                     'name' => 'Riders',
                     'parent_id' => null,
                     'depth' => 0,
+                    'file_count' => 0,
                     'children' => [],
                     'creation_datetime' => '2026-04-04T10:00:00+00:00',
                     'update_datetime' => null,
@@ -225,6 +229,110 @@ class BandSpaceFolderCollectionTest extends ApiTestCase
                 ['id' => 'virtual:note', 'name' => 'Notes', 'source' => 'note', 'file_count' => 0],
                 ['id' => 'virtual:song', 'name' => 'Chansons', 'source' => 'song', 'file_count' => 1],
                 ['id' => 'virtual:setlist', 'name' => 'Setlists', 'source' => 'setlist', 'file_count' => 2],
+            ],
+        ]);
+    }
+
+    /**
+     * The count on a folder row is what opening that folder lists: its own live files, whether or not
+     * they are attached to something, and nothing from its subfolders. A recursive count would promise
+     * rows the folder does not have.
+     */
+    public function test_list_counts_the_live_files_directly_in_each_folder(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $live = BandSpaceFolderFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'name' => 'Live',
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+        $live2026 = BandSpaceFolderFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'name' => '2026',
+            'parent' => $live,
+            'creationDatetime' => new \DateTime('2026-04-02 10:00:00'),
+        ])->create();
+
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $live])->create();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $live])->create();
+
+        // Attached to a note and filed in Live: the folder lists it, so the folder counts it.
+        $attached = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $live])->create();
+        BandSpaceFileAttachmentFactory::createOne([
+            'bandSpaceFile' => $attached,
+            'sourceType' => 'note',
+            'sourceId' => Uuid::uuid4(),
+            'attachedBy' => $user,
+        ]);
+
+        // In the trash, so Live does not list it and must not count it.
+        BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'folder' => $live,
+            'archiveDatetime' => new \DateTimeImmutable(),
+        ])->create();
+
+        // In the subfolder, counted there and not rolled up into Live.
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $live2026])->create();
+
+        // At the root, so it belongs to no folder row at all.
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user])->create();
+
+        $bandSpaceId = $bandSpace->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpaceId . '/folders',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceFolder',
+            '@id' => '/api/band_spaces/' . $bandSpaceId . '/folders',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpaceId . '/folders/' . $live->id,
+                    '@type' => 'BandSpaceFolder',
+                    'id' => $live->id,
+                    'band_space_id' => $bandSpaceId,
+                    'name' => 'Live',
+                    'parent_id' => null,
+                    'depth' => 0,
+                    'file_count' => 3,
+                    'children' => [
+                        [
+                            'id' => $live2026->id,
+                            'band_space_id' => $bandSpaceId,
+                            'name' => '2026',
+                            'parent_id' => $live->id,
+                            'depth' => 1,
+                            'file_count' => 1,
+                            'children' => [],
+                            'creation_datetime' => '2026-04-02T10:00:00+00:00',
+                            'update_datetime' => null,
+                        ],
+                    ],
+                    'creation_datetime' => '2026-04-01T10:00:00+00:00',
+                    'update_datetime' => null,
+                ],
+            ],
+            'virtualFolders' => [
+                ['id' => 'virtual:task', 'name' => 'Tâches', 'source' => 'task', 'file_count' => 0],
+                ['id' => 'virtual:finance', 'name' => 'Finances', 'source' => 'finance', 'file_count' => 0],
+                ['id' => 'virtual:note', 'name' => 'Notes', 'source' => 'note', 'file_count' => 1],
+                ['id' => 'virtual:song', 'name' => 'Chansons', 'source' => 'song', 'file_count' => 0],
+                ['id' => 'virtual:setlist', 'name' => 'Setlists', 'source' => 'setlist', 'file_count' => 0],
             ],
         ]);
     }

--- a/tests/Api/BandSpace/File/BandSpaceFolderItemTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFolderItemTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\File;
+
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFolderFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BandSpaceFolderItemTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    /**
+     * The item endpoint counts a folder's files with a different query from the collection's grouped
+     * one, so a folder read on its own could report a subtree roll-up, or zero, with the collection
+     * test staying green.
+     */
+    public function test_get_returns_the_folder_with_the_files_directly_in_it(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $live = BandSpaceFolderFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'name' => 'Live',
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+        $live2026 = BandSpaceFolderFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'name' => '2026',
+            'parent' => $live,
+            'creationDatetime' => new \DateTime('2026-04-02 10:00:00'),
+        ])->create();
+
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $live2026])->create();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $live2026])->create();
+        // In the parent, so the child must not count it.
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $live])->create();
+        // In the bin, so nothing lists it and nothing counts it.
+        BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'folder' => $live2026,
+            'archiveDatetime' => new \DateTimeImmutable(),
+        ])->create();
+
+        $bandSpaceId = $bandSpace->id;
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpaceId . '/folders/' . $live2026->id,
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceFolder',
+            '@id' => '/api/band_spaces/' . $bandSpaceId . '/folders/' . $live2026->id,
+            '@type' => 'BandSpaceFolder',
+            'id' => $live2026->id,
+            'band_space_id' => $bandSpaceId,
+            'name' => '2026',
+            'parent_id' => $live->id,
+            'depth' => 1,
+            'file_count' => 2,
+            'children' => [],
+            'creation_datetime' => '2026-04-02T10:00:00+00:00',
+            'update_datetime' => null,
+        ]);
+    }
+
+    public function test_get_unknown_folder_returns_404(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/folders/0198c0de-dead-beef-cafe-000000000001',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Dossier introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Dossier introuvable',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/File/BandSpaceFolderUpdateTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFolderUpdateTest.php
@@ -8,6 +8,7 @@ use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFolderFactory;
 use App\Tests\Factory\User\UserFactory;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,6 +39,55 @@ class BandSpaceFolderUpdateTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $this->getResponseAsArray();
         $this->assertSame('Setlist', $response['name']);
+    }
+
+    /**
+     * Renaming moves no file, so the response has to keep reporting what the folder holds. The count is
+     * its own live files: the one in the subfolder belongs to that subfolder and the trashed one is not
+     * listed anywhere but the bin.
+     */
+    public function test_rename_folder_reports_the_files_it_holds(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $folder = BandSpaceFolderFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'name' => 'Setlists',
+            'creationDatetime' => new \DateTime('2026-04-01 10:00:00'),
+        ])->create();
+        $child = BandSpaceFolderFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'name' => '2026',
+            'parent' => $folder,
+            'creationDatetime' => new \DateTime('2026-04-02 10:00:00'),
+        ])->create();
+
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $folder])->create();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $folder])->create();
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'folder' => $child])->create();
+        BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'folder' => $folder,
+            'archiveDatetime' => new \DateTimeImmutable(),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/folders/' . $folder->id,
+            ['name' => 'Setlist'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame('Setlist', $response['name']);
+        $this->assertSame(2, $response['file_count']);
     }
 
     public function test_move_folder_to_new_parent(): void


### PR DESCRIPTION
Closes #918.

The Files module opened on every file in the space, whatever folder it sat in, so a file was listed in two places: the folder somebody filed it in, and the page everybody lands on. Past a handful of folders that stops reading as a file manager, and the organisation a member built carries no meaning on the page they arrive at. It now opens on the root of the tree.

## Root is not "no folder"

Expressing the root needed a third state on the collection, because an absent `folder_id` already means the whole space and the flat listing still wants that. `folder_id=root` is a reserved value (`BandSpaceFileCollectionProvider::ROOT_FOLDER_ID`), and a real folder id is a uuid, so the word cannot collide with one.

The predicate is not `bsf.folder IS NULL`. The attach processors default `folderId` to null, so most attachments have no folder, and a literal null test would list every note, task, finance, setlist and song attachment at the root, beside the virtual folder that already lists them. That is the duplication this issue exists to remove, with the root as the second place instead of the flat list. Root is "no folder and no attachment row", and the second half reuses the `source=manual` predicate rather than a second copy of it, extracted as `standaloneExpression()` so the two definitions cannot drift apart.

## Landing on the tree

The sidebar now has « Racine » at the top of the tree, which is what the move and upload dialogs already called it, and « Tous les fichiers » sits below the tree next to « Corbeille », since neither of those is a folder. The root row keeps the "+" and stays the drop target for "move to the root". Folders and files share one listing, folders first, and `FolderBreadcrumb` walks back up.

The sentinels and the rule that reads them live in `assets/js/constants/folderSelection.js`: `ROOT_FOLDER_ID`, `TRASH_FOLDER_ID`, and `listedFolderId()`, which collapses a selection to the folder the panel is inside. Null at the root, the uuid in a folder, and `NO_FOLDER_LISTED` for the three selections that are not a place at all. Three states rather than two, because the flat listing and the root are both falsy and behave nothing alike: one lists the whole space, the other is a place with subfolders, an upload target and a row that has to leave the listing when the file moves out.

Fixed on the way: a node indented itself with `paddingLeft: depth * 12px` inside an already padded parent, so indentation compounded (0, 12, 36, 72px). It is now one rail width per level, and the rail draws the hierarchy instead of leaving it implied: a vertical line down the siblings with a tick into each row, cut short on the last one. Same rail the finance subcategories use, extracted as `FolderTreeRail.vue` and used at both levels so the tree hangs off « Racine » as one hierarchy.

## Search covers the whole space

Somebody who does not remember where they filed a file is looking for it everywhere, so a search drops the folder scope whatever the sidebar has selected, and the panel says « Recherche dans tout l'espace », because the breadcrumb still names the folder they came from and the results deliberately come from outside it.

Each row then shows the folder it lives in, as a link back to it. The link clears the search on the way, since the search is what widened the listing past that folder and keeping it would answer the click with the same space-wide results. The folder is shown for every listing whose rows can come from anywhere, so « Tous les fichiers » and the virtual folders get it too. No backend work: `folder_path`, root to leaf, was already on the resource.

A virtual folder keeps its `source` while searching, because there the member is searching through one set of attachments rather than through the folder tree. The trash is untouched, it already ignores every filter. Empty states stopped inviting an import when nothing matched: a search that finds nothing says so.

The scoping rules moved out of the store into `assets/js/utils/fileListing.js` (`isSearchActive`, `listedFolderOfRows`, `fileListingParams`), which is what makes them testable on their own, and that is the half of this a browser check reads worst.

## Counts on folder rows

`BandSpaceFileRepository::countActiveByFolder()` is one grouped query for the whole space, since the sidebar draws every folder at once and a per-folder count would be a query per row. The count is what opening the folder lists: its own live files, attached ones included, trashed ones excluded, nothing rolled up from its subfolders, as decided in the issue.

A folder with no files of its own shows nothing rather than `0`. The count leaves out subfolders, so a zero on a folder whose subfolders are full would read as "nothing in there". The tree is refetched after a move, a delete or a restore, so a count never lags behind the row that was just dragged out of it.

`buildItem()` now requires the count, which forces the item endpoint and the update processor to pass a real one rather than quietly reporting zero on a folder holding files.

## Not in the diff

Two of the six steps listed in the issue turned out to be built already. The upload dialog preselects the folder on screen, so it only needed the root mapped to null, which also keeps the reserved word `root` out of an upload payload. Dragging a file onto a folder already worked, for the sidebar tree and for the inline folder rows.

## Verification

Full PHP suite green (2364 tests), PHPStan level 8 clean, 461 JS unit tests green, Biome and the Vite build clean.

Walked the module on the dev site: it opens on the root; moving a file into a folder drops it from the root listing and bumps that folder's count in both the sidebar and the panel; the breadcrumb walks back up; « Tous les fichiers » lists everything flat with each file's folder; searching from inside an empty folder finds a file that lives in another one and its folder link goes there with the search cleared; deleting the folder you are inside falls back to the root.
