### PR TITLE
Band Space: command palette (Ctrl+K) searching across the current space

### DIFF
--- a/assets/js/api/bandSpace/band-space-agenda.js
+++ b/assets/js/api/bandSpace/band-space-agenda.js
@@ -15,6 +15,17 @@ export default {
       .catch(handleApiError)
   },
 
+  /**
+   * One entry on its own, by id. The agenda itself is fetched as a date range, so this is what a
+   * link to a single entry uses to find out which period to show before asking for that range.
+   */
+  getEntry(bandSpaceId, entryId) {
+    return axios
+      .get(Routing.generate('api_band_space_agenda_entries_get_item', { bandSpaceId, id: entryId }))
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
   createEntry(bandSpaceId, data) {
     return axios
       .post(Routing.generate('api_band_space_agenda_entries_post', { bandSpaceId }), data, {

--- a/assets/js/api/bandSpace/band-space-search.js
+++ b/assets/js/api/bandSpace/band-space-search.js
@@ -1,0 +1,24 @@
+/** global: Routing */
+
+import axios from 'axios'
+import { handleApiError } from '../utils/handleApiError.js'
+
+export default {
+  /**
+   * Searches every module of one band space at once, for the command palette.
+   *
+   * The backend answers with an empty collection below two characters rather than an error, so the
+   * caller never has to special case a short query.
+   *
+   * @param {string} bandSpaceId
+   * @param {string} q
+   */
+  search(bandSpaceId, q) {
+    return axios
+      .get(Routing.generate('api_band_space_search_get_collection', { bandSpaceId }), {
+        params: { q }
+      })
+      .then((resp) => resp.data.member ?? [])
+      .catch(handleApiError)
+  }
+}

--- a/assets/js/components/AppBandLayout.vue
+++ b/assets/js/components/AppBandLayout.vue
@@ -17,7 +17,8 @@
     </template>
     <template v-else>
       <SkipLink />
-      <MenuBand v-model:mobile-nav-open="mobileNavOpen" />
+      <MenuBand v-model:mobile-nav-open="mobileNavOpen" @open-search="paletteVisible = true" />
+      <CommandPalette v-model:visible="paletteVisible" />
       <div class="flex">
         <aside
           class="hidden lg:block w-[var(--band-sidebar-width)] shrink-0 sticky top-16 h-[calc(100dvh-4rem)] bg-surface-0 dark:bg-surface-900 border-r border-surface-200 dark:border-surface-700 self-start transition-[width] duration-150"
@@ -157,7 +158,7 @@ import Button from 'primevue/button'
 import Drawer from 'primevue/drawer'
 import Toast from 'primevue/toast'
 import { useToast } from 'primevue/usetoast'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useBandSpaceNavigation } from '../composables/useBandSpaceNavigation.js'
 import { BAND_SPACE_ROUTES, SECTION_NAMES } from '../constants/bandSpace.js'
@@ -168,6 +169,7 @@ import { formatDateLong } from '../utils/date.js'
 import MenuBand from '../views/Global/MenuBand.vue'
 import BandSidebar from './BandSpace/BandSidebar.vue'
 import BandSpaceSelector from './BandSpace/BandSpaceSelector.vue'
+import CommandPalette from './BandSpace/CommandPalette.vue'
 import SkipLink from './SkipLink.vue'
 
 const bandSpaceStore = useBandSpaceStore()
@@ -252,6 +254,24 @@ const deletionScheduledFor = computed(() => currentSpace.value?.deletion_schedul
 const isLoading = ref(true)
 const hasError = ref(false)
 const mobileNavOpen = ref(false)
+const paletteVisible = ref(false)
+
+/**
+ * Bound here rather than globally on purpose: outside a band space there is nothing for the palette
+ * to search, and swallowing the browser's own Ctrl+K on the rest of the site would be a regression.
+ */
+function handleSearchShortcut(event) {
+  if (event.key?.toLowerCase() !== 'k' || !(event.ctrlKey || event.metaKey)) {
+    return
+  }
+  // No space in the URL yet means no space to search, so leave the shortcut alone.
+  if (!route.params.id) {
+    return
+  }
+
+  event.preventDefault()
+  paletteVisible.value = true
+}
 
 // Desktop sidebar collapse state — persists across reloads and drives the
 // --band-sidebar-width CSS variable so the aside, the navbar logo zone,
@@ -301,7 +321,10 @@ useHead({
 
 onMounted(() => {
   loadSpaces()
+  window.addEventListener('keydown', handleSearchShortcut)
 })
+
+onUnmounted(() => window.removeEventListener('keydown', handleSearchShortcut))
 
 async function loadSpaces() {
   isLoading.value = true

--- a/assets/js/components/BandSpace/CommandPalette.vue
+++ b/assets/js/components/BandSpace/CommandPalette.vue
@@ -1,0 +1,314 @@
+<template>
+  <Dialog
+    v-model:visible="visible"
+    modal
+    dismissableMask
+    :show-header="false"
+    :style="{ width: '38rem' }"
+    :breakpoints="{ '40rem': '95vw' }"
+    class="overflow-hidden!"
+    content-class="p-0!"
+    :pt="{ root: { 'aria-labelledby': HEADING_ID } }"
+    @show="reset"
+  >
+    <!-- Own header rather than the Dialog's, so the input is the whole top row. PrimeVue points
+         aria-labelledby at a header element that no longer exists, hence the redirection above. -->
+    <h2 :id="HEADING_ID" class="sr-only">Rechercher dans le Band Space</h2>
+
+    <div class="flex w-full items-center px-4 py-3">
+      <IconField class="flex-1">
+        <InputIcon class="pi pi-search text-surface-500 dark:text-surface-300" />
+        <InputText
+          v-model="query"
+          autofocus
+          class="w-full border-0! shadow-none! outline-0!"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-label="Rechercher dans le Band Space"
+          :aria-expanded="flatResults.length > 0"
+          :aria-controls="flatResults.length > 0 ? LISTBOX_ID : undefined"
+          :aria-activedescendant="activeOptionId"
+          placeholder="Rechercher dans cet espace..."
+          @keydown.down.prevent="moveActive(1)"
+          @keydown.up.prevent="moveActive(-1)"
+          @keydown.enter.prevent="openActiveResult"
+        />
+      </IconField>
+    </div>
+
+    <div class="border-t border-surface p-4">
+      <div v-if="isSearching" class="py-8 flex justify-center">
+        <ProgressSpinner style="width: 2rem; height: 2rem" />
+      </div>
+
+      <Message v-else-if="searchError" severity="error" :closable="false">
+        {{ searchError }}
+      </Message>
+
+      <!-- No query yet: naming what is searchable is what teaches the feature. -->
+      <div v-else-if="!hasSearched" class="flex flex-col gap-3">
+        <p class="text-sm text-surface-600 dark:text-surface-300 m-0">
+          Tapez au moins {{ MIN_QUERY_LENGTH }} caractères pour chercher dans&nbsp;:
+        </p>
+        <ul class="list-none p-0 m-0 flex flex-wrap gap-2">
+          <li
+            v-for="searchType in SEARCH_TYPES"
+            :key="searchType.type"
+            class="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs bg-surface-100 dark:bg-surface-800 text-surface-700 dark:text-surface-200"
+          >
+            <i :class="['pi', searchType.icon, 'text-xs']" aria-hidden="true" />
+            <span>{{ searchType.label }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <p v-else-if="flatResults.length === 0" class="py-6 m-0 text-center text-surface-600 dark:text-surface-300">
+        Aucun résultat pour «&nbsp;{{ query.trim() }}&nbsp;»
+      </p>
+
+      <!--
+        The rows are divs rather than buttons on purpose. This is the ARIA combobox pattern: focus
+        stays on the input and aria-activedescendant points at the current row, so the rows must not
+        be focusable themselves. Elsewhere in the band space a clickable row should still be a button.
+      -->
+      <div
+        v-else
+        :id="LISTBOX_ID"
+        ref="listboxRef"
+        role="listbox"
+        aria-label="Résultats de la recherche"
+        class="flex flex-col gap-3 max-h-[24rem] overflow-y-auto"
+      >
+        <div v-for="group in groups" :key="group.type" role="group" :aria-label="group.label">
+          <p class="flex items-center gap-2 px-2 pb-1 m-0 text-xs font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">
+            <i :class="['pi', group.icon, 'text-xs']" aria-hidden="true" />
+            {{ group.label }}
+          </p>
+          <!-- Pointer move rather than CSS hover, so the mouse and the arrow keys drive the one
+               active row instead of lighting up two at once. -->
+          <div
+            v-for="result in group.results"
+            :id="optionId(result)"
+            :key="result.id"
+            role="option"
+            :aria-selected="result.id === activeResult?.id"
+            :class="[
+              'flex items-center gap-3 px-3 py-2 rounded-lg border cursor-pointer transition-all',
+              result.id === activeResult?.id
+                ? 'border-primary-200 dark:border-primary-700/50 bg-primary-50 dark:bg-primary-800/75 text-primary'
+                : 'border-transparent'
+            ]"
+            @click="openResult(result)"
+            @mousemove="setActiveResult(result)"
+          >
+            <span class="flex-1 min-w-0 truncate palette-title" v-html="highlightedTitle(result)" />
+            <span v-if="result.subtitle" class="shrink-0 text-xs text-surface-600 dark:text-surface-300 truncate max-w-[10rem]">
+              {{ result.subtitle }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-between gap-3 px-4 py-3 border-t border-surface bg-surface-50 dark:bg-surface-900">
+      <div class="flex items-center gap-3">
+        <span class="inline-flex items-center gap-1 text-xs text-surface-600 dark:text-surface-300">
+          <kbd :class="KBD_CLASS">⏎</kbd> Ouvrir
+        </span>
+        <span class="inline-flex items-center gap-1 text-xs text-surface-600 dark:text-surface-300">
+          <kbd :class="KBD_CLASS">↑</kbd><kbd :class="KBD_CLASS">↓</kbd> Naviguer
+        </span>
+        <span class="inline-flex items-center gap-1 text-xs text-surface-600 dark:text-surface-300">
+          <kbd :class="KBD_CLASS">esc</kbd> Fermer
+        </span>
+      </div>
+      <!-- Visible and announced: the count is the one thing a screen reader cannot infer from the
+           list appearing, and sighted users want it too. -->
+      <span class="text-xs text-surface-600 dark:text-surface-300 tabular-nums" aria-live="polite">
+        {{ resultCountLabel }}
+      </span>
+    </div>
+  </Dialog>
+</template>
+
+<script setup>
+import { useDebounceFn } from '@vueuse/core'
+import Dialog from 'primevue/dialog'
+import IconField from 'primevue/iconfield'
+import InputIcon from 'primevue/inputicon'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import ProgressSpinner from 'primevue/progressspinner'
+import { computed, nextTick, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import bandSpaceSearchApi from '../../api/bandSpace/band-space-search.js'
+import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
+import {
+  flattenGroups,
+  groupResultsByType,
+  moveActiveIndex,
+  routeForResult,
+  SEARCH_TYPES
+} from '../../utils/bandSpaceSearch.js'
+import { highlightTerm } from '../../utils/highlight.js'
+
+// A #header slot replaces the element PrimeVue points aria-labelledby at, which would leave the
+// dialog with no accessible name at all, so the reference is redirected at the heading below.
+const HEADING_ID = 'band-space-search-heading'
+const LISTBOX_ID = 'band-space-search-listbox'
+const KBD_CLASS =
+  'font-sans p-1 min-w-5 inline-flex items-center justify-center rounded-md leading-none border border-surface-300 dark:border-surface-600 bg-surface-100 dark:bg-surface-800'
+const MIN_QUERY_LENGTH = 2
+const DEBOUNCE_MS = 250
+
+const visible = defineModel('visible', { type: Boolean, default: false })
+
+const router = useRouter()
+const { currentSpaceId } = useBandSpaceNavigation()
+
+const query = ref('')
+const results = ref([])
+const isSearching = ref(false)
+const searchError = ref(null)
+const hasSearched = ref(false)
+const activeIndex = ref(0)
+const listboxRef = ref(null)
+
+// Monotonic, so a response that arrives after a newer keystroke is dropped instead of overwriting
+// the newer results. Not reactive: nothing renders it.
+let requestId = 0
+
+const groups = computed(() => groupResultsByType(results.value))
+const flatResults = computed(() => flattenGroups(groups.value))
+const activeResult = computed(() => flatResults.value[activeIndex.value] ?? null)
+const activeOptionId = computed(() =>
+  activeResult.value ? optionId(activeResult.value) : undefined
+)
+
+const resultCountLabel = computed(() => {
+  if (!hasSearched.value || isSearching.value) {
+    return ''
+  }
+  const count = flatResults.value.length
+  if (count === 0) {
+    return 'Aucun résultat'
+  }
+
+  return count === 1 ? '1 résultat' : `${count} résultats`
+})
+
+function optionId(result) {
+  return `band-space-search-option-${result.id}`
+}
+
+function highlightedTitle(result) {
+  return highlightTerm(result.title, query.value.trim())
+}
+
+const runSearchDebounced = useDebounceFn(runSearch, DEBOUNCE_MS)
+
+watch(query, (value) => {
+  const trimmed = (value ?? '').trim()
+
+  // Invalidate anything in flight straight away, so deleting back to one character cannot be
+  // undone half a second later by a response for the longer term.
+  requestId += 1
+  activeIndex.value = 0
+
+  if (trimmed.length < MIN_QUERY_LENGTH) {
+    results.value = []
+    searchError.value = null
+    hasSearched.value = false
+    isSearching.value = false
+  } else {
+    isSearching.value = true
+  }
+
+  // Fired even for a short term: the debounce keeps only the latest call, so this is what carries
+  // the shortened term to runSearch, which then declines to ask the server for it.
+  runSearchDebounced(trimmed)
+})
+
+// Watches the results too, not only the index: a new search leaves activeIndex at 0, so without
+// this the list would keep the scroll position of the previous one and open below the active row.
+watch([activeIndex, flatResults], async () => {
+  await nextTick()
+  listboxRef.value?.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: 'nearest' })
+})
+
+async function runSearch(term) {
+  if (term.length < MIN_QUERY_LENGTH || !currentSpaceId.value) {
+    return
+  }
+
+  requestId += 1
+  const id = requestId
+  searchError.value = null
+
+  try {
+    const found = await bandSpaceSearchApi.search(currentSpaceId.value, term)
+    if (id !== requestId) {
+      return
+    }
+    results.value = found
+  } catch (error) {
+    if (id !== requestId) {
+      return
+    }
+    searchError.value = error?.message ?? 'Erreur pendant la recherche'
+    results.value = []
+  } finally {
+    if (id === requestId) {
+      hasSearched.value = true
+      isSearching.value = false
+    }
+  }
+}
+
+function moveActive(step) {
+  activeIndex.value = moveActiveIndex(flatResults.value.length, activeIndex.value, step)
+}
+
+function setActiveResult(result) {
+  const index = flatResults.value.indexOf(result)
+  if (index !== -1) {
+    activeIndex.value = index
+  }
+}
+
+function openActiveResult() {
+  if (activeResult.value) {
+    openResult(activeResult.value)
+  }
+}
+
+function openResult(result) {
+  const target = routeForResult(result, currentSpaceId.value)
+  if (!target) {
+    return
+  }
+
+  visible.value = false
+  router.push(target)
+}
+
+function reset() {
+  query.value = ''
+  results.value = []
+  searchError.value = null
+  hasSearched.value = false
+  isSearching.value = false
+  activeIndex.value = 0
+  requestId += 1
+}
+</script>
+
+<style scoped>
+/* v-html content carries no scope attribute, so the highlight needs :deep to reach it. */
+.palette-title :deep(mark) {
+  background-color: rgba(245, 180, 0, 0.35);
+  color: inherit;
+  padding: 0 0.1em;
+  border-radius: 2px;
+}
+</style>

--- a/assets/js/components/BandSpace/Setlist/RepertoireView.vue
+++ b/assets/js/components/BandSpace/Setlist/RepertoireView.vue
@@ -93,6 +93,7 @@ import Skeleton from 'primevue/skeleton'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
 import { useBandSongsStore } from '../../../store/bandSpace/bandSpaceSongs.js'
 import { formatDuration } from '../../../utils/setlistDuration.js'
@@ -100,9 +101,13 @@ import SongDetailDrawer from './SongDetailDrawer.vue'
 import SongFormDialog from './SongFormDialog.vue'
 
 const props = defineProps({
-  bandSpaceId: { type: String, required: true }
+  bandSpaceId: { type: String, required: true },
+  /** Song the command palette linked to, opened in the detail drawer once the repertoire is loaded. */
+  focusSongId: { type: String, default: null }
 })
 
+const route = useRoute()
+const router = useRouter()
 const songsStore = useBandSongsStore()
 const confirm = useConfirm()
 const toast = useToast()
@@ -150,7 +155,17 @@ onMounted(() => {
 })
 
 watch(drawerVisible, (open, wasOpen) => {
-  if (wasOpen && !open) loadSongsWithFiles()
+  if (!wasOpen || open) return
+
+  loadSongsWithFiles()
+
+  // Dropping the parameter on close is what the finance and files modules already do, and it is
+  // load bearing here rather than cosmetic: the deep link watcher below re-runs on every songs
+  // mutation, so a lingering ?song= would swap the drawer back to the linked song after the member
+  // had moved on to another one. It also stops a reload from reopening a drawer already dismissed.
+  if (route.query.song) {
+    router.replace({ query: { ...route.query, song: undefined } })
+  }
 })
 
 const filteredSongs = computed(() => {
@@ -186,6 +201,22 @@ function openDrawer(song) {
   drawerSong.value = song
   drawerVisible.value = true
 }
+
+/**
+ * Watches the song list too, because the linked id usually arrives before the repertoire has
+ * loaded. Re-opening is prevented by drawerSong keeping the id after a close, so dismissing the
+ * drawer does not bounce it straight back.
+ */
+watch(
+  [() => props.focusSongId, () => songsStore.songs],
+  ([songId]) => {
+    if (!songId || drawerSong.value?.id === songId) return
+
+    const song = songsStore.songs.find((candidate) => candidate.id === songId)
+    if (song) openDrawer(song)
+  },
+  { immediate: true }
+)
 
 function openMenu(event, song) {
   menuTargetSong.value = song

--- a/assets/js/utils/bandSpaceSearch.js
+++ b/assets/js/utils/bandSpaceSearch.js
@@ -1,0 +1,129 @@
+import { BAND_SPACE_ROUTES } from '../constants/bandSpace.js'
+
+/**
+ * The record kinds the command palette can return, in the order it groups them. Mirrors
+ * App\Enum\BandSpace\BandSpaceSearchResultType: keep the two lists in step.
+ *
+ * `route` and `param` are the frontend's own business, which is why the API sends a type and a
+ * resource id rather than a ready made url: these paths are French and belong to the Vue router,
+ * and a rename here must not need a backend deploy.
+ */
+export const SEARCH_TYPES = Object.freeze([
+  {
+    type: 'agenda',
+    label: 'Agenda',
+    icon: 'pi-calendar',
+    route: BAND_SPACE_ROUTES.AGENDA,
+    param: 'entry'
+  },
+  {
+    type: 'task',
+    label: 'Tâches',
+    icon: 'pi-check-square',
+    route: BAND_SPACE_ROUTES.TASKS,
+    param: 'task'
+  },
+  {
+    type: 'note',
+    label: 'Notes',
+    icon: 'pi-file-edit',
+    route: BAND_SPACE_ROUTES.NOTES,
+    param: 'note'
+  },
+  {
+    type: 'file',
+    label: 'Fichiers',
+    icon: 'pi-folder',
+    route: BAND_SPACE_ROUTES.FILES,
+    param: 'file'
+  },
+  {
+    type: 'setlist',
+    label: 'Setlists',
+    icon: 'pi-list',
+    route: BAND_SPACE_ROUTES.SETLIST,
+    param: 'setlist'
+  },
+  {
+    type: 'song',
+    label: 'Morceaux',
+    icon: 'pi-play',
+    route: BAND_SPACE_ROUTES.SETLIST,
+    param: 'song'
+  },
+  {
+    type: 'finance',
+    label: 'Finances',
+    icon: 'pi-wallet',
+    route: BAND_SPACE_ROUTES.FINANCE,
+    param: 'entry'
+  }
+])
+
+const TYPE_BY_KEY = new Map(SEARCH_TYPES.map((entry) => [entry.type, entry]))
+
+/**
+ * Groups a flat result list by record kind, keeping SEARCH_TYPES order and dropping empty groups.
+ * The API already returns them in that order, but the palette must not break if it ever stops.
+ *
+ * @param {ReadonlyArray<{type: string}>} results
+ * @returns {Array<{type: string, label: string, icon: string, results: Array<object>}>}
+ */
+export function groupResultsByType(results) {
+  return SEARCH_TYPES.map(({ type, label, icon }) => ({
+    type,
+    label,
+    icon,
+    results: results.filter((result) => result.type === type)
+  })).filter((group) => group.results.length > 0)
+}
+
+/**
+ * The groups flattened back into the order they are rendered in, which is the order the arrow keys
+ * move through. Keeping this separate from the grouping is what lets the active row be a single
+ * index instead of a group plus an offset.
+ *
+ * @param {ReadonlyArray<{results: Array<object>}>} groups
+ * @returns {Array<object>}
+ */
+export function flattenGroups(groups) {
+  return groups.flatMap((group) => group.results)
+}
+
+/**
+ * The row an arrow key should move to, wrapping at both ends, and -1 when there is nothing to move
+ * through. A bare modulo returns a negative index when stepping up off the first row, which is the
+ * whole reason this is a function rather than inline arithmetic.
+ *
+ * @param {number} length
+ * @param {number} current
+ * @param {number} step -1 for up, 1 for down
+ * @returns {number}
+ */
+export function moveActiveIndex(length, current, step) {
+  if (length <= 0) {
+    return -1
+  }
+
+  return (current + step + length) % length
+}
+
+/**
+ * The vue-router location a result opens, or null for a type the palette does not know.
+ *
+ * @param {{type: string, resource_id: string}} result
+ * @param {string} bandSpaceId
+ * @returns {{name: string, params: {id: string}, query: Record<string, string>}|null}
+ */
+export function routeForResult(result, bandSpaceId) {
+  const entry = TYPE_BY_KEY.get(result?.type)
+  if (!entry) {
+    return null
+  }
+
+  return {
+    name: entry.route,
+    params: { id: bandSpaceId },
+    query: { [entry.param]: result.resource_id }
+  }
+}

--- a/assets/js/utils/bandSpaceSearch.test.js
+++ b/assets/js/utils/bandSpaceSearch.test.js
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  flattenGroups,
+  groupResultsByType,
+  moveActiveIndex,
+  routeForResult,
+  SEARCH_TYPES
+} from './bandSpaceSearch.js'
+
+function result(type, resourceId) {
+  return { type, resource_id: resourceId, title: `${type}-${resourceId}` }
+}
+
+describe('groupResultsByType', () => {
+  it('groups in SEARCH_TYPES order whatever order the results arrive in', () => {
+    const groups = groupResultsByType([result('finance', '1'), result('agenda', '2')])
+
+    assert.deepEqual(
+      groups.map((group) => group.type),
+      ['agenda', 'finance']
+    )
+  })
+
+  it('keeps several results of the same type together', () => {
+    const groups = groupResultsByType([
+      result('song', '1'),
+      result('note', '2'),
+      result('song', '3')
+    ])
+
+    assert.deepEqual(
+      groups.map((group) => group.type),
+      ['note', 'song']
+    )
+    assert.deepEqual(
+      groups[1].results.map((r) => r.resource_id),
+      ['1', '3']
+    )
+  })
+
+  it('drops empty groups rather than rendering an empty heading', () => {
+    assert.deepEqual(groupResultsByType([]), [])
+    assert.equal(groupResultsByType([result('task', '1')]).length, 1)
+  })
+
+  it('carries the label and icon the palette renders', () => {
+    const [group] = groupResultsByType([result('song', '1')])
+
+    assert.equal(group.label, 'Morceaux')
+    assert.equal(group.icon, 'pi-play')
+  })
+})
+
+describe('flattenGroups', () => {
+  it('flattens back into rendered order', () => {
+    const groups = groupResultsByType([
+      result('song', '1'),
+      result('agenda', '2'),
+      result('song', '3')
+    ])
+
+    assert.deepEqual(
+      flattenGroups(groups).map((r) => r.resource_id),
+      ['2', '1', '3']
+    )
+  })
+
+  it('returns nothing for no groups', () => {
+    assert.deepEqual(flattenGroups([]), [])
+  })
+})
+
+describe('moveActiveIndex', () => {
+  it('moves down and up', () => {
+    assert.equal(moveActiveIndex(3, 0, 1), 1)
+    assert.equal(moveActiveIndex(3, 2, -1), 1)
+  })
+
+  it('wraps from the last row to the first', () => {
+    assert.equal(moveActiveIndex(3, 2, 1), 0)
+  })
+
+  // A bare modulo returns -1 here, which is the whole reason this is a function.
+  it('wraps from the first row to the last rather than going negative', () => {
+    assert.equal(moveActiveIndex(3, 0, -1), 2)
+  })
+
+  it('reports no active row when the list is empty', () => {
+    assert.equal(moveActiveIndex(0, -1, 1), -1)
+    assert.equal(moveActiveIndex(0, -1, -1), -1)
+  })
+})
+
+describe('routeForResult', () => {
+  it('builds a location for every declared type', () => {
+    for (const { type, route, param } of SEARCH_TYPES) {
+      assert.deepEqual(routeForResult(result(type, 'abc'), 'space-1'), {
+        name: route,
+        params: { id: 'space-1' },
+        query: { [param]: 'abc' }
+      })
+    }
+  })
+
+  it('sends a song to the setlist module, not to a module of its own', () => {
+    const song = routeForResult(result('song', 'abc'), 'space-1')
+    const setlist = routeForResult(result('setlist', 'def'), 'space-1')
+
+    assert.equal(song.name, setlist.name)
+    assert.deepEqual(song.query, { song: 'abc' })
+  })
+
+  it('returns null for a type the palette does not know', () => {
+    assert.equal(routeForResult(result('rider', 'abc'), 'space-1'), null)
+    assert.equal(routeForResult(undefined, 'space-1'), null)
+  })
+})

--- a/assets/js/views/BandSpace/Agenda.vue
+++ b/assets/js/views/BandSpace/Agenda.vue
@@ -235,6 +235,7 @@ import ProgressSpinner from 'primevue/progressspinner'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import bandSpaceAgendaApi from '../../api/bandSpace/band-space-agenda.js'
 import DateRangePicker from '../../components/Admin/DateRangePicker.vue'
 import AgendaEntryDrawer from '../../components/BandSpace/Agenda/AgendaEntryDrawer.vue'
 import AgendaEventChip from '../../components/BandSpace/Agenda/AgendaEventChip.vue'
@@ -482,17 +483,96 @@ const calendarOptions = computed(() => ({
 }))
 
 onMounted(() => {
+  const linkedEntryId = linkedEntryIdFromRoute()
+  if (linkedEntryId) {
+    // openLinkedEntry does its own fetch, once, over whichever period turns out to hold the entry.
+    openLinkedEntry(linkedEntryId)
+    return
+  }
+
   fetchWithCurrentRange()
 })
+
+function linkedEntryIdFromRoute() {
+  return typeof route.query.entry === 'string' && route.query.entry ? route.query.entry : null
+}
+
+// Fired when the palette links to another entry while the agenda is already on screen: the route
+// name does not change, so the view is never remounted and onMounted never runs again.
+watch(
+  () => route.query.entry,
+  (entryId) => {
+    if (typeof entryId === 'string' && entryId) openLinkedEntry(entryId)
+  }
+)
+
+// Dropping the parameter once the drawer is closed keeps a reload from reopening it, and matches
+// what the files and finance modules do with their own item parameters.
+watch(dialogVisible, (isOpen) => {
+  if (!isOpen && route.query.entry) {
+    router.replace({ query: { ...route.query, entry: undefined } })
+  }
+})
+
+// Monotonic, because openLinkedEntry awaits twice: without it, following a second link before the
+// first has finished lets the slower first call open its entry last and override the newer one.
+// The store's own guard protects agendaStore.items, not the decision to open a drawer.
+let linkedEntryRequestId = 0
+
+/**
+ * Opens the entry a link points at. The agenda is fetched as a date range, so the entry's own date
+ * has to be known before the right range can be asked for, hence the single extra request.
+ *
+ * A recurring entry lands on the day the series starts, which is the one date the whole series
+ * agrees on. If that first occurrence has since been cancelled, no item matches and the agenda just
+ * stays on that period rather than opening something the member did not ask for.
+ */
+async function openLinkedEntry(entryId) {
+  linkedEntryRequestId += 1
+  const requestId = linkedEntryRequestId
+
+  let entry
+  try {
+    entry = await bandSpaceAgendaApi.getEntry(route.params.id, entryId)
+  } catch {
+    if (requestId !== linkedEntryRequestId) return
+
+    // A link to an entry somebody has since deleted: say so and drop the parameter, rather than
+    // leaving the member on an agenda that silently ignored what they clicked.
+    toast.add({ severity: 'error', summary: 'Événement introuvable', life: 4000 })
+    router.replace({ query: { ...route.query, entry: undefined } })
+    fetchWithCurrentRange()
+    return
+  }
+
+  if (requestId !== linkedEntryRequestId) return
+
+  const nextView = agendaViewForSavedEntry(entry, viewedRange.value.from, viewedRange.value.to)
+  if (nextView !== null) {
+    dateFrom.value = nextView.from
+    dateTo.value = nextView.to
+    focusDate.value = nextView.focusDate
+  }
+
+  await fetchWithCurrentRange()
+
+  if (requestId !== linkedEntryRequestId) return
+
+  const item = agendaStore.items.find(
+    (candidate) => candidate.source === 'manual' && candidate.source_id === entryId
+  )
+  if (item) handleItemClick(item)
+}
 
 function fetchRange(from, to) {
   const fromIso = format(from, "yyyy-MM-dd'T'00:00:00")
   const toIso = format(to, "yyyy-MM-dd'T'23:59:59")
-  agendaStore.fetchAgenda(route.params.id, { from: fromIso, to: toIso })
+
+  return agendaStore.fetchAgenda(route.params.id, { from: fromIso, to: toIso })
 }
 
 function fetchWithCurrentRange() {
-  fetchRange(dateFrom.value, dateTo.value)
+  return fetchRange(dateFrom.value, dateTo.value)
 }
 
 function handleDateRangeApply({ from, to }) {

--- a/assets/js/views/BandSpace/Notes.vue
+++ b/assets/js/views/BandSpace/Notes.vue
@@ -85,14 +85,15 @@ import Message from 'primevue/message'
 import ProgressSpinner from 'primevue/progressspinner'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
-import { onBeforeUnmount, onMounted, onUnmounted, ref } from 'vue'
-import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute } from 'vue-router'
+import { onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue'
+import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router'
 import CreateNoteDialog from '../../components/BandSpace/Notes/CreateNoteDialog.vue'
 import NoteEditor from '../../components/BandSpace/Notes/NoteEditor.vue'
 import NoteTree from '../../components/BandSpace/Notes/NoteTree.vue'
 import { useBandSpaceNotesStore } from '../../store/bandSpace/bandSpaceNotes.js'
 
 const route = useRoute()
+const router = useRouter()
 const confirm = useConfirm()
 const toast = useToast()
 const notesStore = useBandSpaceNotesStore()
@@ -174,6 +175,32 @@ function handleSelect(noteId) {
 function handleBack() {
   mobileView.value = 'tree'
 }
+
+/**
+ * The open note is URL state, so the command palette and the activity log can both link straight to
+ * one. selectNote() fetches the note by id on its own, so this does not have to wait for the tree.
+ *
+ * Deliberately routed through openNote(): arriving from a link unmounts the editor exactly like
+ * clicking another note in the tree does, so it has to ask the same question about unsaved text.
+ */
+watch(
+  () => route.query.note,
+  (noteId) => {
+    if (typeof noteId === 'string' && noteId && noteId !== notesStore.selectedNoteId) {
+      openNote(noteId)
+    }
+  },
+  { immediate: true }
+)
+
+watch(
+  () => notesStore.selectedNoteId,
+  (noteId) => {
+    if (noteId && noteId !== route.query.note) {
+      router.replace({ query: { ...route.query, note: noteId } })
+    }
+  }
+)
 
 function openCreateDialog(parentId = null) {
   createParentId.value = parentId

--- a/assets/js/views/BandSpace/Setlist.vue
+++ b/assets/js/views/BandSpace/Setlist.vue
@@ -63,6 +63,7 @@
         <RepertoireView
           v-if="activeView === 'repertoire'"
           :band-space-id="bandSpaceId"
+          :focus-song-id="focusSongId"
         />
         <SetlistEditor
           v-else-if="activeView === 'setlist' && activeSetlistId"
@@ -118,6 +119,13 @@ const activeSetlist = computed(() =>
     ? (setlistsStore.setlists.find((s) => s.id === activeSetlistId.value) ?? null)
     : null
 )
+
+/**
+ * Set by the command palette, which links to a song rather than to the repertoire as a whole. No
+ * branch is needed in syncFromQuery(): a query carrying only ?song= already falls through to the
+ * repertoire, which is the view holding the songs.
+ */
+const focusSongId = computed(() => (typeof route.query.song === 'string' ? route.query.song : null))
 
 const trashCount = computed(
   () => setlistsStore.archivedSetlists.length + songsStore.archivedSongs.length

--- a/assets/js/views/Global/MenuBand.vue
+++ b/assets/js/views/Global/MenuBand.vue
@@ -27,6 +27,25 @@
         <BandSpaceSelector />
       </div>
 
+      <!-- A shortcut nobody knows about helps nobody, hence the visible twin of Ctrl+K. -->
+      <button
+        v-if="currentSpaceId"
+        type="button"
+        class="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-surface-200 dark:border-surface-700 text-surface-600 dark:text-surface-300 hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors duration-150 shrink-0"
+        aria-label="Rechercher dans le Band Space"
+        aria-keyshortcuts="Control+K Meta+K"
+        @click="emit('open-search')"
+      >
+        <i class="pi pi-search text-sm shrink-0" aria-hidden="true" />
+        <span class="hidden sm:inline text-sm">Rechercher</span>
+        <kbd
+          class="hidden lg:inline font-sans text-[0.65rem] px-1.5 py-0.5 rounded border border-surface-300 dark:border-surface-600"
+          aria-hidden="true"
+        >
+          {{ SHORTCUT_LABEL }}
+        </kbd>
+      </button>
+
       <div class="flex-1"></div>
 
       <RouterLink :to="{ name: 'app_home' }" custom v-slot="{ href, navigate }">
@@ -61,7 +80,11 @@ import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation
 import { BAND_SPACE_ROUTES } from '../../constants/bandSpace.js'
 import { useBandSpaceStore } from '../../store/bandSpace/bandSpace.js'
 
+// Showing "Ctrl K" to somebody on a Mac would be advertising a shortcut that does not exist there.
+const SHORTCUT_LABEL = /Mac|iPhone|iPad/.test(navigator.userAgent) ? '⌘ K' : 'Ctrl K'
+
 const mobileNavOpen = defineModel('mobileNavOpen', { type: Boolean, default: false })
+const emit = defineEmits(['open-search'])
 
 const bandSpaceStore = useBandSpaceStore()
 const { currentSpaceId, navigateToSpace } = useBandSpaceNavigation()

--- a/src/ApiResource/BandSpace/BandSpaceSearchResult.php
+++ b/src/ApiResource/BandSpace/BandSpaceSearchResult.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Provider\BandSpace\BandSpaceSearchProvider;
+
+#[ApiResource(
+    shortName: 'BandSpaceSearchResult',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/band_spaces/{bandSpaceId}/search',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            openapi: new Operation(tags: ['Band Space Search']),
+            paginationEnabled: false,
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_search_get_collection',
+            provider: BandSpaceSearchProvider::class,
+            parameters: [
+                'q' => new QueryParameter(key: 'q'),
+            ],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+class BandSpaceSearchResult
+{
+    /**
+     * Synthetic, '<type>-<uuid>', because the collection mixes seven entities and JSON-LD needs one
+     * identifier per member. Same shape as AgendaItem's 'manual-<uuid>'.
+     */
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    #[ApiProperty(identifier: true)]
+    public string $bandSpaceId;
+
+    /** A BandSpaceSearchResultType value. */
+    public string $type;
+
+    /** The matched record's own id, which is what the frontend deep links to. */
+    public string $resourceId;
+
+    public string $title;
+
+    /** Whatever situates the hit: a date, a category, a parent note, a folder. */
+    public ?string $subtitle = null;
+}

--- a/src/Enum/BandSpace/BandSpaceSearchResultType.php
+++ b/src/Enum/BandSpace/BandSpaceSearchResultType.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace App\Enum\BandSpace;
+
+/**
+ * The kinds of record the command palette can return, in the order it groups them.
+ *
+ * Deliberately not BandSpaceModule: that enum describes modules, and the setlist module holds two
+ * different kinds of record. A hit on a song and a hit on a setlist have to be told apart because
+ * they open different things.
+ */
+enum BandSpaceSearchResultType: string
+{
+    case Agenda = 'agenda';
+    case Task = 'task';
+    case Note = 'note';
+    case File = 'file';
+    case Setlist = 'setlist';
+    case Song = 'song';
+    case Finance = 'finance';
+}

--- a/src/Repository/BandSpace/AgendaEntryRepository.php
+++ b/src/Repository/BandSpace/AgendaEntryRepository.php
@@ -97,4 +97,24 @@ class AgendaEntryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Command palette search. Matches the entry rows themselves, so a recurring entry is one hit
+     * rather than one per occurrence: occurrences are expanded at read time by AgendaAggregator,
+     * which needs a date window the palette has no reason to invent.
+     *
+     * @return AgendaEntry[]
+     */
+    public function searchByBandSpace(BandSpace $bandSpace, string $search, int $limit): array
+    {
+        return $this->createQueryBuilder('a')
+            ->where('a.bandSpace = :bandSpace')
+            ->andWhere('LOWER(a.title) LIKE :search OR LOWER(a.description) LIKE :search OR LOWER(a.location) LIKE :search')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('search', '%' . $search . '%')
+            ->orderBy('a.eventDatetime', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -336,4 +336,25 @@ class BandSpaceFileRepository extends ServiceEntityRepository
         // paging would quietly drop files. The id settles every tie.
         $qb->addOrderBy('bsf.id', $direction);
     }
+
+    /**
+     * Command palette search. The folder comes along because it is the hit's subtitle.
+     *
+     * @return BandSpaceFile[]
+     */
+    public function searchByBandSpace(BandSpace $bandSpace, string $search, int $limit): array
+    {
+        return $this->createQueryBuilder('bsf')
+            ->addSelect('f')
+            ->leftJoin('bsf.folder', 'f')
+            ->where('bsf.bandSpace = :bandSpace')
+            ->andWhere('bsf.archiveDatetime IS NULL')
+            ->andWhere('LOWER(bsf.originalName) LIKE :search')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('search', '%' . $search . '%')
+            ->orderBy('bsf.originalName', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/BandSpace/BandSpaceNoteRepository.php
+++ b/src/Repository/BandSpace/BandSpaceNoteRepository.php
@@ -103,4 +103,29 @@ class BandSpaceNoteRepository extends ServiceEntityRepository
 
         return $maxPosition !== null ? ((int) $maxPosition) + 1 : 0;
     }
+
+    /**
+     * Command palette search, titles only. The body is TipTap JSON in a JSON column: LIKE would match
+     * structural keys as well as prose, and Doctrine encodes without JSON_UNESCAPED_UNICODE, so an
+     * accented word is stored as a backslash-u escape and would never match. Searching bodies needs a
+     * plain text shadow column first.
+     *
+     * The parent comes along because it is the hit's subtitle.
+     *
+     * @return BandSpaceNote[]
+     */
+    public function searchByBandSpace(BandSpace $bandSpace, string $search, int $limit): array
+    {
+        return $this->createQueryBuilder('n')
+            ->addSelect('p')
+            ->leftJoin('n.parent', 'p')
+            ->where('n.bandSpace = :bandSpace')
+            ->andWhere('LOWER(n.title) LIKE :search')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('search', '%' . $search . '%')
+            ->orderBy('n.title', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/BandSpace/FinanceEntryRepository.php
+++ b/src/Repository/BandSpace/FinanceEntryRepository.php
@@ -552,4 +552,29 @@ class FinanceEntryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Command palette search. Scoped through the category because a finance entry carries no band
+     * space column of its own, and filtered by applyVisibleTo() like every other read path: a
+     * personal entry belongs to the member it names, and a search box is exactly the surface that
+     * would otherwise show one member's spending to the whole band.
+     *
+     * @return FinanceEntry[]
+     */
+    public function searchByBandSpace(BandSpace $bandSpace, BandSpaceMembership $viewer, string $search, int $limit): array
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->addSelect('c')
+            ->innerJoin('e.category', 'c')
+            ->where('c.bandSpace = :bandSpace')
+            ->andWhere('LOWER(e.label) LIKE :search')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('search', '%' . $search . '%')
+            ->orderBy('e.date', 'DESC')
+            ->setMaxResults($limit);
+
+        $this->applyVisibleTo($qb, $viewer);
+
+        return $qb->getQuery()->getResult();
+    }
 }

--- a/src/Repository/BandSpace/SetlistRepository.php
+++ b/src/Repository/BandSpace/SetlistRepository.php
@@ -108,4 +108,23 @@ class SetlistRepository extends ServiceEntityRepository
             'missing' => (int) $row['missing'],
         ];
     }
+
+    /**
+     * Command palette search.
+     *
+     * @return Setlist[]
+     */
+    public function searchByBandSpace(BandSpace $bandSpace, string $search, int $limit): array
+    {
+        return $this->createQueryBuilder('s')
+            ->where('s.bandSpace = :bandSpace')
+            ->andWhere('s.archiveDatetime IS NULL')
+            ->andWhere('LOWER(s.name) LIKE :search')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('search', '%' . $search . '%')
+            ->orderBy('s.name', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/BandSpace/SongRepository.php
+++ b/src/Repository/BandSpace/SongRepository.php
@@ -60,4 +60,24 @@ class SongRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Command palette search. Notes are plain text on this entity, unlike a band space note's body,
+     * so they can be matched directly.
+     *
+     * @return Song[]
+     */
+    public function searchByBandSpace(BandSpace $bandSpace, string $search, int $limit): array
+    {
+        return $this->createQueryBuilder('s')
+            ->where('s.bandSpace = :bandSpace')
+            ->andWhere('s.archiveDatetime IS NULL')
+            ->andWhere('LOWER(s.title) LIKE :search OR LOWER(s.notes) LIKE :search')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('search', '%' . $search . '%')
+            ->orderBy('s.title', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/BandSpace/TaskRepository.php
+++ b/src/Repository/BandSpace/TaskRepository.php
@@ -324,4 +324,25 @@ class TaskRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Command palette search. The category comes along because it is the hit's subtitle.
+     *
+     * @return Task[]
+     */
+    public function searchByBandSpace(BandSpace $bandSpace, string $search, int $limit): array
+    {
+        return $this->createQueryBuilder('t')
+            ->addSelect('c')
+            ->leftJoin('t.category', 'c')
+            ->where('t.bandSpace = :bandSpace')
+            ->andWhere('t.archiveDatetime IS NULL')
+            ->andWhere('LOWER(t.title) LIKE :search OR LOWER(t.description) LIKE :search')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('search', '%' . $search . '%')
+            ->orderBy('t.creationDatetime', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Service/Builder/BandSpace/BandSpaceSearchResultBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceSearchResultBuilder.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\Builder\BandSpace;
+
+use App\ApiResource\BandSpace\BandSpaceSearchResult;
+use App\Entity\BandSpace\AgendaEntry;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\BandSpace\BandSpaceNote;
+use App\Entity\BandSpace\FinanceEntry;
+use App\Entity\BandSpace\Setlist;
+use App\Entity\BandSpace\Song;
+use App\Entity\BandSpace\Task;
+use App\Enum\BandSpace\BandSpaceSearchResultType;
+
+readonly class BandSpaceSearchResultBuilder
+{
+    /**
+     * Numeric and locale free on purpose: the palette shows this next to a title, and a month name
+     * would be the only piece of the payload needing translation.
+     */
+    private const string DATE_FORMAT = 'd/m/Y';
+
+    public function buildFromAgendaEntry(AgendaEntry $entry): BandSpaceSearchResult
+    {
+        return $this->build(
+            type: BandSpaceSearchResultType::Agenda,
+            resourceId: (string) $entry->id,
+            bandSpaceId: (string) $entry->bandSpace->id,
+            title: $entry->title,
+            subtitle: $entry->eventDatetime->format(self::DATE_FORMAT),
+        );
+    }
+
+    public function buildFromTask(Task $task): BandSpaceSearchResult
+    {
+        return $this->build(
+            type: BandSpaceSearchResultType::Task,
+            resourceId: (string) $task->id,
+            bandSpaceId: (string) $task->bandSpace->id,
+            title: $task->title,
+            subtitle: $task->category?->name,
+        );
+    }
+
+    public function buildFromNote(BandSpaceNote $note): BandSpaceSearchResult
+    {
+        return $this->build(
+            type: BandSpaceSearchResultType::Note,
+            resourceId: (string) $note->id,
+            bandSpaceId: (string) $note->bandSpace->id,
+            title: $note->title,
+            subtitle: $note->parent?->title,
+        );
+    }
+
+    public function buildFromFile(BandSpaceFile $file): BandSpaceSearchResult
+    {
+        return $this->build(
+            type: BandSpaceSearchResultType::File,
+            resourceId: (string) $file->id,
+            bandSpaceId: (string) $file->bandSpace->id,
+            title: $file->originalName,
+            subtitle: $file->folder?->name,
+        );
+    }
+
+    public function buildFromSetlist(Setlist $setlist): BandSpaceSearchResult
+    {
+        return $this->build(
+            type: BandSpaceSearchResultType::Setlist,
+            resourceId: (string) $setlist->id,
+            bandSpaceId: (string) $setlist->bandSpace->id,
+            title: $setlist->name,
+            subtitle: null,
+        );
+    }
+
+    public function buildFromSong(Song $song): BandSpaceSearchResult
+    {
+        return $this->build(
+            type: BandSpaceSearchResultType::Song,
+            resourceId: (string) $song->id,
+            bandSpaceId: (string) $song->bandSpace->id,
+            title: $song->title,
+            subtitle: $song->tonality,
+        );
+    }
+
+    public function buildFromFinanceEntry(FinanceEntry $entry): BandSpaceSearchResult
+    {
+        return $this->build(
+            type: BandSpaceSearchResultType::Finance,
+            resourceId: (string) $entry->id,
+            bandSpaceId: (string) $entry->category->bandSpace->id,
+            title: $entry->label,
+            subtitle: $entry->date->format(self::DATE_FORMAT),
+        );
+    }
+
+    private function build(
+        BandSpaceSearchResultType $type,
+        string $resourceId,
+        string $bandSpaceId,
+        string $title,
+        ?string $subtitle,
+    ): BandSpaceSearchResult {
+        $dto = new BandSpaceSearchResult();
+        $dto->id = $type->value . '-' . $resourceId;
+        $dto->bandSpaceId = $bandSpaceId;
+        $dto->type = $type->value;
+        $dto->resourceId = $resourceId;
+        $dto->title = $title;
+        $dto->subtitle = $subtitle;
+
+        return $dto;
+    }
+}

--- a/src/State/Provider/BandSpace/BandSpaceSearchProvider.php
+++ b/src/State/Provider/BandSpace/BandSpaceSearchProvider.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\BandSpaceSearchResult;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceSearchResultType;
+use App\Repository\BandSpace\AgendaEntryRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceNoteRepository;
+use App\Repository\BandSpace\FinanceEntryRepository;
+use App\Repository\BandSpace\SetlistRepository;
+use App\Repository\BandSpace\SongRepository;
+use App\Repository\BandSpace\TaskRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\BandSpaceSearchResultBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * The command palette's single endpoint: one LIKE query per module, merged and grouped by record
+ * kind. Elasticsearch would be the wrong tool at this size, and would add an index lifecycle and a
+ * consistency window to a feature that answers in milliseconds without them.
+ *
+ * @implements ProviderInterface<BandSpaceSearchResult>
+ */
+readonly class BandSpaceSearchProvider implements ProviderInterface
+{
+    /**
+     * A single character scans every module to say nothing useful. Below this the endpoint answers
+     * with an empty collection rather than a 422: the palette searches while the member types, and
+     * an error on the first keystroke of every search would be noise, not feedback.
+     */
+    private const int MIN_QUERY_LENGTH = 2;
+
+    private const int PER_TYPE_LIMIT = 5;
+
+    private const int TOTAL_LIMIT = 20;
+
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private BandSpaceSearchResultBuilder $builder,
+        private AgendaEntryRepository $agendaEntryRepository,
+        private TaskRepository $taskRepository,
+        private BandSpaceNoteRepository $noteRepository,
+        private BandSpaceFileRepository $fileRepository,
+        private SetlistRepository $setlistRepository,
+        private SongRepository $songRepository,
+        private FinanceEntryRepository $financeEntryRepository,
+        private Security $security,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * @return BandSpaceSearchResult[]
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // Once, not once per module. Everything below may assume the space is already authorised.
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+
+        $search = mb_strtolower(trim($this->requestStack->getCurrentRequest()?->query->getString('q') ?? ''));
+        if (mb_strlen($search) < self::MIN_QUERY_LENGTH) {
+            return [];
+        }
+
+        // Keyed and ordered by BandSpaceSearchResultType, which is the order the palette groups in.
+        // Should per-module permissions ever land (#785), this map is where they have to be applied:
+        // a palette is precisely the surface that leaks a module a member may not open.
+        $groups = [
+            BandSpaceSearchResultType::Agenda->value => array_map(
+                $this->builder->buildFromAgendaEntry(...),
+                $this->agendaEntryRepository->searchByBandSpace($bandSpace, $search, self::PER_TYPE_LIMIT),
+            ),
+            BandSpaceSearchResultType::Task->value => array_map(
+                $this->builder->buildFromTask(...),
+                $this->taskRepository->searchByBandSpace($bandSpace, $search, self::PER_TYPE_LIMIT),
+            ),
+            BandSpaceSearchResultType::Note->value => array_map(
+                $this->builder->buildFromNote(...),
+                $this->noteRepository->searchByBandSpace($bandSpace, $search, self::PER_TYPE_LIMIT),
+            ),
+            BandSpaceSearchResultType::File->value => array_map(
+                $this->builder->buildFromFile(...),
+                $this->fileRepository->searchByBandSpace($bandSpace, $search, self::PER_TYPE_LIMIT),
+            ),
+            BandSpaceSearchResultType::Setlist->value => array_map(
+                $this->builder->buildFromSetlist(...),
+                $this->setlistRepository->searchByBandSpace($bandSpace, $search, self::PER_TYPE_LIMIT),
+            ),
+            BandSpaceSearchResultType::Song->value => array_map(
+                $this->builder->buildFromSong(...),
+                $this->songRepository->searchByBandSpace($bandSpace, $search, self::PER_TYPE_LIMIT),
+            ),
+            // The viewer is load bearing: a personal finance entry belongs to the member it names.
+            BandSpaceSearchResultType::Finance->value => array_map(
+                $this->builder->buildFromFinanceEntry(...),
+                $this->financeEntryRepository->searchByBandSpace($bandSpace, $viewer, $search, self::PER_TYPE_LIMIT),
+            ),
+        ];
+
+        return $this->trimToTotalCap($groups);
+    }
+
+    /**
+     * Round robin rather than truncating in type order. Only a broad query reaches the total cap at
+     * all, since each type is already capped at PER_TYPE_LIMIT, and that is exactly the query where
+     * truncating in order would spend the whole budget on agenda and tasks and never show finances.
+     *
+     * @param array<string, BandSpaceSearchResult[]> $groups
+     * @return BandSpaceSearchResult[]
+     */
+    private function trimToTotalCap(array $groups): array
+    {
+        if (array_sum(array_map('count', $groups)) <= self::TOTAL_LIMIT) {
+            return array_merge([], ...array_values($groups));
+        }
+
+        $shares = array_fill_keys(array_keys($groups), 0);
+        $budget = self::TOTAL_LIMIT;
+        $progressed = true;
+
+        while ($budget > 0 && $progressed) {
+            $progressed = false;
+            foreach ($groups as $type => $results) {
+                if ($budget === 0) {
+                    break;
+                }
+                if ($shares[$type] >= count($results)) {
+                    continue;
+                }
+                ++$shares[$type];
+                --$budget;
+                $progressed = true;
+            }
+        }
+
+        $trimmed = [];
+        foreach ($groups as $type => $results) {
+            $trimmed[] = array_slice($results, 0, $shares[$type]);
+        }
+
+        return array_merge([], ...$trimmed);
+    }
+}

--- a/tests/Api/BandSpace/BandSpaceSearchTest.php
+++ b/tests/Api/BandSpace/BandSpaceSearchTest.php
@@ -1,0 +1,611 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace;
+
+use App\Enum\BandSpace\FinanceEntryScope;
+use App\Enum\BandSpace\MembershipStatus;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\AgendaEntryFactory;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\BandSpaceNoteFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFolderFactory;
+use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
+use App\Tests\Factory\BandSpace\FinanceEntryFactory;
+use App\Tests\Factory\BandSpace\SetlistFactory;
+use App\Tests\Factory\BandSpace\SongFactory;
+use App\Tests\Factory\BandSpace\TaskCategoryFactory;
+use App\Tests\Factory\BandSpace\TaskFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BandSpaceSearchTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_search_returns_one_hit_per_type_grouped_in_type_order(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new(['name' => 'The Rockers'])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $agendaEntry = AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Session mixage',
+            'eventDatetime' => new \DateTimeImmutable('2026-06-15 20:00:00'),
+        ])->create();
+
+        $taskCategory = TaskCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio'])->create();
+        $task = TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'category' => $taskCategory,
+            'title' => 'Relancer le mixage',
+        ])->create();
+
+        $parentNote = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Répétitions',
+        ])->create();
+        $note = BandSpaceNoteFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'parent' => $parentNote,
+            'title' => 'Notes de mixage',
+        ])->create();
+
+        $folder = BandSpaceFolderFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'name' => 'Maquettes',
+        ])->create();
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'folder' => $folder,
+            'originalName' => 'mixage-final.wav',
+        ])->create();
+
+        $setlist = SetlistFactory::new(['bandSpace' => $bandSpace, 'name' => 'Set mixage'])->create();
+
+        $song = SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Mixage nocturne',
+            'tonality' => 'Am',
+        ])->create();
+
+        $financeCategory = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio'])->create();
+        $financeEntry = FinanceEntryFactory::new([
+            'category' => $financeCategory,
+            'label' => 'Séance de mixage',
+            'date' => new \DateTime('2026-05-04 00:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceSearchResult',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/search',
+            '@type' => 'Collection',
+            'totalItems' => 7,
+            'member' => [
+                [
+                    '@id' => '/api/band_space_search_results/id=agenda-' . $agendaEntry->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'agenda-' . $agendaEntry->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'agenda',
+                    'resource_id' => (string) $agendaEntry->id,
+                    'title' => 'Session mixage',
+                    'subtitle' => '15/06/2026',
+                ],
+                [
+                    '@id' => '/api/band_space_search_results/id=task-' . $task->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'task-' . $task->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'task',
+                    'resource_id' => (string) $task->id,
+                    'title' => 'Relancer le mixage',
+                    'subtitle' => 'Studio',
+                ],
+                [
+                    '@id' => '/api/band_space_search_results/id=note-' . $note->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'note-' . $note->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'note',
+                    'resource_id' => (string) $note->id,
+                    'title' => 'Notes de mixage',
+                    'subtitle' => 'Répétitions',
+                ],
+                [
+                    '@id' => '/api/band_space_search_results/id=file-' . $file->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'file-' . $file->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'file',
+                    'resource_id' => (string) $file->id,
+                    'title' => 'mixage-final.wav',
+                    'subtitle' => 'Maquettes',
+                ],
+                [
+                    '@id' => '/api/band_space_search_results/id=setlist-' . $setlist->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'setlist-' . $setlist->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'setlist',
+                    'resource_id' => (string) $setlist->id,
+                    'title' => 'Set mixage',
+                    'subtitle' => null,
+                ],
+                [
+                    '@id' => '/api/band_space_search_results/id=song-' . $song->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'song-' . $song->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'song',
+                    'resource_id' => (string) $song->id,
+                    'title' => 'Mixage nocturne',
+                    'subtitle' => 'Am',
+                ],
+                [
+                    '@id' => '/api/band_space_search_results/id=finance-' . $financeEntry->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'finance-' . $financeEntry->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'finance',
+                    'resource_id' => (string) $financeEntry->id,
+                    'title' => 'Séance de mixage',
+                    'subtitle' => '04/05/2026',
+                ],
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_search_matches_a_substring_whatever_the_case(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $song = SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'RENDEZ-VOUS'])->create();
+        SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Autre chose'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=dez',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceSearchResult',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/search',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/band_space_search_results/id=song-' . $song->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'song-' . $song->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'song',
+                    'resource_id' => (string) $song->id,
+                    'title' => 'RENDEZ-VOUS',
+                    'subtitle' => null,
+                ],
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/search?q=dez',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_search_below_two_characters_returns_nothing(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Mixage nocturne'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=m',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceSearchResult',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/search',
+            '@type' => 'Collection',
+            'totalItems' => 0,
+            'member' => [],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/search?q=m',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_search_without_a_query_returns_nothing(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Mixage nocturne'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceSearchResult',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/search',
+            '@type' => 'Collection',
+            'totalItems' => 0,
+            'member' => [],
+        ]);
+    }
+
+    public function test_search_ignores_archived_records(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $archivedAt = new \DateTimeImmutable('2026-01-05 10:00:00');
+        TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Mixage archivé',
+            'archiveDatetime' => $archivedAt,
+        ])->create();
+        BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'originalName' => 'mixage.wav',
+            'archiveDatetime' => $archivedAt,
+        ])->create();
+        SetlistFactory::new([
+            'bandSpace' => $bandSpace,
+            'name' => 'Set mixage',
+            'archiveDatetime' => $archivedAt,
+        ])->create();
+        SongFactory::new([
+            'bandSpace' => $bandSpace,
+            'title' => 'Mixage nocturne',
+            'archiveDatetime' => $archivedAt,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceSearchResult',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/search',
+            '@type' => 'Collection',
+            'totalItems' => 0,
+            'member' => [],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_search_ignores_records_of_another_band_space(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $otherBandSpace, 'user' => $user])->create();
+
+        SongFactory::new(['bandSpace' => $otherBandSpace, 'title' => 'Mixage nocturne'])->create();
+        $otherCategory = FinanceCategoryFactory::new(['bandSpace' => $otherBandSpace, 'name' => 'Studio'])->create();
+        FinanceEntryFactory::new(['category' => $otherCategory, 'label' => 'Séance de mixage'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceSearchResult',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/search',
+            '@type' => 'Collection',
+            'totalItems' => 0,
+            'member' => [],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_search_hides_a_personal_finance_entry_of_another_member(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $otherUser = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $otherMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $otherUser,
+        ])->create();
+
+        $category = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio'])->create();
+        $bandEntry = FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Mixage du groupe',
+            'scope' => FinanceEntryScope::Band,
+            'date' => new \DateTime('2026-05-04 00:00:00'),
+        ])->create();
+        FinanceEntryFactory::new([
+            'category' => $category,
+            'label' => 'Mixage perso',
+            'scope' => FinanceEntryScope::Personal,
+            'member' => $otherMembership,
+            'date' => new \DateTime('2026-05-06 00:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/BandSpaceSearchResult',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/search',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/band_space_search_results/id=finance-' . $bandEntry->id . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'BandSpaceSearchResult',
+                    'id' => 'finance-' . $bandEntry->id,
+                    'band_space_id' => (string) $bandSpace->id,
+                    'type' => 'finance',
+                    'resource_id' => (string) $bandEntry->id,
+                    'title' => 'Mixage du groupe',
+                    'subtitle' => '04/05/2026',
+                ],
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_search_caps_each_type_at_five_hits(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // Seven matching songs and nothing else: the per type cap is what trims them, not the total.
+        foreach (range(1, 7) as $index) {
+            SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Mixage ' . $index])->create();
+        }
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+        $this->assertSame(5, $response['totalItems']);
+        $this->assertSame(
+            ['Mixage 1', 'Mixage 2', 'Mixage 3', 'Mixage 4', 'Mixage 5'],
+            array_column($response['member'], 'title'),
+        );
+    }
+
+    public function test_search_spreads_the_total_cap_across_the_types_that_match(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $financeCategory = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Studio'])->create();
+
+        // Five of every type, so all seven hit the per type cap and the total of 35 has to be trimmed.
+        foreach (range(1, 5) as $index) {
+            AgendaEntryFactory::new([
+                'bandSpace' => $bandSpace,
+                'creator' => $user,
+                'title' => 'Mixage ' . $index,
+            ])->create();
+            TaskFactory::new([
+                'bandSpace' => $bandSpace,
+                'createdBy' => $user,
+                'title' => 'Mixage ' . $index,
+            ])->create();
+            BandSpaceNoteFactory::new([
+                'bandSpace' => $bandSpace,
+                'createdBy' => $user,
+                'title' => 'Mixage ' . $index,
+            ])->create();
+            BandSpaceFileFactory::new([
+                'bandSpace' => $bandSpace,
+                'createdBy' => $user,
+                'originalName' => 'mixage-' . $index . '.wav',
+            ])->create();
+            SetlistFactory::new(['bandSpace' => $bandSpace, 'name' => 'Mixage ' . $index])->create();
+            SongFactory::new(['bandSpace' => $bandSpace, 'title' => 'Mixage ' . $index])->create();
+            FinanceEntryFactory::new(['category' => $financeCategory, 'label' => 'Mixage ' . $index])->create();
+        }
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->getResponseAsArray();
+
+        $this->assertSame(20, $response['totalItems']);
+
+        // Round robin: six types keep three rows and the seventh keeps the two the budget still had.
+        // Truncating in type order would instead have returned agenda, tasks, notes and files only.
+        $countByType = array_count_values(array_column($response['member'], 'type'));
+        $this->assertSame(
+            ['agenda' => 3, 'task' => 3, 'note' => 3, 'file' => 3, 'setlist' => 3, 'song' => 3, 'finance' => 2],
+            $countByType,
+        );
+    }
+
+    public function test_search_is_forbidden_for_a_non_member(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $otherUser = UserFactory::new()->create(['username' => 'other_user', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+
+        $this->client->loginUser($otherUser);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    public function test_search_is_forbidden_for_a_member_who_left(): void
+    {
+        $departedUser = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $departedUser,
+            'status' => MembershipStatus::Left,
+        ])->create();
+
+        $this->client->loginUser($departedUser);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    public function test_search_on_an_unknown_band_space_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/6a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Band Space introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Band Space introuvable',
+        ]);
+    }
+
+    public function test_search_is_unauthorized_without_a_session(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/search?q=mixage',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
+    }
+}


### PR DESCRIPTION
Closes #784.

`Ctrl+K` (`Cmd+K`) inside a Band Space opens a palette that searches agenda, tâches, notes, fichiers, setlists, morceaux and finances at once, and `Enter` opens the exact record rather than the module holding it. There is a visible trigger in the header next to the space selector, because a shortcut nobody knows about helps nobody.

Elasticsearch is not used, as the issue argues: a space holds tens to low hundreds of rows per module, so one `LIKE` per module answers in milliseconds with no index lifecycle, no reindex command and no consistency window.

## The endpoint

`GET /api/band_spaces/{bandSpaceId}/search?q=`, unpaginated, modelled on `AgendaItem`, the existing cross-module DTO. `BandSpaceSearchProvider` calls `checkMember` once and then seven repository methods, each of which owns its own query per the repository rule.

Below two characters it answers with an empty collection rather than a 422. `ForumSearchProvider` throws on a short term because it backs a submitted search page; a palette searches while the member types, and an error on the first keystroke of every search is noise rather than feedback.

Per type the cap is 5 and the total is 20. The trim is round robin rather than truncation in type order: only a broad query reaches the total at all, and that is exactly the query where truncating in order would spend the whole budget on agenda and tâches and never show finances.

## Finance results are per viewer

`FinanceEntry` has no `band_space_id` of its own, so the query is scoped through `category.bandSpace`. More importantly a personal entry belongs to the member it names, and `FinanceEntryRepository::searchByBandSpace()` therefore takes the viewer's membership and reuses the existing `applyVisibleTo()` like every other finance read path. A search box is precisely the surface that would otherwise show one member's spending to the whole band. `test_search_hides_a_personal_finance_entry_of_another_member` covers it. Finance is the only one of the seven modules with a per member visibility concept.

## Two deliberate departures from the issue

**The payload carries `type` and `resource_id`, not a ready `url`.** The frontend routes are French and belong to the Vue router, so building `/band/<id>/taches?task=<id>` in PHP would let a route rename break every search result until the backend was redeployed too. `assets/js/utils/bandSpaceSearch.js` is the single place that maps a type to a route name and its query parameter.

**Tech riders are excluded.** `RIDER_SUPER_ADMIN_ONLY` still hides that module from everyone but super admins, and search results would tear that curtain. Adding the module later is one repository method and one entry in the type map.

Notes are searched by title only, as the issue recommends, and there is a second reason beyond the one it gives: `BandSpaceNote::$content` is TipTap JSON in a Doctrine `Types::JSON` column, and `JsonTypeConvert` encodes without `JSON_UNESCAPED_UNICODE`, so every accented character is stored as a backslash-u escape. A `LIKE` on any accented word would silently match nothing. Searching bodies needs a plain text shadow column first.

## Three deep links the palette needed

Tâches, finances, fichiers and setlists already accepted `?task=`, `?entry=`, `?file=` and `?setlist=`. Notes, morceaux and agenda entries did not, so they were added on the pattern the other modules already use.

The notes one also revives an existing dead link: `Settings/ActivitySection.vue` has been pushing `{ name: 'app_band_notes', query: { note: ... } }` for a while and nothing was reading it.

Agenda is the awkward one. The agenda is fetched as a date range, so the entry's own date has to be known before the right range can be asked for, which is one extra request against the existing item endpoint. A recurring entry lands on the day the series starts, the one date the whole series agrees on. If that first occurrence has since been cancelled no item matches, and the agenda stays on that period rather than opening something nobody asked for. A link to a deleted entry gets a toast and the parameter is dropped.

## Accessibility

The palette is the first `combobox` and `listbox` in the codebase, so it sets the pattern: focus stays on the input, `aria-activedescendant` tracks the active row, `aria-controls` is omitted while no list is rendered, and the result count sits in the footer as a polite live region so it is both visible and announced. The rows are divs rather than buttons on purpose, since options in this pattern must not be focusable; a clickable row anywhere else in the band space should still be a button.

Using a PrimeVue `Dialog` gives the focus trap and the focus restore that the lightbox in #688 never got. Its `aria-labelledby` had to be redirected, because a custom header removes the element it points at and the dialog would otherwise have no accessible name at all. Contrast was measured in both themes, lowest is 5.62:1.

Binding the shortcut in `AppBandLayout` rather than globally is what keeps the browser's own `Ctrl+K` intact on the rest of the site.

## Verification

Full suite green at 2400, PHPStan level 8 clean, Biome clean, 508 frontend unit tests, build clean.

`BandSpaceSearchTest` has 13 tests with full body assertions throughout, including the 401, 403 and 404 paths, cross space isolation, archived exclusion, the per type cap and the exact distribution the round robin produces once the total cap bites.

Exercised in the browser in both themes: the shortcut and the header button both open it, arrows move, `Enter` opens the record in each module, `Escape` closes and returns focus to the trigger, and `Ctrl+K` is untouched outside `/band`.
