### PR TITLE
Files: multi-select with Ctrl and Shift click, for bulk delete, move and restore

### DIFF
--- a/assets/js/api/bandSpace/band-space-files.js
+++ b/assets/js/api/bandSpace/band-space-files.js
@@ -83,6 +83,40 @@ export default {
       .catch(handleApiError)
   },
 
+  /**
+   * The three bulk endpoints answer 204 with no body, so nothing is returned. A refusal names every
+   * file that blocked the batch in its detail, which handleApiError puts on error.message.
+   */
+  bulkDeleteFiles(bandSpaceId, fileIds) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_files_bulk_delete', { bandSpaceId }),
+        { file_ids: fileIds },
+        { headers: { 'Content-Type': 'application/ld+json' } }
+      )
+      .catch(handleApiError)
+  },
+
+  bulkMoveFiles(bandSpaceId, fileIds, folderId) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_files_bulk_patch', { bandSpaceId }),
+        { file_ids: fileIds, folder_id: folderId },
+        { headers: { 'Content-Type': 'application/ld+json' } }
+      )
+      .catch(handleApiError)
+  },
+
+  bulkRestoreFiles(bandSpaceId, fileIds) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_files_bulk_restore', { bandSpaceId }),
+        { file_ids: fileIds },
+        { headers: { 'Content-Type': 'application/ld+json' } }
+      )
+      .catch(handleApiError)
+  },
+
   getFileActivities(bandSpaceId, fileId) {
     return axios
       .get(

--- a/assets/js/components/BandSpace/Files/FileBulkActionBar.vue
+++ b/assets/js/components/BandSpace/Files/FileBulkActionBar.vue
@@ -1,0 +1,209 @@
+<template>
+  <div
+    v-if="selectedFiles.length > 0"
+    class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 bg-surface-900 dark:bg-surface-800 text-white rounded-xl shadow-xl px-4 py-2 flex items-center gap-3"
+    role="region"
+    aria-label="Actions sur la sélection"
+  >
+    <span class="text-sm font-medium">
+      {{ selectedFiles.length }}
+      fichier{{ selectedFiles.length > 1 ? 's' : '' }} sélectionné{{ selectedFiles.length > 1 ? 's' : '' }}
+    </span>
+
+    <div class="w-px h-6 bg-surface-600"></div>
+
+    <template v-if="isTrash">
+      <!-- The tooltip sits on the wrapper, since a disabled button fires no pointer event of its
+           own, and a tooltip carries no accessible name either, hence the sr-only twin. -->
+      <span v-tooltip.top="restoreBlockedReason">
+        <Button
+          label="Restaurer"
+          icon="pi pi-undo"
+          size="small"
+          severity="secondary"
+          :loading="busy === 'restore'"
+          :disabled="!!busy || restoreBlockedReason !== null"
+          @click="handleRestore"
+        />
+        <span v-if="restoreBlockedReason" class="sr-only">{{ restoreBlockedReason }}</span>
+      </span>
+    </template>
+
+    <template v-else>
+      <Button
+        label="Déplacer"
+        icon="pi pi-arrows-h"
+        size="small"
+        severity="secondary"
+        :disabled="!!busy"
+        @click="(event) => movePopover.toggle(event)"
+      />
+      <Popover ref="movePopover">
+        <div class="flex flex-col gap-2 min-w-[18rem]">
+          <Select
+            v-model="folderDraft"
+            aria-label="Dossier de destination"
+            :options="folderOptions"
+            option-label="label"
+            option-value="value"
+            option-disabled="disabled"
+            placeholder="Racine"
+          />
+          <small v-if="rootRefusal" class="text-xs text-surface-300">{{ rootRefusal }}</small>
+          <Button label="Déplacer" size="small" :loading="busy === 'move'" @click="handleMove" />
+        </div>
+      </Popover>
+
+      <span v-tooltip.top="deleteBlocked">
+        <Button
+          label="Supprimer"
+          icon="pi pi-trash"
+          size="small"
+          severity="danger"
+          :loading="busy === 'delete'"
+          :disabled="!!busy || deleteBlocked !== null"
+          @click="confirmDelete"
+        />
+        <span v-if="deleteBlocked" class="sr-only">{{ deleteBlocked }}</span>
+      </span>
+    </template>
+
+    <div class="w-px h-6 bg-surface-600"></div>
+
+    <Button
+      icon="pi pi-times"
+      size="small"
+      text
+      severity="secondary"
+      class="!text-white"
+      v-tooltip.top="'Annuler la sélection'"
+      aria-label="Annuler la sélection"
+      @click="filesStore.clearSelection"
+    />
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Popover from 'primevue/popover'
+import Select from 'primevue/select'
+import { useConfirm } from 'primevue/useconfirm'
+import { useToast } from 'primevue/usetoast'
+import { computed, ref } from 'vue'
+import { apiErrorDetail } from '../../../api/utils/apiErrorDetail.js'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
+import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
+import { useUserSecurityStore } from '../../../store/user/security.js'
+import { deleteBlockedReason, restoreOwnershipReason } from '../../../utils/fileActions.js'
+import { canFileSitAtRoot, folderSelectOptions } from '../../../utils/fileListing.js'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true },
+  /** The trash lists different rows and offers only Restaurer. */
+  isTrash: { type: Boolean, default: false }
+})
+
+const filesStore = useBandFilesStore()
+const userSecurityStore = useUserSecurityStore()
+const { isAdmin } = useBandSpaceNavigation()
+const toast = useToast()
+const confirm = useConfirm()
+
+const busy = ref(null)
+const folderDraft = ref(null)
+const movePopover = ref()
+
+// Selection only happens on rows the list holds, so every ticked id is one of the loaded files.
+const selectedFiles = computed(() =>
+  filesStore.files.filter((file) => filesStore.selectedFileIds.has(file.id))
+)
+
+const currentUserId = computed(() => userSecurityStore.userProfile?.id ?? null)
+
+/**
+ * The batch is one transaction, so a single file in the way takes the whole selection down. Rather
+ * than let somebody run it and read a refusal, the button is greyed out and says which files it is
+ * waiting on: with twelve rows ticked, "un fichier est attaché" is not something a member can act on.
+ */
+const deleteBlocked = computed(() =>
+  deleteBlockedReason(selectedFiles.value, currentUserId.value, isAdmin.value)
+)
+
+const restoreBlockedReason = computed(() =>
+  restoreOwnershipReason(selectedFiles.value, currentUserId.value, isAdmin.value)
+)
+
+/**
+ * The root lists only the files nothing points at, so it is refused as soon as one selected file
+ * carries an attachment. Same rule as the single file move dialog, read across the selection.
+ */
+const rootRefusal = computed(() => {
+  const attached = selectedFiles.value.filter((file) => !canFileSitAtRoot(file))
+  if (attached.length === 0) {
+    return null
+  }
+
+  return attached.length === 1
+    ? 'Un fichier de la sélection est attaché à une ressource : la racine ne liste que les fichiers attachés à aucune ressource.'
+    : `${attached.length} fichiers de la sélection sont attachés à une ressource : la racine ne liste que les fichiers attachés à aucune ressource.`
+})
+
+const folderOptions = computed(() =>
+  folderSelectOptions(filesStore.folders, rootRefusal.value !== null)
+)
+
+async function runBulk(name, fn) {
+  busy.value = name
+  try {
+    await fn()
+  } catch (e) {
+    // The refusal names the files that blocked the batch, which is the only part worth reading.
+    toast.add({
+      severity: 'error',
+      summary: 'Action en lot impossible',
+      detail: apiErrorDetail(e, 'Une erreur est survenue'),
+      life: 8000
+    })
+  } finally {
+    busy.value = null
+  }
+}
+
+function handleMove() {
+  movePopover.value?.hide()
+  runBulk('move', async () => {
+    await filesStore.bulkMoveFiles(props.bandSpaceId, folderDraft.value ?? null)
+    toast.add({ severity: 'success', summary: 'Fichiers déplacés', life: 3000 })
+    folderDraft.value = null
+  })
+}
+
+function handleRestore() {
+  runBulk('restore', async () => {
+    await filesStore.bulkRestoreFiles(props.bandSpaceId)
+    toast.add({ severity: 'success', summary: 'Fichiers restaurés', life: 3000 })
+  })
+}
+
+function confirmDelete() {
+  const count = selectedFiles.value.length
+  confirm.require({
+    message: `${count} fichier${count > 1 ? 's seront déplacés' : ' sera déplacé'} dans la corbeille, où vous pourrez ${count > 1 ? 'les' : 'le'} restaurer pendant ${filesStore.trashRetentionDays} jours. Continuer ?`,
+    header: 'Déplacer dans la corbeille',
+    icon: 'pi pi-trash',
+    acceptLabel: 'Supprimer',
+    rejectLabel: 'Annuler',
+    acceptClass: 'p-button-danger',
+    accept: () => {
+      runBulk('delete', async () => {
+        await filesStore.bulkDeleteFiles(props.bandSpaceId)
+        toast.add({
+          severity: 'success',
+          summary: 'Fichiers déplacés dans la corbeille',
+          life: 3000
+        })
+      })
+    }
+  })
+}
+</script>

--- a/assets/js/components/BandSpace/Files/FileList.vue
+++ b/assets/js/components/BandSpace/Files/FileList.vue
@@ -14,12 +14,23 @@
 
     <div v-else class="flex flex-col">
       <div
-        class="hidden md:grid grid-cols-12 gap-2 px-3 py-2 text-xs font-medium uppercase tracking-wide text-surface-400 border-b border-surface-200 dark:border-surface-700"
+        class="hidden md:flex items-center gap-2 px-3 py-2 text-xs font-medium uppercase tracking-wide text-surface-400 border-b border-surface-200 dark:border-surface-700"
       >
-        <div class="col-span-6">Nom</div>
-        <div class="col-span-2">Taille</div>
-        <div class="col-span-2">Tags</div>
-        <div class="col-span-2">Ajouté le</div>
+        <Checkbox
+          :model-value="allSelected"
+          binary
+          size="small"
+          class="shrink-0"
+          aria-label="Tout sélectionner"
+          @update:model-value="toggleAll"
+        />
+        <div class="grid grid-cols-12 gap-2 flex-1 min-w-0">
+          <div class="col-span-6">Nom</div>
+          <div class="col-span-2">Taille</div>
+          <div class="col-span-2">Tags</div>
+          <div class="col-span-2">Ajouté le</div>
+        </div>
+        <span class="shrink-0 w-7" aria-hidden="true"></span>
       </div>
 
       <!-- Folders first, in the same grid as the files, so the panel reads as one list. Focusable and
@@ -73,13 +84,29 @@
       <div
         v-for="file in files"
         :key="file.id"
-        class="flex items-center gap-2 px-3 py-2 text-sm border-b border-surface-100 dark:border-surface-800 hover:bg-surface-50 dark:hover:bg-surface-800/40 cursor-pointer"
-        :draggable="true"
-        @click="emit('select', file)"
+        class="flex items-center gap-2 px-3 py-2 text-sm border-b border-surface-100 dark:border-surface-800 cursor-pointer"
+        :class="
+          isSelected(file)
+            ? 'bg-primary-50 dark:bg-primary-900/30'
+            : 'hover:bg-surface-50 dark:hover:bg-surface-800/40'
+        "
+        :draggable="!hasSelection"
+        @click="(event) => handleRowClick(event, file)"
         @contextmenu="(event) => openContextMenu(event, file)"
         @dragstart="(event) => handleDragStart(event, file)"
         @dragend="handleDragEnd"
       >
+        <Checkbox
+          :model-value="isSelected(file)"
+          binary
+          size="small"
+          class="shrink-0"
+          :aria-label="`Sélectionner ${file.original_name}`"
+          @click.stop
+          @mousedown="rememberModifiers"
+          @keydown="rememberModifiers"
+          @update:model-value="() => toggleFromCheckbox(file)"
+        />
         <div class="grid grid-cols-12 gap-2 flex-1 min-w-0 items-center">
           <div class="col-span-12 md:col-span-6 flex items-center gap-2 min-w-0">
             <i :class="iconForMime(file.mime_type)" class="text-lg text-surface-500 shrink-0"></i>
@@ -136,6 +163,7 @@
 </template>
 
 <script setup>
+import Checkbox from 'primevue/checkbox'
 import ContextMenu from 'primevue/contextmenu'
 import Skeleton from 'primevue/skeleton'
 import Tag from 'primevue/tag'
@@ -154,6 +182,7 @@ import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
 import { isFileCreatorOrAdmin } from '../../../utils/bandSpaceFilePermissions.js'
 import { fileLocation, folderFileCountLabel } from '../../../utils/fileListing.js'
+import { areAllSelected, selectionAfterClick } from '../../../utils/fileSelection.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -188,6 +217,66 @@ const toast = useToast()
 const isAdmin = computed(() => bandSpaceStore.getById(props.bandSpaceId)?.role === 'admin')
 
 const dropTargetId = ref(null)
+
+const orderedIds = computed(() => props.files.map((file) => file.id))
+const hasSelection = computed(() => filesStore.selectedFileIds.size > 0)
+const allSelected = computed(() =>
+  areAllSelected(orderedIds.value, [...filesStore.selectedFileIds])
+)
+
+function isSelected(file) {
+  return filesStore.selectedFileIds.has(file.id)
+}
+
+/**
+ * A bare click opens the file, as it always has. Ctrl/Cmd and Shift are what turn a click into
+ * selection, so the default gesture on a file list keeps meaning "show me this one".
+ */
+function handleRowClick(event, file) {
+  if (event.ctrlKey || event.metaKey || event.shiftKey) {
+    applySelection(file, event.shiftKey)
+
+    return
+  }
+
+  emit('select', file)
+}
+
+function applySelection(file, shift) {
+  const { selected, anchorId } = selectionAfterClick({
+    id: file.id,
+    orderedIds: orderedIds.value,
+    selected: [...filesStore.selectedFileIds],
+    anchorId: filesStore.selectionAnchorId,
+    shift
+  })
+
+  filesStore.setSelection(selected, anchorId)
+}
+
+/**
+ * PrimeVue's Checkbox keeps its own internal state, so the toggle has to arrive through its model
+ * event rather than a raw click. Binding @click as well left the two one click out of phase: the row
+ * highlighted while the box stayed empty, then the box ticked on the click that deselected the row.
+ *
+ * Shift is read on mousedown and keydown, both of which run before the model event does.
+ */
+let shiftHeld = false
+
+function rememberModifiers(event) {
+  shiftHeld = event.shiftKey === true
+}
+
+function toggleFromCheckbox(file) {
+  applySelection(file, shiftHeld)
+  shiftHeld = false
+}
+
+function toggleAll(checked) {
+  // The list pages, so this is every row on screen and never the ones still unloaded. The bar says
+  // how many are selected rather than implying the rest.
+  filesStore.setSelection(checked ? orderedIds.value : [], null)
+}
 
 const contextMenuRef = ref(null)
 const contextMenuFile = ref(null)

--- a/assets/js/components/BandSpace/Files/FileMoveDialog.vue
+++ b/assets/js/components/BandSpace/Files/FileMoveDialog.vue
@@ -58,7 +58,7 @@ import Select from 'primevue/select'
 import { computed, ref, watch } from 'vue'
 import bandSpaceFilesApi from '../../../api/bandSpace/band-space-files.js'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
-import { rootDestinationRefusal } from '../../../utils/fileListing.js'
+import { folderSelectOptions, rootDestinationRefusal } from '../../../utils/fileListing.js'
 
 const props = defineProps({
   bandSpaceId: { type: String, required: true },
@@ -82,19 +82,9 @@ const globalError = ref(null)
  */
 const rootRefusal = computed(() => rootDestinationRefusal(props.file, filesStore.virtualFolders))
 
-const folderOptions = computed(() => {
-  const out = [{ label: 'Racine', value: null, disabled: rootRefusal.value !== null }]
-  const walk = (nodes, depth) => {
-    for (const node of nodes) {
-      out.push({ label: '— '.repeat(depth) + node.name, value: node.id })
-      if (Array.isArray(node.children) && node.children.length > 0) {
-        walk(node.children, depth + 1)
-      }
-    }
-  }
-  walk(filesStore.folders, 0)
-  return out
-})
+const folderOptions = computed(() =>
+  folderSelectOptions(filesStore.folders, rootRefusal.value !== null)
+)
 
 const hasChanged = computed(() => {
   const current = props.file?.folder_id ?? null

--- a/assets/js/components/BandSpace/Files/FileTrashList.vue
+++ b/assets/js/components/BandSpace/Files/FileTrashList.vue
@@ -18,11 +18,37 @@
         définitivement effacés. Vous pouvez les restaurer avant cette date.
       </p>
 
+      <div class="flex items-center gap-2 px-1">
+        <Checkbox
+          :model-value="allSelected"
+          binary
+          size="small"
+          aria-label="Tout sélectionner"
+          @update:model-value="toggleAll"
+        />
+        <span class="text-xs text-surface-500 dark:text-surface-400">Tout sélectionner</span>
+      </div>
+
       <div
         v-for="file in files"
         :key="file.id"
-        class="flex items-center gap-3 p-3 rounded-lg bg-surface-0 dark:bg-surface-900 border border-surface-200 dark:border-surface-700"
+        class="flex items-center gap-3 p-3 rounded-lg border"
+        :class="
+          isSelected(file)
+            ? 'bg-primary-50 dark:bg-primary-900/30 border-primary-200 dark:border-primary-700/50'
+            : 'bg-surface-0 dark:bg-surface-900 border-surface-200 dark:border-surface-700'
+        "
       >
+        <Checkbox
+          :model-value="isSelected(file)"
+          binary
+          size="small"
+          class="shrink-0"
+          :aria-label="`Sélectionner ${file.original_name}`"
+          @mousedown="rememberModifiers"
+          @keydown="rememberModifiers"
+          @update:model-value="() => toggleFromCheckbox(file)"
+        />
         <i class="pi pi-file text-lg text-surface-500 shrink-0" aria-hidden="true"></i>
 
         <div class="flex-1 min-w-0">
@@ -63,14 +89,16 @@
 
 <script setup>
 import Button from 'primevue/button'
+import Checkbox from 'primevue/checkbox'
 import Skeleton from 'primevue/skeleton'
 import { useConfirm } from 'primevue/useconfirm'
 import { useToast } from 'primevue/usetoast'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useBandFilesStore } from '../../../store/bandSpace/bandSpaceFiles.js'
 import { useUserSecurityStore } from '../../../store/user/security.js'
 import { isFileCreatorOrAdmin } from '../../../utils/bandSpaceFilePermissions.js'
 import { formatDateLong } from '../../../utils/date.js'
+import { areAllSelected, selectionAfterClick } from '../../../utils/fileSelection.js'
 import { formatBytes } from '../../../utils/formatBytes.js'
 
 const props = defineProps({
@@ -86,6 +114,49 @@ const confirm = useConfirm()
 const toast = useToast()
 
 const busyId = ref(null)
+
+const orderedIds = computed(() => props.files.map((file) => file.id))
+const allSelected = computed(() =>
+  areAllSelected(orderedIds.value, [...filesStore.selectedFileIds])
+)
+
+function isSelected(file) {
+  return filesStore.selectedFileIds.has(file.id)
+}
+
+function applySelection(file, shift) {
+  const { selected, anchorId } = selectionAfterClick({
+    id: file.id,
+    orderedIds: orderedIds.value,
+    selected: [...filesStore.selectedFileIds],
+    anchorId: filesStore.selectionAnchorId,
+    shift
+  })
+
+  filesStore.setSelection(selected, anchorId)
+}
+
+/**
+ * PrimeVue's Checkbox keeps its own internal state, so the toggle has to arrive through its model
+ * event rather than a raw click. Binding @click as well left the two one click out of phase: the row
+ * highlighted while the box stayed empty, then the box ticked on the click that deselected the row.
+ *
+ * Shift is read on mousedown and keydown, both of which run before the model event does.
+ */
+let shiftHeld = false
+
+function rememberModifiers(event) {
+  shiftHeld = event.shiftKey === true
+}
+
+function toggleFromCheckbox(file) {
+  applySelection(file, shiftHeld)
+  shiftHeld = false
+}
+
+function toggleAll(checked) {
+  filesStore.setSelection(checked ? orderedIds.value : [], null)
+}
 
 function canRestore(file) {
   return isFileCreatorOrAdmin(file, userSecurityStore.userProfile?.id, props.isAdmin)

--- a/assets/js/constants/fileSources.js
+++ b/assets/js/constants/fileSources.js
@@ -124,6 +124,26 @@ export const QUOTA_BREAKDOWN_SOURCES = Object.freeze([
   )
 ])
 
+/**
+ * Enumerates source types as a French list, « une tâche et une note ».
+ *
+ * Mirrors BandSpaceFileAttachmentLabels::describe down to the deduplication and the « et » before
+ * the last one, because the bulk delete bar and the endpoint it calls have to say the same sentence:
+ * one greys the button out, the other refuses the request, and a member comparing the two must not
+ * read two different reasons.
+ *
+ * @param {string[]} sourceTypes
+ * @returns {string}
+ */
+export function describeFileSources(sourceTypes) {
+  const labels = [...new Set(sourceTypes.map((type) => sourceFor(type).indefiniteNoun))]
+
+  if (labels.length === 0) return UNKNOWN_SOURCE.indefiniteNoun
+  if (labels.length === 1) return labels[0]
+
+  return `${labels.slice(0, -1).join(', ')} et ${labels.at(-1)}`
+}
+
 function sourceFor(sourceType) {
   return FILE_SOURCE_BY_TYPE[sourceType] ?? UNKNOWN_SOURCE
 }

--- a/assets/js/store/bandSpace/bandSpaceFiles.js
+++ b/assets/js/store/bandSpace/bandSpaceFiles.js
@@ -22,6 +22,7 @@ import {
   nextPageToLoad,
   queryKeyOf
 } from '../../utils/filePagination.js'
+import { prunedSelection } from '../../utils/fileSelection.js'
 
 export const useBandFilesStore = defineStore('bandFiles', () => {
   const files = ref([])
@@ -43,6 +44,10 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
   // The trash is selected through activeFolderId, like the virtual source folders, so the whole existing
   // selection and fetch path is reused. This count feeds the sidebar badge even when the trash is closed.
   const archivedCount = ref(0)
+  // Bulk selection. Replaced wholesale rather than mutated, so computeds reading it re-evaluate.
+  const selectedFileIds = ref(new Set())
+  // The row the last toggle happened on, which a shift-click draws its run from.
+  const selectionAnchorId = ref(null)
 
   const filters = reactive({
     query: '',
@@ -127,6 +132,14 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
       files.value = result.member ?? []
       totalFiles.value = result.totalItems ?? 0
       loadedQueryKey.value = queryKeyOf(params)
+      // A filter change or a refresh after a bulk write changes which rows exist. Acting on an id
+      // the member can no longer see is the one outcome worth preventing.
+      selectedFileIds.value = new Set(
+        prunedSelection(
+          [...selectedFileIds.value],
+          files.value.map((file) => file.id)
+        )
+      )
     } catch (e) {
       if (requestId !== filesRequestId) return
       loadError.value = e.message
@@ -509,12 +522,86 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     return created
   }
 
+  function setSelection(ids, anchorId = null) {
+    selectedFileIds.value = new Set(ids)
+    selectionAnchorId.value = anchorId
+  }
+
+  function clearSelection() {
+    selectedFileIds.value = new Set()
+    selectionAnchorId.value = null
+  }
+
+  /**
+   * Bulk delete and bulk restore both answer 204, so the rows are pruned locally the way deleteFile
+   * and removeFromTrash already do, and the folder counts and quota are refetched.
+   */
+  /**
+   * The ticked ids that are still rows on screen.
+   *
+   * A single row action prunes files.value without touching the selection: trashing one card from
+   * its own kebab menu while three are ticked leaves a fourth id in the Set. Sending it would make
+   * the endpoint refuse the whole batch as "introuvable", so the two files the member can see
+   * selected would not be deleted either. The bar already displays the selection this way.
+   */
+  function selectedVisibleIds() {
+    return prunedSelection(
+      [...selectedFileIds.value],
+      files.value.map((file) => file.id)
+    )
+  }
+
+  async function bulkDeleteFiles(bandSpaceId) {
+    const ids = selectedVisibleIds()
+    await bandSpaceFilesApi.bulkDeleteFiles(bandSpaceId, ids)
+    dropRows(ids)
+    archivedCount.value += ids.length
+    clearSelection()
+    fetchQuota(bandSpaceId)
+    fetchFolders(bandSpaceId)
+  }
+
+  async function bulkRestoreFiles(bandSpaceId) {
+    const ids = selectedVisibleIds()
+    await bandSpaceFilesApi.bulkRestoreFiles(bandSpaceId, ids)
+    dropRows(ids)
+    archivedCount.value = Math.max(0, archivedCount.value - ids.length)
+    clearSelection()
+    fetchQuota(bandSpaceId)
+    fetchFolders(bandSpaceId)
+  }
+
+  /**
+   * Refetches rather than reconciling row by row: a move can take every file out of the listing at
+   * once, and the page window is derived from how many rows are loaded, so pruning a batch spread
+   * across pages is the bug filePagination.js exists for.
+   */
+  async function bulkMoveFiles(bandSpaceId, folderId) {
+    await bandSpaceFilesApi.bulkMoveFiles(bandSpaceId, selectedVisibleIds(), folderId)
+    clearSelection()
+    await fetchFiles(bandSpaceId)
+    fetchFolders(bandSpaceId)
+  }
+
+  function dropRows(ids) {
+    const removed = new Set(ids)
+    files.value = files.value.filter((file) => !removed.has(file.id))
+    totalFiles.value = Math.max(0, totalFiles.value - ids.length)
+    if (removed.has(activeFileId.value)) {
+      activeFileId.value = null
+      activeFileFull.value = null
+    }
+  }
+
   function setFilter(key, value) {
     filters[key] = value
   }
 
   function setActiveFolder(folderId) {
     activeFolderId.value = folderId
+    // The action bar always describes rows the member can see, so a selection never survives a move
+    // to another folder or into the trash.
+    clearSelection()
   }
 
   function startDrag(source) {
@@ -551,6 +638,8 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     loadError.value = null
     loadMoreError.value = null
     activeFileError.value = null
+    selectedFileIds.value = new Set()
+    selectionAnchorId.value = null
   }
 
   return {
@@ -590,6 +679,13 @@ export const useBandFilesStore = defineStore('bandFiles', () => {
     dragSource: readonly(dragSource),
     startDrag,
     endDrag,
+    selectedFileIds: readonly(selectedFileIds),
+    selectionAnchorId: readonly(selectionAnchorId),
+    setSelection,
+    clearSelection,
+    bulkDeleteFiles,
+    bulkRestoreFiles,
+    bulkMoveFiles,
     isLoadingActiveFile: readonly(isLoadingActiveFile),
     isLoadingActivities: readonly(isLoadingActivities),
     isSavingFile: readonly(isSavingFile),

--- a/assets/js/utils/fileActions.js
+++ b/assets/js/utils/fileActions.js
@@ -1,0 +1,103 @@
+/**
+ * Which bulk actions the API will accept, decided on the rows the list already holds.
+ *
+ * Trashing a file is the uploader's or an administrator's, and a file some task or note still points
+ * at cannot be trashed at all. A bulk write is one transaction, so a single row in the way takes the
+ * whole selection with it: a member who ticked twelve rows then reads a refusal naming none of them.
+ * Working it out here lets the bar grey the button out and say which files it is waiting on, instead
+ * of letting somebody confirm a destructive dialog to find out. The server still has the last word.
+ *
+ * The sentences are byte for byte the ones BandSpaceFileBulkDeleteProcedure and
+ * BandSpaceFileBulkRestoreProcedure throw, so the greyed out tooltip and the refusal read the same.
+ *
+ * Run with `npm test`.
+ */
+
+import { describeFileSources } from '../constants/fileSources.js'
+import { isFileCreatorOrAdmin } from './bandSpaceFilePermissions.js'
+
+/**
+ * The names of the selected files the member neither uploaded nor administrates.
+ *
+ * @param {{original_name: string, created_by?: {id?: string}}[]} files
+ * @param {string|null} currentUserId
+ * @param {boolean} isAdmin
+ * @returns {string[]}
+ */
+export function filesNotOwnedBy(files, currentUserId, isAdmin) {
+  return files
+    .filter((file) => !isFileCreatorOrAdmin(file, currentUserId, isAdmin))
+    .map((file) => file.original_name)
+}
+
+/**
+ * The names of the selected files something else still points at.
+ *
+ * @param {{original_name: string, attachments?: object[]}[]} files
+ * @returns {string[]}
+ */
+export function attachedFiles(files) {
+  return files.filter((file) => (file.attachments?.length ?? 0) > 0)
+}
+
+/**
+ * Mirrors BandSpaceFileBulkDeleteProcedure::assertEveryFileIsOwnedBy.
+ *
+ * @returns {string|null} null when nothing blocks
+ */
+export function deleteOwnershipReason(files, currentUserId, isAdmin) {
+  const blocking = filesNotOwnedBy(files, currentUserId, isAdmin)
+
+  return blocking.length === 0
+    ? null
+    : `Seul le créateur ou un administrateur peut supprimer ces fichiers : ${blocking.join(', ')}`
+}
+
+/**
+ * Mirrors BandSpaceFileBulkRestoreProcedure::assertEveryFileIsOwnedBy.
+ *
+ * @returns {string|null} null when nothing blocks
+ */
+export function restoreOwnershipReason(files, currentUserId, isAdmin) {
+  const blocking = filesNotOwnedBy(files, currentUserId, isAdmin)
+
+  return blocking.length === 0
+    ? null
+    : `Seul le créateur ou un administrateur peut restaurer ces fichiers : ${blocking.join(', ')}`
+}
+
+/**
+ * Mirrors BandSpaceFileBulkDeleteProcedure::assertNoAttachedFile, singular and plural both.
+ *
+ * The source types are sorted before being named, exactly as the server sorts them, so the two
+ * sentences enumerate the sources in the same order.
+ *
+ * @param {{original_name: string, attachments?: {source_type?: string}[]}[]} files
+ * @returns {string|null} null when nothing blocks
+ */
+export function attachmentReason(files) {
+  const blocking = attachedFiles(files)
+  if (blocking.length === 0) {
+    return null
+  }
+
+  const sources = describeFileSources(
+    blocking.flatMap((file) => file.attachments.map((attachment) => attachment.source_type)).sort()
+  )
+
+  return blocking.length === 1
+    ? `1 fichier sélectionné est attaché à ${sources}. Détachez-le d'abord depuis la ressource concernée.`
+    : `${blocking.length} fichiers sélectionnés sont attachés à ${sources}. Détachez-les d'abord depuis les ressources concernées.`
+}
+
+/**
+ * The one sentence to show under a disabled Supprimer button.
+ *
+ * Ownership comes first because it is the refusal the server reaches first, so the member is never
+ * told to detach files only to be refused again for a reason nobody mentioned.
+ *
+ * @returns {string|null}
+ */
+export function deleteBlockedReason(files, currentUserId, isAdmin) {
+  return deleteOwnershipReason(files, currentUserId, isAdmin) ?? attachmentReason(files)
+}

--- a/assets/js/utils/fileActions.test.js
+++ b/assets/js/utils/fileActions.test.js
@@ -1,0 +1,182 @@
+/**
+ * These pin the sentences the bulk bar shows under a disabled button against the ones the endpoints
+ * throw. The two drifting apart is the whole failure this guards: the tooltip would explain one
+ * refusal and the server would answer with another.
+ *
+ * The file names are the ones BandSpaceFileBulkDeleteTest and BandSpaceFileBulkRestoreTest use, so
+ * both layers can be diffed by eye.
+ *
+ * Run with `npm test`.
+ */
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  attachedFiles,
+  attachmentReason,
+  deleteBlockedReason,
+  deleteOwnershipReason,
+  filesNotOwnedBy,
+  restoreOwnershipReason
+} from './fileActions.js'
+
+const ALICE = 'user-alice'
+const BOB = 'user-bob'
+
+function file(overrides = {}) {
+  return {
+    id: 'file-1',
+    original_name: 'la-mienne.wav',
+    created_by: { id: ALICE },
+    attachments: [],
+    ...overrides
+  }
+}
+
+describe('filesNotOwnedBy', () => {
+  it('names every file of the selection the member did not upload, in selection order', () => {
+    const selection = [
+      file({ original_name: 'la-mienne.wav', created_by: { id: BOB } }),
+      file({ original_name: 'mix-final.wav' }),
+      file({ original_name: 'contrat.pdf' })
+    ]
+
+    assert.deepEqual(filesNotOwnedBy(selection, BOB, false), ['mix-final.wav', 'contrat.pdf'])
+  })
+
+  it('blocks nothing for an admin', () => {
+    const selection = [file({ created_by: { id: BOB } })]
+
+    assert.deepEqual(filesNotOwnedBy(selection, ALICE, true), [])
+  })
+
+  // The profile arrives with the session rather than with the list, so it can still be missing.
+  it('blocks everything when the current member is not known yet', () => {
+    assert.deepEqual(filesNotOwnedBy([file()], null, false), ['la-mienne.wav'])
+  })
+
+  it('blocks nothing on an empty selection', () => {
+    assert.deepEqual(filesNotOwnedBy([], ALICE, false), [])
+  })
+})
+
+describe('deleteOwnershipReason and restoreOwnershipReason', () => {
+  const selection = [
+    file({ original_name: 'mix-final.wav', created_by: { id: BOB } }),
+    file({ original_name: 'contrat.pdf', created_by: { id: BOB } })
+  ]
+
+  it('reads exactly as the delete endpoint refuses', () => {
+    assert.equal(
+      deleteOwnershipReason(selection, ALICE, false),
+      'Seul le créateur ou un administrateur peut supprimer ces fichiers : mix-final.wav, contrat.pdf'
+    )
+  })
+
+  it('reads exactly as the restore endpoint refuses', () => {
+    assert.equal(
+      restoreOwnershipReason(selection, ALICE, false),
+      'Seul le créateur ou un administrateur peut restaurer ces fichiers : mix-final.wav, contrat.pdf'
+    )
+  })
+
+  it('says nothing when nothing blocks', () => {
+    assert.equal(deleteOwnershipReason([file()], ALICE, false), null)
+    assert.equal(restoreOwnershipReason([file()], ALICE, false), null)
+  })
+})
+
+describe('attachedFiles', () => {
+  it('keeps only the files something still points at', () => {
+    const selection = [
+      file({ original_name: 'libre.wav' }),
+      file({ original_name: 'devis.pdf', attachments: [{ source_type: 'task' }] })
+    ]
+
+    assert.deepEqual(
+      attachedFiles(selection).map((f) => f.original_name),
+      ['devis.pdf']
+    )
+  })
+
+  it('treats a missing attachments array as unattached', () => {
+    assert.deepEqual(attachedFiles([{ original_name: 'x.wav' }]), [])
+  })
+})
+
+describe('attachmentReason', () => {
+  it('reads exactly as the endpoint refuses one file', () => {
+    const selection = [
+      file({ original_name: 'facture.pdf', attachments: [{ source_type: 'finance' }] })
+    ]
+
+    assert.equal(
+      attachmentReason(selection),
+      "1 fichier sélectionné est attaché à une entrée financière. Détachez-le d'abord depuis la ressource concernée."
+    )
+  })
+
+  // Sorted source types, so the client and the server enumerate them in the same order: 'note'
+  // sorts before 'task', which is why the sentence names the note first.
+  it('reads exactly as the endpoint refuses several, sources named in the same order', () => {
+    const selection = [
+      file({ original_name: 'libre.wav' }),
+      file({ original_name: 'devis.pdf', attachments: [{ source_type: 'task' }] }),
+      file({ original_name: 'paroles.pdf', attachments: [{ source_type: 'note' }] })
+    ]
+
+    assert.equal(
+      attachmentReason(selection),
+      "2 fichiers sélectionnés sont attachés à une note et une tâche. Détachez-les d'abord depuis les ressources concernées."
+    )
+  })
+
+  it('names a repeated source once, like the server does', () => {
+    const selection = [
+      file({ original_name: 'a.pdf', attachments: [{ source_type: 'task' }] }),
+      file({ original_name: 'b.pdf', attachments: [{ source_type: 'task' }] })
+    ]
+
+    assert.equal(
+      attachmentReason(selection),
+      "2 fichiers sélectionnés sont attachés à une tâche. Détachez-les d'abord depuis les ressources concernées."
+    )
+  })
+
+  it('says nothing when nothing is attached', () => {
+    assert.equal(attachmentReason([file()]), null)
+    assert.equal(attachmentReason([]), null)
+  })
+})
+
+describe('deleteBlockedReason', () => {
+  // Ownership is the refusal the server reaches first, so the member is never told to detach files
+  // only to be refused again for a reason nobody mentioned.
+  it('reports ownership before attachment when both block', () => {
+    const selection = [
+      file({
+        original_name: 'mix-final.wav',
+        created_by: { id: BOB },
+        attachments: [{ source_type: 'task' }]
+      })
+    ]
+
+    assert.equal(
+      deleteBlockedReason(selection, ALICE, false),
+      'Seul le créateur ou un administrateur peut supprimer ces fichiers : mix-final.wav'
+    )
+  })
+
+  it('falls through to attachment when ownership is fine', () => {
+    const selection = [file({ original_name: 'devis.pdf', attachments: [{ source_type: 'task' }] })]
+
+    assert.equal(
+      deleteBlockedReason(selection, ALICE, false),
+      "1 fichier sélectionné est attaché à une tâche. Détachez-le d'abord depuis la ressource concernée."
+    )
+  })
+
+  it('says nothing when the selection is clean', () => {
+    assert.equal(deleteBlockedReason([file()], ALICE, false), null)
+  })
+})

--- a/assets/js/utils/fileListing.js
+++ b/assets/js/utils/fileListing.js
@@ -246,3 +246,29 @@ export function uploadBelongsInListing(activeFolderId, filters, uploadedFolderId
 
   return listedFolderId(activeFolderId) === (uploadedFolderId ?? null)
 }
+
+/**
+ * The folder tree flattened into Select options, indented by depth, with « Racine » on top.
+ *
+ * Shared by the single file move dialog and the bulk action bar so the two destination lists cannot
+ * drift: a folder reachable in one and not the other is the kind of difference nobody reports.
+ *
+ * @param {object[]} tree nested folders, each node optionally carrying `children`
+ * @param {boolean} [rootDisabled] whether « Racine » is a refused destination
+ * @returns {{label: string, value: ?string, disabled?: boolean}[]}
+ */
+export function folderSelectOptions(tree, rootDisabled = false) {
+  const options = [{ label: 'Racine', value: null, disabled: rootDisabled }]
+
+  const walk = (nodes, depth) => {
+    for (const node of nodes ?? []) {
+      options.push({ label: '— '.repeat(depth) + node.name, value: node.id })
+      if (Array.isArray(node.children) && node.children.length > 0) {
+        walk(node.children, depth + 1)
+      }
+    }
+  }
+  walk(tree, 0)
+
+  return options
+}

--- a/assets/js/utils/fileListing.test.js
+++ b/assets/js/utils/fileListing.test.js
@@ -8,6 +8,7 @@ import {
   fileVirtualFolders,
   folderFileCountLabel,
   folderPathOf,
+  folderSelectOptions,
   isSearchActive,
   listedFolderOfRows,
   rootDestinationRefusal,
@@ -324,5 +325,29 @@ describe('rootDestinationRefusal', () => {
       rootDestinationRefusal(file, virtualFolders),
       'Ce fichier est listé dans Notes et Tâches : la racine ne liste que les fichiers attachés à aucune ressource.'
     )
+  })
+})
+
+describe('folderSelectOptions', () => {
+  const TREE = [
+    { id: 'a', name: 'Concerts', children: [{ id: 'a1', name: '2026', children: [] }] },
+    { id: 'b', name: 'Maquettes', children: [] }
+  ]
+
+  it('puts Racine first and indents by depth', () => {
+    assert.deepEqual(folderSelectOptions(TREE), [
+      { label: 'Racine', value: null, disabled: false },
+      { label: 'Concerts', value: 'a' },
+      { label: '— 2026', value: 'a1' },
+      { label: 'Maquettes', value: 'b' }
+    ])
+  })
+
+  it('can refuse Racine, which is what an attached file does to it', () => {
+    assert.equal(folderSelectOptions(TREE, true)[0].disabled, true)
+  })
+
+  it('offers Racine alone for an empty tree', () => {
+    assert.deepEqual(folderSelectOptions([]), [{ label: 'Racine', value: null, disabled: false }])
   })
 })

--- a/assets/js/utils/fileSelection.js
+++ b/assets/js/utils/fileSelection.js
@@ -1,0 +1,104 @@
+/**
+ * Which rows a click leaves selected in the file list.
+ *
+ * Extracted from the component because it is the only part of a multi-select worth testing, and
+ * because there is no component test harness here: the anchor bookkeeping and the range arithmetic
+ * are easy to get subtly wrong in ways nobody notices until a member trashes the wrong photos.
+ *
+ * The model is the one every file manager uses:
+ *   - a checkbox, or Ctrl/Cmd+click, toggles one row and moves the anchor to it
+ *   - Shift+click selects the whole run between the anchor and the row clicked, anchor unchanged
+ *   - a bare click is not selection at all, it opens the file, so it never reaches here
+ *
+ * Run with `npm test`.
+ */
+
+/**
+ * The inclusive run between two rows, in rendered order, whichever of the two comes first.
+ *
+ * @param {string[]} orderedIds ids in the order the list renders them
+ * @param {string} fromId
+ * @param {string} toId
+ * @returns {string[]} empty when either row is not on screen
+ */
+export function rangeBetween(orderedIds, fromId, toId) {
+  const from = orderedIds.indexOf(fromId)
+  const to = orderedIds.indexOf(toId)
+
+  if (from === -1 || to === -1) {
+    return []
+  }
+
+  const [start, end] = from <= to ? [from, to] : [to, from]
+
+  return orderedIds.slice(start, end + 1)
+}
+
+/**
+ * The selection and anchor after a click on one row.
+ *
+ * Shift without an anchor, or with an anchor that has since scrolled out of the loaded rows, falls
+ * back to a plain toggle rather than selecting nothing: a member holding Shift always means to
+ * select something.
+ *
+ * @param {object} params
+ * @param {string} params.id row that was clicked
+ * @param {string[]} params.orderedIds ids in the order the list renders them
+ * @param {string[]} params.selected currently selected ids
+ * @param {?string} params.anchorId row the last toggle happened on
+ * @param {boolean} [params.shift]
+ * @returns {{selected: string[], anchorId: string}}
+ */
+export function selectionAfterClick({ id, orderedIds, selected, anchorId, shift = false }) {
+  const current = [...selected]
+
+  if (shift && anchorId) {
+    const range = rangeBetween(orderedIds, anchorId, id)
+    if (range.length > 0) {
+      // The anchor stays put, so dragging the shift-click up and down redraws one run instead of
+      // walking the anchor along behind it.
+      return { selected: range, anchorId }
+    }
+  }
+
+  return {
+    selected: current.includes(id)
+      ? current.filter((selectedId) => selectedId !== id)
+      : [...current, id],
+    anchorId: id
+  }
+}
+
+/**
+ * The selection with everything no longer on screen dropped.
+ *
+ * The list pages, and a bulk action removes rows, so a selection outlives the rows it names. Acting
+ * on an id the member can no longer see is the one outcome this has to prevent.
+ *
+ * @param {string[]} selected
+ * @param {string[]} availableIds
+ * @returns {string[]}
+ */
+export function prunedSelection(selected, availableIds) {
+  const available = new Set(availableIds)
+
+  return [...selected].filter((id) => available.has(id))
+}
+
+/**
+ * Whether the header checkbox should read as ticked: every row on screen is selected, and there is
+ * at least one. An empty list is not "all selected".
+ *
+ * @param {string[]} orderedIds
+ * @param {string[]} selected
+ * @returns {boolean}
+ */
+export function areAllSelected(orderedIds, selected) {
+  if (orderedIds.length === 0) {
+    return false
+  }
+
+  const chosen = new Set(selected)
+
+  return orderedIds.every((id) => chosen.has(id))
+}

--- a/assets/js/utils/fileSelection.test.js
+++ b/assets/js/utils/fileSelection.test.js
@@ -1,0 +1,142 @@
+/**
+ * These pin the click arithmetic the file list reads before it acts on a selection, so a range or an
+ * anchor cannot drift without a failing test. Trashing the wrong photos is the failure mode.
+ *
+ * Run with `npm test`.
+ */
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  areAllSelected,
+  prunedSelection,
+  rangeBetween,
+  selectionAfterClick
+} from './fileSelection.js'
+
+const ROWS = ['a', 'b', 'c', 'd', 'e']
+
+describe('rangeBetween', () => {
+  it('reads downwards', () => {
+    assert.deepEqual(rangeBetween(ROWS, 'b', 'd'), ['b', 'c', 'd'])
+  })
+
+  it('reads upwards too, so shift-clicking above the anchor works', () => {
+    assert.deepEqual(rangeBetween(ROWS, 'd', 'b'), ['b', 'c', 'd'])
+  })
+
+  it('is inclusive of a single row', () => {
+    assert.deepEqual(rangeBetween(ROWS, 'c', 'c'), ['c'])
+  })
+
+  it('spans the whole list', () => {
+    assert.deepEqual(rangeBetween(ROWS, 'a', 'e'), ROWS)
+  })
+
+  it('selects nothing when a row is not on screen', () => {
+    assert.deepEqual(rangeBetween(ROWS, 'a', 'zz'), [])
+    assert.deepEqual(rangeBetween(ROWS, 'zz', 'a'), [])
+  })
+})
+
+describe('selectionAfterClick', () => {
+  it('adds a row and takes the anchor with it', () => {
+    assert.deepEqual(
+      selectionAfterClick({ id: 'b', orderedIds: ROWS, selected: [], anchorId: null }),
+      { selected: ['b'], anchorId: 'b' }
+    )
+  })
+
+  it('removes a row that was already selected', () => {
+    assert.deepEqual(
+      selectionAfterClick({ id: 'b', orderedIds: ROWS, selected: ['a', 'b'], anchorId: 'a' }),
+      { selected: ['a'], anchorId: 'b' }
+    )
+  })
+
+  it('selects the run between the anchor and the row, leaving the anchor where it was', () => {
+    assert.deepEqual(
+      selectionAfterClick({
+        id: 'd',
+        orderedIds: ROWS,
+        selected: ['b'],
+        anchorId: 'b',
+        shift: true
+      }),
+      { selected: ['b', 'c', 'd'], anchorId: 'b' }
+    )
+  })
+
+  // The anchor staying put is what lets a member widen and narrow one run by shift-clicking around.
+  it('redraws the run rather than growing it when shift-clicking back towards the anchor', () => {
+    const wide = selectionAfterClick({
+      id: 'e',
+      orderedIds: ROWS,
+      selected: ['b'],
+      anchorId: 'b',
+      shift: true
+    })
+    assert.deepEqual(wide.selected, ['b', 'c', 'd', 'e'])
+
+    const narrow = selectionAfterClick({
+      id: 'c',
+      orderedIds: ROWS,
+      selected: wide.selected,
+      anchorId: wide.anchorId,
+      shift: true
+    })
+    assert.deepEqual(narrow, { selected: ['b', 'c'], anchorId: 'b' })
+  })
+
+  it('falls back to a toggle when shift is held with no anchor yet', () => {
+    assert.deepEqual(
+      selectionAfterClick({ id: 'c', orderedIds: ROWS, selected: [], anchorId: null, shift: true }),
+      { selected: ['c'], anchorId: 'c' }
+    )
+  })
+
+  // A member holding shift always means to select something, so an anchor that has scrolled out of
+  // the loaded rows must not select nothing at all.
+  it('falls back to a toggle when the anchor is no longer on screen', () => {
+    assert.deepEqual(
+      selectionAfterClick({
+        id: 'c',
+        orderedIds: ROWS,
+        selected: [],
+        anchorId: 'gone',
+        shift: true
+      }),
+      { selected: ['c'], anchorId: 'c' }
+    )
+  })
+})
+
+describe('prunedSelection', () => {
+  it('drops ids the list no longer holds', () => {
+    assert.deepEqual(prunedSelection(['a', 'zz', 'c'], ROWS), ['a', 'c'])
+  })
+
+  it('keeps a selection that is entirely on screen', () => {
+    assert.deepEqual(prunedSelection(['a', 'c'], ROWS), ['a', 'c'])
+  })
+
+  it('empties a selection when the list does', () => {
+    assert.deepEqual(prunedSelection(['a', 'c'], []), [])
+  })
+})
+
+describe('areAllSelected', () => {
+  it('is true only when every row on screen is ticked', () => {
+    assert.equal(areAllSelected(ROWS, ROWS), true)
+    assert.equal(areAllSelected(ROWS, ['a', 'b']), false)
+  })
+
+  it('ignores selected ids that are not on screen', () => {
+    assert.equal(areAllSelected(['a', 'b'], ['a', 'b', 'zz']), true)
+  })
+
+  // An empty list has nothing to tick, so the header checkbox must not read as ticked.
+  it('is false for an empty list', () => {
+    assert.equal(areAllSelected([], []), false)
+  })
+})

--- a/assets/js/views/BandSpace/Files.vue
+++ b/assets/js/views/BandSpace/Files.vue
@@ -223,6 +223,8 @@
       :parent-id="activeRealFolderId"
     />
 
+    <FileBulkActionBar :band-space-id="bandSpaceId" :is-trash="isTrashActive" />
+
     <FileUploadDialog
       v-if="bandSpaceId"
       v-model:visible="uploadDialogVisible"
@@ -272,6 +274,7 @@ import Skeleton from 'primevue/skeleton'
 import { useToast } from 'primevue/usetoast'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import FileBulkActionBar from '../../components/BandSpace/Files/FileBulkActionBar.vue'
 import FileDetailDrawer from '../../components/BandSpace/Files/FileDetailDrawer.vue'
 import FileFilterBar from '../../components/BandSpace/Files/FileFilterBar.vue'
 import FileList from '../../components/BandSpace/Files/FileList.vue'
@@ -401,10 +404,27 @@ let queryDebounce = null
 
 onMounted(() => {
   loadAll()
+  window.addEventListener('keydown', handleSelectionEscape)
 })
+
+/**
+ * Escape is the way out of a selection, alongside the action bar's own close button. Ignored while a
+ * dialog or drawer is open, because Escape belongs to whatever is on top.
+ */
+function handleSelectionEscape(event) {
+  if (event.key !== 'Escape' || filesStore.selectedFileIds.size === 0) {
+    return
+  }
+  if (document.querySelector('.p-dialog, .p-drawer')) {
+    return
+  }
+
+  filesStore.clearSelection()
+}
 
 onUnmounted(() => {
   if (queryDebounce) clearTimeout(queryDebounce)
+  window.removeEventListener('keydown', handleSelectionEscape)
   filesStore.clear()
 })
 

--- a/src/ApiResource/BandSpace/File/BandSpaceFileBulkDelete.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileBulkDelete.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\File;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\File\BandSpaceFileBulkDeleteProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/files/bulk_delete',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: BandSpaceFileResource::class, identifiers: ['bandSpaceId']),
+    ],
+    openapi: new Operation(tags: ['Band Space File']),
+    status: 204,
+    security: "is_granted('ROLE_USER')",
+    output: false,
+    name: 'api_band_space_files_bulk_delete',
+    processor: BandSpaceFileBulkDeleteProcessor::class,
+)]
+class BandSpaceFileBulkDelete
+{
+    /**
+     * The maximum matches BandSpaceFolderDeleteProcessor::MAX_CASCADE_FILES, which #823 measured
+     * rather than guessed, so the two paths that trash many files at once refuse at the same size.
+     *
+     * @var string[]
+     */
+    #[Assert\Count(
+        min: 1,
+        max: 2000,
+        minMessage: 'Au moins un fichier doit être sélectionné',
+        maxMessage: 'Au maximum {{ limit }} fichiers peuvent être supprimés en une fois',
+    )]
+    #[Assert\All([new Assert\NotBlank()])]
+    public array $fileIds = [];
+}

--- a/src/ApiResource/BandSpace/File/BandSpaceFileBulkPatch.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileBulkPatch.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\File;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\File\BandSpaceFileBulkPatchProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/files/bulk_patch',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: BandSpaceFileResource::class, identifiers: ['bandSpaceId']),
+    ],
+    openapi: new Operation(tags: ['Band Space File']),
+    status: 204,
+    security: "is_granted('ROLE_USER')",
+    output: false,
+    name: 'api_band_space_files_bulk_patch',
+    processor: BandSpaceFileBulkPatchProcessor::class,
+)]
+class BandSpaceFileBulkPatch
+{
+    /** @var string[] */
+    #[Assert\Count(
+        min: 1,
+        max: 2000,
+        minMessage: 'Au moins un fichier doit être sélectionné',
+        maxMessage: 'Au maximum {{ limit }} fichiers peuvent être modifiés en une fois',
+    )]
+    #[Assert\All([new Assert\NotBlank()])]
+    public array $fileIds = [];
+
+    /**
+     * Declared for the OpenAPI schema only. The processor re-reads the raw request, because a move to
+     * the root sends null and presence has to be told apart from absence.
+     */
+    public ?string $folderId = null;
+}

--- a/src/ApiResource/BandSpace/File/BandSpaceFileBulkRestore.php
+++ b/src/ApiResource/BandSpace/File/BandSpaceFileBulkRestore.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\File;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\File\BandSpaceFileBulkRestoreProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/files/bulk_restore',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: BandSpaceFileResource::class, identifiers: ['bandSpaceId']),
+    ],
+    openapi: new Operation(tags: ['Band Space File']),
+    status: 204,
+    security: "is_granted('ROLE_USER')",
+    output: false,
+    name: 'api_band_space_files_bulk_restore',
+    processor: BandSpaceFileBulkRestoreProcessor::class,
+)]
+class BandSpaceFileBulkRestore
+{
+    /** @var string[] */
+    #[Assert\Count(
+        min: 1,
+        max: 2000,
+        minMessage: 'Au moins un fichier doit être sélectionné',
+        maxMessage: 'Au maximum {{ limit }} fichiers peuvent être restaurés en une fois',
+    )]
+    #[Assert\All([new Assert\NotBlank()])]
+    public array $fileIds = [];
+}

--- a/src/Procedure/BandSpace/BandSpaceFileBulkDeleteProcedure.php
+++ b/src/Procedure/BandSpace/BandSpaceFileBulkDeleteProcedure.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace App\Procedure\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\User;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceFileAttachmentRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Service\BandSpace\File\BandSpaceFileArchiver;
+use App\Service\BandSpace\File\BandSpaceFileAttachmentLabels;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Moves a selection of files to the trash in one call.
+ *
+ * Both guards run over the whole selection before anything is written, for the reason the folder
+ * cascade documents: the batch is one transaction, so a single file in the way takes the selection
+ * with it, and a member who ticked twelve rows can only act on that if the answer says which ones.
+ */
+readonly class BandSpaceFileBulkDeleteProcedure
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceFileRepository $fileRepository,
+        private BandSpaceFileAttachmentRepository $attachmentRepository,
+        private BandSpaceFileArchiver $fileArchiver,
+    ) {
+    }
+
+    /**
+     * @param string[] $fileIds
+     */
+    public function delete(BandSpace $bandSpace, BandSpaceMembership $membership, array $fileIds, User $user): void
+    {
+        if (count($fileIds) === 0) {
+            return;
+        }
+
+        // Already trashed rows are not deletable, exactly as the single file endpoint 404s on one:
+        // the trash is a separate listing with its own actions, so such an id is not in this list.
+        $files = array_values(array_filter(
+            $this->fileRepository->findByIdsAndBandSpace($fileIds, $bandSpace),
+            static fn (BandSpaceFile $file): bool => !$file->isArchived(),
+        ));
+
+        $this->assertEveryFileWasFound($fileIds, $files);
+
+        if ($membership->role !== Role::Admin) {
+            $this->assertEveryFileIsOwnedBy($files, $user);
+        }
+
+        $this->assertNoAttachedFile($files);
+
+        $this->entityManager->wrapInTransaction(function () use ($files, $bandSpace, $user): void {
+            $this->fileArchiver->archive($files, $bandSpace, $user);
+        });
+    }
+
+    /**
+     * @param string[] $fileIds
+     * @param BandSpaceFile[] $files
+     */
+    private function assertEveryFileWasFound(array $fileIds, array $files): void
+    {
+        $foundIds = array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files);
+        $missing = array_diff($fileIds, $foundIds);
+
+        if (count($missing) > 0) {
+            throw new BadRequestHttpException(sprintf('Fichier %s introuvable dans ce Band Space', reset($missing)));
+        }
+    }
+
+    /**
+     * @param BandSpaceFile[] $files
+     */
+    private function assertEveryFileIsOwnedBy(array $files, User $user): void
+    {
+        $userId = (string) $user->id;
+        $foreign = array_filter(
+            $files,
+            static fn (BandSpaceFile $file): bool => (string) $file->createdBy->id !== $userId,
+        );
+
+        if ($foreign === []) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException(sprintf(
+            'Seul le créateur ou un administrateur peut supprimer ces fichiers : %s',
+            implode(', ', array_map(static fn (BandSpaceFile $file): string => $file->originalName, $foreign)),
+        ));
+    }
+
+    /**
+     * Refuses the batch when it would trash a file some task, note or finance entry still points at,
+     * which is what the single file endpoint and the folder cascade both already do.
+     *
+     * @param BandSpaceFile[] $files
+     */
+    private function assertNoAttachedFile(array $files): void
+    {
+        $sourceTypesByFile = $this->attachmentRepository->findSourceTypesByFileIds(
+            array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files),
+        );
+
+        if (count($sourceTypesByFile) === 0) {
+            return;
+        }
+
+        // Sorted because the sentence is asserted verbatim: without it the list follows whatever order
+        // the database returned the attachment rows in.
+        $sourceTypes = array_merge(...array_values($sourceTypesByFile));
+        sort($sourceTypes);
+        $sources = BandSpaceFileAttachmentLabels::describe($sourceTypes);
+
+        throw new UnprocessableEntityHttpException(count($sourceTypesByFile) === 1
+            ? sprintf("1 fichier sélectionné est attaché à %s. Détachez-le d'abord depuis la ressource concernée.", $sources)
+            : sprintf(
+                "%d fichiers sélectionnés sont attachés à %s. Détachez-les d'abord depuis les ressources concernées.",
+                count($sourceTypesByFile),
+                $sources,
+            ));
+    }
+}

--- a/src/Procedure/BandSpace/BandSpaceFileBulkPatchProcedure.php
+++ b/src/Procedure/BandSpace/BandSpaceFileBulkPatchProcedure.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace App\Procedure\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Applies one merge-patch to a selection of files, which today means moving them to a folder.
+ *
+ * Delegates per file to BandSpaceFileUpdateProcedure, the same procedure the single file PATCH runs,
+ * so folder validation and the Moved activity stay in one place rather than being restated here.
+ *
+ * No ownership check, deliberately: the single file PATCH has none either, so moving is member level
+ * while deleting is creator-or-admin. Adding one here would make the two disagree.
+ *
+ * Note that "an attached file cannot sit at the root" is a client side rule only, enforced by
+ * canDrop() and the move dialog. The batch inherits the server's actual behaviour, which is to allow
+ * it, rather than inventing a refusal the single file path does not have.
+ */
+readonly class BandSpaceFileBulkPatchProcedure
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceFileRepository $fileRepository,
+        private BandSpaceFileUpdateProcedure $fileUpdateProcedure,
+    ) {
+    }
+
+    /**
+     * @param string[] $fileIds
+     * @param array<string, mixed> $patchPayload raw merge-patch fields applied to every file
+     */
+    public function patch(BandSpace $bandSpace, array $fileIds, array $patchPayload, User $user): void
+    {
+        if (count($fileIds) === 0 || count($patchPayload) === 0) {
+            return;
+        }
+
+        // A trashed file is not in the listing the selection came from, and the single file PATCH 404s
+        // on one, so an id pointing at the trash counts as missing here.
+        $files = array_values(array_filter(
+            $this->fileRepository->findByIdsAndBandSpace($fileIds, $bandSpace),
+            static fn (BandSpaceFile $file): bool => !$file->isArchived(),
+        ));
+
+        $foundIds = array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files);
+        $missing = array_diff($fileIds, $foundIds);
+        if (count($missing) > 0) {
+            throw new BadRequestHttpException(sprintf('Fichier %s introuvable dans ce Band Space', reset($missing)));
+        }
+
+        // Resolved once: the destination is the same for every file, so leaving the lookup inside the
+        // per file path would repeat one identical query per row, up to the 2000 the cap allows.
+        // It also refuses an unknown folder before anything is written.
+        $folder = $this->fileUpdateProcedure->resolveFolder($patchPayload['folder_id'] ?? null, $bandSpace);
+
+        $this->entityManager->wrapInTransaction(function () use ($files, $folder, $user): void {
+            // One instance for the batch, so every file it moves carries the same timestamp. Mutable
+            // on purpose: updateDatetime is a DATETIME_MUTABLE column and DBAL's DateTimeType accepts
+            // only null or DateTime, so the DateTimeImmutable the archiver uses would throw here.
+            $movedAt = new DateTime();
+
+            foreach ($files as $file) {
+                if ($this->fileUpdateProcedure->moveToFolder($file, $folder, $user)) {
+                    $file->updateDatetime = $movedAt;
+                }
+            }
+            // wrapInTransaction flushes once at the end, rather than the single file path's flush per
+            // call, which at this size would be a changeset computation per row.
+        });
+    }
+}

--- a/src/Procedure/BandSpace/BandSpaceFileBulkRestoreProcedure.php
+++ b/src/Procedure/BandSpace/BandSpaceFileBulkRestoreProcedure.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace App\Procedure\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFileVersionRepository;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\File\BandSpaceFileQuotaService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+/**
+ * Brings a selection of files back out of the trash in one call.
+ *
+ * Mirrors BandSpaceFileRestoreProcessor refusal for refusal, with one difference that is the whole
+ * point of doing it here: the quota is asserted once for the batch rather than once per file.
+ */
+readonly class BandSpaceFileBulkRestoreProcedure
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceFileRepository $fileRepository,
+        private BandSpaceFileVersionRepository $versionRepository,
+        private BandSpaceFileQuotaService $quotaService,
+        private BandSpaceActivityRecorder $activityRecorder,
+    ) {
+    }
+
+    /**
+     * @param string[] $fileIds
+     */
+    public function restore(BandSpace $bandSpace, BandSpaceMembership $membership, array $fileIds, User $user): void
+    {
+        if (count($fileIds) === 0) {
+            return;
+        }
+
+        $files = $this->fileRepository->findByIdsAndBandSpace($fileIds, $bandSpace);
+
+        $this->assertEveryFileWasFound($fileIds, $files);
+        $this->assertEveryFileIsInTheTrash($files);
+
+        if ($membership->role !== Role::Admin) {
+            $this->assertEveryFileIsOwnedBy($files, $user);
+        }
+
+        // Once for the whole batch, never once per file. The quota counts live files only, so asserting
+        // per file would weigh each one against a total none of its siblings had been added to yet and
+        // let a selection walk the space past its limit one restore at a time.
+        $this->quotaService->assertCanUpload(
+            $bandSpace,
+            $this->versionRepository->sumBytesByFileIds(
+                array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files),
+            ),
+        );
+
+        $this->entityManager->wrapInTransaction(function () use ($files, $bandSpace, $user): void {
+            foreach ($files as $file) {
+                // Only the archive flag comes off. Share links revoked on the way into the trash stay
+                // revoked: a link the band watched disappear must not come back behind their back.
+                $file->archiveDatetime = null;
+
+                $this->activityRecorder->record(
+                    $bandSpace,
+                    BandSpaceModule::File,
+                    BandSpaceFileActivityType::Restored,
+                    resourceId: (string) $file->id,
+                    actor: $user,
+                    payload: ['original_name' => $file->originalName],
+                );
+            }
+        });
+    }
+
+    /**
+     * @param string[] $fileIds
+     * @param BandSpaceFile[] $files
+     */
+    private function assertEveryFileWasFound(array $fileIds, array $files): void
+    {
+        $foundIds = array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files);
+        $missing = array_diff($fileIds, $foundIds);
+
+        if (count($missing) > 0) {
+            throw new BadRequestHttpException(sprintf('Fichier %s introuvable dans ce Band Space', reset($missing)));
+        }
+    }
+
+    /**
+     * @param BandSpaceFile[] $files
+     */
+    private function assertEveryFileIsInTheTrash(array $files): void
+    {
+        $live = array_filter($files, static fn (BandSpaceFile $file): bool => !$file->isArchived());
+
+        if ($live === []) {
+            return;
+        }
+
+        throw new ConflictHttpException(sprintf(
+            'Ces fichiers ne sont pas dans la corbeille : %s',
+            implode(', ', array_map(static fn (BandSpaceFile $file): string => $file->originalName, $live)),
+        ));
+    }
+
+    /**
+     * @param BandSpaceFile[] $files
+     */
+    private function assertEveryFileIsOwnedBy(array $files, User $user): void
+    {
+        $userId = (string) $user->id;
+        $foreign = array_filter(
+            $files,
+            static fn (BandSpaceFile $file): bool => (string) $file->createdBy->id !== $userId,
+        );
+
+        if ($foreign === []) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException(sprintf(
+            'Seul le créateur ou un administrateur peut restaurer ces fichiers : %s',
+            implode(', ', array_map(static fn (BandSpaceFile $file): string => $file->originalName, $foreign)),
+        ));
+    }
+}

--- a/src/Procedure/BandSpace/BandSpaceFileUpdateProcedure.php
+++ b/src/Procedure/BandSpace/BandSpaceFileUpdateProcedure.php
@@ -5,6 +5,7 @@ namespace App\Procedure\BandSpace;
 use App\ApiResource\BandSpace\File\BandSpaceFileResource;
 use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\BandSpace\BandSpaceFolder;
 use App\Entity\BandSpace\BandSpaceFileTag;
 use App\Entity\User;
 use App\Enum\BandSpace\BandSpaceFileActivityType;
@@ -100,18 +101,40 @@ readonly class BandSpaceFileUpdateProcedure
         return true;
     }
 
-    private function applyMove(BandSpaceFile $file, ?string $folderId, BandSpace $bandSpace, User $user): bool
+    /**
+     * The destination a folder id names, or null for the root.
+     *
+     * Public because a bulk move resolves it once for the whole batch: the id is the same for every
+     * file, so leaving the lookup inside the per file path would repeat one identical query per row.
+     */
+    public function resolveFolder(?string $folderId, BandSpace $bandSpace): ?BandSpaceFolder
     {
-        $newFolder = null;
-        if ($folderId !== null && $folderId !== '') {
-            $newFolder = $this->folderRepository->findOneByIdAndBandSpace($folderId, $bandSpace);
-            if (!$newFolder instanceof \App\Entity\BandSpace\BandSpaceFolder) {
-                throw new UnprocessableEntityHttpException('Dossier introuvable dans ce Band Space');
-            }
+        if ($folderId === null || $folderId === '') {
+            return null;
         }
 
-        $oldFolderId = $file->folder instanceof \App\Entity\BandSpace\BandSpaceFolder ? (string) $file->folder->id : null;
-        $newFolderId = $newFolder instanceof \App\Entity\BandSpace\BandSpaceFolder ? (string) $newFolder->id : null;
+        $folder = $this->folderRepository->findOneByIdAndBandSpace($folderId, $bandSpace);
+        if (!$folder instanceof BandSpaceFolder) {
+            throw new UnprocessableEntityHttpException('Dossier introuvable dans ce Band Space');
+        }
+
+        return $folder;
+    }
+
+    private function applyMove(BandSpaceFile $file, ?string $folderId, BandSpace $bandSpace, User $user): bool
+    {
+        return $this->moveToFolder($file, $this->resolveFolder($folderId, $bandSpace), $user);
+    }
+
+    /**
+     * Moves one file to an already resolved folder, recording the activity, and answers whether it
+     * actually moved. Public for the bulk path, which resolves the destination once and then flushes
+     * once for the whole batch rather than once per file.
+     */
+    public function moveToFolder(BandSpaceFile $file, ?BandSpaceFolder $newFolder, User $user): bool
+    {
+        $oldFolderId = $file->folder instanceof BandSpaceFolder ? (string) $file->folder->id : null;
+        $newFolderId = $newFolder instanceof BandSpaceFolder ? (string) $newFolder->id : null;
         if ($oldFolderId === $newFolderId) {
             return false;
         }

--- a/src/Repository/BandSpace/BandSpaceFileRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileRepository.php
@@ -357,4 +357,42 @@ class BandSpaceFileRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * The files of a bulk selection, scoped to the band space so an id from another space comes back
+     * as missing rather than acted on.
+     *
+     * Archived rows are deliberately not filtered, like findOneByIdAndBandSpace: bulk delete wants
+     * live files and bulk restore wants trashed ones, so each caller applies its own predicate.
+     *
+     * Results are re-sorted into the requested order, because the refusals name the files that
+     * blocked the batch and that list has to read in the order the member ticked them.
+     *
+     * @param string[] $ids
+     * @return BandSpaceFile[]
+     */
+    public function findByIdsAndBandSpace(array $ids, BandSpace $bandSpace): array
+    {
+        if (count($ids) === 0) {
+            return [];
+        }
+
+        /** @var BandSpaceFile[] $files */
+        $files = $this->createQueryBuilder('bsf')
+            ->addSelect('u', 'f')
+            ->leftJoin('bsf.createdBy', 'u')
+            ->leftJoin('bsf.folder', 'f')
+            ->where('bsf.id IN (:ids)')
+            ->andWhere('bsf.bandSpace = :bandSpace')
+            ->setParameter('ids', $ids)
+            ->setParameter('bandSpace', $bandSpace)
+            ->getQuery()
+            ->getResult();
+
+        $rank = array_flip(array_values($ids));
+        usort($files, static fn (BandSpaceFile $a, BandSpaceFile $b): int
+            => ($rank[(string) $a->id] ?? PHP_INT_MAX) <=> ($rank[(string) $b->id] ?? PHP_INT_MAX));
+
+        return $files;
+    }
 }

--- a/src/Repository/BandSpace/BandSpaceFileVersionRepository.php
+++ b/src/Repository/BandSpace/BandSpaceFileVersionRepository.php
@@ -131,4 +131,27 @@ class BandSpaceFileVersionRepository extends ServiceEntityRepository
             $rows,
         );
     }
+
+    /**
+     * The bytes a whole bulk restore would put back into the band's usage, in one query.
+     *
+     * The per file sumBytesByFile() would be one query per row here, and worse, asserting the quota
+     * once per file admits each of them against a total the others have not been counted into yet, so
+     * a batch can walk a space past its limit one file at a time.
+     *
+     * @param string[] $fileIds
+     */
+    public function sumBytesByFileIds(array $fileIds): int
+    {
+        if (count($fileIds) === 0) {
+            return 0;
+        }
+
+        return (int) $this->createQueryBuilder('v')
+            ->select('COALESCE(SUM(v.size), 0)')
+            ->where('IDENTITY(v.bandSpaceFile) IN (:fileIds)')
+            ->setParameter('fileIds', $fileIds)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/src/Service/BandSpace/File/BandSpaceFileArchiver.php
+++ b/src/Service/BandSpace/File/BandSpaceFileArchiver.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace\File;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceFile;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceFileActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceFolderRepository;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use DateTimeImmutable;
+
+/**
+ * Moves a set of files to the trash, the way the single file endpoint does it one at a time.
+ *
+ * Two paths trash several files at once, the folder cascade and the bulk selection, and they have to
+ * agree on what trashing means: the archive flag, one Archived activity per file, and the share links
+ * revoked. The folder cascade owning that loop privately is how the single file path and the cascade
+ * came to disagree in the first place (#823), so it lives here instead.
+ *
+ * Deliberately does not flush. Both callers wrap the write in their own transaction and have more to
+ * persist than the files.
+ */
+readonly class BandSpaceFileArchiver
+{
+    public function __construct(
+        private BandSpaceFolderRepository $folderRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private BandSpaceFileShareRevoker $shareRevoker,
+    ) {
+    }
+
+    /**
+     * Each file keeps the path it was archived from in its Archived activity. The folder cascade needs
+     * it because band_space_file.folder_id is ON DELETE SET NULL and the folder rows are about to go,
+     * so without it a restore drops the file at the root with nothing left saying where it lived.
+     *
+     * Paths are memoised per folder. Walking a chain pulls each ancestor in once and the identity map
+     * serves every later walk, which caps the extra queries at the number of distinct folders in the
+     * set plus the chain above them, never at the number of files.
+     *
+     * @param BandSpaceFile[] $files
+     */
+    public function archive(array $files, BandSpace $bandSpace, User $actor): void
+    {
+        if (count($files) === 0) {
+            return;
+        }
+
+        $archivedAt = new DateTimeImmutable();
+        $pathByFolderId = [];
+
+        foreach ($files as $file) {
+            $file->archiveDatetime = $archivedAt;
+
+            $folderId = (string) $file->folder?->id;
+            $pathByFolderId[$folderId] ??= implode(
+                ' / ',
+                array_column($this->folderRepository->buildPath($file->folder), 'name'),
+            );
+
+            $this->activityRecorder->record(
+                $bandSpace,
+                BandSpaceModule::File,
+                BandSpaceFileActivityType::Archived,
+                resourceId: (string) $file->id,
+                actor: $actor,
+                payload: [
+                    'original_name' => $file->originalName,
+                    'folder_path' => $pathByFolderId[$folderId],
+                ],
+            );
+        }
+
+        $this->shareRevoker->revokeForArchivedFiles(
+            $bandSpace,
+            array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files),
+            $actor,
+        );
+    }
+}

--- a/src/State/Processor/BandSpace/File/BandSpaceFileBulkDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileBulkDeleteProcessor.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\File;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\File\BandSpaceFileBulkDelete;
+use App\Entity\User;
+use App\Procedure\BandSpace\BandSpaceFileBulkDeleteProcedure;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @implements ProcessorInterface<BandSpaceFileBulkDelete, void>
+ */
+readonly class BandSpaceFileBulkDeleteProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private BandSpaceFileBulkDeleteProcedure $bulkDeleteProcedure,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param BandSpaceFileBulkDelete $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $this->bulkDeleteProcedure->delete($bandSpace, $membership, $data->fileIds, $user);
+    }
+}

--- a/src/State/Processor/BandSpace/File/BandSpaceFileBulkPatchProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileBulkPatchProcessor.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\File;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\File\BandSpaceFileBulkPatch;
+use App\Entity\User;
+use App\Procedure\BandSpace\BandSpaceFileBulkPatchProcedure;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @implements ProcessorInterface<BandSpaceFileBulkPatch, void>
+ */
+readonly class BandSpaceFileBulkPatchProcessor implements ProcessorInterface
+{
+    /**
+     * Moving is the only field the batch applies today. Renaming twelve files to one name is never
+     * what somebody meant, and bulk tagging needs add and remove semantics the single file PATCH does
+     * not have, since it replaces the whole set.
+     */
+    private const array ALLOWED_KEYS = ['folder_id'];
+
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private BandSpaceFileBulkPatchProcedure $bulkPatchProcedure,
+        private Security $security,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * @param BandSpaceFileBulkPatch $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        // Read raw rather than off the DTO: a move to the root sends folder_id null, so presence has
+        // to be told apart from absence. file_ids is excluded by the allowlist so it can never leak
+        // into the per file merge-patch.
+        $payload = $this->requestStack->getCurrentRequest()?->toArray() ?? [];
+        $patchPayload = array_intersect_key($payload, array_flip(self::ALLOWED_KEYS));
+
+        $this->bulkPatchProcedure->patch($bandSpace, $data->fileIds, $patchPayload, $user);
+    }
+}

--- a/src/State/Processor/BandSpace/File/BandSpaceFileBulkRestoreProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileBulkRestoreProcessor.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\File;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\File\BandSpaceFileBulkRestore;
+use App\Entity\User;
+use App\Procedure\BandSpace\BandSpaceFileBulkRestoreProcedure;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @implements ProcessorInterface<BandSpaceFileBulkRestore, void>
+ */
+readonly class BandSpaceFileBulkRestoreProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private BandSpaceFileBulkRestoreProcedure $bulkRestoreProcedure,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param BandSpaceFileBulkRestore $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $membership] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $this->bulkRestoreProcedure->restore($bandSpace, $membership, $data->fileIds, $user);
+    }
+}

--- a/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFolderDeleteProcessor.php
@@ -19,7 +19,7 @@ use App\Repository\BandSpace\BandSpaceFolderRepository;
 use App\Security\BandSpace\BandSpaceMemberChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\File\BandSpaceFileAttachmentLabels;
-use App\Service\BandSpace\File\BandSpaceFileShareRevoker;
+use App\Service\BandSpace\File\BandSpaceFileArchiver;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -63,8 +63,8 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
         private BandSpaceFolderRepository $folderRepository,
         private BandSpaceFileRepository $fileRepository,
         private BandSpaceFileAttachmentRepository $attachmentRepository,
-        private BandSpaceFileShareRevoker $shareRevoker,
         private BandSpaceActivityRecorder $activityRecorder,
+        private BandSpaceFileArchiver $fileArchiver,
         private Security $security,
         private RequestStack $requestStack,
     ) {
@@ -123,7 +123,7 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
         $connection->beginTransaction();
         try {
             if ($strategy === self::STRATEGY_CASCADE) {
-                $this->archive($filesToArchive, $membership->bandSpace, $user);
+                $this->fileArchiver->archive($filesToArchive, $membership->bandSpace, $user);
             } else {
                 $this->folderRepository->detachChildrenFrom($folder);
                 $this->fileRepository->detachFromFolder($folder);
@@ -183,57 +183,5 @@ readonly class BandSpaceFolderDeleteProcessor implements ProcessorInterface
                 count($sourceTypesByFile),
                 $sources,
             ));
-    }
-
-    /**
-     * Trashes the subtree file by file, the way the single file endpoint does it.
-     *
-     * The folder rows are about to go and band_space_file.folder_id is ON DELETE SET NULL, so each
-     * file keeps the path it was archived from in its Archived activity: without it a restore drops
-     * the file at the root with nothing left saying where it used to live.
-     *
-     * Paths are memoised per folder. findActiveByFolderIds() fetch joins the file's own folder but not
-     * its ancestors, so walking the chain pulls each ancestor in once; the identity map then serves
-     * every later walk, which caps the extra queries at the number of distinct folders in the subtree
-     * plus the chain above it, never at the number of files. Six levels at most, MAX_DEPTH sees to it.
-     *
-     * @param BandSpaceFile[] $files
-     */
-    private function archive(array $files, BandSpace $bandSpace, User $actor): void
-    {
-        if (count($files) === 0) {
-            return;
-        }
-
-        $archivedAt = new DateTimeImmutable();
-        $pathByFolderId = [];
-
-        foreach ($files as $file) {
-            $file->archiveDatetime = $archivedAt;
-
-            $folderId = (string) $file->folder?->id;
-            $pathByFolderId[$folderId] ??= implode(
-                ' / ',
-                array_column($this->folderRepository->buildPath($file->folder), 'name'),
-            );
-
-            $this->activityRecorder->record(
-                $bandSpace,
-                BandSpaceModule::File,
-                BandSpaceFileActivityType::Archived,
-                resourceId: (string) $file->id,
-                actor: $actor,
-                payload: [
-                    'original_name' => $file->originalName,
-                    'folder_path' => $pathByFolderId[$folderId],
-                ],
-            );
-        }
-
-        $this->shareRevoker->revokeForArchivedFiles(
-            $bandSpace,
-            array_map(static fn (BandSpaceFile $file): string => (string) $file->id, $files),
-            $actor,
-        );
     }
 }

--- a/tests/Api/BandSpace/File/BandSpaceFileBulkDeleteTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileBulkDeleteTest.php
@@ -1,0 +1,360 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\File;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceFileShareRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileShareFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BandSpaceFileBulkDeleteTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    public function test_bulk_delete_trashes_every_selected_file(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $first = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'live-1.wav'])->create();
+        $second = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'live-2.wav'])->create();
+        $untouched = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'garde-moi.wav'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $first->id, (string) $second->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNotNull($repo->find($first->id)?->archiveDatetime);
+        $this->assertNotNull($repo->find($second->id)?->archiveDatetime);
+        $this->assertNull($repo->find($untouched->id)?->archiveDatetime);
+
+        // One Archived activity per file, the way the single file endpoint and the folder cascade write them.
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(2, $activityRepo->findBy(['bandSpace' => $bandSpace->id, 'module' => BandSpaceModule::File]));
+    }
+
+    public function test_bulk_delete_by_an_admin_trashes_another_members_file(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $member, 'originalName' => 'pas-la-mienne.wav'])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $file->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNotNull($repo->find($file->id)?->archiveDatetime);
+    }
+
+    public function test_bulk_delete_revokes_the_share_links_of_every_trashed_file(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'rough-mix.mp3'])->create();
+        $share = BandSpaceFileShareFactory::new(['bandSpaceFile' => $file, 'createdBy' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $file->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // Trashing a file has to unshare it, or a bandmate restoring it weeks later brings the public URL back.
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $shareRepo = self::getContainer()->get(BandSpaceFileShareRepository::class);
+        $this->assertNotNull($shareRepo->find($share->id)?->revocationDatetime);
+    }
+
+    public function test_bulk_delete_names_every_file_the_member_did_not_create(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other])->create();
+
+        $own = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'la-mienne.wav'])->create();
+        $firstForeign = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $other, 'originalName' => 'mix-final.wav'])->create();
+        $secondForeign = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $other, 'originalName' => 'contrat.pdf'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $own->id, (string) $firstForeign->id, (string) $secondForeign->id]],
+            self::HEADERS,
+        );
+
+        // The batch is all or nothing, so the answer has to say which rows of the selection are in
+        // the way, not just that one of them was.
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $detail = 'Seul le créateur ou un administrateur peut supprimer ces fichiers : mix-final.wav, contrat.pdf';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($repo->find($own->id)?->archiveDatetime);
+        $this->assertNull($repo->find($firstForeign->id)?->archiveDatetime);
+    }
+
+    public function test_bulk_delete_names_how_many_files_are_attached_and_to_what(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $free = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'libre.wav'])->create();
+        $attachedToTask = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'devis.pdf'])
+            ->withAttachment(['type' => 'task', 'id' => \Ramsey\Uuid\Uuid::uuid4()->toString()])
+            ->create();
+        $attachedToNote = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'paroles.pdf'])
+            ->withAttachment(['type' => 'note', 'id' => \Ramsey\Uuid\Uuid::uuid4()->toString()])
+            ->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $free->id, (string) $attachedToTask->id, (string) $attachedToNote->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $detail = "2 fichiers sélectionnés sont attachés à une note et une tâche. Détachez-les d'abord depuis les ressources concernées.";
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => $detail,
+        ]);
+
+        // Not even the unattached file beside them was touched, and nothing was written.
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($repo->find($free->id)?->archiveDatetime);
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findBy(['bandSpace' => $bandSpace->id, 'module' => BandSpaceModule::File]));
+    }
+
+    public function test_bulk_delete_names_the_single_attached_file_in_the_singular(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $attached = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'facture.pdf'])
+            ->withAttachment(['type' => 'finance', 'id' => \Ramsey\Uuid\Uuid::uuid4()->toString()])
+            ->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $attached->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $detail = "1 fichier sélectionné est attaché à une entrée financière. Détachez-le d'abord depuis la ressource concernée.";
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => $detail,
+        ]);
+    }
+
+    public function test_bulk_delete_rejects_an_id_from_another_band_space(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $own = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'ok.wav'])->create();
+        $foreign = BandSpaceFileFactory::new(['bandSpace' => $otherBandSpace, 'createdBy' => $user, 'originalName' => 'ailleurs.wav'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $own->id, (string) $foreign->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $detail = 'Fichier ' . $foreign->id . ' introuvable dans ce Band Space';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/400',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 400,
+            'type' => '/errors/400',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($repo->find($own->id)?->archiveDatetime);
+    }
+
+    public function test_bulk_delete_rejects_a_file_already_in_the_trash(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // Already trashed, so it is not a row of the listing the selection came from.
+        $trashed = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'originalName' => 'deja-corbeille.wav',
+            'archiveDatetime' => new \DateTimeImmutable('2026-06-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $trashed->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $detail = 'Fichier ' . $trashed->id . ' introuvable dans ce Band Space';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/400',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 400,
+            'type' => '/errors/400',
+            'description' => $detail,
+        ]);
+    }
+
+    public function test_bulk_delete_is_forbidden_for_a_non_member(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $owner, 'originalName' => 'prive.wav'])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => [(string) $file->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    public function test_bulk_delete_requires_at_least_one_file(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_delete',
+            ['file_ids' => []],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'file_ids',
+                    'message' => 'Au moins un fichier doit être sélectionné',
+                    'code' => 'bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+                ],
+            ],
+            'detail' => 'file_ids: Au moins un fichier doit être sélectionné',
+            'type' => '/validation_errors/bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+            'title' => 'An error occurred',
+            'description' => 'file_ids: Au moins un fichier doit être sélectionné',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/File/BandSpaceFileBulkPatchTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileBulkPatchTest.php
@@ -1,0 +1,355 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\File;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFolderFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BandSpaceFileBulkPatchTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    public function test_bulk_patch_moves_every_selected_file_into_the_folder(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $target = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Concerts'])->create();
+        $first = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'live-1.wav'])->create();
+        $second = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'live-2.wav'])->create();
+        $untouched = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'reste.wav'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [(string) $first->id, (string) $second->id], 'folder_id' => (string) $target->id],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertSame((string) $target->id, (string) $repo->find($first->id)?->folder?->id);
+        $this->assertSame((string) $target->id, (string) $repo->find($second->id)?->folder?->id);
+        $this->assertNull($repo->find($untouched->id)?->folder);
+
+        // Stamped because they moved, and the file left out of the selection is untouched.
+        $this->assertNotNull($repo->find($first->id)?->updateDatetime);
+        $this->assertNotNull($repo->find($second->id)?->updateDatetime);
+        $this->assertNull($repo->find($untouched->id)?->updateDatetime);
+    }
+
+    public function test_bulk_patch_moves_files_back_to_the_root_with_a_null_folder(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Concerts'])->create();
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'originalName' => 'live-1.wav',
+            'folder' => $folder,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [(string) $file->id], 'folder_id' => null],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($repo->find($file->id)?->folder);
+    }
+
+    public function test_bulk_patch_does_not_stamp_a_file_that_did_not_move(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $folder = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Concerts'])->create();
+        $alreadyThere = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'originalName' => 'deja-dedans.wav',
+            'folder' => $folder,
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [(string) $alreadyThere->id], 'folder_id' => (string) $folder->id],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // Moving a file to the folder it is already in is a no-op, so nothing is stamped and no
+        // Moved activity is written. The single file PATCH draws the same distinction.
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertSame((string) $folder->id, (string) $repo->find($alreadyThere->id)?->folder?->id);
+        $this->assertNull($repo->find($alreadyThere->id)?->updateDatetime);
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findBy(['bandSpace' => $bandSpace->id, 'module' => BandSpaceModule::File]));
+    }
+
+    public function test_bulk_patch_moves_a_file_created_by_another_member(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other])->create();
+
+        $target = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Concerts'])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $other, 'originalName' => 'pas-la-mienne.wav'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [(string) $file->id], 'folder_id' => (string) $target->id],
+            self::HEADERS,
+        );
+
+        // Moving is member level, like the single file PATCH. Only deleting is creator-or-admin.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertSame((string) $target->id, (string) $repo->find($file->id)?->folder?->id);
+    }
+
+    public function test_bulk_patch_drops_a_field_outside_the_allowlist(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $target = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Concerts'])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'live-1.wav'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            [
+                'file_ids' => [(string) $file->id],
+                'folder_id' => (string) $target->id,
+                // Renaming a whole selection to one name is never what anybody meant, so the
+                // allowlist drops it rather than applying it twelve times.
+                'original_name' => 'renomme-en-lot.wav',
+            ],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $reloaded = $repo->find($file->id);
+        $this->assertSame('live-1.wav', $reloaded?->originalName);
+        $this->assertSame((string) $target->id, (string) $reloaded?->folder?->id);
+    }
+
+    public function test_bulk_patch_rejects_a_folder_from_another_band_space(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $foreignFolder = BandSpaceFolderFactory::new(['bandSpace' => $otherBandSpace, 'createdBy' => $user, 'name' => 'Ailleurs'])->create();
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'live-1.wav'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [(string) $file->id], 'folder_id' => (string) $foreignFolder->id],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $detail = 'Dossier introuvable dans ce Band Space';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($repo->find($file->id)?->folder);
+    }
+
+    public function test_bulk_patch_rejects_an_id_from_another_band_space(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $target = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Concerts'])->create();
+        $own = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'ok.wav'])->create();
+        $foreign = BandSpaceFileFactory::new(['bandSpace' => $otherBandSpace, 'createdBy' => $user, 'originalName' => 'ailleurs.wav'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [(string) $own->id, (string) $foreign->id], 'folder_id' => (string) $target->id],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $detail = 'Fichier ' . $foreign->id . ' introuvable dans ce Band Space';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/400',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 400,
+            'type' => '/errors/400',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($repo->find($own->id)?->folder);
+    }
+
+    public function test_bulk_patch_rejects_a_file_already_in_the_trash(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $target = BandSpaceFolderFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'name' => 'Concerts'])->create();
+        // Not a row of the listing the selection came from, so the same refusal as bulk delete.
+        $trashed = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'originalName' => 'deja-corbeille.wav',
+            'archiveDatetime' => new \DateTimeImmutable('2026-06-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [(string) $trashed->id], 'folder_id' => (string) $target->id],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $detail = 'Fichier ' . $trashed->id . ' introuvable dans ce Band Space';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/400',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 400,
+            'type' => '/errors/400',
+            'description' => $detail,
+        ]);
+    }
+
+    public function test_bulk_patch_is_forbidden_for_a_non_member(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+
+        $file = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $owner, 'originalName' => 'prive.wav'])->create();
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [(string) $file->id], 'folder_id' => null],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    public function test_bulk_patch_requires_at_least_one_file(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_patch',
+            ['file_ids' => [], 'folder_id' => null],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'file_ids',
+                    'message' => 'Au moins un fichier doit être sélectionné',
+                    'code' => 'bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+                ],
+            ],
+            'detail' => 'file_ids: Au moins un fichier doit être sélectionné',
+            'type' => '/validation_errors/bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+            'title' => 'An error occurred',
+            'description' => 'file_ids: Au moins un fichier doit être sélectionné',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/File/BandSpaceFileBulkRestoreTest.php
+++ b/tests/Api/BandSpace/File/BandSpaceFileBulkRestoreTest.php
@@ -1,0 +1,320 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\File;
+
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\BandSpaceActivityRepository;
+use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
+use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class BandSpaceFileBulkRestoreTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+    private const string ARCHIVED_AT = '2026-06-01 10:00:00';
+
+    public function test_bulk_restore_brings_every_selected_file_out_of_the_trash(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $first = $this->archivedFile($bandSpace, $user, 'live-1.wav');
+        $second = $this->archivedFile($bandSpace, $user, 'live-2.wav');
+        $stays = $this->archivedFile($bandSpace, $user, 'reste-en-corbeille.wav');
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_restore',
+            ['file_ids' => [(string) $first->id, (string) $second->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($repo->find($first->id)?->archiveDatetime);
+        $this->assertNull($repo->find($second->id)?->archiveDatetime);
+        $this->assertNotNull($repo->find($stays->id)?->archiveDatetime);
+
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(2, $activityRepo->findBy(['bandSpace' => $bandSpace->id, 'module' => BandSpaceModule::File]));
+    }
+
+    public function test_bulk_restore_by_an_admin_restores_another_members_file(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+
+        $file = $this->archivedFile($bandSpace, $member, 'pas-la-mienne.wav');
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_restore',
+            ['file_ids' => [(string) $file->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNull($repo->find($file->id)?->archiveDatetime);
+    }
+
+    public function test_bulk_restore_refuses_the_whole_batch_when_it_would_exceed_the_quota(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new(['quotaBytesOverride' => 100])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // 60 each. Restored one at a time both would fit, which is exactly why the quota is asserted
+        // for the batch: otherwise a selection walks the space past its limit one file at a time.
+        $first = $this->archivedFile($bandSpace, $user, 'gros-1.wav', 60);
+        $second = $this->archivedFile($bandSpace, $user, 'gros-2.wav', 60);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_restore',
+            ['file_ids' => [(string) $first->id, (string) $second->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $detail = 'Quota de stockage dépassé : 0 o utilisés sur 100 o autorisés, il manque 20 o pour ajouter 120 o.';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNotNull($repo->find($first->id)?->archiveDatetime);
+        $this->assertNotNull($repo->find($second->id)?->archiveDatetime);
+
+        // The quota is asserted before the transaction opens, so not even an activity was written.
+        $activityRepo = self::getContainer()->get(BandSpaceActivityRepository::class);
+        $this->assertCount(0, $activityRepo->findBy(['bandSpace' => $bandSpace->id, 'module' => BandSpaceModule::File]));
+    }
+
+    public function test_bulk_restore_names_every_file_that_is_not_in_the_trash(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $archived = $this->archivedFile($bandSpace, $user, 'corbeille.wav');
+        BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'vivant-1.wav'])->create();
+        $firstLive = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'vivant-2.wav'])->create();
+        $secondLive = BandSpaceFileFactory::new(['bandSpace' => $bandSpace, 'createdBy' => $user, 'originalName' => 'vivant-3.wav'])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_restore',
+            ['file_ids' => [(string) $archived->id, (string) $firstLive->id, (string) $secondLive->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $detail = 'Ces fichiers ne sont pas dans la corbeille : vivant-2.wav, vivant-3.wav';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 409,
+            'type' => '/errors/409',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNotNull($repo->find($archived->id)?->archiveDatetime);
+    }
+
+    public function test_bulk_restore_names_every_file_the_member_did_not_create(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->create(['username' => 'other_member', 'email' => 'other@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $other])->create();
+
+        $own = $this->archivedFile($bandSpace, $user, 'la-mienne.wav');
+        $firstForeign = $this->archivedFile($bandSpace, $other, 'mix-final.wav');
+        $secondForeign = $this->archivedFile($bandSpace, $other, 'contrat.pdf');
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_restore',
+            ['file_ids' => [(string) $own->id, (string) $firstForeign->id, (string) $secondForeign->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $detail = 'Seul le créateur ou un administrateur peut restaurer ces fichiers : mix-final.wav, contrat.pdf';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => $detail,
+        ]);
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $repo = self::getContainer()->get(BandSpaceFileRepository::class);
+        $this->assertNotNull($repo->find($own->id)?->archiveDatetime);
+    }
+
+    public function test_bulk_restore_rejects_an_id_from_another_band_space(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $own = $this->archivedFile($bandSpace, $user, 'ok.wav');
+        $foreign = $this->archivedFile($otherBandSpace, $user, 'ailleurs.wav');
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_restore',
+            ['file_ids' => [(string) $own->id, (string) $foreign->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $detail = 'Fichier ' . $foreign->id . ' introuvable dans ce Band Space';
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/400',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => $detail,
+            'status' => 400,
+            'type' => '/errors/400',
+            'description' => $detail,
+        ]);
+    }
+
+    public function test_bulk_restore_is_forbidden_for_a_non_member(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create();
+        $outsider = UserFactory::new()->create(['username' => 'outsider', 'email' => 'outsider@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $owner])->create();
+
+        $file = $this->archivedFile($bandSpace, $owner, 'prive.wav');
+
+        $this->client->loginUser($outsider);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_restore',
+            ['file_ids' => [(string) $file->id]],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Vous n'êtes pas membre de ce Band Space",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Vous n'êtes pas membre de ce Band Space",
+        ]);
+    }
+
+    public function test_bulk_restore_requires_at_least_one_file(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/files/bulk_restore',
+            ['file_ids' => []],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'file_ids',
+                    'message' => 'Au moins un fichier doit être sélectionné',
+                    'code' => 'bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+                ],
+            ],
+            'detail' => 'file_ids: Au moins un fichier doit être sélectionné',
+            'type' => '/validation_errors/bef8e338-6ae5-4caf-b8e2-50e7b0579e69',
+            'title' => 'An error occurred',
+            'description' => 'file_ids: Au moins un fichier doit être sélectionné',
+        ]);
+    }
+
+    /**
+     * A trashed file with one version, so the batch has bytes to weigh against the quota.
+     */
+    private function archivedFile(object $bandSpace, object $createdBy, string $originalName, int $size = 10): object
+    {
+        $file = BandSpaceFileFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $createdBy,
+            'originalName' => $originalName,
+            'archiveDatetime' => new \DateTimeImmutable(self::ARCHIVED_AT),
+        ])->create();
+
+        $version = BandSpaceFileVersionFactory::new([
+            'bandSpaceFile' => $file,
+            'versionNumber' => 1,
+            'createdBy' => $createdBy,
+            'size' => $size,
+        ])->create();
+
+        $file->currentVersion = $version;
+        \Zenstruck\Foundry\Persistence\save($file);
+
+        return $file;
+    }
+}


### PR DESCRIPTION
Closes #887.

The Files module had no selection at all: `FileList.vue` held two refs, `dropTargetId` and `contextMenuFile`, and every action went through a per-row context menu. Tidying up after a gig meant opening that menu once per photo.

Rows now carry a checkbox, `Ctrl`/`Cmd+click` toggles one and `Shift+click` takes a run, and a bar offers **Supprimer**, **Déplacer** and, in the trash, **Restaurer**. Tags are left out: the single file endpoint replaces the whole tag set, and bulk tagging needs add and remove semantics that are a separate decision.

## Four interaction decisions

**Always visible checkboxes, no selection mode.** Tasks makes you enter one first; a file list is a file manager, so the column is simply there. A bare click still opens the file, which is what a click on a file list has always meant. Only a modifier or the checkbox selects.

**Selection clears on folder navigation**, which the issue suggested and which is the simpler half of the choice: the bar always describes rows the member can see, and select-all is unambiguously "this folder".

**Drag is disabled while a selection exists.** `FileList.vue` already runs drag and drop to move files into folders, and #885 still has to disambiguate an incoming OS-file drag on those same handlers. Gating on `!hasSelection` leaves them untouched. Folder drag keeps working throughout.

**Select-all means the rows that are loaded.** The list pages at 50 and `totalItems` can be far larger, so the bar says `50 fichiers sélectionnés` and never implies the other 300. Anything else needs an "all matching this filter" concept the API does not have.

## Every refusal names every file that blocked it

Three endpoints, shaped like the Tasks bulk pair: `POST .../files/bulk_delete`, `/bulk_patch` and `/bulk_restore`, all 204 with no body, `Assert\Count(min: 1, max: 2000)`.

The cap matches `BandSpaceFolderDeleteProcessor::MAX_CASCADE_FILES`, which #867 measured rather than guessed, so the two paths that trash many files at once refuse at the same size.

Both guards run over the whole selection before anything is written, and the message enumerates the blockers:

- `Seul le créateur ou un administrateur peut supprimer ces fichiers : mix-final.wav, contrat.pdf`
- `2 fichiers sélectionnés sont attachés à une note et une tâche. Détachez-les d'abord depuis les ressources concernées.`
- `Ces fichiers ne sont pas dans la corbeille : vivant-2.wav, vivant-3.wav`

Those strings are byte for byte the ones `assets/js/utils/fileActions.js` builds, so the greyed out tooltip under a disabled button and the refusal from the server read the same. Both sides are asserted, including the singular and plural forms, the deduplication of repeated sources and their sort order.

## Trashing files has one implementation now, not two

`BandSpaceFolderDeleteProcessor::archive()` already did what a bulk delete needs: set the archive flag, write one `Archived` activity per file carrying its `folder_path`, and revoke the share links in one batch. Writing that a third time is how the single file path and the folder cascade came to disagree in the first place (#823), so it moved to `BandSpaceFileArchiver` and the cascade was migrated onto it. Behaviour preserving, and `BandSpaceFolderDeleteTest` pins it.

`BandSpaceFileDeleteProcessor` is deliberately left alone: its `Archived` payload carries no `folder_path`, and changing that for this issue buys nothing.

## The quota trap in bulk restore

`BandSpaceFileRestoreProcessor` asserts the quota per file, because the quota counts only live files. Restoring twenty files that way weighs each one against a total the other nineteen have not been added to yet, so a selection walks the space past its limit one file at a time.

The bulk procedure sums the whole batch with a new `sumBytesByFileIds()` and asserts once, before the transaction opens. A test pins it: quota 100 bytes, two 60 byte files, each of which would individually fit, refused together.

## Bulk move reuses the single file procedure

`bulk_patch` rather than a dedicated `bulk_move`, mirroring Tasks, with `ALLOWED_KEYS = ['folder_id']` read off the raw request so a move to the root can send `null` and still be told apart from an absent field. The allowlist is load bearing: without it a stray `tag_ids` or `original_name` in the body would reach the shared per-file procedure and mass-mutate the selection. That is tested.

`resolveFolder()` and `moveToFolder()` were split out of `BandSpaceFileUpdateProcedure` so the batch resolves the destination once instead of once per file, and `wrapInTransaction` flushes once instead of once per file. The single file PATCH goes through the same two methods.

There is no ownership check on the move, matching the single file PATCH: moving is member level, only deleting and restoring are creator or admin.

Note that "an attached file cannot sit at the root" is a client side rule only, enforced by `canDrop()` and the move dialog. The bar applies it across the selection; the endpoint inherits the server's actual behaviour rather than inventing a refusal the single file path does not have.

## Frontend

Two pure modules with tests, since there is no component test harness: `utils/fileSelection.js` holds the anchor and range arithmetic, which did not exist anywhere in the codebase before, and `utils/fileActions.js` holds the blocked reason sentences. `folderSelectOptions` came out of `FileMoveDialog.vue` into `fileListing.js` so the single file and bulk destination lists cannot drift.

`FileBulkActionBar.vue` follows `TaskBulkActionBar`: one `busy` ref, one `runBulk` wrapper, and the disabled button wrapped in a `v-tooltip` span with an `sr-only` twin, because a disabled button fires no pointer event and a tooltip carries no accessible name.

## Verification

Full suite green at 2428, PHPStan level 8 clean, Biome clean, 544 frontend unit tests, build clean.

28 new API tests across three files, full body `assertJsonEquals` on every success and refusal, each refusal followed by a rollback assertion proving nothing was archived and no activity written. Two blockers are seeded wherever a message enumerates them, so the join is exercised.

Exercised by hand in both themes: shift click over a range, select all, `Escape` to clear, file rows refusing to drag while a selection exists with folder drag still working, delete then restore round trip, move round trip, and a selection containing an attached file greying out Supprimer with the exact sentence the endpoint would answer.
