### PR TITLE
Files: one method counting the live files in a folder

### DIFF
--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -76,29 +76,6 @@ class BandSpaceFileRepository extends ServiceEntityRepository
     }
 
     /**
-     * How many live files sit directly in any of the given folders.
-     *
-     * Asked before findActiveByFolderIds() hydrates anything, so a subtree too large to archive in one
-     * request is refused without ever being loaded into memory.
-     *
-     * @param string[] $folderIds
-     */
-    public function countActiveByFolderIds(array $folderIds): int
-    {
-        if (count($folderIds) === 0) {
-            return 0;
-        }
-
-        return (int) $this->createQueryBuilder('bsf')
-            ->select('COUNT(bsf.id)')
-            ->where('bsf.folder IN (:folderIds)')
-            ->andWhere('bsf.archiveDatetime IS NULL')
-            ->setParameter('folderIds', $folderIds)
-            ->getQuery()
-            ->getSingleScalarResult();
-    }
-
-    /**
      * Live files sitting directly in any of the given folders, uploader and folder included.
      *
      * Entities rather than a bulk UPDATE on purpose: archiving a folder subtree has to write one
@@ -188,24 +165,38 @@ class BandSpaceFileRepository extends ServiceEntityRepository
     }
 
     /**
-     * Live files sitting directly in each folder of the space, so a folder row can say how many rows
-     * opening it shows. Subfolders are not rolled up: a recursive count would need the tree walked per
-     * folder, and a number that counts files the folder does not list is a number nobody can check.
+     * Live files sitting directly in each of the given folders, keyed by folder id.
      *
-     * One grouped query for the whole space rather than one per folder, because the sidebar draws every
-     * folder at once. Folders with nothing in them are absent from the result rather than zero.
+     * The one definition of a folder's own files, in the one shape that answers every caller: the
+     * sidebar wants a number per folder, the folder endpoints want the number for one of them, and the
+     * delete guard wants the total over a subtree, which is array_sum() over the same rows. It used to
+     * be two methods with near identical names and different return shapes, so reaching for the wrong
+     * one gave a plausible value nothing could flag, and the next change to what live means had to be
+     * made twice or the two answers started disagreeing.
+     *
+     * Subfolders are not rolled up: a recursive count would need the tree walked per folder, and a
+     * number that counts files the folder does not list is a number nobody can check. Folders holding
+     * nothing are absent rather than zero, so a caller reads `$counts[$id] ?? 0`.
+     *
+     * One grouped query however many folders are asked for, which is what lets the delete guard refuse
+     * a subtree too large to archive before findActiveByFolderIds() hydrates any of it.
+     *
+     * @param string[] $folderIds
      *
      * @return array<string, int> folder id => active file count
      */
-    public function countActiveByFolder(BandSpace $bandSpace): array
+    public function countActiveByFolderIds(array $folderIds): array
     {
+        if (count($folderIds) === 0) {
+            return [];
+        }
+
         $rows = $this->createQueryBuilder('bsf')
             ->select('IDENTITY(bsf.folder) AS folder_id', 'COUNT(bsf.id) AS file_count')
-            ->where('bsf.bandSpace = :bandSpace')
-            ->andWhere('bsf.folder IS NOT NULL')
+            ->where('bsf.folder IN (:folderIds)')
             ->andWhere('bsf.archiveDatetime IS NULL')
             ->groupBy('bsf.folder')
-            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('folderIds', $folderIds)
             ->getQuery()
             ->getArrayResult();
 

--- a/src/Service/Builder/BandSpace/File/BandSpaceFolderBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFolderBuilder.php
@@ -28,7 +28,7 @@ readonly class BandSpaceFolderBuilder
      *
      * @param BandSpaceFolder[]     $entities
      * @param array<string, int>    $fileCounts folder id => live files directly in it, from
-     *                                          BandSpaceFileRepository::countActiveByFolder()
+     *                                          BandSpaceFileRepository::countActiveByFolderIds()
      *
      * @return BandSpaceFolderResource[]
      */

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
@@ -104,7 +104,7 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
         $filesToArchive = [];
         if ($strategy === self::STRATEGY_CASCADE) {
             $descendantIds = $this->folderRepository->findDescendantIds($folder);
-            $this->assertSubtreeIsSmallEnough($this->fileRepository->countActiveByFolderIds($descendantIds));
+            $this->assertSubtreeIsSmallEnough(array_sum($this->fileRepository->countActiveByFolderIds($descendantIds)));
             $filesToArchive = $this->fileRepository->findActiveByFolderIds($descendantIds);
         }
 

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderUpdateProcessor.php
@@ -142,10 +142,12 @@ readonly class BandSpaceFolderUpdateProcessor implements ProcessorInterface
 
         $this->entityManager->flush();
 
+        $folderId = (string) $folder->id;
+
         return $this->folderBuilder->buildItem(
             $folder,
             $this->folderRepository->computeDepth($folder),
-            $this->fileRepository->countActiveByFolderIds([(string) $folder->id]),
+            $this->fileRepository->countActiveByFolderIds([$folderId])[$folderId] ?? 0,
         );
     }
 }

--- a/src/State/Provider/BandSpace/File/BandSpaceFolderCollectionProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFolderCollectionProvider.php
@@ -5,6 +5,7 @@ namespace App\State\Provider\BandSpace\File;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\BandSpace\File\BandSpaceFolderResource;
+use App\Entity\BandSpace\BandSpaceFolder;
 use App\Entity\User;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\BandSpaceFolderRepository;
@@ -43,7 +44,9 @@ readonly class BandSpaceFolderCollectionProvider implements ProviderInterface
 
         return $this->folderBuilder->buildTree(
             $folders,
-            $this->fileRepository->countActiveByFolder($bandSpace),
+            $this->fileRepository->countActiveByFolderIds(
+                array_map(static fn (BandSpaceFolder $folder): string => (string) $folder->id, $folders),
+            ),
         );
     }
 }

--- a/src/State/Provider/BandSpace/File/BandSpaceFolderItemProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFolderItemProvider.php
@@ -42,10 +42,12 @@ readonly class BandSpaceFolderItemProvider implements ProviderInterface
             throw new NotFoundHttpException('Dossier introuvable');
         }
 
+        $folderId = (string) $folder->id;
+
         return $this->folderBuilder->buildItem(
             $folder,
             $this->folderRepository->computeDepth($folder),
-            $this->fileRepository->countActiveByFolderIds([(string) $folder->id]),
+            $this->fileRepository->countActiveByFolderIds([$folderId])[$folderId] ?? 0,
         );
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceFolderDeleteTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFolderDeleteTest.php
@@ -367,6 +367,11 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
      * The cascade archives file by file, so an unbounded subtree would run the whole thing inside one
      * HTTP request. Nothing caps how many files a space holds (the quota caps bytes), so the processor
      * counts first and refuses rather than letting the admin hit a 504 that explains nothing.
+     *
+     * The limit is on the subtree, so the files are spread over two folders of it: the count comes from
+     * one grouped query returning a row per folder, and it is the total across those rows the guard
+     * compares. A count that only looked at the folder being deleted would read 1000 here and let the
+     * whole thing through.
      */
     public function test_delete_cascade_refuses_a_subtree_above_the_file_limit(): void
     {
@@ -375,9 +380,10 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
         BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
 
         $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Photos'])->create();
+        $child = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Live', 'parent' => $folder])->create();
 
-        $overTheLimit = 2001;
-        $this->seedFiles($bandSpace->id, (string) $folder->id, $overTheLimit);
+        $this->seedFiles($bandSpace->id, (string) $folder->id, 1000);
+        $this->seedFiles($bandSpace->id, (string) $child->id, 1001);
 
         $this->client->loginUser($admin);
         $this->client->jsonRequest(
@@ -426,7 +432,7 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
 
         /** @var BandSpaceFileRepository $fileRepo */
         $fileRepo = self::getContainer()->get(BandSpaceFileRepository::class);
-        $this->assertSame(0, $fileRepo->countActiveByFolderIds([$folderId]));
+        $this->assertSame(0, array_sum($fileRepo->countActiveByFolderIds([$folderId])));
     }
 
     public function test_delete_move_to_root_by_admin_non_creator_succeeds(): void


### PR DESCRIPTION
Closes #923.

Two methods computed the same rule, "live files sitting directly in a folder", with near identical names and different return shapes: `countActiveByFolderIds(array): int` and `countActiveByFolder(BandSpace): array<string, int>`. Reaching for the wrong one gave a plausible value of the wrong shape that PHPStan could not flag, and the next change to what live means had to be made twice or the two answers started disagreeing.

There is now one method, `countActiveByFolderIds(array $folderIds): array<string, int>`, which is the issue's first option. It also puts the method back in line with its neighbours in the same repository: `countVersionsByFileIds()` and `countByTagIds()` both already answer a set of ids with a map. The scalar version was the outlier.

Callers take the shape they need from it:

- the sidebar reads it as it comes, one count per folder
- the folder item endpoint and the folder update indexed by their one id
- the cascade delete guard sums it, which is what it always wanted: a subtree total

The collection provider used to scope the query by band space and now passes the ids of the tree it has already loaded. Same set, since `findTree()` is itself scoped by band space, and the sibling `findActiveByFolderIds()` was already written that way.

## The guard test now discriminates

`test_delete_cascade_refuses_a_subtree_above_the_file_limit` seeded its 2001 files into a single folder, so it could not tell a subtree total from a single folder's count. The fixture is now 1000 in the parent and 1001 in the child. A count scoped to the folder being deleted reads 1000 there, passes the 2000 guard and lets the delete through, which is the failure this refactor has to stay clear of.

Full suite green at 2367, PHPStan clean.
