### PR TITLE
Files: refuse « Racine » as a destination for an attached file

### DIFF
--- a/assets/js/components/BandSpace/Files/FileDetailDrawer.vue
+++ b/assets/js/components/BandSpace/Files/FileDetailDrawer.vue
@@ -136,11 +136,14 @@
           :options="folderOptions"
           option-label="label"
           option-value="value"
+          option-disabled="disabled"
           placeholder="Racine"
-          :show-clear="true"
           :disabled="filesStore.isSavingFile"
           @update:model-value="commitFolder"
         />
+        <small v-if="rootRefusal" class="text-xs text-surface-500 dark:text-surface-400">
+          {{ rootRefusal }}
+        </small>
       </div>
 
       <div v-if="attachments.length > 0" class="flex flex-col gap-1">
@@ -234,6 +237,7 @@ import { useBandSpaceStore } from '../../../store/bandSpace/bandSpace.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
 import { isFileCreatorOrAdmin } from '../../../utils/bandSpaceFilePermissions.js'
+import { rootDestinationRefusal } from '../../../utils/fileListing.js'
 import Avatar from '../../User/Avatar.vue'
 import FileActivityFeed from './FileActivityFeed.vue'
 
@@ -293,8 +297,11 @@ const deleteDisabledReason = computed(() => {
   return null
 })
 
+/** Why the root is not a destination for this file, or null when it is one. */
+const rootRefusal = computed(() => rootDestinationRefusal(file.value, filesStore.virtualFolders))
+
 const folderOptions = computed(() => {
-  const out = [{ label: 'Racine', value: null }]
+  const out = [{ label: 'Racine', value: null, disabled: rootRefusal.value !== null }]
   const walk = (nodes, depth) => {
     for (const node of nodes) {
       out.push({ label: '— '.repeat(depth) + node.name, value: node.id })
@@ -390,6 +397,9 @@ async function commitTagsIfChanged() {
 async function commitFolder(value) {
   if (!file.value) return
   if (value === file.value.folder_id) return
+  // Same guard as the move dialog: the root is not a place an attached file can be in, whatever the
+  // field in front of it offers.
+  if (value === null && rootRefusal.value !== null) return
   await filesStore.updateFile(props.bandSpaceId, file.value.id, { folder_id: value })
   filesStore.fetchFileActivities(props.bandSpaceId, file.value.id)
 }

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -309,7 +309,10 @@ function handleDragStart(event, file) {
   filesStore.startDrag({
     type: 'file',
     id: file.id,
-    folderId: file.folder_id ?? null
+    folderId: file.folder_id ?? null,
+    // Read by canDrop(), which refuses « Racine » for an attached file: the root lists no attachments,
+    // so dropping one there takes it out of the tree instead of moving it.
+    attachments: file.attachments ?? []
   })
   event.dataTransfer.effectAllowed = 'move'
   event.dataTransfer.setData('text/plain', file.id)

--- a/assets/js/components/BandSpace/Files/FileMoveDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileMoveDialog.vue
@@ -20,10 +20,13 @@
           :options="folderOptions"
           option-label="label"
           option-value="value"
+          option-disabled="disabled"
           placeholder="Racine"
-          :show-clear="true"
           :disabled="isSubmitting"
         />
+        <small v-if="rootRefusal" class="text-xs text-surface-500 dark:text-surface-400">
+          {{ rootRefusal }}
+        </small>
       </div>
 
       <Message v-if="globalError" severity="error" :closable="false">{{ globalError }}</Message>
@@ -55,6 +58,7 @@ import Select from 'primevue/select'
 import { computed, ref, watch } from 'vue'
 import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
+import { rootDestinationRefusal } from '../../../utils/fileListing.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -71,8 +75,15 @@ const targetFolderId = ref(null)
 const isSubmitting = ref(false)
 const globalError = ref(null)
 
+/**
+ * « Racine » is a destination like any other, and a refused one for a file with attachments: see
+ * canFileSitAtRoot(). It used to be reachable only by clearing the field, which is how the refusal
+ * came to be unsayable.
+ */
+const rootRefusal = computed(() => rootDestinationRefusal(props.file, filesStore.virtualFolders))
+
 const folderOptions = computed(() => {
-  const out = []
+  const out = [{ label: 'Racine', value: null, disabled: rootRefusal.value !== null }]
   const walk = (nodes, depth) => {
     for (const node of nodes) {
       out.push({ label: '— '.repeat(depth) + node.name, value: node.id })
@@ -99,6 +110,13 @@ watch(visible, (open) => {
 
 async function handleConfirm() {
   if (!props.file) return
+  // The disabled option is what stops this in the UI; this is what stops it if the field is ever
+  // swapped for another control. The root taking an attached file out of the tree is the whole bug.
+  if (targetFolderId.value === null && rootRefusal.value !== null) {
+    globalError.value = rootRefusal.value
+
+    return
+  }
   isSubmitting.value = true
   globalError.value = null
   try {

--- a/assets/js/composables/useFolderDragDrop.js
+++ b/assets/js/composables/useFolderDragDrop.js
@@ -1,9 +1,11 @@
+import { canFileSitAtRoot } from '../utils/fileListing.js'
+
 /**
  * Drag-and-drop helpers for the folder tree + file list.
  *
  * Drag sources:
  *   - folder: { type: 'folder', id, parentId, descendantIds: string[] }
- *   - file:   { type: 'file', id, folderId }
+ *   - file:   { type: 'file', id, folderId, attachments: object[] }
  *
  * Drop targets:
  *   - any folder in the tree
@@ -13,6 +15,7 @@
  *   - folder cannot drop on itself or a descendant (cycle)
  *   - folder cannot drop on its current parent (no-op)
  *   - file cannot drop on its current folder (no-op)
+ *   - an attached file cannot drop on the root, which lists no attachments
  */
 
 /**
@@ -90,7 +93,16 @@ export function canDrop(source, targetFolderId) {
   }
 
   if (source.type === 'file') {
-    return (source.folderId ?? null) !== (targetFolderId ?? null)
+    if ((source.folderId ?? null) === (targetFolderId ?? null)) {
+      return false
+    }
+    // Dropping an attached file on « Racine » would take it out of the tree rather than move it there,
+    // since the root lists only the files nothing points at. The move dialog refuses it too.
+    if ((targetFolderId ?? null) === null) {
+      return canFileSitAtRoot(source)
+    }
+
+    return true
   }
 
   return false

--- a/assets/js/composables/useFolderDragDrop.test.js
+++ b/assets/js/composables/useFolderDragDrop.test.js
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { canDrop, collectFolderAndDescendants, directChildren } from './useFolderDragDrop.js'
+
+/**
+ * Drag and drop is the one move surface with no dialog to explain itself, so what it refuses has to be
+ * refused before the drop rather than undone after it. The root is the case worth pinning: it lists the
+ * files nothing is attached to, so dropping an attached file there would take it out of the tree
+ * instead of moving it, exactly what the move dialog used to allow.
+ *
+ * Run with `npm test`.
+ */
+
+const TREE = [
+  {
+    id: 'live',
+    name: 'Live',
+    children: [{ id: '2026', name: '2026', children: [{ id: 'paris', name: 'Paris' }] }]
+  },
+  { id: 'riders', name: 'Riders' }
+]
+
+describe('collectFolderAndDescendants', () => {
+  it('takes the folder and everything under it', () => {
+    assert.deepEqual(collectFolderAndDescendants(TREE, 'live'), ['live', '2026', 'paris'])
+  })
+
+  it('is just the folder when it has no children', () => {
+    assert.deepEqual(collectFolderAndDescendants(TREE, 'riders'), ['riders'])
+  })
+})
+
+describe('directChildren', () => {
+  it('is the roots at the top and the direct children below', () => {
+    assert.deepEqual(directChildren(TREE, null), TREE)
+    assert.deepEqual(directChildren(TREE, '2026'), [{ id: 'paris', name: 'Paris' }])
+  })
+
+  it('is empty for a leaf and for a folder the tree does not hold', () => {
+    assert.deepEqual(directChildren(TREE, 'riders'), [])
+    assert.deepEqual(directChildren(TREE, 'deleted'), [])
+  })
+})
+
+describe('canDrop', () => {
+  const folder = (overrides = {}) => ({
+    type: 'folder',
+    id: 'live',
+    parentId: null,
+    descendantIds: ['live', '2026', 'paris'],
+    ...overrides
+  })
+
+  const file = (overrides = {}) => ({
+    type: 'file',
+    id: 'f1',
+    folderId: 'live',
+    attachments: [],
+    ...overrides
+  })
+
+  it('refuses a drop with nothing being dragged, and an unknown source', () => {
+    assert.equal(canDrop(null, 'riders'), false)
+    assert.equal(canDrop({ type: 'tag', id: 't1' }, 'riders'), false)
+  })
+
+  it('refuses a folder on itself or on a descendant, which would orphan the subtree', () => {
+    assert.equal(canDrop(folder(), 'live'), false)
+    assert.equal(canDrop(folder(), 'paris'), false)
+  })
+
+  it('refuses a folder on the parent it already hangs on', () => {
+    assert.equal(canDrop(folder(), null), false)
+    assert.equal(canDrop(folder({ parentId: 'riders' }), 'riders'), false)
+  })
+
+  it('accepts a folder anywhere else, the root included', () => {
+    assert.equal(canDrop(folder(), 'riders'), true)
+    assert.equal(canDrop(folder({ parentId: 'riders' }), null), true)
+  })
+
+  it('refuses a file on the folder it is already in', () => {
+    assert.equal(canDrop(file(), 'live'), false)
+    assert.equal(canDrop(file({ folderId: null }), null), false)
+  })
+
+  it('accepts a file into another folder, attached or not', () => {
+    assert.equal(canDrop(file(), 'riders'), true)
+    assert.equal(canDrop(file({ attachments: [{ source_type: 'note' }] }), 'riders'), true)
+  })
+
+  it('accepts an unattached file on the root, which lists it', () => {
+    assert.equal(canDrop(file(), null), true)
+  })
+
+  it('refuses an attached file on the root, which would take it out of the tree', () => {
+    assert.equal(canDrop(file({ attachments: [{ source_type: 'note' }] }), null), false)
+  })
+})

--- a/assets/js/utils/fileListing.js
+++ b/assets/js/utils/fileListing.js
@@ -15,6 +15,10 @@ import { FILES_PAGE_SIZE } from './filePagination.js'
  *
  * Extracted from the store because the scoping rules are the interesting part: which of the sidebar
  * selection and the filter bar wins, and when a listing stops being one place in the tree.
+ *
+ * The same rules answer where a row can be moved to, so what the root holds is written here once
+ * rather than once per surface offering it as a destination, which is how the move dialog came to
+ * offer a destination the root does not show.
  */
 
 /**
@@ -143,12 +147,64 @@ export function folderPathOf(tree, folderId) {
 }
 
 /**
+ * The virtual folders a file's attachments put it in, one per distinct source, named the way the
+ * sidebar names them and falling back to the source's own label before the tree has loaded. Empty for
+ * a file nothing is attached to.
+ *
+ * @param {object} file
+ * @param {Array<{source: string, name: string}>} virtualFolders
+ * @returns {Array<{label: string, folderId: string}>}
+ */
+export function fileVirtualFolders(file, virtualFolders = []) {
+  const sourceTypes = [...new Set((file?.attachments ?? []).map((att) => att.source_type))]
+
+  return sourceTypes.map((sourceType) => ({
+    label:
+      virtualFolders.find((folder) => folder.source === sourceType)?.name ??
+      fileSourceLabel(sourceType),
+    folderId: virtualFolderId(sourceType)
+  }))
+}
+
+/**
+ * Whether the root of the tree is a place this file can be in.
+ *
+ * The root is not every file without a folder: it is the files with no folder *and* no attachment,
+ * because an attachment with no folder is already listed in its virtual folder. So a file with
+ * attachments has no place at the root, and offering it as a destination hides the file from the tree.
+ *
+ * @param {object} file  anything carrying the API's `attachments`, a row or a drag source
+ * @returns {boolean}
+ */
+export function canFileSitAtRoot(file) {
+  return (file?.attachments ?? []).length === 0
+}
+
+/**
+ * Why the root is refused as a destination, naming where the file is listed instead, or null when it
+ * is not refused. Reads under the destination field rather than in a toast after the move, so the rule
+ * is visible before the member commits to it.
+ *
+ * @param {object} file
+ * @param {Array<{source: string, name: string}>} virtualFolders
+ * @returns {?string}
+ */
+export function rootDestinationRefusal(file, virtualFolders = []) {
+  if (canFileSitAtRoot(file)) return null
+
+  const names = fileVirtualFolders(file, virtualFolders).map((folder) => folder.label)
+  const listedIn =
+    names.length > 1 ? `${names.slice(0, -1).join(', ')} et ${names.at(-1)}` : names[0]
+
+  return `Ce fichier est listé dans ${listedIn} : la racine ne liste que les fichiers attachés à aucune ressource.`
+}
+
+/**
  * Where a file row says it lives, and where clicking that says takes the member.
  *
  * A file in a folder names its path. A file in no folder is only at the root if nothing is attached to
  * it: the root excludes attachments, so sending an attached file's reader there would land them in a
- * listing the file is missing from. Its place is the virtual folder grouping its source, named the way
- * the sidebar names it, falling back to the source's own label before the tree has loaded.
+ * listing the file is missing from. Its place is the virtual folder grouping its source.
  *
  * @param {object} file
  * @param {Array<{source: string, name: string}>} virtualFolders
@@ -163,17 +219,9 @@ export function fileLocation(file, virtualFolders = []) {
     }
   }
 
-  const sourceType = (file.attachments ?? [])[0]?.source_type ?? null
-  if (sourceType !== null) {
-    const virtual = virtualFolders.find((folder) => folder.source === sourceType)
-
-    return {
-      label: virtual?.name ?? fileSourceLabel(sourceType),
-      folderId: virtualFolderId(sourceType)
-    }
-  }
-
-  return { label: 'Racine', folderId: ROOT_FOLDER_ID }
+  return (
+    fileVirtualFolders(file, virtualFolders)[0] ?? { label: 'Racine', folderId: ROOT_FOLDER_ID }
+  )
 }
 
 /**

--- a/assets/js/utils/fileListing.test.js
+++ b/assets/js/utils/fileListing.test.js
@@ -2,12 +2,15 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { NO_FOLDER_LISTED, ROOT_FOLDER_ID, TRASH_FOLDER_ID } from '../constants/folderSelection.js'
 import {
+  canFileSitAtRoot,
   fileListingParams,
   fileLocation,
+  fileVirtualFolders,
   folderFileCountLabel,
   folderPathOf,
   isSearchActive,
   listedFolderOfRows,
+  rootDestinationRefusal,
   treeHoldsFolder,
   uploadBelongsInListing
 } from './fileListing.js'
@@ -246,5 +249,80 @@ describe('uploadBelongsInListing', () => {
   it('holds nothing in a virtual folder, which lists attachments rather than uploads', () => {
     assert.equal(uploadBelongsInListing('virtual:note', filters(), null), false)
     assert.equal(uploadBelongsInListing(TRASH_FOLDER_ID, filters(), null), false)
+  })
+})
+
+describe('fileVirtualFolders', () => {
+  const virtualFolders = [
+    { id: 'virtual:note', source: 'note', name: 'Notes' },
+    { id: 'virtual:task', source: 'task', name: 'Tâches' }
+  ]
+
+  it('is empty for a file nothing is attached to', () => {
+    assert.deepEqual(fileVirtualFolders({ attachments: [] }, virtualFolders), [])
+    assert.deepEqual(fileVirtualFolders({}, virtualFolders), [])
+  })
+
+  it('names one folder per source, however many attachments share it', () => {
+    const file = {
+      attachments: [
+        { source_type: 'note', source_id: 'n1' },
+        { source_type: 'task', source_id: 't1' },
+        { source_type: 'note', source_id: 'n2' }
+      ]
+    }
+    assert.deepEqual(fileVirtualFolders(file, virtualFolders), [
+      { label: 'Notes', folderId: 'virtual:note' },
+      { label: 'Tâches', folderId: 'virtual:task' }
+    ])
+  })
+
+  it('falls back to the source label when the tree has not loaded yet', () => {
+    assert.deepEqual(fileVirtualFolders({ attachments: [{ source_type: 'setlist' }] }, []), [
+      { label: 'Setlist', folderId: 'virtual:setlist' }
+    ])
+  })
+})
+
+describe('canFileSitAtRoot', () => {
+  it('holds a file nothing is attached to', () => {
+    assert.equal(canFileSitAtRoot({ attachments: [] }), true)
+    assert.equal(canFileSitAtRoot({}), true)
+  })
+
+  it('refuses an attached file, which the root listing leaves out', () => {
+    assert.equal(canFileSitAtRoot({ attachments: [{ source_type: 'note' }] }), false)
+  })
+})
+
+describe('rootDestinationRefusal', () => {
+  const virtualFolders = [
+    { id: 'virtual:note', source: 'note', name: 'Notes' },
+    { id: 'virtual:task', source: 'task', name: 'Tâches' }
+  ]
+
+  it('says nothing for a file the root can hold', () => {
+    assert.equal(rootDestinationRefusal({ attachments: [] }, virtualFolders), null)
+  })
+
+  it('names the virtual folder listing the file instead of the root', () => {
+    const file = { attachments: [{ source_type: 'note', source_id: 'n1' }] }
+    assert.equal(
+      rootDestinationRefusal(file, virtualFolders),
+      'Ce fichier est listé dans Notes : la racine ne liste que les fichiers attachés à aucune ressource.'
+    )
+  })
+
+  it('names every virtual folder listing it, so the sentence is not half true', () => {
+    const file = {
+      attachments: [
+        { source_type: 'note', source_id: 'n1' },
+        { source_type: 'task', source_id: 't1' }
+      ]
+    }
+    assert.equal(
+      rootDestinationRefusal(file, virtualFolders),
+      'Ce fichier est listé dans Notes et Tâches : la racine ne liste que les fichiers attachés à aucune ressource.'
+    )
   })
 })


### PR DESCRIPTION
Closes #921.

The root of the folder tree is "no folder AND no attachment": `BandSpaceFileRepository::buildBandSpaceQuery()` adds `standaloneExpression('attRoot')` on top of `bsf.folder IS NULL`, because an attachment with no folder is already listed in its virtual folder. The three move surfaces did not know that rule, so sending an attached file to « Racine » succeeded, said « Fichier déplacé », and left the file out of the tree with nothing to explain it.

Option 1 from the issue: refuse the destination, and say why where the rule applies.

## The rule, written once

`assets/js/utils/fileListing.js` already held half of it: `fileLocation()` knows an attached file's place is its virtual folder rather than the root. That half is extracted into `fileVirtualFolders()`, and two functions are built on it:

- `canFileSitAtRoot(file)`, false as soon as `attachments` is non empty
- `rootDestinationRefusal(file, virtualFolders)`, the sentence naming where the file is listed instead

## The three ways in

- `FileMoveDialog.vue`: « Racine » becomes an explicit first option, disabled through `option-disabled`, with the refusal under the field. `show-clear` is dropped, since clearing set `folder_id` to null and would have walked straight past the disabled option.
- `FileDetailDrawer.vue`: same treatment on its folder Select.
- `useFolderDragDrop.js`: `canDrop()` refuses a file drop on the root when the drag source carries attachments, so the sidebar « Racine » row stops accepting it. `FileList.vue` puts `attachments` on the drag source, which lets the one rule function serve both a row and a drag source.

Both commit paths keep a guard of their own, so the rule does not depend on the control in front of it.

## Deliberately frontend only

The API still accepts `PATCH folder_id: null` on an attached file. An attached file with no folder is the normal state, that is how attachments are created, so a backend rule would have to target the transition rather than the state, and it would permanently close the door on taking a file back out of a folder once it has been filed. That is a product decision rather than a bug fix.

Known consequence: once an attached file is filed into a folder, it can no longer be moved out of it from the UI. It stays visible both in that folder and in its virtual folder, so nothing is hidden, but the move is one way.

## Tests

`npm test` 494 pass. 8 cases added to `fileListing.test.js` for the new helpers, and a new `assets/js/composables/useFolderDragDrop.test.js` covering `canDrop`, `collectFolderAndDescendants` and `directChildren`, which had no tests at all. Biome and `npm run build` clean.
