### PR TITLE
Agenda: convert a datetime to UTC instead of dropping its offset

### DIFF
--- a/src/ApiResource/BandSpace/AgendaEntryCreate.php
+++ b/src/ApiResource/BandSpace/AgendaEntryCreate.php
@@ -33,11 +33,18 @@ class AgendaEntryCreate
     #[Assert\Length(max: 255, maxMessage: 'Le lieu ne peut pas dépasser {{ limit }} caractères')]
     public ?string $location = null;
 
+    /**
+     * ISO-8601. Any offset is converted to UTC before it is stored, so `2026-08-25T20:00:00+02:00` and
+     * `2026-08-25T18:00:00Z` name the same instant and both read back as `2026-08-25T18:00:00+00:00`.
+     *
+     * The exception is an all day entry, which is a date rather than an instant: there the offset is
+     * dropped rather than applied, so the day is the one the caller wrote.
+     */
     #[Assert\NotBlank(message: 'Veuillez spécifier une date et heure')]
-    public string $eventDatetime;
+    public \DateTimeImmutable $eventDatetime;
 
     #[Assert\GreaterThan(propertyPath: 'eventDatetime', message: 'La fin doit être postérieure au début')]
-    public ?string $endDatetime = null;
+    public ?\DateTimeImmutable $endDatetime = null;
 
     public bool $isAllDay = false;
 

--- a/src/ApiResource/BandSpace/AgendaEntryResource.php
+++ b/src/ApiResource/BandSpace/AgendaEntryResource.php
@@ -116,11 +116,19 @@ class AgendaEntryResource
     #[Assert\Length(max: 255, maxMessage: 'Le lieu ne peut pas dépasser {{ limit }} caractères')]
     public ?string $location = null;
 
+    /**
+     * ISO-8601 in, always UTC out. Any offset sent is converted before it is stored, so
+     * `2026-08-25T20:00:00+02:00` and `2026-08-25T18:00:00Z` name the same instant and both read back
+     * as `2026-08-25T18:00:00+00:00`.
+     *
+     * The exception is an all day entry, which is a date rather than an instant: there the offset is
+     * dropped rather than applied, so the day is the one the caller wrote.
+     */
     #[Assert\NotBlank(message: 'Veuillez spécifier une date et heure')]
-    public string $eventDatetime;
+    public \DateTimeImmutable $eventDatetime;
 
     #[Assert\GreaterThan(propertyPath: 'eventDatetime', message: 'La fin doit être postérieure au début')]
-    public ?string $endDatetime = null;
+    public ?\DateTimeImmutable $endDatetime = null;
 
     public bool $isAllDay = false;
 

--- a/src/Service/Builder/BandSpace/AgendaEntryBuilder.php
+++ b/src/Service/Builder/BandSpace/AgendaEntryBuilder.php
@@ -27,8 +27,8 @@ readonly class AgendaEntryBuilder
         $dto->title = $entity->title;
         $dto->description = $entity->description;
         $dto->location = $entity->location;
-        $dto->eventDatetime = $entity->eventDatetime->format(\DateTimeInterface::ATOM);
-        $dto->endDatetime = $entity->endDatetime?->format(\DateTimeInterface::ATOM);
+        $dto->eventDatetime = $entity->eventDatetime;
+        $dto->endDatetime = $entity->endDatetime;
         $dto->isAllDay = $entity->isAllDay;
         $dto->recurrenceFrequency = $entity->recurrenceFrequency?->value;
         $dto->recurrenceUntilDate = $entity->recurrenceUntilDate?->format('Y-m-d');

--- a/src/State/Processor/BandSpace/AgendaEntryCreateProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryCreateProcessor.php
@@ -17,10 +17,10 @@ use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\AgendaEntryBuilder;
 use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -50,26 +50,28 @@ readonly class AgendaEntryCreateProcessor implements ProcessorInterface
 
         [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
 
-        try {
-            $eventDatetime = new DateTimeImmutable($data->eventDatetime);
-        } catch (\Exception) {
-            throw new BadRequestHttpException('Date et heure invalides');
-        }
-
-        $endDatetime = null;
-        if ($data->endDatetime !== null) {
-            try {
-                $endDatetime = new DateTimeImmutable($data->endDatetime);
-            } catch (\Exception) {
-                throw new BadRequestHttpException('Date de fin invalide');
-            }
-        }
+        $eventDatetime = $data->eventDatetime;
+        $endDatetime = $data->endDatetime;
 
         if ($data->isAllDay) {
+            // A whole day is a date, not an instant, and the date is the caller's own: read off the
+            // wall clock they sent, before any conversion, then pinned to midnight UTC. Converting
+            // first would move 2026-08-25T00:00+02:00 to the 24th.
             $eventDatetime = new DateTimeImmutable($eventDatetime->format('Y-m-d') . 'T00:00:00+00:00');
             $endDatetime = $endDatetime instanceof \DateTimeImmutable
                 ? new DateTimeImmutable($endDatetime->format('Y-m-d') . 'T00:00:00+00:00')
                 : null;
+        } else {
+            // AgendaEntry::$eventDatetime is mapped DATETIME_IMMUTABLE, Doctrine's `datetime`, which
+            // persists the object's wall clock and drops its timezone. So the column can only hold UTC
+            // correctly, and an offset the caller sent has to be converted here or the instant moves:
+            // 20:00+02:00 would be stored as 20:00 and read back as 20:00Z, two hours late.
+            //
+            // The reading half of that rests on the runtime's own timezone, since Doctrine hydrates the
+            // column with date_default_timezone_get() and nothing in this repository pins it. The two
+            // tiers disagreed on it once already, which is what #888 was about.
+            $eventDatetime = $eventDatetime->setTimezone(new DateTimeZone('UTC'));
+            $endDatetime = $endDatetime?->setTimezone(new DateTimeZone('UTC'));
         }
 
         $entry = new AgendaEntry();

--- a/src/State/Processor/BandSpace/AgendaEntryUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaEntryUpdateProcessor.php
@@ -17,12 +17,12 @@ use App\Service\BandSpace\AgendaSeriesReconciler;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\AgendaEntryBuilder;
 use DateTimeImmutable;
+use DateTimeZone;
 use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -81,23 +81,11 @@ readonly class AgendaEntryUpdateProcessor implements ProcessorInterface
         }
 
         if (array_key_exists('event_datetime', $payload) || array_key_exists('eventDatetime', $payload)) {
-            try {
-                $entry->eventDatetime = new DateTimeImmutable($data->eventDatetime);
-            } catch (\Exception) {
-                throw new BadRequestHttpException('Date et heure invalides');
-            }
+            $entry->eventDatetime = $data->eventDatetime;
         }
 
         if (array_key_exists('end_datetime', $payload) || array_key_exists('endDatetime', $payload)) {
-            if ($data->endDatetime === null) {
-                $entry->endDatetime = null;
-            } else {
-                try {
-                    $entry->endDatetime = new DateTimeImmutable($data->endDatetime);
-                } catch (\Exception) {
-                    throw new BadRequestHttpException('Date de fin invalide');
-                }
-            }
+            $entry->endDatetime = $data->endDatetime;
         }
 
         if (array_key_exists('is_all_day', $payload) || array_key_exists('isAllDay', $payload)) {
@@ -105,10 +93,16 @@ readonly class AgendaEntryUpdateProcessor implements ProcessorInterface
         }
 
         if ($entry->isAllDay) {
+            // The caller's own date, read before any conversion: see AgendaEntryCreateProcessor.
             $entry->eventDatetime = new DateTimeImmutable($entry->eventDatetime->format('Y-m-d') . 'T00:00:00+00:00');
             $entry->endDatetime = $entry->endDatetime instanceof \DateTimeImmutable
                 ? new DateTimeImmutable($entry->endDatetime->format('Y-m-d') . 'T00:00:00+00:00')
                 : null;
+        } else {
+            // The column holds a wall clock with no timezone, so anything not already UTC has to be
+            // converted before it is written. A no-op for a value that came back from the database.
+            $entry->eventDatetime = $entry->eventDatetime->setTimezone(new DateTimeZone('UTC'));
+            $entry->endDatetime = $entry->endDatetime?->setTimezone(new DateTimeZone('UTC'));
         }
 
         // Each recurrence field accepts an independent PATCH. ValidRecurrence runs against

--- a/src/Validator/BandSpace/Agenda/ValidRecurrenceValidator.php
+++ b/src/Validator/BandSpace/Agenda/ValidRecurrenceValidator.php
@@ -101,6 +101,12 @@ class ValidRecurrenceValidator extends ConstraintValidator
 
     private function parseEventDatetime(mixed $raw): ?DateTimeImmutable
     {
+        // The DTO carries a real datetime now; the serializer has already parsed and rejected anything
+        // malformed. The string branch stays for a caller passing the raw value.
+        if ($raw instanceof DateTimeImmutable) {
+            return $raw;
+        }
+
         if (!is_string($raw) || $raw === '') {
             return null;
         }

--- a/tests/Api/BandSpace/AgendaEntry/AgendaEntryCreateTest.php
+++ b/tests/Api/BandSpace/AgendaEntry/AgendaEntryCreateTest.php
@@ -201,6 +201,53 @@ class AgendaEntryCreateTest extends ApiTestCase
         ]);
     }
 
+    /**
+     * Assert\GreaterThan only parses a value into a date when the value under validation already is
+     * one. While both fields were strings it fell through to PHP's `>` and sorted them character by
+     * character, which works only when both carry the same offset: 10:00Z sorts after 09:00-05:00 and
+     * is four hours before it, so this payload was accepted and the entry stored ending before it
+     * began. The fields are real datetimes now, so the constraint compares instants.
+     */
+    public function test_create_agenda_entry_rejects_an_end_before_the_start_across_two_offsets(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries',
+            [
+                'title' => 'Concert',
+                'eventDatetime' => '2026-08-25T09:00:00-05:00',
+                'endDatetime' => '2026-08-25T10:00:00+00:00',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@id' => '/api/validation_errors/778b7ae0-84d3-481a-9dec-35fdb64b1d78',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'end_datetime',
+                    'message' => 'La fin doit être postérieure au début',
+                    'code' => '778b7ae0-84d3-481a-9dec-35fdb64b1d78',
+                ],
+            ],
+            'detail' => 'end_datetime: La fin doit être postérieure au début',
+            'type' => '/validation_errors/778b7ae0-84d3-481a-9dec-35fdb64b1d78',
+            'title' => 'An error occurred',
+            '@context' => '/api/contexts/ConstraintViolation',
+            'description' => 'end_datetime: La fin doit être postérieure au début',
+        ]);
+
+        $this->assertCount(0, self::getContainer()->get(AgendaEntryRepository::class)->findByBandSpace($bandSpace));
+    }
+
     public function test_create_agenda_entry_all_day_single_day(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();
@@ -282,6 +329,113 @@ class AgendaEntryCreateTest extends ApiTestCase
             'location' => null,
             'event_datetime' => '2026-06-19T00:00:00+00:00',
             'end_datetime' => '2026-06-21T00:00:00+00:00',
+            'is_all_day' => true,
+            'recurrence_frequency' => null,
+            'recurrence_until_date' => null,
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * The column is Doctrine's `datetime`, which keeps the wall clock and drops the timezone, so an
+     * offset the caller sends has to be converted on the way in. It used to be ignored: 20:00+02:00 was
+     * stored as 20:00 and read back as 20:00Z, two hours after the instant that was asked for.
+     *
+     * The SPA has always sent UTC (`Date.toISOString()`), which is why nothing noticed. Anything else
+     * talking to the API sends a local offset, which is the normal thing to do, and #779's iCal feed
+     * will carry timezone-qualified datetimes by definition.
+     */
+    public function test_create_agenda_entry_converts_a_non_utc_offset_to_the_same_instant(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries',
+            [
+                'title' => 'Répétition hebdo',
+                'eventDatetime' => '2026-08-25T20:00:00+02:00',
+                'endDatetime' => '2026-08-25T23:00:00+02:00',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $repo = self::getContainer()->get(AgendaEntryRepository::class);
+        $entries = $repo->findByBandSpace($bandSpace);
+        $this->assertCount(1, $entries);
+
+        $entry = $entries[0];
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            '@type' => 'AgendaEntry',
+            'id' => $entry->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Répétition hebdo',
+            'description' => null,
+            'location' => null,
+            // 20:00+02:00 is 18:00Z. Before the fix this read back as 20:00+00:00.
+            'event_datetime' => '2026-08-25T18:00:00+00:00',
+            'end_datetime' => '2026-08-25T21:00:00+00:00',
+            'is_all_day' => false,
+            'recurrence_frequency' => null,
+            'recurrence_until_date' => null,
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * An all day entry is a date, not an instant, so the offset is dropped rather than applied: the day
+     * is the one the caller wrote. Converting first would move midnight on the 25th in Brussels to the
+     * 24th at 22:00 UTC and file the entry under the wrong day.
+     */
+    public function test_create_all_day_entry_keeps_the_day_the_caller_wrote(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries',
+            [
+                'title' => 'Festival',
+                'eventDatetime' => '2026-08-25T00:00:00+02:00',
+                'isAllDay' => true,
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $repo = self::getContainer()->get(AgendaEntryRepository::class);
+        $entries = $repo->findByBandSpace($bandSpace);
+        $this->assertCount(1, $entries);
+
+        $entry = $entries[0];
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            '@type' => 'AgendaEntry',
+            'id' => $entry->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Festival',
+            'description' => null,
+            'location' => null,
+            'event_datetime' => '2026-08-25T00:00:00+00:00',
+            'end_datetime' => null,
             'is_all_day' => true,
             'recurrence_frequency' => null,
             'recurrence_until_date' => null,

--- a/tests/Api/BandSpace/AgendaEntry/AgendaEntryUpdateTest.php
+++ b/tests/Api/BandSpace/AgendaEntry/AgendaEntryUpdateTest.php
@@ -81,6 +81,157 @@ class AgendaEntryUpdateTest extends ApiTestCase
         $this->assertEqualsCanonicalizing(['title_changed', 'event_datetime_changed'], $types);
     }
 
+    /**
+     * PATCH parsed the offset and then dropped it exactly the way POST did, so the same two hour shift
+     * happened on an edit. See AgendaEntryCreateTest for why the column can only hold UTC.
+     */
+    public function test_update_agenda_entry_converts_a_non_utc_offset_to_the_same_instant(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition hebdo',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-08-25 18:00:00', new DateTimeZone('UTC')),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            [
+                'eventDatetime' => '2026-08-25T21:00:00+02:00',
+                'endDatetime' => '2026-08-25T23:30:00+02:00',
+            ],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            '@type' => 'AgendaEntry',
+            'id' => $entry->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Répétition hebdo',
+            'description' => null,
+            'location' => null,
+            // 21:00+02:00 is 19:00Z. Before the fix this read back as 21:00+00:00.
+            'event_datetime' => '2026-08-25T19:00:00+00:00',
+            'end_datetime' => '2026-08-25T21:30:00+00:00',
+            'is_all_day' => false,
+            'recurrence_frequency' => null,
+            'recurrence_until_date' => null,
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * Turning an entry into an all day one without resending a datetime reads the day off the stored
+     * instant, which is UTC. The request carries no timezone to read it in, so an entry that starts
+     * within the offset of midnight can land on the day before the one its author had in mind. That is
+     * inherent to storing instants and is pinned here rather than left to be discovered.
+     */
+    public function test_update_to_all_day_pins_the_day_of_the_stored_utc_instant(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Festival',
+            'description' => null,
+            'location' => null,
+            // 2026-08-26T00:30+02:00, the instant a Brussels caller means by half past midnight.
+            'eventDatetime' => new DateTimeImmutable('2026-08-25 22:30:00', new DateTimeZone('UTC')),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            ['isAllDay' => true],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            '@type' => 'AgendaEntry',
+            'id' => $entry->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Festival',
+            'description' => null,
+            'location' => null,
+            'event_datetime' => '2026-08-25T00:00:00+00:00',
+            'end_datetime' => null,
+            'is_all_day' => true,
+            'recurrence_frequency' => null,
+            'recurrence_until_date' => null,
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * The caller's own day when they do send one, offset included: converting before reading the date
+     * would file midnight on the 25th in Brussels under the 24th.
+     */
+    public function test_update_to_all_day_with_an_offset_keeps_the_day_the_caller_wrote(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $entry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Festival',
+            'description' => null,
+            'location' => null,
+            'eventDatetime' => new DateTimeImmutable('2026-07-01 12:00:00', new DateTimeZone('UTC')),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            ['eventDatetime' => '2026-08-25T00:00:00+02:00', 'isAllDay' => true],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaEntry',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-entries/' . $entry->id,
+            '@type' => 'AgendaEntry',
+            'id' => $entry->id,
+            'band_space_id' => $bandSpace->id,
+            'title' => 'Festival',
+            'description' => null,
+            'location' => null,
+            'event_datetime' => '2026-08-25T00:00:00+00:00',
+            'end_datetime' => null,
+            'is_all_day' => true,
+            'recurrence_frequency' => null,
+            'recurrence_until_date' => null,
+            'recurrence_monthly_mode' => null,
+            'creator_id' => $user->id,
+            'creator_username' => $user->username,
+            'creation_datetime' => $entry->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
     public function test_update_agenda_entry_partial_keeps_other_fields(): void
     {
         $user = UserFactory::new()->asBaseUser()->create();


### PR DESCRIPTION
Closes #912.

`new DateTimeImmutable($data->eventDatetime)` parsed the offset correctly, and then `Types::DATETIME_IMMUTABLE`, Doctrine's `datetime`, persisted only the object's wall clock and dropped its timezone. So `20:00+02:00` went into the column as `20:00` and came back as `20:00+00:00`, two hours after the instant that was asked for. PATCH did the same.

Option 1 from the issue, normalise on the way in. The conversion sits in an `else` after the existing all-day block, and the order is the whole subtlety: an all-day entry is a date, not an instant, and its day is read off the wall clock the caller sent, before any conversion. Converting first would file midnight on the 25th in Brussels under the 24th.

`recurrenceUntilDate` is left alone. It is mapped `DATE_IMMUTABLE` and `AgendaAggregator::expandRule()` re-reads it as a bare civil date in the expansion timezone, so converting it could only shift the day.

The contract is stated on `AgendaEntryCreate::$eventDatetime` and `AgendaEntryResource::$eventDatetime`, since it was implicit and only the SPA happened to satisfy it.

## A second bug, found reviewing the first

`endDatetime` carried `#[Assert\GreaterThan(propertyPath: 'eventDatetime')]`, and both fields were declared as `string` on the DTO. Symfony's comparison validator only parses a value into a date when the value under validation already is one, so it fell through to PHP's `>` and compared the two ISO-8601 strings character by character. That sorts correctly only while both carry the same offset:

```
eventDatetime = 2026-08-25T09:00:00-05:00   (14:00 UTC)
endDatetime   = 2026-08-25T10:00:00+00:00   (10:00 UTC, four hours earlier)
```

`"10"` sorts after `"09"`, so this payload was accepted. Reproduced against the running app before touching anything: **201 Created, entry stored ending four hours before it began.** It is easier to hit on PATCH, where the item provider pre-fills `eventDatetime` from the entity and so always contributes a `+00:00` string.

The fix is to stop declaring a datetime as a string. `eventDatetime` and `endDatetime` are `DateTimeImmutable` on both DTOs now, which is what `creationDatetime` on the same resource already was, so the serializer parses them and `GreaterThan` compares instants. That deletes rather than adds: the two processors no longer parse and no longer carry four try/catch blocks, and the constraint stays the framework's own.

Two knock-on effects. A malformed datetime is now refused by the serializer rather than by the processor, so the message changes from « Date et heure invalides » to the serializer's; no test covered that path. And `ValidRecurrenceValidator` reads `eventDatetime` off the same DTO, so it accepts the object as well as the string.

## Tests

Six added, all full body. POST and PATCH with `+02:00` reading back as the same instant in UTC; POST and PATCH all-day with an offset keeping the caller's day; the mixed-offset end-before-start now refused with nothing persisted; and one pinning what toggling `is_all_day` without a datetime does.

That last one is a behaviour change worth naming: the day then comes off the stored UTC instant, because the request carries no timezone to read it in, so an entry starting within the offset of midnight can land on the previous day. It is inherent to storing instants rather than offsets, and it is pinned rather than left to be discovered.

Full suite green at 2387, PHPStan clean.

## Not addressed here

Doctrine hydrates the column with `date_default_timezone_get()`, and nothing in this repository pins that; the two tiers disagreed on it once already (#888). The dependency is now called out in a comment where the conversion happens, but pinning it, or asserting it at boot, is its own change.

Existing rows cannot be audited retrospectively: the stored value carries no trace of the offset it came from, so there is no way to tell a wrongly converted row from a correct one. Nothing is expected to need repair, since the SPA has always sent UTC.
