### PR TITLE
OAuth: one return_url rule, refusing tab, newline and foreign schemes

### DIFF
--- a/assets/js/utils/returnUrl.js
+++ b/assets/js/utils/returnUrl.js
@@ -1,10 +1,12 @@
 /**
  * Guards post-login `return_url` redirects against open-redirect abuse.
  *
- * Mirrors the backend `AbstractOAuthController::isValidReturnUrl()` policy for the
- * SPA login path: only same-origin relative paths are accepted, so a crafted
- * `?return_url=https://evil.example` cannot bounce a freshly authenticated user
- * off-site.
+ * The matched pair of the backend `App\Http\ReturnUrl::isSafe()`, pinned on both
+ * sides by tests carrying the same cases. Only same-origin relative paths are
+ * accepted here, so a crafted `?return_url=https://evil.example` cannot bounce a
+ * freshly authenticated user off-site. The backend applies the same relative rule
+ * and additionally accepts an absolute URL on the frontend's own host, which the
+ * OAuth entry point needs and the SPA does not.
  *
  * A safe value must start with a single "/" that is NOT followed by another "/"
  * or a "\". The backslash case matters: browsers normalise "\" to "/", so
@@ -15,6 +17,12 @@
  */
 export function isSafeReturnUrl(url) {
   if (typeof url !== 'string' || url.length === 0) {
+    return false
+  }
+  // The URL parser deletes every ASCII tab, CR and LF from the whole input before parsing it, so
+  // "/\t/evil.example" reaches it as the protocol relative "//evil.example". Refused rather than
+  // stripped and re-checked, so what is checked is what gets assigned to location.href.
+  if (/[\t\r\n]/.test(url)) {
     return false
   }
   if (url[0] !== '/') {

--- a/assets/js/utils/returnUrl.test.js
+++ b/assets/js/utils/returnUrl.test.js
@@ -5,6 +5,9 @@ import { isSafeReturnUrl } from './returnUrl.js'
 // This is the app's open-redirect gate: security.js checks it before handing a value to
 // window.location.href. It had no tests, and the guard change in #915 makes it the safety net on the
 // most common unauthenticated path rather than a rarely reached manual-URL edge case.
+//
+// tests/Unit/Http/ReturnUrlTest.php is the other half: the same relative cases run against the backend
+// rule, so a policy that drifts on one side fails on the other. That drift is what #917 was.
 describe('isSafeReturnUrl', () => {
   it('accepts a same-origin relative path', () => {
     assert.equal(isSafeReturnUrl('/'), true)
@@ -26,6 +29,16 @@ describe('isSafeReturnUrl', () => {
   // exactly like "//evil.example" while still reading as an internal path.
   it('refuses a backslash standing in for the second slash', () => {
     assert.equal(isSafeReturnUrl('/\\evil.example'), false)
+  })
+
+  // The URL parser deletes every ASCII tab, CR and LF from the whole input before parsing it, so each
+  // of these reaches it as "//evil.example". This is the side that matters most: security.js assigns
+  // the value straight to location.href, with no origin in front of it to anchor the authority.
+  it('refuses a tab or a newline standing in for the second slash', () => {
+    assert.equal(isSafeReturnUrl('/\t/evil.example'), false)
+    assert.equal(isSafeReturnUrl('/\n/evil.example'), false)
+    assert.equal(isSafeReturnUrl('/\r/evil.example'), false)
+    assert.equal(isSafeReturnUrl('/messages\n//evil.example'), false)
   })
 
   it('refuses a scheme that is not http', () => {

--- a/src/Controller/OAuth/AbstractOAuthController.php
+++ b/src/Controller/OAuth/AbstractOAuthController.php
@@ -7,6 +7,7 @@ namespace App\Controller\OAuth;
 use App\Entity\User;
 use App\Exception\OAuth\OAuthEmailExistsException;
 use App\Exception\OAuth\OAuthEmailNotVerifiedException;
+use App\Http\ReturnUrl;
 use App\Service\OAuth\OAuthUserData;
 use App\Service\OAuth\OAuthUserService;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
@@ -68,15 +69,7 @@ abstract class AbstractOAuthController extends AbstractController
 
     private function isValidReturnUrl(string $url): bool
     {
-        // Only allow relative URLs or URLs from the same domain
-        if (str_starts_with($url, '/')) {
-            return true;
-        }
-
-        $parsedUrl = parse_url($url);
-        $frontendParsed = parse_url($this->frontendUrl);
-
-        return isset($parsedUrl['host'], $frontendParsed['host']) && $parsedUrl['host'] === $frontendParsed['host'];
+        return ReturnUrl::isSafe($url, $this->frontendUrl);
     }
 
     public function callback(Request $request): RedirectResponse

--- a/src/Http/ReturnUrl.php
+++ b/src/Http/ReturnUrl.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\Http;
+
+/**
+ * Whether a `return_url` can be redirected to after a login.
+ *
+ * The rule is the one `assets/js/utils/returnUrl.js` applies on the SPA login path, plus a branch the
+ * SPA has no use for: a leading `/` that is not followed by another `/` or by a `\`, or an absolute URL
+ * whose host is the frontend's own.
+ *
+ * The two forbidden second characters are the same trick. `//evil.example` is protocol relative, and a
+ * browser normalises `\` to `/` on a special scheme, so `/\evil.example` resolves the same way. Both
+ * read as an internal path and both leave the origin. An ASCII tab, CR or LF anywhere in the value is
+ * the same trick once more, and the one that reads least like an attack: the URL parser deletes those
+ * three characters from the whole input before it parses anything, so `/<tab>/evil.example` is handed
+ * to it as `//evil.example`.
+ *
+ * This lives here rather than in AbstractOAuthController because the check used to accept any leading
+ * `/` and was saved only by what its caller happened to do with the value, concatenating it onto a
+ * fixed origin. That is protection one function away from the check, invisible to anyone reusing the
+ * check for a new redirect. Written once, in a class of its own, it can also be tested as the matched
+ * pair of the frontend rule, which is what keeps the two from drifting apart again.
+ */
+final class ReturnUrl
+{
+    /** The schemes a redirect may use. Anything else is somebody else's application. */
+    private const array ALLOWED_SCHEMES = ['http', 'https'];
+
+    public static function isSafe(string $url, string $frontendUrl): bool
+    {
+        // Refused rather than stripped and re-checked, so the string that is checked is the string that
+        // gets used. No legitimate return_url carries one of these.
+        if (strpbrk($url, "\t\r\n") !== false) {
+            return false;
+        }
+
+        if (str_starts_with($url, '/')) {
+            return !str_starts_with($url, '//') && !str_starts_with($url, '/\\');
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        $host = parse_url($url, PHP_URL_HOST);
+        $frontendHost = parse_url($frontendUrl, PHP_URL_HOST);
+
+        // The host alone is not enough: parse_url reads one out of any scheme written with an authority,
+        // so `javascript://musicall.fr/x` would otherwise match the frontend and be handed straight to a
+        // Location header. Browsers block that particular scheme there, which is not a reason to emit it.
+        return is_string($scheme)
+            && in_array(strtolower($scheme), self::ALLOWED_SCHEMES, true)
+            && is_string($host)
+            && is_string($frontendHost)
+            // A host is case insensitive, so MUSICALL.FR really is the frontend's own origin.
+            && strcasecmp($host, $frontendHost) === 0;
+    }
+}

--- a/tests/Api/OAuth/GoogleOAuthConnectTest.php
+++ b/tests/Api/OAuth/GoogleOAuthConnectTest.php
@@ -26,6 +26,46 @@ class GoogleOAuthConnectTest extends ApiTestCase
         $this->assertStringNotContainsString('return_url', (string) base64_decode($state, true));
     }
 
+    /**
+     * connect() only stashes a return URL it accepts, so the session is where the rule shows through.
+     * App\Http\ReturnUrl decides what is accepted and tests/Unit/Http/ReturnUrlTest.php pins that;
+     * what these two add is that the controller asks it at all, which no unit test can say.
+     */
+    public function test_connect_stashes_a_return_url_it_accepts(): void
+    {
+        $this->client->request('GET', '/oauth/google?return_url=' . urlencode('/band-space/abc'));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FOUND);
+        $this->assertSame(['/band-space/abc'], $this->stashedReturnUrls());
+    }
+
+    public function test_connect_stashes_nothing_for_a_return_url_that_leaves_the_origin(): void
+    {
+        foreach (['//evil.example', '/\\evil.example', "/\t/evil.example", 'https://evil.example'] as $returnUrl) {
+            $this->client->request('GET', '/oauth/google?return_url=' . urlencode($returnUrl));
+
+            $this->assertResponseStatusCodeSame(Response::HTTP_FOUND);
+            $this->assertSame([], $this->stashedReturnUrls(), sprintf('%s must not be stashed', json_encode($returnUrl)));
+        }
+    }
+
+    /**
+     * @return string[] the return URLs connect() put in the session, in insertion order
+     */
+    private function stashedReturnUrls(): array
+    {
+        $session = $this->client->getRequest()->getSession();
+
+        $stashed = [];
+        foreach ($session->all() as $key => $value) {
+            if (str_starts_with($key, 'oauth_return_url.') && is_string($value)) {
+                $stashed[] = $value;
+            }
+        }
+
+        return $stashed;
+    }
+
     public function test_connect_without_return_url_still_redirects(): void
     {
         $this->client->request('GET', '/oauth/google');

--- a/tests/Unit/Http/ReturnUrlTest.php
+++ b/tests/Unit/Http/ReturnUrlTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Http;
+
+use App\Http\ReturnUrl;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The other half of assets/js/utils/returnUrl.test.js. One parameter, `return_url`, is guarded by two
+ * validators, and until #917 they disagreed: the backend accepted any leading `/`, so `//evil.example`
+ * passed here and was refused by the SPA. Nothing was exploitable, because getReturnUrl() concatenates
+ * a `/`-prefixed value onto a fixed origin, which anchors the authority. That is the caller saving the
+ * check rather than the check being right.
+ *
+ * The relative cases below are deliberately the same ones the JS test lists, so a policy that drifts on
+ * one side fails on the other. The same-host absolute branch has no JS counterpart: the SPA refuses
+ * every absolute URL, the OAuth entry point accepts its own origin.
+ */
+class ReturnUrlTest extends TestCase
+{
+    private const string FRONTEND_URL = 'https://musicall.fr';
+
+    public function test_a_same_origin_relative_path_is_safe(): void
+    {
+        self::assertTrue(ReturnUrl::isSafe('/', self::FRONTEND_URL));
+        self::assertTrue(ReturnUrl::isSafe('/messages', self::FRONTEND_URL));
+        self::assertTrue(ReturnUrl::isSafe('/band/invitation/abc123', self::FRONTEND_URL));
+        self::assertTrue(ReturnUrl::isSafe('/band/1/tech-riders?rider=42#top', self::FRONTEND_URL));
+    }
+
+    public function test_a_protocol_relative_url_is_refused(): void
+    {
+        self::assertFalse(ReturnUrl::isSafe('//evil.example', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('//evil.example/path?a=b', self::FRONTEND_URL));
+    }
+
+    /**
+     * A browser normalises a backslash to a slash on a special scheme, so this resolves exactly like
+     * the protocol relative form above while still reading as an internal path.
+     */
+    public function test_a_backslash_standing_in_for_the_second_slash_is_refused(): void
+    {
+        self::assertFalse(ReturnUrl::isSafe('/\\evil.example', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('/\\/evil.example', self::FRONTEND_URL));
+    }
+
+    public function test_an_absolute_url_on_another_host_is_refused(): void
+    {
+        self::assertFalse(ReturnUrl::isSafe('https://evil.example', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('http://evil.example/path', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('https://musicall.fr.evil.example', self::FRONTEND_URL));
+    }
+
+    public function test_an_absolute_url_on_the_frontend_host_is_safe(): void
+    {
+        self::assertTrue(ReturnUrl::isSafe('https://musicall.fr', self::FRONTEND_URL));
+        self::assertTrue(ReturnUrl::isSafe('https://musicall.fr/messages', self::FRONTEND_URL));
+    }
+
+    public function test_a_scheme_that_is_not_http_is_refused(): void
+    {
+        self::assertFalse(ReturnUrl::isSafe('javascript:alert(1)', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('data:text/html,<script>', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('mailto:someone@example.com', self::FRONTEND_URL));
+    }
+
+    /**
+     * The three above carry no authority, so they are refused for having no host at all rather than for
+     * their scheme. These do carry one, and parse_url reads the frontend's own host straight out of
+     * them, so only the scheme check stands between them and a Location header.
+     */
+    public function test_a_foreign_scheme_on_the_frontend_host_is_refused(): void
+    {
+        self::assertFalse(ReturnUrl::isSafe('javascript://musicall.fr/%0aalert(1)', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('ftp://musicall.fr/x', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('file://musicall.fr/x', self::FRONTEND_URL));
+    }
+
+    /**
+     * The URL parser deletes every ASCII tab, CR and LF from the whole input before parsing it, so each
+     * of these reaches it as the protocol relative "//evil.example" while reading as an internal path.
+     * The frontend rule refuses them too: assets/js/utils/returnUrl.test.js carries the same three.
+     */
+    public function test_a_tab_or_a_newline_standing_in_for_the_second_slash_is_refused(): void
+    {
+        self::assertFalse(ReturnUrl::isSafe("/\t/evil.example", self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe("/\n/evil.example", self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe("/\r/evil.example", self::FRONTEND_URL));
+        // Not only in second position: the deletion applies to the whole input.
+        self::assertFalse(ReturnUrl::isSafe("/messages\n//evil.example", self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe("https://musicall\t.fr/x", self::FRONTEND_URL));
+    }
+
+    public function test_the_frontend_host_is_matched_whatever_its_case(): void
+    {
+        self::assertTrue(ReturnUrl::isSafe('https://MUSICALL.FR/messages', self::FRONTEND_URL));
+    }
+
+    public function test_an_empty_url_and_a_bare_path_are_refused(): void
+    {
+        self::assertFalse(ReturnUrl::isSafe('', self::FRONTEND_URL));
+        self::assertFalse(ReturnUrl::isSafe('messages', self::FRONTEND_URL));
+    }
+
+    /**
+     * A frontend URL with no host would otherwise make every absolute URL match on null === null.
+     */
+    public function test_nothing_absolute_is_safe_when_the_frontend_url_has_no_host(): void
+    {
+        self::assertFalse(ReturnUrl::isSafe('https://evil.example', ''));
+        self::assertTrue(ReturnUrl::isSafe('/messages', ''));
+    }
+}


### PR DESCRIPTION
Closes #917.

One parameter, `return_url`, guarded by two validators that disagreed. The frontend required a leading `/` not followed by `/` or `\`; the backend accepted any leading `/`, so `//evil.example` and `/\evil.example` passed it. As the issue says, that was not exploitable: `getReturnUrl()` concatenates a `/`-prefixed value onto a fixed origin, which anchors the authority. The check was saved by what its caller happened to do with the value.

The rule now lives in `App\Http\ReturnUrl::isSafe()`, next to the existing `App\Http\ContentDisposition`, and `AbstractOAuthController::isValidReturnUrl()` delegates to it. Extracted rather than fixed in place because a private controller method cannot be tested, and pinning the two policies as a matched pair is half the point of the ticket.

## Two more holes, found while reviewing the extraction

Neither is in the issue. The first is a live open redirect today.

**An ASCII tab, CR or LF anywhere in the value.** The URL parser deletes those three characters from the whole input before it parses anything, so `/<tab>/evil.example` reaches it as `//evil.example`. It is the same trick as the two the ticket is about, with a character that reads even less like an attack, and neither side refused it. On the backend it was masked the same way the original bug was, by the concatenation onto a fixed origin. On the frontend it was not masked at all: `assets/js/store/user/security.js` assigns the value straight to `window.location.href` with nothing in front of it, so `?return_url=%2F%09%2Fevil.example` bounced a freshly authenticated user off-site. Both sides now refuse it.

Refused rather than stripped and re-checked, so the string that is checked is the string that gets used. No legitimate `return_url` carries one.

**A foreign scheme on the frontend's own host.** `parse_url` reads a host out of any scheme written with an authority, so `javascript://musicall.fr/x` matched the host check and `extractReturnUrlFromState()` returns that branch raw, with no anchor, into a `Location` header. Browsers block `javascript:` and `data:` there, which is not a reason to emit them, and it does not cover `file:`, `ftp:` or a custom scheme some installed application has registered. The absolute branch now requires `http` or `https`.

Also fixed while there: the host comparison was case sensitive, so `https://MUSICALL.FR/x` was refused. It failed safe, but a host is case insensitive and that really is the frontend's own origin.

## Tests

`tests/Unit/Http/ReturnUrlTest.php` and `assets/js/utils/returnUrl.test.js` carry the same relative cases on purpose, tab and newline included, so a policy that drifts on one side fails on the other. Each file points at the other.

The PHP suite also gained the case the old scheme test only looked like it covered: the three values it asserted (`javascript:alert(1)`, `data:`, `mailto:`) carry no authority, so they were refused for having no host rather than for their scheme. `javascript://musicall.fr/x` is the one that tells them apart, and it passed before this change.

`GoogleOAuthConnectTest` gained two tests reading the session `connect()` writes: one that an accepted return URL is stashed, one that four rejected ones are not. `ReturnUrl` decides what is accepted and the unit test pins that; these say the controller asks it at all, which no unit test can.

Full suite green at 2380, PHPStan clean, `npm test` 475, Biome clean.
