### PR TITLE
Files: build every folder path from one query per request

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -34,6 +34,11 @@ when@test:
         dbal:
             # "TEST_TOKEN" is typically set by ParaTest
             dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+            # phpunit.dist.xml runs with APP_DEBUG=0, and profiling defaults to %kernel.debug%, so the
+            # DBAL middleware feeding the profiler's db collector is not registered. Without this the
+            # collector answers 0 to getQueryCount() and any test asserting a query budget passes
+            # whatever the endpoint does.
+            profiling: true
 
 when@prod:
     doctrine:

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -247,26 +247,6 @@ class BandSpaceFileRepository extends ServiceEntityRepository
     }
 
     /**
-     * Active-file counts grouped by attached source type. Manual files
-     * (no attached source) are not returned. Order: source ASC.
-     *
-     * @return array<string, int> source => file count
-     */
-    /**
-     * @return array<int, array{id: string, name: string}> root → leaf
-     */
-    public function buildFolderPath(?BandSpaceFolder $folder): array
-    {
-        $path = [];
-        while ($folder instanceof \App\Entity\BandSpace\BandSpaceFolder) {
-            array_unshift($path, ['id' => (string) $folder->id, 'name' => $folder->name]);
-            $folder = $folder->parent;
-        }
-
-        return $path;
-    }
-
-    /**
      * A file nobody attached to anything: no row in band_space_file_attachment.
      *
      * Shared by the `source=manual` filter and by the root of the folder tree, so the two cannot drift

--- a/src/Repository/BandSpace/BandSpaceFolderRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFolderRepository.php
@@ -32,6 +32,45 @@ class BandSpaceFolderRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Every folder of the space with the path down to it, keyed by folder id, root first.
+     *
+     * One query for the whole space, rather than the walk below run per file. BandSpaceFolder::$parent
+     * is a plain ManyToOne and so LAZY, and the file collection hydrates only bsf.folder, so walking up
+     * from a listing costs a SELECT per level per distinct folder. #918 put that walk on every row of
+     * the space wide listings, which made a page of 50 files across a depth 3 tree cost upwards of a
+     * hundred extra queries. findTree() already fetch joins the parents, and it loads every folder of
+     * the space, so each ancestor is in the identity map by the time buildPath() reaches it.
+     *
+     * @return array<string, array<int, array{id: string, name: string}>> folder id => path
+     */
+    public function findPathsByBandSpace(BandSpace $bandSpace): array
+    {
+        $paths = [];
+        foreach ($this->findTree($bandSpace) as $folder) {
+            $paths[(string) $folder->id] = $this->buildPath($folder);
+        }
+
+        return $paths;
+    }
+
+    /**
+     * The path down to one folder, root first. Costs a query per level unless the ancestors are already
+     * loaded, so a collection wants findPathsByBandSpace() instead.
+     *
+     * @return array<int, array{id: string, name: string}> root → leaf
+     */
+    public function buildPath(?BandSpaceFolder $folder): array
+    {
+        $path = [];
+        while ($folder instanceof BandSpaceFolder) {
+            array_unshift($path, ['id' => (string) $folder->id, 'name' => $folder->name]);
+            $folder = $folder->parent;
+        }
+
+        return $path;
+    }
+
     public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?BandSpaceFolder
     {
         return $this->createQueryBuilder('f')

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
@@ -3,10 +3,12 @@
 namespace App\Service\Builder\BandSpace\File;
 
 use App\ApiResource\BandSpace\File\BandSpaceFileResource;
+use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceFile;
 use App\Entity\BandSpace\BandSpaceFileTag;
 use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
 use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
 use App\Enum\BandSpace\FinanceEntryScope;
 use App\Repository\BandSpace\FinanceEntryRepository;
@@ -22,6 +24,7 @@ readonly class BandSpaceFileBuilder
     public function __construct(
         private BandSpaceFileRepository $fileRepository,
         private BandSpaceFileAttachmentRepository $attachmentRepository,
+        private BandSpaceFolderRepository $folderRepository,
         private TaskRepository $taskRepository,
         private FinanceEntryRepository $financeEntryRepository,
         private BandSpaceNoteRepository $noteRepository,
@@ -35,25 +38,38 @@ readonly class BandSpaceFileBuilder
     }
 
     /**
-     * @param BandSpaceFile[] $entities
+     * @param BandSpaceFile[] $entities all belonging to $bandSpace
      *
      * @return BandSpaceFileResource[]
      */
-    public function buildFromList(array $entities): array
+    public function buildFromList(array $entities, BandSpace $bandSpace): array
     {
+        if (count($entities) === 0) {
+            return [];
+        }
+
         $fileIds = array_map(fn (BandSpaceFile $file): string => (string) $file->id, $entities);
         $versionCounts = $this->fileRepository->countVersionsByFileIds($fileIds);
+        // One query for the whole tree, handed down the way BandSpaceFolderBuilder::buildTree() is
+        // handed its counts. Without it each row walks its own ancestors, one lazy SELECT per level.
+        $folderPaths = $this->folderRepository->findPathsByBandSpace($bandSpace);
 
         return array_map(
             fn (BandSpaceFile $entity): BandSpaceFileResource => $this->buildItem(
                 $entity,
                 $versionCounts[(string) $entity->id] ?? 0,
+                $folderPaths,
             ),
             $entities,
         );
     }
 
-    public function buildItem(BandSpaceFile $entity, ?int $versionCount = null): BandSpaceFileResource
+    /**
+     * @param array<string, array<int, array{id: string, name: string}>>|null $folderPaths paths of the
+     *        whole space, keyed by folder id, from BandSpaceFolderRepository::findPathsByBandSpace().
+     *        Null walks this file's own ancestors instead, which is what a single item wants.
+     */
+    public function buildItem(BandSpaceFile $entity, ?int $versionCount = null, ?array $folderPaths = null): BandSpaceFileResource
     {
         $dto = new BandSpaceFileResource();
         $dto->id = (string) $entity->id;
@@ -62,7 +78,7 @@ readonly class BandSpaceFileBuilder
         $dto->size = $entity->currentVersion?->size;
         $dto->mimeType = $entity->currentVersion?->mimeType;
         $dto->folderId = $entity->folder instanceof \App\Entity\BandSpace\BandSpaceFolder ? (string) $entity->folder->id : null;
-        $dto->folderPath = $this->fileRepository->buildFolderPath($entity->folder);
+        $dto->folderPath = $this->resolveFolderPath($entity->folder, $folderPaths);
 
         $dto->tags = array_values(array_map(
             fn (BandSpaceFileTag $tag): array => [
@@ -106,6 +122,24 @@ readonly class BandSpaceFileBuilder
         $dto->purgeDatetime = $entity->archiveDatetime?->modify(sprintf('+%d days', $this->retentionDays));
 
         return $dto;
+    }
+
+    /**
+     * The path down to $folder, read off the per space map when the caller loaded one and walked from
+     * the entity when it did not. The map holds every folder of the space, so a miss means the folder
+     * is not one of its own and the walk is a truer answer than an empty path.
+     *
+     * @param array<string, array<int, array{id: string, name: string}>>|null $folderPaths
+     *
+     * @return array<int, array{id: string, name: string}>
+     */
+    private function resolveFolderPath(?\App\Entity\BandSpace\BandSpaceFolder $folder, ?array $folderPaths): array
+    {
+        if (!$folder instanceof \App\Entity\BandSpace\BandSpaceFolder) {
+            return [];
+        }
+
+        return $folderPaths[(string) $folder->id] ?? $this->folderRepository->buildPath($folder);
     }
 
     /**

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
@@ -214,7 +214,7 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
             $folderId = (string) $file->folder?->id;
             $pathByFolderId[$folderId] ??= implode(
                 ' / ',
-                array_column($this->fileRepository->buildFolderPath($file->folder), 'name'),
+                array_column($this->folderRepository->buildPath($file->folder), 'name'),
             );
 
             $this->activityRecorder->record(

--- a/src/State/Provider/BandSpace/File/BandSpaceFileCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFileCollectionProvider.php
@@ -52,7 +52,7 @@ readonly class BandSpaceFileCollectionProvider implements ProviderInterface
         $entities = $this->fileRepository->findByBandSpace($bandSpace, $filter);
         $totalItems = $this->fileRepository->countByBandSpace($bandSpace, $filter);
 
-        $dtos = $this->fileBuilder->buildFromList($entities);
+        $dtos = $this->fileBuilder->buildFromList($entities, $bandSpace);
 
         return new TraversablePaginator(
             new \ArrayIterator($dtos),

--- a/src/State/Provider/BandSpace/File/BandSpaceFinanceEntryFileCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFinanceEntryFileCollectionProvider.php
@@ -69,7 +69,7 @@ readonly class BandSpaceFinanceEntryFileCollectionProvider implements ProviderIn
         $entities = $this->fileRepository->findByBandSpace($bandSpace, $filter);
         $totalItems = $this->fileRepository->countByBandSpace($bandSpace, $filter);
 
-        $dtos = $this->fileBuilder->buildFromList($entities);
+        $dtos = $this->fileBuilder->buildFromList($entities, $bandSpace);
 
         return new TraversablePaginator(
             new \ArrayIterator($dtos),

--- a/src/State/Provider/BandSpace/File/BandSpaceSetlistFileCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceSetlistFileCollectionProvider.php
@@ -60,7 +60,7 @@ readonly class BandSpaceSetlistFileCollectionProvider implements ProviderInterfa
         $entities = $this->fileRepository->findByBandSpace($bandSpace, $filter);
         $totalItems = $this->fileRepository->countByBandSpace($bandSpace, $filter);
 
-        $dtos = $this->fileBuilder->buildFromList($entities);
+        $dtos = $this->fileBuilder->buildFromList($entities, $bandSpace);
 
         return new TraversablePaginator(
             new \ArrayIterator($dtos),

--- a/src/State/Provider/BandSpace/File/BandSpaceSongFileCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceSongFileCollectionProvider.php
@@ -60,7 +60,7 @@ readonly class BandSpaceSongFileCollectionProvider implements ProviderInterface
         $entities = $this->fileRepository->findByBandSpace($bandSpace, $filter);
         $totalItems = $this->fileRepository->countByBandSpace($bandSpace, $filter);
 
-        $dtos = $this->fileBuilder->buildFromList($entities);
+        $dtos = $this->fileBuilder->buildFromList($entities, $bandSpace);
 
         return new TraversablePaginator(
             new \ArrayIterator($dtos),

--- a/src/State/Provider/BandSpace/File/BandSpaceTaskFileCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceTaskFileCollectionProvider.php
@@ -60,7 +60,7 @@ readonly class BandSpaceTaskFileCollectionProvider implements ProviderInterface
         $entities = $this->fileRepository->findByBandSpace($bandSpace, $filter);
         $totalItems = $this->fileRepository->countByBandSpace($bandSpace, $filter);
 
-        $dtos = $this->fileBuilder->buildFromList($entities);
+        $dtos = $this->fileBuilder->buildFromList($entities, $bandSpace);
 
         return new TraversablePaginator(
             new \ArrayIterator($dtos),

--- a/tests/Api/BandSpace/File/BandSpaceFileCollectionTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileCollectionTest.php
@@ -48,6 +48,87 @@ class BandSpaceFileCollectionTest extends ApiTestCase
         $this->assertSame('rider.pdf', $response['member'][0]['original_name']);
     }
 
+    /**
+     * folder_path is the most expensive field on the resource. BandSpaceFolder::$parent is a plain
+     * ManyToOne and so LAZY, and the collection hydrates only the file's own folder, so building the
+     * path per file costs a SELECT per level per folder. #918 put that field on every row of the space
+     * wide listings, which is what made it hot.
+     *
+     * Three files, each at the bottom of its own three deep chain, so nothing is shared and the walk
+     * has nine ancestors to fetch. The whole tree is read in one query now, and that is what is pinned
+     * here rather than a total: the total hides the trade, one query up front against N lazy loads.
+     */
+    public function test_list_reads_the_whole_folder_tree_in_one_query_however_deep_it_is(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create(['username' => 'alice']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $files = [];
+        $paths = [];
+        // Pinned datetimes so the date desc default puts the rows in a known order, and a chain per
+        // file so no ancestor is already in the identity map when the next row is built.
+        foreach ([['Live', '2026', 'Paris'], ['Studio', 'Demos', 'Avril'], ['Admin', 'Contrats', 'Signés']] as $index => $names) {
+            $parent = null;
+            $path = [];
+            foreach ($names as $name) {
+                $parent = BandSpaceFolderFactory::new([
+                    'bandSpace' => $bandSpace,
+                    'createdBy' => $user,
+                    'name' => $name,
+                    'parent' => $parent,
+                ])->create();
+                $path[] = ['id' => $parent->id, 'name' => $name];
+            }
+
+            $files[] = BandSpaceFileFactory::new([
+                'bandSpace' => $bandSpace,
+                'createdBy' => $user,
+                'folder' => $parent,
+                'originalName' => 'chain-' . $index . '.pdf',
+                'creationDatetime' => new \DateTime(sprintf('2026-0%d-01T01:01:01+00:00', 3 - $index)),
+            ])->create();
+            $paths['chain-' . $index . '.pdf'] = $path;
+        }
+
+        $this->client->loginUser($user);
+        $this->client->enableProfiler();
+        // A real request starts with an empty identity map. The factories above left every folder
+        // managed, which would hide the very lazy loads this test exists to count.
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        // The debug holder lives as long as the connection, so everything the factories above just
+        // wrote is already in it. Emptied here, the collector answers for the request alone.
+        self::getContainer()->get('doctrine.debug_data_holder')->reset();
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/files', [], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(3, $response['totalItems']);
+        $this->assertSame(
+            [
+                ['chain-0.pdf', $paths['chain-0.pdf']],
+                ['chain-1.pdf', $paths['chain-1.pdf']],
+                ['chain-2.pdf', $paths['chain-2.pdf']],
+            ],
+            array_map(
+                static fn (array $member): array => [$member['original_name'], $member['folder_path']],
+                $response['member'],
+            ),
+        );
+
+        $profile = $this->client->getProfile();
+        $this->assertNotFalse($profile, 'The profiler must be enabled to assert the query count.');
+        $folderReads = array_filter(
+            $profile->getCollector('db')->getQueries()['default'] ?? [],
+            static fn (array $query): bool => str_contains((string) $query['sql'], 'FROM band_space_folder'),
+        );
+        $this->assertCount(
+            1,
+            $folderReads,
+            'The tree must be read once for the whole space, not one SELECT per ancestor per file.',
+        );
+    }
+
     public function test_list_filtered_by_folder(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/Musician/MusicianAnnounceGetLastCollectionTest.php
+++ b/tests/Api/Musician/MusicianAnnounceGetLastCollectionTest.php
@@ -163,6 +163,12 @@ class MusicianAnnounceGetLastCollectionTest extends ApiTestCase
         ]);
 
         $this->client->enableProfiler();
+        // Not paired with an EntityManager::clear() the way the file listing budget is: this endpoint
+        // projects its authors rather than hydrating them, so there is nothing lazy for a warm identity
+        // map to hide, and clearing reorders the styles collection, which carries no ORDER BY.
+        // The debug holder lives as long as the connection, so the factory writes above are already in
+        // it. Emptied here, getQueryCount() answers for the request alone rather than for the test.
+        self::getContainer()->get('doctrine.debug_data_holder')->reset();
         $this->client->request('GET', '/api/musician_announces/last');
 
         $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');


### PR DESCRIPTION
Closes #920.

`folder_path` was built per file by walking `BandSpaceFolder::$parent`, which is a plain LAZY `ManyToOne`. The collection query fetch-joins only `bsf.folder`, so every ancestor above it was its own SELECT. #918 put that field on every row of the space-wide listings, which is what made it hot: a page of 50 files over a depth-3 tree cost on the order of a hundred extra queries.

## The change

`BandSpaceFolderRepository::findPathsByBandSpace()` folds `findTree()` into `array<string, path>` keyed by folder id. `findTree()` already fetch-joins `parent` and loads every folder of the space, so each ancestor is in the identity map by the time the walk reaches it: one query for the whole tree, whatever its depth.

`BandSpaceFileBuilder::buildFromList()` takes the band space, loads the map once and hands it down, the way `BandSpaceFolderBuilder::buildTree()` is handed its counts. `buildItem()` keeps a `?array $folderPaths = null` parameter, so the single-item callers still walk, which is fine for one file.

The walk itself moved from `BandSpaceFileRepository::buildFolderPath()` to `BandSpaceFolderRepository::buildPath()`. It takes a `?BandSpaceFolder` and is now used from both the map and the single-item path, so it belongs with the folders and stays written once. A stale docblock that had been orphaned above the old method is gone with it.

## The test env could not have caught this

`phpunit.dist.xml` forces `APP_DEBUG=0`, and `doctrine.dbal.profiling` defaults to `%kernel.debug%`, so the middleware feeding the profiler's db collector was never registered. `getCollector('db')->getQueryCount()` answered 0, which means the query budget asserted in `MusicianAnnounceGetLastCollectionTest` had never checked anything: `0 <= 3` passes whatever the endpoint does. `profiling: true` is now set under `when@test`, and that assertion holds for real.

Two things are needed to make such a count honest, and the new test does both: reset `doctrine.debug_data_holder`, which lives as long as the connection and so still holds every factory write, and clear the EntityManager, because a real request starts with an empty identity map while the factories leave every folder managed, hiding the very lazy loads being counted.

## Test

`test_list_reads_the_whole_folder_tree_in_one_query_however_deep_it_is` puts three files at the bottom of three separate depth-3 chains, so nothing is shared, and pins the number of queries reading `FROM band_space_folder`. Checked against the pre-fix source: **6 folder reads before, 1 after**.

The budget is expressed as folder reads rather than as a total, because the total hides the trade: the fix pays one query up front to save N.

Full suite green at 2368, PHPStan clean.

## Left alone on purpose

`BandSpaceFileBuilder::buildAttachments()` still runs one query per file. Pre-existing, and a different fix from this one.

The musician budget test is deliberately not given the same `EntityManager::clear()`. That endpoint projects its authors instead of hydrating them, so a warm identity map hides nothing there, and clearing reorders its styles collection, which carries no `ORDER BY`. Pinning that ordering is its own change.
