### PR TITLE
Band Space: make the author mandatory on the eight nullable author columns

### DIFF
--- a/migrations/2026/08/Version20260829120000.php
+++ b/migrations/2026/08/Version20260829120000.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * The eight Band Space columns that still allowed an authorless row, converted to the shape #908 landed
+ * on for notes: NOT NULL with no onDelete, so the foreign key defaults to RESTRICT.
+ *
+ * The nullability was never the point. task.created_by_id started NOT NULL with ON DELETE CASCADE, and
+ * Version20260501100000 relaxed both so that deleting a user could not wipe a band's tasks. Dropping
+ * the CASCADE alone would have done it: RESTRICT refuses to delete a member who still owns content, so
+ * the band keeps its tasks and keeps knowing who wrote them. SET NULL bought the same protection by
+ * throwing the authorship away. The file module copied the pattern to five more tables the week after.
+ *
+ * Nothing hard-deletes a fos_user row today (DeleteAccountProcedure anonymises in place and keeps the
+ * primary key), so RESTRICT changes no behaviour; it only stops a future hard delete from silently
+ * orphaning content.
+ */
+final class Version20260829120000 extends AbstractMigration
+{
+    /** @var array<string, string> table => author column */
+    private const array AUTHOR_COLUMNS = [
+        'task' => 'created_by_id',
+        'band_space_file' => 'created_by_id',
+        'band_space_file_version' => 'created_by_id',
+        'band_space_file_attachment' => 'attached_by_id',
+        'band_space_folder' => 'created_by_id',
+        'band_space_file_share' => 'created_by_id',
+        'band_space_tech_rider' => 'created_by_id',
+        // Named creator rather than createdBy, which is why #909's own sweep for the pattern missed it.
+        'agenda_entry' => 'creator_id',
+    ];
+
+    /** @var array<string, string> table => foreign key constraint name */
+    private const array FOREIGN_KEYS = [
+        'task' => 'FK_527EDB25B03A8386',
+        'band_space_file' => 'FK_1CDD155DB03A8386',
+        'band_space_file_version' => 'FK_3B2112B2B03A8386',
+        'band_space_file_attachment' => 'FK_A6E57146A7B6C524',
+        'band_space_folder' => 'FK_B12D9B5B03A8386',
+        'band_space_file_share' => 'FK_BC2C494DB03A8386',
+        'band_space_tech_rider' => 'FK_C4F3158FB03A8386',
+        'agenda_entry' => 'FK_7B19C9EE61220EA6',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Make the author mandatory on the eight remaining nullable Band Space author columns';
+    }
+
+    /**
+     * A leftover NULL would fail the CHANGE below with a bare SQL error naming neither the table nor
+     * what to do about it. Checked for every table before any of them is altered, because MariaDB does
+     * not roll DDL back: aborting here leaves the schema untouched, aborting halfway would not.
+     */
+    public function preUp(Schema $schema): void
+    {
+        foreach (self::AUTHOR_COLUMNS as $table => $column) {
+            $withoutAuthor = (int) $this->connection->fetchOne(
+                sprintf('SELECT COUNT(*) FROM %s WHERE %s IS NULL', $table, $column)
+            );
+
+            $this->abortIf(
+                $withoutAuthor > 0,
+                sprintf(
+                    '%d row(s) in %s still have no author. Fill %s from the actor of the matching '
+                    . 'band_space_activity row, and assign one by hand where no such row exists.',
+                    $withoutAuthor,
+                    $table,
+                    $column,
+                ),
+            );
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::AUTHOR_COLUMNS as $table => $column) {
+            $foreignKey = self::FOREIGN_KEYS[$table];
+            $this->addSql(sprintf('ALTER TABLE %s DROP FOREIGN KEY %s', $table, $foreignKey));
+            $this->addSql(sprintf('ALTER TABLE %s CHANGE %s %s CHAR(36) NOT NULL', $table, $column, $column));
+            $this->addSql(sprintf(
+                'ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES fos_user (id)',
+                $table,
+                $foreignKey,
+                $column,
+            ));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::AUTHOR_COLUMNS as $table => $column) {
+            $foreignKey = self::FOREIGN_KEYS[$table];
+            $this->addSql(sprintf('ALTER TABLE %s DROP FOREIGN KEY %s', $table, $foreignKey));
+            $this->addSql(sprintf('ALTER TABLE %s CHANGE %s %s CHAR(36) DEFAULT NULL', $table, $column, $column));
+            $this->addSql(sprintf(
+                'ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES fos_user (id) ON DELETE SET NULL',
+                $table,
+                $foreignKey,
+                $column,
+            ));
+        }
+    }
+}

--- a/src/ApiResource/BandSpace/AgendaEntryResource.php
+++ b/src/ApiResource/BandSpace/AgendaEntryResource.php
@@ -138,7 +138,7 @@ class AgendaEntryResource
 
     public ?string $recurrenceMonthlyMode = null;
 
-    public ?string $creatorId = null;
-    public ?string $creatorUsername = null;
+    public string $creatorId;
+    public string $creatorUsername;
     public \DateTimeInterface $creationDatetime;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFileResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileResource.php
@@ -269,8 +269,8 @@ class BandSpaceFileResource
     public ?int $currentVersionNumber = null;
     public int $versionCount = 0;
 
-    /** @var array{id: string, username: string, profile_picture_url: string|null}|null */
-    public ?array $createdBy = null;
+    /** @var array{id: string, username: string, profile_picture_url: string|null} */
+    public array $createdBy;
 
     public ?string $downloadUrl = null;
 

--- a/src/ApiResource/BandSpace/File/BandSpaceFileShareResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileShareResource.php
@@ -59,6 +59,6 @@ class BandSpaceFileShareResource
     public bool $isActive = true;
     public \DateTimeInterface $creationDatetime;
 
-    /** @var array{id: string, username: string}|null */
-    public ?array $createdBy = null;
+    /** @var array{id: string, username: string} */
+    public array $createdBy;
 }

--- a/src/ApiResource/BandSpace/File/BandSpaceFileVersionResource.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileVersionResource.php
@@ -44,8 +44,8 @@ class BandSpaceFileVersionResource
     public bool $isCurrent = false;
     public string $downloadUrl;
 
-    /** @var array{id: string, username: string, profile_picture_url: string|null}|null */
-    public ?array $createdBy = null;
+    /** @var array{id: string, username: string, profile_picture_url: string|null} */
+    public array $createdBy;
 
     public \DateTimeInterface $creationDatetime;
 }

--- a/src/ApiResource/BandSpace/Task/TaskResource.php
+++ b/src/ApiResource/BandSpace/Task/TaskResource.php
@@ -101,8 +101,8 @@ class TaskResource
     public string $priority;
 
     public ?string $dueDate = null;
-    public ?string $createdById = null;
-    public ?string $createdByUsername = null;
+    public string $createdById;
+    public string $createdByUsername;
     public ?string $categoryId = null;
     public ?string $categoryName = null;
 

--- a/src/ApiResource/BandSpace/TechRider/TechRiderResource.php
+++ b/src/ApiResource/BandSpace/TechRider/TechRiderResource.php
@@ -115,7 +115,7 @@ class TechRiderResource
     public string $name;
 
     #[Groups([self::LIST, self::ITEM])]
-    public ?string $createdByUsername = null;
+    public string $createdByUsername;
 
     #[Groups([self::LIST, self::ITEM])]
     public ?\DateTimeInterface $archiveDatetime = null;

--- a/src/Entity/BandSpace/AgendaEntry.php
+++ b/src/Entity/BandSpace/AgendaEntry.php
@@ -36,8 +36,8 @@ class AgendaEntry
     public BandSpace $bandSpace;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    public ?User $creator = null;
+    #[ORM\JoinColumn(nullable: false)]
+    public User $creator;
 
     #[ORM\Column(type: Types::STRING, length: 255)]
     public string $title;

--- a/src/Entity/BandSpace/BandSpaceFile.php
+++ b/src/Entity/BandSpace/BandSpaceFile.php
@@ -34,8 +34,8 @@ class BandSpaceFile
     public BandSpace $bandSpace;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    public ?User $createdBy = null;
+    #[ORM\JoinColumn(nullable: false)]
+    public User $createdBy;
 
     #[ORM\ManyToOne(targetEntity: BandSpaceFolder::class)]
     #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]

--- a/src/Entity/BandSpace/BandSpaceFileAttachment.php
+++ b/src/Entity/BandSpace/BandSpaceFileAttachment.php
@@ -45,8 +45,8 @@ class BandSpaceFileAttachment
     public DateTimeInterface $attachedDatetime;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    public ?User $attachedBy = null;
+    #[ORM\JoinColumn(nullable: false)]
+    public User $attachedBy;
 
     public function __construct()
     {

--- a/src/Entity/BandSpace/BandSpaceFileShare.php
+++ b/src/Entity/BandSpace/BandSpaceFileShare.php
@@ -32,8 +32,8 @@ class BandSpaceFileShare
     public BandSpaceFile $bandSpaceFile;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    public ?User $createdBy = null;
+    #[ORM\JoinColumn(nullable: false)]
+    public User $createdBy;
 
     #[ORM\Column(type: Types::STRING, length: 64, unique: true)]
     public string $tokenHash;

--- a/src/Entity/BandSpace/BandSpaceFileVersion.php
+++ b/src/Entity/BandSpace/BandSpaceFileVersion.php
@@ -37,8 +37,8 @@ class BandSpaceFileVersion
     public int $versionNumber = 1;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    public ?User $createdBy = null;
+    #[ORM\JoinColumn(nullable: false)]
+    public User $createdBy;
 
     #[ORM\Column(type: Types::STRING, length: 191)]
     public string $mimeType;

--- a/src/Entity/BandSpace/BandSpaceFolder.php
+++ b/src/Entity/BandSpace/BandSpaceFolder.php
@@ -39,8 +39,8 @@ class BandSpaceFolder
     public string $name;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    public ?User $createdBy = null;
+    #[ORM\JoinColumn(nullable: false)]
+    public User $createdBy;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     public DateTimeInterface $creationDatetime;

--- a/src/Entity/BandSpace/Task.php
+++ b/src/Entity/BandSpace/Task.php
@@ -53,8 +53,8 @@ class Task
     public ?DateTimeImmutable $dueDate = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    public ?User $createdBy = null;
+    #[ORM\JoinColumn(nullable: false)]
+    public User $createdBy;
 
     /**
      * @var Collection<int, User>

--- a/src/Entity/BandSpace/TechRider.php
+++ b/src/Entity/BandSpace/TechRider.php
@@ -44,8 +44,8 @@ class TechRider
      * needs the document. Same shape as BandSpaceFile::$createdBy.
      */
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
-    public ?User $createdBy = null;
+    #[ORM\JoinColumn(nullable: false)]
+    public User $createdBy;
 
     #[ORM\Column(type: Types::STRING, length: 255)]
     public string $name;

--- a/src/EventSubscriber/BandSpaceTaskCommentedListener.php
+++ b/src/EventSubscriber/BandSpaceTaskCommentedListener.php
@@ -57,9 +57,6 @@ readonly class BandSpaceTaskCommentedListener
 
             $candidateIds = [];
             foreach ($candidates as $candidate) {
-                if (!$candidate instanceof User) {
-                    continue;
-                }
                 $candidateId = (string) $candidate->id;
                 if (!isset($excludedIds[$candidateId])) {
                     $candidateIds[$candidateId] = $candidateId;

--- a/src/Procedure/BandSpace/TaskBulkDeleteProcedure.php
+++ b/src/Procedure/BandSpace/TaskBulkDeleteProcedure.php
@@ -69,7 +69,7 @@ readonly class TaskBulkDeleteProcedure
         $userId = (string) $user->id;
         $foreign = array_filter(
             $tasks,
-            static fn(Task $task): bool => !$task->createdBy instanceof User || (string) $task->createdBy->id !== $userId,
+            static fn(Task $task): bool => (string) $task->createdBy->id !== $userId,
         );
 
         if ($foreign === []) {

--- a/src/Service/Builder/BandSpace/AgendaEntryBuilder.php
+++ b/src/Service/Builder/BandSpace/AgendaEntryBuilder.php
@@ -33,8 +33,8 @@ readonly class AgendaEntryBuilder
         $dto->recurrenceFrequency = $entity->recurrenceFrequency?->value;
         $dto->recurrenceUntilDate = $entity->recurrenceUntilDate?->format('Y-m-d');
         $dto->recurrenceMonthlyMode = $entity->recurrenceMonthlyMode?->value;
-        $dto->creatorId = $entity->creator instanceof \App\Entity\User ? (string) $entity->creator->id : null;
-        $dto->creatorUsername = $entity->creator?->username;
+        $dto->creatorId = (string) $entity->creator->id;
+        $dto->creatorUsername = $entity->creator->username;
         $dto->creationDatetime = $entity->creationDatetime;
 
         return $dto;

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileBuilder.php
@@ -98,13 +98,11 @@ readonly class BandSpaceFileBuilder
 
         $dto->versionCount = $versionCount ?? $this->fileRepository->countVersionsByFileIds([(string) $entity->id])[(string) $entity->id] ?? 0;
 
-        if ($entity->createdBy instanceof \App\Entity\User) {
-            $dto->createdBy = [
-                'id' => (string) $entity->createdBy->id,
-                'username' => $entity->createdBy->username,
-                'profile_picture_url' => $this->profilePictureUrlBuilder->build($entity->createdBy),
-            ];
-        }
+        $dto->createdBy = [
+            'id' => (string) $entity->createdBy->id,
+            'username' => $entity->createdBy->username,
+            'profile_picture_url' => $this->profilePictureUrlBuilder->build($entity->createdBy),
+        ];
 
         $dto->downloadUrl = $this->urlGenerator->generate(
             'api_band_space_files_get_item',

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileShareBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileShareBuilder.php
@@ -25,12 +25,10 @@ readonly class BandSpaceFileShareBuilder
             && (!$entity->expiryDatetime instanceof \DateTimeImmutable || $entity->expiryDatetime > $now);
         $dto->creationDatetime = $entity->creationDatetime;
 
-        if ($entity->createdBy instanceof \App\Entity\User) {
-            $dto->createdBy = [
-                'id' => (string) $entity->createdBy->id,
-                'username' => $entity->createdBy->username,
-            ];
-        }
+        $dto->createdBy = [
+            'id' => (string) $entity->createdBy->id,
+            'username' => $entity->createdBy->username,
+        ];
 
         return $dto;
     }

--- a/src/Service/Builder/BandSpace/File/BandSpaceFileVersionBuilder.php
+++ b/src/Service/Builder/BandSpace/File/BandSpaceFileVersionBuilder.php
@@ -37,13 +37,11 @@ readonly class BandSpaceFileVersionBuilder
             UrlGeneratorInterface::ABSOLUTE_PATH,
         );
 
-        if ($entity->createdBy instanceof \App\Entity\User) {
-            $dto->createdBy = [
-                'id' => (string) $entity->createdBy->id,
-                'username' => $entity->createdBy->username,
-                'profile_picture_url' => $this->profilePictureUrlBuilder->build($entity->createdBy),
-            ];
-        }
+        $dto->createdBy = [
+            'id' => (string) $entity->createdBy->id,
+            'username' => $entity->createdBy->username,
+            'profile_picture_url' => $this->profilePictureUrlBuilder->build($entity->createdBy),
+        ];
 
         $dto->creationDatetime = $entity->creationDatetime;
 

--- a/src/Service/Builder/BandSpace/TaskBuilder.php
+++ b/src/Service/Builder/BandSpace/TaskBuilder.php
@@ -42,8 +42,8 @@ readonly class TaskBuilder
         $dto->status = $entity->status->value;
         $dto->priority = $entity->priority->value;
         $dto->dueDate = $entity->dueDate?->format('Y-m-d');
-        $dto->createdById = $entity->createdBy instanceof \App\Entity\User ? (string) $entity->createdBy->id : null;
-        $dto->createdByUsername = $entity->createdBy?->username;
+        $dto->createdById = (string) $entity->createdBy->id;
+        $dto->createdByUsername = $entity->createdBy->username;
         $dto->categoryId = $entity->category instanceof \App\Entity\BandSpace\TaskCategory ? (string) $entity->category->id : null;
         $dto->categoryName = $entity->category?->name;
         $dto->assignees = $entity->assignees->map(

--- a/src/Service/Builder/BandSpace/TechRider/TechRiderBuilder.php
+++ b/src/Service/Builder/BandSpace/TechRider/TechRiderBuilder.php
@@ -66,7 +66,7 @@ readonly class TechRiderBuilder
         $dto->id = (string) $entity->id;
         $dto->bandSpaceId = (string) $entity->bandSpace->id;
         $dto->name = $entity->name;
-        $dto->createdByUsername = $entity->createdBy?->username;
+        $dto->createdByUsername = $entity->createdBy->username;
         $dto->archiveDatetime = $entity->archiveDatetime;
         $dto->creationDatetime = $entity->creationDatetime;
         $dto->updateDatetime = $entity->updateDatetime;

--- a/src/State/Processor/BandSpace/File/BandSpaceFileDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileDeleteProcessor.php
@@ -52,7 +52,7 @@ readonly class BandSpaceFileDeleteProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Fichier introuvable');
         }
 
-        $isOwner = $file->createdBy instanceof \App\Entity\User && $file->createdBy->id === $user->id;
+        $isOwner = $file->createdBy->id === $user->id;
         if (!$isOwner && $membership->role !== Role::Admin) {
             throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut supprimer ce fichier');
         }

--- a/src/State/Processor/BandSpace/File/BandSpaceFileRestoreProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileRestoreProcessor.php
@@ -60,7 +60,7 @@ readonly class BandSpaceFileRestoreProcessor implements ProcessorInterface
         }
 
         // Same rule as archiving: whoever could delete it can bring it back.
-        $isOwner = $file->createdBy instanceof User && $file->createdBy->id === $user->id;
+        $isOwner = $file->createdBy->id === $user->id;
         if (!$isOwner && $membership->role !== Role::Admin) {
             throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut restaurer ce fichier');
         }

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
@@ -94,7 +94,7 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('Seul un administrateur peut supprimer un dossier en cascade');
         }
 
-        $isOwner = $folder->createdBy instanceof User && $folder->createdBy->id === $user->id;
+        $isOwner = $folder->createdBy->id === $user->id;
         if ($strategy === self::STRATEGY_MOVE_TO_ROOT && !$isOwner && $membership->role !== Role::Admin) {
             throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut supprimer ce dossier');
         }

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderUpdateProcessor.php
@@ -55,7 +55,7 @@ readonly class BandSpaceFolderUpdateProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Dossier introuvable');
         }
 
-        $isOwner = $folder->createdBy instanceof \App\Entity\User && $folder->createdBy->id === $user->id;
+        $isOwner = $folder->createdBy->id === $user->id;
         if (!$isOwner && $membership->role !== Role::Admin) {
             throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut modifier ce dossier');
         }

--- a/src/State/Processor/BandSpace/TaskDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/TaskDeleteProcessor.php
@@ -46,7 +46,7 @@ readonly class TaskDeleteProcessor implements ProcessorInterface
             throw new NotFoundHttpException('Tâche introuvable');
         }
 
-        $isCreator = $task->createdBy instanceof \App\Entity\User && $task->createdBy->id === $user->id;
+        $isCreator = $task->createdBy->id === $user->id;
         if (!$isCreator && $membership->role !== Role::Admin) {
             throw new AccessDeniedHttpException('Seul le créateur ou un administrateur peut supprimer cette tâche');
         }

--- a/tests/Api/BandSpace/File/BandSpaceFolderDeleteTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFolderDeleteTest.php
@@ -382,8 +382,8 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
         $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Photos'])->create();
         $child = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Live', 'parent' => $folder])->create();
 
-        $this->seedFiles($bandSpace->id, (string) $folder->id, 1000);
-        $this->seedFiles($bandSpace->id, (string) $child->id, 1001);
+        $this->seedFiles($bandSpace->id, (string) $folder->id, (string) $admin->id, 1000);
+        $this->seedFiles($bandSpace->id, (string) $child->id, (string) $admin->id, 1001);
 
         $this->client->loginUser($admin);
         $this->client->jsonRequest(
@@ -415,7 +415,7 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
         $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $admin, 'name' => 'Photos'])->create();
 
         // Exactly on the limit: the guard rejects above it, never at it.
-        $this->seedFiles($bandSpace->id, (string) $folder->id, 2000);
+        $this->seedFiles($bandSpace->id, (string) $folder->id, (string) $admin->id, 2000);
 
         $bandSpaceId = $bandSpace->id;
         $folderId = (string) $folder->id;
@@ -457,9 +457,9 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
     /**
      * Rows straight through the connection: thousands of files is the whole point of the two limit
      * tests, and building them as Foundry objects would cost minutes for state no assertion reads.
-     * created_by_id is left null, which the uploader join tolerates and the count ignores.
+     * The author is passed in rather than left out, because created_by_id is NOT NULL since #909.
      */
-    private function seedFiles(string $bandSpaceId, string $folderId, int $count): void
+    private function seedFiles(string $bandSpaceId, string $folderId, string $createdById, int $count): void
     {
         $connection = self::getContainer()->get(EntityManagerInterface::class)->getConnection();
         $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
@@ -467,12 +467,12 @@ class BandSpaceFolderDeleteTest extends ApiTestCase
         $rows = [];
         $parameters = [];
         for ($i = 0; $i < $count; $i++) {
-            $rows[] = '(?, ?, ?, ?, ?)';
-            array_push($parameters, Uuid::uuid4()->toString(), $bandSpaceId, $folderId, 'photo-' . $i . '.jpg', $now);
+            $rows[] = '(?, ?, ?, ?, ?, ?)';
+            array_push($parameters, Uuid::uuid4()->toString(), $bandSpaceId, $folderId, $createdById, 'photo-' . $i . '.jpg', $now);
         }
 
         $connection->executeStatement(
-            'INSERT INTO band_space_file (id, band_space_id, folder_id, original_name, creation_datetime) VALUES '
+            'INSERT INTO band_space_file (id, band_space_id, folder_id, created_by_id, original_name, creation_datetime) VALUES '
             . implode(', ', $rows),
             $parameters,
         );

--- a/tests/Api/BandSpace/TechRider/TechRiderGetCollectionTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderGetCollectionTest.php
@@ -91,11 +91,13 @@ class TechRiderGetCollectionTest extends ApiTestCase
         TechRiderFactory::new([
             'bandSpace' => $bandSpace,
             'name' => 'Live rider',
+            'createdBy' => $user,
             'creationDatetime' => new DateTime('2026-01-15T10:00:00+00:00'),
         ])->create();
         $archived = TechRiderFactory::new([
             'bandSpace' => $bandSpace,
             'name' => 'Archived rider',
+            'createdBy' => $user,
             'creationDatetime' => new DateTime('2025-01-15T10:00:00+00:00'),
             'archiveDatetime' => new DateTimeImmutable('2026-03-01T10:00:00+00:00'),
         ])->create();
@@ -115,7 +117,7 @@ class TechRiderGetCollectionTest extends ApiTestCase
                     'id' => $archived->id,
                     'band_space_id' => $bandSpace->id,
                     'name' => 'Archived rider',
-                    'created_by_username' => null,
+                    'created_by_username' => $user->username,
                     'archive_datetime' => $archived->archiveDatetime?->format(DateTimeInterface::ATOM),
                     'creation_datetime' => $archived->creationDatetime->format(DateTimeInterface::ATOM),
                     'update_datetime' => null,
@@ -141,6 +143,7 @@ class TechRiderGetCollectionTest extends ApiTestCase
         $mine = TechRiderFactory::new([
             'bandSpace' => $myBand,
             'name' => 'Mine',
+            'createdBy' => $user,
             'creationDatetime' => new DateTime('2026-01-15T10:00:00+00:00'),
         ])->create();
         TechRiderFactory::new(['bandSpace' => $otherBand, 'name' => 'Theirs'])->create();
@@ -160,7 +163,7 @@ class TechRiderGetCollectionTest extends ApiTestCase
                     'id' => $mine->id,
                     'band_space_id' => $myBand->id,
                     'name' => 'Mine',
-                    'created_by_username' => null,
+                    'created_by_username' => $user->username,
                     'archive_datetime' => null,
                     'creation_datetime' => $mine->creationDatetime->format(DateTimeInterface::ATOM),
                     'update_datetime' => null,

--- a/tests/Api/BandSpace/TechRider/TechRiderGetItemTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderGetItemTest.php
@@ -65,6 +65,7 @@ class TechRiderGetItemTest extends ApiTestCase
         $rider = TechRiderFactory::new([
             'bandSpace' => $bandSpace,
             'name' => 'Technical rider 2025',
+            'createdBy' => $user,
             'creationDatetime' => new DateTime('2025-01-15T10:00:00+00:00'),
             'archiveDatetime' => new DateTimeImmutable('2026-01-05T09:00:00+00:00'),
         ])->create();
@@ -80,7 +81,7 @@ class TechRiderGetItemTest extends ApiTestCase
             'id' => $rider->id,
             'band_space_id' => $bandSpace->id,
             'name' => 'Technical rider 2025',
-            'created_by_username' => null,
+            'created_by_username' => $user->username,
             'archive_datetime' => $rider->archiveDatetime?->format(DateTimeInterface::ATOM),
             'creation_datetime' => $rider->creationDatetime->format(DateTimeInterface::ATOM),
             'update_datetime' => null,

--- a/tests/Api/BandSpace/TechRider/TechRiderItemTest.php
+++ b/tests/Api/BandSpace/TechRider/TechRiderItemTest.php
@@ -494,6 +494,7 @@ class TechRiderItemTest extends ApiTestCase
         $rider = TechRiderFactory::new([
             'bandSpace' => $bandSpace,
             'name' => 'Rider',
+            'createdBy' => $user,
             'creationDatetime' => new DateTime('2026-01-15T10:00:00+00:00'),
         ])->create();
         TechRiderItemFactory::new([
@@ -519,7 +520,7 @@ class TechRiderItemTest extends ApiTestCase
                     'id' => (string) $rider->id,
                     'band_space_id' => (string) $bandSpace->id,
                     'name' => 'Rider',
-                    'created_by_username' => null,
+                    'created_by_username' => $user->username,
                     'archive_datetime' => null,
                     'creation_datetime' => $rider->creationDatetime->format(DateTimeInterface::ATOM),
                     'update_datetime' => null,

--- a/tests/Factory/BandSpace/TechRiderFactory.php
+++ b/tests/Factory/BandSpace/TechRiderFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Factory\BandSpace;
 
 use App\Entity\BandSpace\TechRider;
+use App\Tests\Factory\User\UserFactory;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
 /**
@@ -17,6 +18,7 @@ final class TechRiderFactory extends PersistentObjectFactory
         return [
             'bandSpace' => BandSpaceFactory::new(),
             'name' => self::faker()->sentence(3),
+            'createdBy' => UserFactory::new(),
             'creationDatetime' => self::faker()->dateTime(),
         ];
     }


### PR DESCRIPTION
Closes #909.

Seven Band Space columns carried their author as `nullable: true` with `onDelete: 'SET NULL'`, and an eighth turned up during the work. The nullability was never the point. `task.created_by_id` started `NOT NULL` with `ON DELETE CASCADE`, and `Version20260501100000` relaxed both so that deleting a user could not wipe a band's tasks. Dropping the CASCADE alone would have done it: RESTRICT refuses to delete a member who still owns content, so the band keeps its tasks and keeps knowing who wrote them. SET NULL bought the same protection by throwing the authorship away, and the file module copied the pattern to five more tables the week after.

All eight now match the shape #908 landed on for notes: `NOT NULL`, no `onDelete`.

## Production was audited first

| Table | Column | Rows | Without an author |
|---|---|---|---|
| `task` | `created_by_id` | 74 | 0 |
| `band_space_file` | `created_by_id` | - | 0 |
| `band_space_file_version` | `created_by_id` | 18 | 0 |
| `band_space_folder` | `created_by_id` | 4 | 0 |
| `band_space_file_attachment` | `attached_by_id` | 3 | 0 |
| `band_space_file_share` | `created_by_id` | 1 | 0 |
| `band_space_tech_rider` | `created_by_id` | 0 | 0 |
| `agenda_entry` | `creator_id` | 37 | 0 |

Nothing was blocked, so the eight are converted together rather than split. The issue suggested keeping `task` for last on the grounds that tasks are the most numerous of these rows; at 74 against 18 for the next one, that argument does not survive the count.

## The eighth column

`AgendaEntry::$creator` has the identical `?User` plus `SET NULL` shape and is set on exactly one path, `AgendaEntryCreateProcessor`. #909 lists seven because its sweep looked for `createdBy` and this property is called `creator`.

Two other nullable `?User` associations were checked and left alone, because their nullability is real rather than dropped authorship: `BandSpaceInvitation::$existingUser`, since an invitee may have no account yet, and `BandSpaceActivity::$actor`, which is null for genuinely actor-less events (a public share download, and the invitation-expiry cron).

## The migration

One migration for the eight tables. Its `preUp` checks every table before any of them is altered: MariaDB does not roll DDL back, so aborting in the pre-check leaves the schema untouched, while aborting halfway would not. Each table then drops its foreign key, changes the column to `NOT NULL`, and re-adds the key with no `onDelete`. Constraint names were read from the migration database rather than derived.

Validated on the migration database, which is the only one that proves a migration: applied, checked `IS_NULLABLE` and `DELETE_RULE` for all eight, rolled back, confirmed the original nullable and `SET NULL` shape returns, re-applied. `doctrine:schema:validate` reports only pre-existing drift unrelated to these columns.

RESTRICT changes nothing today: `DeleteAccountProcedure` anonymises the row in place and keeps its primary key, and nothing anywhere hard-deletes a `fos_user`. It only stops a future hard delete from silently orphaning content.

## What the type change removed

Twelve places read as though the author might be absent. #909 lists ten; PHPStan found two more once the properties were non-nullable, in `BandSpaceTaskCommentedListener` and `TechRiderBuilder`.

Four of them are ownership checks of the form `$x->createdBy instanceof User && $x->createdBy->id === $user->id`, where a null author meant nobody owned the row and only an admin could act on it. That case is gone rather than handled.

Seven DTO fields follow the author and become non-nullable, which is what #908 did for notes. The serialized output is unchanged; only the declared types stop allowing a value no row can hold.

## Tests

`TechRiderFactory` was the only one of eight missing a `createdBy` default. `seedFiles()` in the folder delete test writes rows through the connection and now passes an author. Four tech rider tests asserted `created_by_username => null`, which was a byproduct of that missing factory default rather than a state anyone meant to test; they now name their author.

Full suite green at 2387, PHPStan clean.
