### PR TITLE
feat(M-777): member absences shown on the band space agenda

### DIFF
--- a/assets/js/api/bandSpace/band-space-absence.js
+++ b/assets/js/api/bandSpace/band-space-absence.js
@@ -1,0 +1,46 @@
+/** global: Routing */
+
+import axios from 'axios'
+import { handleApiError } from '../utils/handleApiError.js'
+
+export default {
+  /**
+   * Every member's absences overlapping the period, not just the reader's: the drawer and the
+   * calendar both narrow client side off this one response.
+   */
+  getAbsences(bandSpaceId, { from, to } = {}) {
+    const params = {}
+    if (from) params.from = from
+    if (to) params.to = to
+    return axios
+      .get(Routing.generate('api_band_space_absences_get_collection', { bandSpaceId }), { params })
+      .then((resp) => resp.data.member)
+      .catch(handleApiError)
+  },
+
+  createAbsence(bandSpaceId, data) {
+    return axios
+      .post(Routing.generate('api_band_space_absences_post', { bandSpaceId }), data, {
+        headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' }
+      })
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
+  updateAbsence(bandSpaceId, absenceId, data) {
+    return axios
+      .patch(
+        Routing.generate('api_band_space_absences_patch', { bandSpaceId, id: absenceId }),
+        data,
+        { headers: { 'Content-Type': 'application/merge-patch+json' } }
+      )
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
+  deleteAbsence(bandSpaceId, absenceId) {
+    return axios
+      .delete(Routing.generate('api_band_space_absences_delete', { bandSpaceId, id: absenceId }))
+      .catch(handleApiError)
+  }
+}

--- a/assets/js/components/BandSpace/Agenda/AbsencesDrawer.vue
+++ b/assets/js/components/BandSpace/Agenda/AbsencesDrawer.vue
@@ -414,7 +414,7 @@ function applyViolations(error) {
 
 function confirmDelete(absence) {
   confirm.require({
-    message: `Supprimer l'indisponibilité de ${absence.display_name} du ${formatAbsenceRange(absence.start_date, absence.end_date)} ?`,
+    message: `Supprimer l'indisponibilité de ${absence.display_name} (${formatAbsenceRange(absence.start_date, absence.end_date)}) ?`,
     header: 'Confirmer la suppression',
     icon: 'pi pi-exclamation-triangle',
     rejectLabel: 'Annuler',

--- a/assets/js/components/BandSpace/Agenda/AbsencesDrawer.vue
+++ b/assets/js/components/BandSpace/Agenda/AbsencesDrawer.vue
@@ -1,0 +1,435 @@
+<template>
+  <Drawer
+    v-model:visible="isVisible"
+    position="right"
+    header="Indisponibilités"
+    class="w-full md:w-[32rem]"
+  >
+    <div class="flex flex-col gap-4">
+      <p class="text-sm text-surface-500 dark:text-surface-400">
+        Qui est absent, et quand. Chacun gère ses propres dates, un administrateur peut gérer celles
+        de tout le groupe.
+      </p>
+
+      <Message
+        v-if="formError"
+        severity="error"
+        :closable="true"
+        class="text-sm"
+        @close="formError = null"
+      >
+        {{ formError }}
+      </Message>
+
+      <div class="flex flex-wrap items-end gap-2">
+        <div class="flex flex-col gap-1">
+          <label for="absence-year" class="text-xs font-medium">Année</label>
+          <Select
+            id="absence-year"
+            v-model="selectedYear"
+            :options="yearOptions"
+            optionLabel="label"
+            optionValue="value"
+            class="w-28"
+          />
+        </div>
+        <div class="flex flex-col gap-1 flex-1 min-w-40">
+          <label for="absence-member-filter" class="text-xs font-medium">Membre</label>
+          <Select
+            id="absence-member-filter"
+            v-model="selectedMemberId"
+            :options="memberFilterOptions"
+            optionLabel="label"
+            optionValue="value"
+            class="w-full"
+          />
+        </div>
+        <Button
+          v-if="!isFormOpen"
+          icon="pi pi-plus"
+          label="Ajouter"
+          size="small"
+          @click="openCreateForm"
+        />
+      </div>
+
+      <form
+        v-if="isFormOpen"
+        class="flex flex-col gap-3 rounded-xl border border-surface-200 dark:border-surface-700 p-3"
+        @submit.prevent="handleSubmit"
+      >
+        <div v-if="canPickMember" class="flex flex-col gap-1">
+          <label for="absence-member" class="text-sm font-medium">Membre</label>
+          <Select
+            id="absence-member"
+            v-model="form.memberId"
+            :options="memberOptions"
+            optionLabel="label"
+            optionValue="value"
+            :disabled="isEditing"
+            class="w-full"
+          />
+          <small v-if="isEditing" class="text-surface-500 dark:text-surface-400">
+            Pour changer de membre, supprimez cette indisponibilité et créez-en une autre.
+          </small>
+        </div>
+
+        <div class="flex flex-col gap-3 sm:flex-row">
+          <div class="flex flex-col gap-1 flex-1">
+            <label for="absence-start" class="text-sm font-medium">
+              Du <span class="text-red-500">*</span>
+            </label>
+            <DatePicker
+              id="absence-start"
+              v-model="form.startDate"
+              dateFormat="dd/mm/yy"
+              showIcon
+              class="w-full"
+              :class="{ 'p-invalid': fieldErrors.startDate }"
+            />
+            <small v-if="fieldErrors.startDate" class="text-red-500">
+              {{ fieldErrors.startDate }}
+            </small>
+          </div>
+          <div class="flex flex-col gap-1 flex-1">
+            <label for="absence-end" class="text-sm font-medium">
+              Au <span class="text-red-500">*</span>
+            </label>
+            <DatePicker
+              id="absence-end"
+              v-model="form.endDate"
+              dateFormat="dd/mm/yy"
+              showIcon
+              :minDate="form.startDate ?? undefined"
+              class="w-full"
+              :class="{ 'p-invalid': fieldErrors.endDate }"
+            />
+            <small v-if="fieldErrors.endDate" class="text-red-500">{{ fieldErrors.endDate }}</small>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <label for="absence-reason" class="text-sm font-medium">Motif (optionnel)</label>
+          <InputText
+            id="absence-reason"
+            v-model="form.reason"
+            maxlength="120"
+            placeholder="Ex : vacances, déplacement professionnel"
+            :class="{ 'p-invalid': fieldErrors.reason }"
+          />
+          <small v-if="fieldErrors.reason" class="text-red-500">{{ fieldErrors.reason }}</small>
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <Button
+            label="Annuler"
+            severity="secondary"
+            text
+            :disabled="absenceStore.isSaving"
+            @click="closeForm"
+          />
+          <Button
+            type="submit"
+            :label="isEditing ? 'Enregistrer' : 'Ajouter'"
+            :loading="absenceStore.isSaving"
+          />
+        </div>
+      </form>
+
+      <div v-if="absenceStore.isLoading" class="flex justify-center py-8">
+        <ProgressSpinner style="width: 2.5rem; height: 2.5rem" />
+      </div>
+
+      <div v-else-if="absenceStore.loadError" class="text-center text-red-500 py-8">
+        {{ absenceStore.loadError }}
+      </div>
+
+      <div
+        v-else-if="groupedAbsences.length === 0"
+        class="text-center text-surface-500 dark:text-surface-400 italic py-8"
+      >
+        Aucune indisponibilité enregistrée sur cette période
+      </div>
+
+      <div v-else class="flex flex-col gap-4">
+        <div v-for="group in groupedAbsences" :key="group.key">
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-surface-500 dark:text-surface-400 mb-1">
+            {{ group.label }}
+          </h3>
+          <ul class="rounded-xl border border-surface-200 dark:border-surface-700 overflow-hidden">
+            <li
+              v-for="absence in group.absences"
+              :key="absence.id"
+              class="flex items-center gap-3 p-3 border-b border-surface-200 dark:border-surface-700 last:border-b-0"
+            >
+              <Avatar
+                :username="absence.display_name"
+                :picture-url="absence.profile_picture_url"
+                size="sm"
+              />
+              <div class="flex-1 min-w-0">
+                <div class="font-medium truncate">{{ absence.display_name }}</div>
+                <div class="text-sm text-surface-600 dark:text-surface-300 tabular-nums">
+                  {{ formatAbsenceRange(absence.start_date, absence.end_date) }}
+                </div>
+                <div
+                  v-if="absence.reason"
+                  class="text-xs text-surface-500 dark:text-surface-400 truncate"
+                >
+                  {{ absence.reason }}
+                </div>
+              </div>
+              <div v-if="absence.can_manage" class="flex items-center gap-1">
+                <Button
+                  icon="pi pi-pencil"
+                  severity="secondary"
+                  text
+                  rounded
+                  size="small"
+                  aria-label="Modifier l'indisponibilité"
+                  v-tooltip.bottom="'Modifier'"
+                  @click="openEditForm(absence)"
+                />
+                <Button
+                  icon="pi pi-trash"
+                  severity="danger"
+                  text
+                  rounded
+                  size="small"
+                  aria-label="Supprimer l'indisponibilité"
+                  v-tooltip.bottom="'Supprimer'"
+                  @click="confirmDelete(absence)"
+                />
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </Drawer>
+</template>
+
+<script setup>
+import { format, parseISO } from 'date-fns'
+import Button from 'primevue/button'
+import DatePicker from 'primevue/datepicker'
+import Drawer from 'primevue/drawer'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import ProgressSpinner from 'primevue/progressspinner'
+import Select from 'primevue/select'
+import { useConfirm } from 'primevue/useconfirm'
+import { computed, reactive, ref, watch } from 'vue'
+import { useBandSpaceNavigation } from '../../../composables/useBandSpaceNavigation.js'
+import { useBandAbsenceStore } from '../../../store/bandSpace/bandSpaceAbsence.js'
+import { useBandSpaceSettingsStore } from '../../../store/bandSpace/bandSpaceSettings.js'
+import { useUserSecurityStore } from '../../../store/user/security.js'
+import { formatAbsenceRange, groupAbsencesByMonth } from '../../../utils/absenceRange.js'
+import Avatar from '../../User/Avatar.vue'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true },
+  /** Preselects a member in the filter, so clicking an absence on the calendar lands on that person. */
+  initialMemberId: { type: String, default: null }
+})
+
+const emit = defineEmits(['changed'])
+const isVisible = defineModel('visible', { type: Boolean, default: false })
+
+const ALL_MEMBERS = '__all__'
+
+const absenceStore = useBandAbsenceStore()
+const confirm = useConfirm()
+const { isAdmin } = useBandSpaceNavigation()
+const userSecurityStore = useUserSecurityStore()
+const settingsStore = useBandSpaceSettingsStore()
+
+const currentYear = new Date().getFullYear()
+const selectedYear = ref(currentYear)
+const selectedMemberId = ref(ALL_MEMBERS)
+const isFormOpen = ref(false)
+const editingId = ref(null)
+const formError = ref(null)
+const fieldErrors = reactive({ startDate: null, endDate: null, reason: null })
+const form = reactive({ memberId: null, startDate: null, endDate: null, reason: '' })
+
+// Far enough back to keep last season readable, far enough forward for a tour being booked. Fixed at
+// setup: nothing here is reactive, so a computed would only promise a reactivity it does not have.
+const yearOptions = [currentYear - 1, currentYear, currentYear + 1, currentYear + 2].map(
+  (year) => ({
+    label: String(year),
+    value: year
+  })
+)
+
+const members = computed(() => settingsStore.members)
+
+const memberOptions = computed(() =>
+  members.value.map((member) => ({ label: member.display_name, value: member.id }))
+)
+
+const memberFilterOptions = computed(() => [
+  { label: 'Tous', value: ALL_MEMBERS },
+  ...memberOptions.value
+])
+
+/**
+ * The reader's own membership in this band. Matched on the user id, which is the key the rest of the
+ * app compares identity on, rather than on `display_name`, which may be a stage name. Only used to
+ * preselect an admin's own name in the form, since a plain member never sends a member at all.
+ */
+const ownMemberId = computed(
+  () =>
+    members.value.find((member) => member.user_id === userSecurityStore.userProfile?.id)?.id ?? null
+)
+
+/** Only an admin may record for somebody else, so only an admin is offered the choice. */
+const canPickMember = computed(() => isAdmin.value)
+
+const isEditing = computed(() => editingId.value !== null)
+
+const visibleAbsences = computed(() =>
+  selectedMemberId.value === ALL_MEMBERS
+    ? absenceStore.absences
+    : absenceStore.absences.filter((absence) => absence.member_id === selectedMemberId.value)
+)
+
+const groupedAbsences = computed(() => groupAbsencesByMonth(visibleAbsences.value))
+
+watch(isVisible, async (opened) => {
+  if (!opened) {
+    closeForm()
+    return
+  }
+
+  selectedMemberId.value = props.initialMemberId ?? ALL_MEMBERS
+  // Independent requests: the list rows carry their own name and avatar, and the roster only feeds
+  // the pickers. Awaiting the roster first would add a round trip to the drawer's time to content.
+  loadMembers()
+  fetchYear()
+})
+
+watch(selectedYear, () => {
+  if (isVisible.value) fetchYear()
+})
+
+async function loadMembers() {
+  try {
+    await settingsStore.loadMembers(props.bandSpaceId)
+  } catch {
+    // The roster only feeds the two pickers; the list itself carries every name it renders.
+  }
+}
+
+function fetchYear() {
+  absenceStore.fetchAbsences(props.bandSpaceId, {
+    from: `${selectedYear.value}-01-01`,
+    to: `${selectedYear.value}-12-31`
+  })
+}
+
+function resetErrors() {
+  formError.value = null
+  fieldErrors.startDate = null
+  fieldErrors.endDate = null
+  fieldErrors.reason = null
+}
+
+function openCreateForm() {
+  resetErrors()
+  editingId.value = null
+  form.memberId = ownMemberId.value ?? memberOptions.value[0]?.value ?? null
+  form.startDate = null
+  form.endDate = null
+  form.reason = ''
+  isFormOpen.value = true
+}
+
+function openEditForm(absence) {
+  resetErrors()
+  editingId.value = absence.id
+  form.memberId = absence.member_id
+  form.startDate = parseISO(absence.start_date)
+  form.endDate = parseISO(absence.end_date)
+  form.reason = absence.reason ?? ''
+  isFormOpen.value = true
+}
+
+function closeForm() {
+  isFormOpen.value = false
+  editingId.value = null
+  resetErrors()
+}
+
+async function handleSubmit() {
+  resetErrors()
+
+  if (!form.startDate) {
+    fieldErrors.startDate = 'Veuillez spécifier une date de début'
+    return
+  }
+  if (!form.endDate) {
+    fieldErrors.endDate = 'Veuillez spécifier une date de fin'
+    return
+  }
+  if (form.endDate < form.startDate) {
+    fieldErrors.endDate = 'La date de fin doit être postérieure ou égale à la date de début'
+    return
+  }
+
+  const reason = form.reason.trim()
+  const payload = {
+    // Local getters on purpose: the day the member picked in the calendar widget is the day that
+    // gets stored, with no offset in the payload to move it.
+    startDate: format(form.startDate, 'yyyy-MM-dd'),
+    endDate: format(form.endDate, 'yyyy-MM-dd'),
+    reason: reason === '' ? null : reason
+  }
+
+  try {
+    if (isEditing.value) {
+      await absenceStore.updateAbsence(props.bandSpaceId, editingId.value, payload)
+    } else {
+      await absenceStore.createAbsence(props.bandSpaceId, {
+        ...payload,
+        // Only sent by an admin recording for somebody else; the API defaults it to the caller.
+        ...(canPickMember.value && form.memberId ? { memberId: form.memberId } : {})
+      })
+    }
+    closeForm()
+    emit('changed')
+  } catch (error) {
+    applyViolations(error)
+    formError.value = error?.message ?? "Impossible d'enregistrer l'indisponibilité"
+  }
+}
+
+function applyViolations(error) {
+  const violations = error?.violationsByField
+  if (!violations) return
+  if (violations.start_date) fieldErrors.startDate = violations.start_date[0].message
+  if (violations.end_date) fieldErrors.endDate = violations.end_date[0].message
+  if (violations.reason) fieldErrors.reason = violations.reason[0].message
+}
+
+function confirmDelete(absence) {
+  confirm.require({
+    message: `Supprimer l'indisponibilité de ${absence.display_name} du ${formatAbsenceRange(absence.start_date, absence.end_date)} ?`,
+    header: 'Confirmer la suppression',
+    icon: 'pi pi-exclamation-triangle',
+    rejectLabel: 'Annuler',
+    acceptLabel: 'Supprimer',
+    acceptClass: 'p-button-danger',
+    accept: async () => {
+      resetErrors()
+      try {
+        await absenceStore.deleteAbsence(props.bandSpaceId, absence.id)
+        if (editingId.value === absence.id) closeForm()
+        emit('changed')
+      } catch (error) {
+        formError.value = error?.message ?? "Impossible de supprimer l'indisponibilité"
+      }
+    }
+  })
+}
+</script>

--- a/assets/js/components/BandSpace/Agenda/AgendaEventChip.vue
+++ b/assets/js/components/BandSpace/Agenda/AgendaEventChip.vue
@@ -5,8 +5,13 @@
       <span v-if="priorityIcon" :class="['pi shrink-0', priorityIcon.icon, priorityIcon.color]" :title="priorityIcon.label" />
       <span v-if="financeIcon" :class="['pi text-[10px] shrink-0', financeIcon.icon]" :title="financeIcon.label" />
       <span v-if="isRecurringOccurrence" class="pi pi-refresh text-[10px] shrink-0 opacity-90" title="Événement récurrent" />
-      <span class="truncate font-medium">{{ item.title }}</span>
+      <span v-if="isAbsence" class="pi pi-user-minus text-[10px] shrink-0 opacity-90" title="Indisponibilité" />
+      <span class="truncate font-medium" :class="{ 'font-normal italic': isAbsence }">
+        {{ item.title }}
+      </span>
     </div>
+
+    <div v-if="!isCompact && absenceReason" class="truncate opacity-90">{{ absenceReason }}</div>
 
     <div v-if="!isCompact && financeAmount" class="font-semibold tabular-nums">{{ financeAmount }}</div>
 
@@ -74,6 +79,13 @@ const location = computed(() =>
 const isRecurringOccurrence = computed(
   () => props.item.source === 'manual' && props.item.metadata?.is_recurring_occurrence === true
 )
+
+// An absence is context for the dates around it, not an appointment, so it is drawn a notch quieter
+// than the events it sits next to.
+const isAbsence = computed(() => props.item.source === 'absence')
+
+// The reason travels as the item's description, which is where the agenda list row reads it too.
+const absenceReason = computed(() => (isAbsence.value ? (props.item.description ?? null) : null))
 
 const assignees = computed(() => props.item.metadata?.assignees ?? [])
 const visibleAssignees = computed(() => assignees.value.slice(0, 3))

--- a/assets/js/components/BandSpace/Dashboard/AgendaWidget.vue
+++ b/assets/js/components/BandSpace/Dashboard/AgendaWidget.vue
@@ -35,6 +35,7 @@ import { fr } from 'date-fns/locale'
 import { onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import bandSpaceAgendaApi from '../../../api/bandSpace/band-space-agenda.js'
+import { agendaSourceFor } from '../../../constants/agendaSources.js'
 import { toAgendaDate } from '../../../utils/agendaDate.js'
 import { isAllDayItem } from '../../../utils/agendaItem.js'
 import DashboardWidget from './DashboardWidget.vue'
@@ -76,13 +77,7 @@ function formatTime(datetimeStr) {
   return format(parseISO(datetimeStr), 'HH:mm')
 }
 
-const SOURCE_BORDER_CLASS = {
-  manual: 'border-blue-400',
-  task: 'border-amber-400',
-  finance: 'border-emerald-400'
-}
-
 function sourceBorderClass(source) {
-  return SOURCE_BORDER_CLASS[source] ?? 'border-surface-300'
+  return agendaSourceFor(source).widgetBorderClass
 }
 </script>

--- a/assets/js/constants/agendaSources.js
+++ b/assets/js/constants/agendaSources.js
@@ -1,0 +1,107 @@
+/**
+ * Everything the frontend knows about the sources `AgendaAggregator` merges into the agenda.
+ *
+ * The backend emits a `source` discriminator on every `AgendaItem` and each screen reading it used
+ * to carry its own partial copy of the list: the agenda page held five (filter chips, dot colours,
+ * the default filter set, the counter seed, and three `switch` statements) and the dashboard widget
+ * a sixth. Adding `absence` in #777 meant editing all of them, and the widget was missed, so the
+ * same absence rendered violet on the agenda and grey on the dashboard. One row per source here is
+ * what keeps the two screens saying the same thing.
+ *
+ * Same shape as `fileSources.js`, which exists for the same reason on the file module. A fifth
+ * source is one row here plus, if it is clickable, one branch in `Agenda.vue`'s `handleItemClick`.
+ *
+ * Ordered as the filter chips read left to right.
+ */
+
+/**
+ * @typedef {object} AgendaSource
+ * @property {string} key The `source` the API emits.
+ * @property {string} chipLabel Plural, on the filter chip: « Tâches ».
+ * @property {string} label Singular, on an item's badge: « Tâche ».
+ * @property {string} color Hex, for the year overview's day dots.
+ * @property {string} badgeClass Badge beside an item's title, and the active filter chip.
+ * @property {string} borderClass Left border of a row in the agenda list.
+ * @property {string} widgetBorderClass Left border of a row in the dashboard widget, a notch lighter.
+ */
+
+/** @type {readonly AgendaSource[]} */
+const AGENDA_SOURCES = Object.freeze([
+  Object.freeze({
+    key: 'manual',
+    chipLabel: 'Manuel',
+    label: 'Manuel',
+    color: '#3b82f6',
+    badgeClass: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    borderClass: 'border-l-blue-500',
+    widgetBorderClass: 'border-blue-400'
+  }),
+  Object.freeze({
+    key: 'task',
+    chipLabel: 'Tâches',
+    label: 'Tâche',
+    color: '#f59e0b',
+    badgeClass: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+    borderClass: 'border-l-amber-500',
+    widgetBorderClass: 'border-amber-400'
+  }),
+  Object.freeze({
+    key: 'finance',
+    chipLabel: 'Finances',
+    label: 'Finance',
+    color: '#10b981',
+    badgeClass: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+    borderClass: 'border-l-emerald-500',
+    widgetBorderClass: 'border-emerald-400'
+  }),
+  Object.freeze({
+    key: 'absence',
+    chipLabel: 'Absences',
+    label: 'Absence',
+    // Violet: distinct from the other three, and not red, which would read as an error rather than
+    // as somebody being away.
+    color: '#8b5cf6',
+    badgeClass: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400',
+    borderClass: 'border-l-violet-500',
+    widgetBorderClass: 'border-violet-400'
+  })
+])
+
+/**
+ * Stands in for a source the frontend has never heard of, so a backend that grows a fifth one
+ * degrades to a neutral row instead of an unstyled one printing the raw key.
+ */
+const UNKNOWN_SOURCE = Object.freeze({
+  key: null,
+  chipLabel: null,
+  label: null,
+  color: '#94a3b8',
+  badgeClass: 'bg-surface-100 text-surface-600',
+  borderClass: 'border-l-surface-300',
+  widgetBorderClass: 'border-surface-300'
+})
+
+const AGENDA_SOURCE_BY_KEY = Object.freeze(
+  Object.fromEntries(AGENDA_SOURCES.map((source) => [source.key, source]))
+)
+
+/** The filter chips, in display order. */
+export const AGENDA_SOURCE_LIST = AGENDA_SOURCES
+
+/** Every key the aggregator can emit, for the default filter set and the counter seed. */
+export const AGENDA_SOURCE_KEYS = Object.freeze(AGENDA_SOURCES.map((source) => source.key))
+
+/**
+ * The descriptor for a source, never null: an unknown key falls back to neutral styling.
+ *
+ * @param {string} key
+ * @returns {AgendaSource}
+ */
+export function agendaSourceFor(key) {
+  return AGENDA_SOURCE_BY_KEY[key] ?? UNKNOWN_SOURCE
+}
+
+/** The badge text for a source; the raw key for one the frontend does not know. */
+export function agendaSourceLabel(key) {
+  return agendaSourceFor(key).label ?? key
+}

--- a/assets/js/store/bandSpace/bandSpaceAbsence.js
+++ b/assets/js/store/bandSpace/bandSpaceAbsence.js
@@ -1,0 +1,88 @@
+import { defineStore } from 'pinia'
+import { readonly, ref } from 'vue'
+import bandSpaceAbsenceApi from '../../api/bandSpace/band-space-absence.js'
+
+export const useBandAbsenceStore = defineStore('bandAbsence', () => {
+  const absences = ref([])
+  const isLoading = ref(false)
+  const isSaving = ref(false)
+  const isRefreshing = ref(false)
+  const loadError = ref(null)
+
+  let requestId = 0
+  // The period the drawer last asked for. Every mutation refetches it rather than the API's own
+  // default window, so saving while looking at next year does not swap the list for the next 30 days.
+  let currentRange = { from: undefined, to: undefined }
+
+  async function fetchAbsences(bandSpaceId, range) {
+    const { from, to } = range ?? currentRange
+    currentRange = { from, to }
+    const currentRequestId = ++requestId
+    // A refetch with rows already on screen keeps them there: the full spinner is for the first
+    // load only, so reopening the drawer does not blank a list it is about to redraw identically.
+    isLoading.value = absences.value.length === 0
+    isRefreshing.value = true
+    loadError.value = null
+    try {
+      const data = await bandSpaceAbsenceApi.getAbsences(bandSpaceId, { from, to })
+      // A slower earlier request must not overwrite a newer one: switching the year selector twice
+      // in a row would otherwise settle on the first year asked for.
+      if (currentRequestId !== requestId) return
+      absences.value = data
+    } catch (error) {
+      if (currentRequestId !== requestId) return
+      loadError.value = error?.message ?? 'Erreur lors du chargement des indisponibilités'
+    } finally {
+      if (currentRequestId === requestId) {
+        isLoading.value = false
+        isRefreshing.value = false
+      }
+    }
+  }
+
+  async function createAbsence(bandSpaceId, data) {
+    isSaving.value = true
+    try {
+      const created = await bandSpaceAbsenceApi.createAbsence(bandSpaceId, data)
+      await fetchAbsences(bandSpaceId)
+      return created
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  async function updateAbsence(bandSpaceId, absenceId, data) {
+    isSaving.value = true
+    try {
+      const updated = await bandSpaceAbsenceApi.updateAbsence(bandSpaceId, absenceId, data)
+      await fetchAbsences(bandSpaceId)
+      return updated
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  async function deleteAbsence(bandSpaceId, absenceId) {
+    await bandSpaceAbsenceApi.deleteAbsence(bandSpaceId, absenceId)
+    await fetchAbsences(bandSpaceId)
+  }
+
+  function clear() {
+    absences.value = []
+    loadError.value = null
+    currentRange = { from: undefined, to: undefined }
+  }
+
+  return {
+    absences: readonly(absences),
+    isLoading: readonly(isLoading),
+    isSaving: readonly(isSaving),
+    isRefreshing: readonly(isRefreshing),
+    loadError: readonly(loadError),
+    fetchAbsences,
+    createAbsence,
+    updateAbsence,
+    deleteAbsence,
+    clear
+  }
+})

--- a/assets/js/utils/absenceRange.js
+++ b/assets/js/utils/absenceRange.js
@@ -1,0 +1,85 @@
+import { format } from 'date-fns'
+import { fr } from 'date-fns/locale'
+import { toAgendaDate } from './agendaDate.js'
+
+/**
+ * How a member absence reads in the management drawer: its date range as one label, and the list
+ * grouped by the month it starts in.
+ *
+ * Both take the API shape, so bare `yyyy-MM-dd` strings. An absence is a range of calendar dates and
+ * never an instant, so the dates are read through `toAgendaDate`, the one helper that knows how an
+ * agenda date has to be unpinned. Reading them any other way is the bug class agendaDate.js exists
+ * to keep closed, and the day `start_date` ever grows a time, this module follows it rather than
+ * disagreeing with the calendar by a day west of UTC.
+ *
+ * Pure date arithmetic, so it is unit tested without a browser (npm test).
+ */
+
+/** A `yyyy-MM-dd` string as a local Date, or null when it is unusable. */
+function toDate(dateString) {
+  return toAgendaDate(dateString, true)
+}
+
+/**
+ * The range as one line: « 22 août » for a single day, « 10 → 12 août » when both ends share a
+ * month, « 28 août → 2 septembre » otherwise. The year is added only when the range crosses one, so
+ * the common case stays short.
+ */
+export function formatAbsenceRange(startDate, endDate) {
+  const start = toDate(startDate)
+  const end = toDate(endDate)
+  if (start === null || end === null) return ''
+
+  if (start.getTime() === end.getTime()) {
+    return format(start, 'd MMMM', { locale: fr })
+  }
+
+  const sameYear = start.getFullYear() === end.getFullYear()
+  const sameMonth = sameYear && start.getMonth() === end.getMonth()
+
+  if (sameMonth) {
+    return `${format(start, 'd', { locale: fr })} → ${format(end, 'd MMMM', { locale: fr })}`
+  }
+
+  const pattern = sameYear ? 'd MMMM' : 'd MMMM yyyy'
+
+  return `${format(start, pattern, { locale: fr })} → ${format(end, pattern, { locale: fr })}`
+}
+
+/**
+ * The absences grouped by the month they start in, months in chronological order and each group's
+ * rows sorted by start date then end date.
+ *
+ * Grouped by the start alone, so an absence spanning two months appears once. Repeating it under
+ * every month it touches would double count a fortnight straddling the 1st, and the list is a
+ * register of what was declared, not a calendar.
+ *
+ * Returns `[{ key: 'yyyy-MM', label: 'Août 2026', absences: [...] }]`.
+ */
+export function groupAbsencesByMonth(absences) {
+  const groups = new Map()
+
+  for (const absence of absences ?? []) {
+    const start = toDate(absence?.start_date)
+    if (start === null) continue
+
+    // The key is the row's own month prefix; formatting the parsed Date would give the same string
+    // at the cost of a locale-aware format call per row.
+    const key = absence.start_date.slice(0, 7)
+    if (!groups.has(key)) {
+      const label = format(start, 'LLLL yyyy', { locale: fr })
+      groups.set(key, { key, label: label.charAt(0).toUpperCase() + label.slice(1), absences: [] })
+    }
+    groups.get(key).absences.push(absence)
+  }
+
+  // Sorted in place: these groups were built here and belong to nobody else, and the spread that
+  // used to wrap them read as a copy while sort mutated the array underneath it anyway.
+  for (const group of groups.values()) {
+    group.absences.sort(
+      (a, b) => a.start_date.localeCompare(b.start_date) || a.end_date.localeCompare(b.end_date)
+    )
+  }
+
+  return Array.from(groups.values()).sort((a, b) => a.key.localeCompare(b.key))
+}

--- a/assets/js/utils/absenceRange.test.js
+++ b/assets/js/utils/absenceRange.test.js
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { formatAbsenceRange, groupAbsencesByMonth } from './absenceRange.js'
+
+/**
+ * The absence labels and month grouping. Dates are bare `yyyy-MM-dd`, the shape the API sends, so
+ * the assertions hold in whatever timezone the runner uses.
+ *
+ * Run with `npm test`.
+ */
+
+/** An absence as the API returns it. */
+function absence(fields) {
+  return { id: 'a', start_date: '2026-08-10', end_date: '2026-08-12', reason: null, ...fields }
+}
+
+describe('formatAbsenceRange', () => {
+  it('prints a single day once', () => {
+    assert.equal(formatAbsenceRange('2026-08-22', '2026-08-22'), '22 août')
+  })
+
+  it('names the month once when both ends share it', () => {
+    assert.equal(formatAbsenceRange('2026-08-10', '2026-08-12'), '10 → 12 août')
+  })
+
+  it('names both months when the range crosses one', () => {
+    assert.equal(formatAbsenceRange('2026-08-28', '2026-09-02'), '28 août → 2 septembre')
+  })
+
+  it('adds the year only when the range crosses one', () => {
+    assert.equal(
+      formatAbsenceRange('2026-12-28', '2027-01-03'),
+      '28 décembre 2026 → 3 janvier 2027'
+    )
+  })
+
+  // The same day in two different years is a range, not a single day: the day-of-month shortcut
+  // must not swallow it.
+  it('does not read the same day of two years as a single day', () => {
+    assert.equal(formatAbsenceRange('2026-08-22', '2027-08-22'), '22 août 2026 → 22 août 2027')
+  })
+
+  it('returns an empty string for anything unusable', () => {
+    assert.equal(formatAbsenceRange(null, '2026-08-12'), '')
+    assert.equal(formatAbsenceRange('2026-08-10', ''), '')
+    assert.equal(formatAbsenceRange('pas-une-date', '2026-08-12'), '')
+  })
+})
+
+describe('groupAbsencesByMonth', () => {
+  it('groups by the starting month, in chronological order', () => {
+    const groups = groupAbsencesByMonth([
+      absence({ id: 'sept', start_date: '2026-09-05', end_date: '2026-09-08' }),
+      absence({ id: 'aug', start_date: '2026-08-10', end_date: '2026-08-12' })
+    ])
+
+    assert.deepEqual(
+      groups.map((group) => [group.key, group.label, group.absences.map((a) => a.id)]),
+      [
+        ['2026-08', 'Août 2026', ['aug']],
+        ['2026-09', 'Septembre 2026', ['sept']]
+      ]
+    )
+  })
+
+  it('sorts within a month by start date, then by end date', () => {
+    const groups = groupAbsencesByMonth([
+      absence({ id: 'late', start_date: '2026-08-20', end_date: '2026-08-21' }),
+      absence({ id: 'long', start_date: '2026-08-10', end_date: '2026-08-18' }),
+      absence({ id: 'short', start_date: '2026-08-10', end_date: '2026-08-11' })
+    ])
+
+    assert.deepEqual(
+      groups[0].absences.map((a) => a.id),
+      ['short', 'long', 'late']
+    )
+  })
+
+  // Grouped by the start alone: a fortnight straddling the 1st is one entry in the register, not
+  // one under each month it touches.
+  it('lists an absence spanning two months once, under the month it starts in', () => {
+    const groups = groupAbsencesByMonth([
+      absence({ id: 'straddling', start_date: '2026-08-28', end_date: '2026-09-04' })
+    ])
+
+    assert.deepEqual(
+      groups.map((group) => [group.key, group.absences.map((a) => a.id)]),
+      [['2026-08', ['straddling']]]
+    )
+  })
+
+  it('skips rows with no usable start date rather than throwing', () => {
+    const groups = groupAbsencesByMonth([
+      absence({ id: 'broken', start_date: null }),
+      absence({ id: 'fine' })
+    ])
+
+    assert.deepEqual(
+      groups.map((group) => group.absences.map((a) => a.id)),
+      [['fine']]
+    )
+  })
+
+  it('reads an empty or missing list as no groups', () => {
+    assert.deepEqual(groupAbsencesByMonth([]), [])
+    assert.deepEqual(groupAbsencesByMonth(undefined), [])
+  })
+})

--- a/assets/js/views/BandSpace/Agenda.vue
+++ b/assets/js/views/BandSpace/Agenda.vue
@@ -12,14 +12,26 @@
           Mise à jour…
         </span>
       </div>
-      <Button
-        icon="pi pi-plus"
-        label="Nouvel événement"
-        size="small"
-        :pt="{ label: { class: 'hidden sm:inline' } }"
-        aria-label="Nouvel événement"
-        @click="openCreateDialog"
-      />
+      <div class="flex items-center gap-2">
+        <Button
+          icon="pi pi-user-minus"
+          label="Indisponibilités"
+          size="small"
+          severity="secondary"
+          outlined
+          :pt="{ label: { class: 'hidden sm:inline' } }"
+          aria-label="Indisponibilités"
+          @click="openAbsencesDrawer()"
+        />
+        <Button
+          icon="pi pi-plus"
+          label="Nouvel événement"
+          size="small"
+          :pt="{ label: { class: 'hidden sm:inline' } }"
+          aria-label="Nouvel événement"
+          @click="openCreateDialog"
+        />
+      </div>
     </div>
 
     <div class="flex flex-col gap-3 mb-4 sm:flex-row sm:flex-wrap sm:items-center">
@@ -31,14 +43,14 @@
       />
       <div class="flex items-center gap-1 -mx-3 px-3 overflow-x-auto sm:overflow-visible sm:mx-0 sm:px-0">
         <button
-          v-for="src in sourceOptions"
+          v-for="src in AGENDA_SOURCE_LIST"
           :key="src.key"
           type="button"
           class="text-xs font-medium px-2.5 py-1 rounded-full transition-all text-center tabular-nums whitespace-nowrap sm:min-w-20"
-          :class="selectedSources.has(src.key) ? src.activeClass : src.inactiveClass"
+          :class="selectedSources.has(src.key) ? src.badgeClass : INACTIVE_CHIP_CLASS"
           @click="toggleSource(src.key)"
         >
-          {{ src.label }} · {{ countsBySource[src.key] }}
+          {{ src.chipLabel }} · {{ countsBySource[src.key] }}
         </button>
       </div>
       <div class="flex items-center gap-1 sm:ml-auto">
@@ -186,7 +198,7 @@
                     v-for="(source, index) in dayEventSources(arg.date).slice(0, YEAR_DOT_LIMIT)"
                     :key="`${source}-${index}`"
                     class="agenda-year-dot"
-                    :style="{ backgroundColor: SOURCE_COLORS[source] }"
+                    :style="{ backgroundColor: agendaSourceFor(source).color }"
                   />
                 </span>
               </template>
@@ -203,6 +215,13 @@
       :agendaItem="dialogItem"
       :initialDatetime="dialogInitialDatetime"
       @saved="handleEntrySaved"
+    />
+
+    <AbsencesDrawer
+      v-model:visible="absencesDrawerVisible"
+      :bandSpaceId="route.params.id"
+      :initialMemberId="absencesDrawerMemberId"
+      @changed="fetchWithCurrentRange"
     />
   </div>
 </template>
@@ -237,9 +256,17 @@ import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import bandSpaceAgendaApi from '../../api/bandSpace/band-space-agenda.js'
 import DateRangePicker from '../../components/Admin/DateRangePicker.vue'
+import AbsencesDrawer from '../../components/BandSpace/Agenda/AbsencesDrawer.vue'
 import AgendaEntryDrawer from '../../components/BandSpace/Agenda/AgendaEntryDrawer.vue'
 import AgendaEventChip from '../../components/BandSpace/Agenda/AgendaEventChip.vue'
 import Avatar from '../../components/User/Avatar.vue'
+import {
+  AGENDA_SOURCE_KEYS,
+  AGENDA_SOURCE_LIST,
+  agendaSourceFor,
+  agendaSourceLabel
+} from '../../constants/agendaSources.js'
+import { useBandAbsenceStore } from '../../store/bandSpace/bandSpaceAbsence.js'
 import { useBandAgendaStore } from '../../store/bandSpace/bandSpaceAgenda.js'
 import {
   agendaCalendarEventDates,
@@ -254,16 +281,22 @@ const route = useRoute()
 const router = useRouter()
 const toast = useToast()
 const agendaStore = useBandAgendaStore()
+const absenceStore = useBandAbsenceStore()
 // Wipe any previous space's items synchronously before the first render so
 // switching from /band/A/agenda to /band/B/agenda doesn't flash A's entries
 // while B's fetch is in flight. The :key on <router-view> remounts this view
 // on space switch but the Pinia store itself is an app-singleton and keeps
 // A's state until cleared.
 agendaStore.clear()
+// Same reason, same singleton problem: the drawer would otherwise render the previous space's
+// absences for a frame when it opens.
+absenceStore.clear()
 
 const dialogVisible = ref(false)
 const dialogItem = ref(null)
 const dialogInitialDatetime = ref(null)
+const absencesDrawerVisible = ref(false)
+const absencesDrawerMemberId = ref(null)
 
 const today = startOfDay(new Date())
 const dateFrom = ref(today)
@@ -324,44 +357,19 @@ const agendaPresets = [
   }
 ]
 
-const sourceOptions = [
-  {
-    key: 'manual',
-    label: 'Manuel',
-    activeClass: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-    inactiveClass:
-      'bg-surface-100 text-surface-400 dark:bg-surface-800 dark:text-surface-500 line-through'
-  },
-  {
-    key: 'task',
-    label: 'Tâches',
-    activeClass: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-    inactiveClass:
-      'bg-surface-100 text-surface-400 dark:bg-surface-800 dark:text-surface-500 line-through'
-  },
-  {
-    key: 'finance',
-    label: 'Finances',
-    activeClass: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-    inactiveClass:
-      'bg-surface-100 text-surface-400 dark:bg-surface-800 dark:text-surface-500 line-through'
-  }
-]
-
-const SOURCE_COLORS = {
-  manual: '#3b82f6',
-  task: '#f59e0b',
-  finance: '#10b981'
-}
+// One shared descriptor per source; the chip's inactive styling is the same for all of them.
+const INACTIVE_CHIP_CLASS =
+  'bg-surface-100 text-surface-400 dark:bg-surface-800 dark:text-surface-500 line-through'
 
 // Max dots drawn per day in the year overview; any extra events are reflected in the
 // aria-label count only.
 const YEAR_DOT_LIMIT = 10
 
-const selectedSources = reactive(new Set(['manual', 'task', 'finance']))
+// Absences are on by default: shared visibility is the whole point of recording them.
+const selectedSources = reactive(new Set(AGENDA_SOURCE_KEYS))
 
 const countsBySource = computed(() => {
-  const counts = { manual: 0, task: 0, finance: 0 }
+  const counts = Object.fromEntries(AGENDA_SOURCE_KEYS.map((key) => [key, 0]))
   for (const item of agendaStore.items) {
     if (counts[item.source] !== undefined) {
       counts[item.source]++
@@ -431,7 +439,7 @@ function dayEventSources(date) {
 }
 
 function yearDotsLabel(sources) {
-  const distinct = Object.keys(SOURCE_COLORS).filter((source) => sources.includes(source))
+  const distinct = AGENDA_SOURCE_KEYS.filter((source) => sources.includes(source))
   return `${sources.length} événement${sources.length > 1 ? 's' : ''} : ${distinct.map(sourceLabel).join(', ')}`
 }
 
@@ -441,7 +449,7 @@ const calendarEvents = computed(() =>
     title: item.title,
     ...agendaCalendarEventDates(item),
     allDay: isAllDayItem(item),
-    color: SOURCE_COLORS[item.source] ?? '#94a3b8',
+    color: agendaSourceFor(item.source).color,
     contrastColor: '#fff',
     className: 'agenda-event-clickable',
     extendedProps: { item }
@@ -645,7 +653,18 @@ function handleItemClick(item) {
       params: { id: route.params.id },
       query: { entry: item.source_id }
     })
+    return
   }
+  if (item.source === 'absence') {
+    // Straight to the drawer, narrowed to that member: it is the one place absences are managed,
+    // and it is the only payload that knows whether the reader may edit the row.
+    openAbsencesDrawer(item.metadata?.member_id ?? null)
+  }
+}
+
+function openAbsencesDrawer(memberId = null) {
+  absencesDrawerMemberId.value = memberId
+  absencesDrawerVisible.value = true
 }
 
 function handleEventClick(info) {
@@ -709,42 +728,15 @@ function formatTime(datetimeString) {
 }
 
 function sourceLabel(source) {
-  switch (source) {
-    case 'manual':
-      return 'Manuel'
-    case 'task':
-      return 'Tâche'
-    case 'finance':
-      return 'Finance'
-    default:
-      return source
-  }
+  return agendaSourceLabel(source)
 }
 
 function sourceBorderClass(source) {
-  switch (source) {
-    case 'manual':
-      return 'border-l-blue-500'
-    case 'task':
-      return 'border-l-amber-500'
-    case 'finance':
-      return 'border-l-emerald-500'
-    default:
-      return 'border-l-surface-300'
-  }
+  return agendaSourceFor(source).borderClass
 }
 
 function sourceBadgeClass(source) {
-  switch (source) {
-    case 'manual':
-      return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-    case 'task':
-      return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-    case 'finance':
-      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-    default:
-      return 'bg-surface-100 text-surface-600'
-  }
+  return agendaSourceFor(source).badgeClass
 }
 
 function metadataLine(item) {

--- a/migrations/2026/08/Version20260830192026.php
+++ b/migrations/2026/08/Version20260830192026.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * The absence table behind #777: a period a band member is not available, so the agenda can answer
+ * "who can actually be there".
+ *
+ * It hangs off band_space_membership rather than fos_user, so a record belongs to one band and
+ * survives the member being in several. ON DELETE CASCADE because an absence is meaningless once the
+ * membership is gone, unlike the authored content Version20260829120000 moved to RESTRICT.
+ *
+ * The only index is IDX_9DE6D6877597D3FE, the one Doctrine emits for the join column. A composite
+ * (member_id, start_date, end_date) was measured and dropped: MariaDB drives from the membership
+ * side on band_space_id and then does a ref into this table on the foreign key index, so it never
+ * picks the composite while that index exists, and DBAL's Index::isFulfilledBy needs an equal column
+ * count so the composite can never absorb it either. At band scale - single digit members, tens of
+ * absences a year - the plans are indistinguishable, so the composite was pure write cost.
+ */
+final class Version20260830192026 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create band_space_member_absence, the member unavailability shown on the agenda';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE band_space_member_absence (id CHAR(36) NOT NULL, start_date DATE NOT NULL, end_date DATE NOT NULL, reason VARCHAR(120) DEFAULT NULL, creation_datetime DATETIME NOT NULL, member_id CHAR(36) NOT NULL, INDEX IDX_9DE6D6877597D3FE (member_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE band_space_member_absence ADD CONSTRAINT FK_9DE6D6877597D3FE FOREIGN KEY (member_id) REFERENCES band_space_membership (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space_member_absence DROP FOREIGN KEY FK_9DE6D6877597D3FE');
+        $this->addSql('DROP TABLE band_space_member_absence');
+    }
+}

--- a/src/ApiResource/BandSpace/MemberAbsenceCreate.php
+++ b/src/ApiResource/BandSpace/MemberAbsenceCreate.php
@@ -7,6 +7,8 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\Processor\BandSpace\MemberAbsenceCreateProcessor;
 use App\Validator\BandSpace\Agenda\ValidAbsenceRange;
+use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[Post(
@@ -15,8 +17,9 @@ use Symfony\Component\Validator\Constraints as Assert;
         'bandSpaceId' => new Link(fromClass: MemberAbsenceResource::class, identifiers: ['bandSpaceId']),
     ],
     openapi: new Operation(tags: ['Band Space Agenda']),
-    security: "is_granted('ROLE_USER')",
     normalizationContext: ['skip_null_values' => false],
+    collectDenormalizationErrors: true,
+    security: "is_granted('ROLE_USER')",
     output: MemberAbsenceResource::class,
     name: 'api_band_space_absences_post',
     processor: MemberAbsenceCreateProcessor::class,
@@ -30,17 +33,32 @@ class MemberAbsenceCreate
      */
     public ?string $memberId = null;
 
-    /** `Y-m-d`. A calendar date and never an instant, so no offset can move the day. */
-    #[Assert\NotBlank(message: 'Veuillez spécifier une date de début')]
-    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
-    public string $startDate;
+    /** A calendar date, `Y-m-d` on the wire in both directions. */
+    #[Assert\NotNull(message: 'Veuillez spécifier une date de début')]
+    // Out as a bare `Y-m-d`: an absence is a calendar date, and an ATOM instant would have to be
+    // unpinned by every reader, which is the bug class assets/js/utils/agendaDate.js documents.
+    //
+    // In through the loose parser on purpose, NOT a strict `!Y-m-d`. createFromFormat raises a
+    // ValueError on a null byte, and DateTimeNormalizer only catches Exception, so a strict format
+    // turns `2026-08-10\0` into a 500. The constructor parses the same input and tolerates that byte.
+    // The offset a loose parse may carry is neutralised by the processor, which keeps the caller's
+    // own written day.
+    #[Context(normalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
+    public ?\DateTimeImmutable $startDate = null;
 
-    /** `Y-m-d`, inclusive: the member is away for the whole of this day too. */
-    #[Assert\NotBlank(message: 'Veuillez spécifier une date de fin')]
-    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
-    // Both are zero padded ISO dates, so the string comparison this makes is chronological.
+    /** Inclusive: the member is away for the whole of this day too. */
+    #[Assert\NotNull(message: 'Veuillez spécifier une date de fin')]
     #[Assert\GreaterThanOrEqual(propertyPath: 'startDate', message: 'La date de fin doit être postérieure ou égale à la date de début.')]
-    public string $endDate;
+    // Out as a bare `Y-m-d`: an absence is a calendar date, and an ATOM instant would have to be
+    // unpinned by every reader, which is the bug class assets/js/utils/agendaDate.js documents.
+    //
+    // In through the loose parser on purpose, NOT a strict `!Y-m-d`. createFromFormat raises a
+    // ValueError on a null byte, and DateTimeNormalizer only catches Exception, so a strict format
+    // turns `2026-08-10\0` into a 500. The constructor parses the same input and tolerates that byte.
+    // The offset a loose parse may carry is neutralised by the processor, which keeps the caller's
+    // own written day.
+    #[Context(normalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
+    public ?\DateTimeImmutable $endDate = null;
 
     #[Assert\Length(max: 120, maxMessage: 'Le motif ne peut pas dépasser {{ limit }} caractères')]
     public ?string $reason = null;

--- a/src/ApiResource/BandSpace/MemberAbsenceCreate.php
+++ b/src/ApiResource/BandSpace/MemberAbsenceCreate.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\MemberAbsenceCreateProcessor;
+use App\Validator\BandSpace\Agenda\ValidAbsenceRange;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/absences',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: MemberAbsenceResource::class, identifiers: ['bandSpaceId']),
+    ],
+    openapi: new Operation(tags: ['Band Space Agenda']),
+    security: "is_granted('ROLE_USER')",
+    normalizationContext: ['skip_null_values' => false],
+    output: MemberAbsenceResource::class,
+    name: 'api_band_space_absences_post',
+    processor: MemberAbsenceCreateProcessor::class,
+)]
+#[ValidAbsenceRange]
+class MemberAbsenceCreate
+{
+    /**
+     * The membership the absence is recorded for. Null means the caller's own, which is what a member
+     * always gets: only an admin may name somebody else, and the processor enforces it.
+     */
+    public ?string $memberId = null;
+
+    /** `Y-m-d`. A calendar date and never an instant, so no offset can move the day. */
+    #[Assert\NotBlank(message: 'Veuillez spécifier une date de début')]
+    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
+    public string $startDate;
+
+    /** `Y-m-d`, inclusive: the member is away for the whole of this day too. */
+    #[Assert\NotBlank(message: 'Veuillez spécifier une date de fin')]
+    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
+    // Both are zero padded ISO dates, so the string comparison this makes is chronological.
+    #[Assert\GreaterThanOrEqual(propertyPath: 'startDate', message: 'La date de fin doit être postérieure ou égale à la date de début.')]
+    public string $endDate;
+
+    #[Assert\Length(max: 120, maxMessage: 'Le motif ne peut pas dépasser {{ limit }} caractères')]
+    public ?string $reason = null;
+}

--- a/src/ApiResource/BandSpace/MemberAbsenceResource.php
+++ b/src/ApiResource/BandSpace/MemberAbsenceResource.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\MemberAbsenceDeleteProcessor;
+use App\State\Processor\BandSpace\MemberAbsenceUpdateProcessor;
+use App\State\Provider\BandSpace\MemberAbsenceCollectionProvider;
+use App\State\Provider\BandSpace\MemberAbsenceItemProvider;
+use App\Validator\BandSpace\Agenda\ValidAbsenceRange;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    shortName: 'MemberAbsence',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/band_spaces/{bandSpaceId}/absences',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            openapi: new Operation(tags: ['Band Space Agenda']),
+            paginationEnabled: false,
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_absences_get_collection',
+            provider: MemberAbsenceCollectionProvider::class,
+            parameters: [
+                'from' => new QueryParameter(key: 'from'),
+                'to' => new QueryParameter(key: 'to'),
+            ],
+        ),
+        // Nothing on the front end fetches one absence on its own, but the IRI every payload
+        // advertises has to resolve: without an item Get, API Platform falls back to a generic
+        // /member_absences/id=...;bandSpaceId=... that answers nothing.
+        new Get(
+            uriTemplate: '/band_spaces/{bandSpaceId}/absences/{id}',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space Agenda']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_absences_get_item',
+            provider: MemberAbsenceItemProvider::class,
+        ),
+        new Patch(
+            uriTemplate: '/band_spaces/{bandSpaceId}/absences/{id}',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space Agenda']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_absences_patch',
+            provider: MemberAbsenceItemProvider::class,
+            processor: MemberAbsenceUpdateProcessor::class,
+        ),
+        new Delete(
+            uriTemplate: '/band_spaces/{bandSpaceId}/absences/{id}',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+                'id' => new Link(fromClass: self::class, identifiers: ['id']),
+            ],
+            openapi: new Operation(tags: ['Band Space Agenda']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_absences_delete',
+            provider: MemberAbsenceItemProvider::class,
+            processor: MemberAbsenceDeleteProcessor::class,
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+#[ValidAbsenceRange]
+class MemberAbsenceResource
+{
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    #[ApiProperty(identifier: true)]
+    public string $bandSpaceId;
+
+    /** The membership the absence belongs to. A PATCH never moves it: that is a delete plus a create. */
+    public string $memberId;
+
+    /** The member's stage name when they have one, their username otherwise. */
+    public string $displayName;
+
+    public ?string $profilePictureUrl = null;
+
+    /** `Y-m-d`. A calendar date and never an instant, so no offset can move the day. */
+    #[Assert\NotBlank(message: 'Veuillez spécifier une date de début')]
+    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
+    public string $startDate;
+
+    /** `Y-m-d`, inclusive: the member is away for the whole of this day too. */
+    #[Assert\NotBlank(message: 'Veuillez spécifier une date de fin')]
+    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
+    // Both are zero padded ISO dates, so the string comparison this makes is chronological.
+    #[Assert\GreaterThanOrEqual(propertyPath: 'startDate', message: 'La date de fin doit être postérieure ou égale à la date de début.')]
+    public string $endDate;
+
+    #[Assert\Length(max: 120, maxMessage: 'Le motif ne peut pas dépasser {{ limit }} caractères')]
+    public ?string $reason = null;
+
+    /**
+     * Whether the reader may edit or delete this absence: their own, or anyone's when they are an
+     * admin. Resolved server side because the client cannot work it out - the security store carries
+     * a username and roles, and the band space payload a role, but never the membership id.
+     */
+    public bool $canManage = false;
+
+    public \DateTimeInterface $creationDatetime;
+}

--- a/src/ApiResource/BandSpace/MemberAbsenceResource.php
+++ b/src/ApiResource/BandSpace/MemberAbsenceResource.php
@@ -16,6 +16,8 @@ use App\State\Processor\BandSpace\MemberAbsenceUpdateProcessor;
 use App\State\Provider\BandSpace\MemberAbsenceCollectionProvider;
 use App\State\Provider\BandSpace\MemberAbsenceItemProvider;
 use App\Validator\BandSpace\Agenda\ValidAbsenceRange;
+use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
@@ -57,6 +59,7 @@ use Symfony\Component\Validator\Constraints as Assert;
                 'id' => new Link(fromClass: self::class, identifiers: ['id']),
             ],
             openapi: new Operation(tags: ['Band Space Agenda']),
+            collectDenormalizationErrors: true,
             security: "is_granted('ROLE_USER')",
             name: 'api_band_space_absences_patch',
             provider: MemberAbsenceItemProvider::class,
@@ -94,17 +97,32 @@ class MemberAbsenceResource
 
     public ?string $profilePictureUrl = null;
 
-    /** `Y-m-d`. A calendar date and never an instant, so no offset can move the day. */
-    #[Assert\NotBlank(message: 'Veuillez spécifier une date de début')]
-    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
-    public string $startDate;
+    /** A calendar date, `Y-m-d` on the wire in both directions. */
+    #[Assert\NotNull(message: 'Veuillez spécifier une date de début')]
+    // Out as a bare `Y-m-d`: an absence is a calendar date, and an ATOM instant would have to be
+    // unpinned by every reader, which is the bug class assets/js/utils/agendaDate.js documents.
+    //
+    // In through the loose parser on purpose, NOT a strict `!Y-m-d`. createFromFormat raises a
+    // ValueError on a null byte, and DateTimeNormalizer only catches Exception, so a strict format
+    // turns `2026-08-10\0` into a 500. The constructor parses the same input and tolerates that byte.
+    // The offset a loose parse may carry is neutralised by the processor, which keeps the caller's
+    // own written day.
+    #[Context(normalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
+    public ?\DateTimeImmutable $startDate = null;
 
-    /** `Y-m-d`, inclusive: the member is away for the whole of this day too. */
-    #[Assert\NotBlank(message: 'Veuillez spécifier une date de fin')]
-    #[Assert\Date(message: 'Le format de la date est invalide (attendu : AAAA-MM-JJ)')]
-    // Both are zero padded ISO dates, so the string comparison this makes is chronological.
+    /** Inclusive: the member is away for the whole of this day too. */
+    #[Assert\NotNull(message: 'Veuillez spécifier une date de fin')]
     #[Assert\GreaterThanOrEqual(propertyPath: 'startDate', message: 'La date de fin doit être postérieure ou égale à la date de début.')]
-    public string $endDate;
+    // Out as a bare `Y-m-d`: an absence is a calendar date, and an ATOM instant would have to be
+    // unpinned by every reader, which is the bug class assets/js/utils/agendaDate.js documents.
+    //
+    // In through the loose parser on purpose, NOT a strict `!Y-m-d`. createFromFormat raises a
+    // ValueError on a null byte, and DateTimeNormalizer only catches Exception, so a strict format
+    // turns `2026-08-10\0` into a 500. The constructor parses the same input and tolerates that byte.
+    // The offset a loose parse may carry is neutralised by the processor, which keeps the caller's
+    // own written day.
+    #[Context(normalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
+    public ?\DateTimeImmutable $endDate = null;
 
     #[Assert\Length(max: 120, maxMessage: 'Le motif ne peut pas dépasser {{ limit }} caractères')]
     public ?string $reason = null;

--- a/src/Entity/BandSpace/MemberAbsence.php
+++ b/src/Entity/BandSpace/MemberAbsence.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity\BandSpace;
+
+use App\Repository\BandSpace\MemberAbsenceRepository;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * A period a band member is not available, so the calendar can answer "who can actually be there"
+ * instead of the question being re-asked in a chat thread every time somebody proposes a date.
+ *
+ * Day granularity, not datetime: "I am away from 10 to 12 August" is the real unit, and a single
+ * day is a range where start equals end. Half day availability is a rabbit hole, and the band level
+ * question is only ever whether this person is around that day.
+ */
+#[ORM\Entity(repositoryClass: MemberAbsenceRepository::class)]
+#[ORM\Table(name: 'band_space_member_absence')]
+class MemberAbsence
+{
+    #[ORM\Id]
+    #[ORM\Column(type: "uuid", unique: true)]
+    #[ORM\GeneratedValue(strategy: "CUSTOM")]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    public UuidInterface|string|null $id = null {
+        get {
+            return is_string($this->id) ? $this->id : $this->id?->toString();
+        }
+    }
+
+    /**
+     * The membership rather than the user, so an absence belongs to this band the way a finance
+     * split does, and a member who later leaves does not drag their other bands' records along.
+     * The band space is reached through `member->bandSpace`.
+     */
+    #[ORM\ManyToOne(targetEntity: BandSpaceMembership::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    public BandSpaceMembership $member;
+
+    #[ORM\Column(type: Types::DATE_IMMUTABLE)]
+    public DateTimeImmutable $startDate;
+
+    /** Inclusive: the member is away for the whole of this day too. */
+    #[ORM\Column(type: Types::DATE_IMMUTABLE)]
+    public DateTimeImmutable $endDate;
+
+    #[ORM\Column(type: Types::STRING, length: 120, nullable: true)]
+    public ?string $reason = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    public DateTimeInterface $creationDatetime;
+
+    public function __construct()
+    {
+        $this->creationDatetime = new DateTime();
+    }
+}

--- a/src/Repository/BandSpace/MemberAbsenceRepository.php
+++ b/src/Repository/BandSpace/MemberAbsenceRepository.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository\BandSpace;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\MemberAbsence;
+use DateTimeInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<MemberAbsence>
+ */
+class MemberAbsenceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, MemberAbsence::class);
+    }
+
+    /**
+     * Every absence in the band whose range intersects [$from, $to]. Both bounds are inclusive, so an
+     * absence that merely touches the edge of the window is in it.
+     *
+     * @return MemberAbsence[]
+     */
+    public function findOverlappingForBand(BandSpace $bandSpace, DateTimeInterface $from, DateTimeInterface $to): array
+    {
+        return $this->withMember()
+            ->where('m.bandSpace = :bandSpace')
+            ->andWhere('a.startDate <= :to')
+            ->andWhere('a.endDate >= :from')
+            ->setParameter('bandSpace', $bandSpace)
+            ->setParameter('from', $from)
+            ->setParameter('to', $to)
+            ->orderBy('a.startDate', 'ASC')
+            ->addOrderBy('a.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Every reader needs the member and their user on each row, because the display name and the
+     * avatar are always rendered. One proxy load per absence would undo the point of the query.
+     */
+    private function withMember(): QueryBuilder
+    {
+        return $this->createQueryBuilder('a')
+            ->addSelect('m', 'u')
+            ->innerJoin('a.member', 'm')
+            ->innerJoin('m.user', 'u');
+    }
+
+    public function findOneByIdAndBandSpace(string $id, BandSpace $bandSpace): ?MemberAbsence
+    {
+        return $this->withMember()
+            ->where('a.id = :id')
+            ->andWhere('m.bandSpace = :bandSpace')
+            ->setParameter('id', $id)
+            ->setParameter('bandSpace', $bandSpace)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/src/Security/BandSpace/MemberAbsenceChecker.php
+++ b/src/Security/BandSpace/MemberAbsenceChecker.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\BandSpace;
+
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Enum\BandSpace\Role;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Who may record, edit or delete an absence: a member manages their own, an admin manages anyone's.
+ *
+ * Membership in the band space is a separate question, already answered by BandSpaceMemberChecker
+ * before this is reached; this only compares the two memberships it is handed.
+ */
+readonly class MemberAbsenceChecker
+{
+    public function canManage(BandSpaceMembership $target, BandSpaceMembership $actor): bool
+    {
+        return $actor->role === Role::Admin || (string) $target->id === (string) $actor->id;
+    }
+
+    public function assertCanManage(BandSpaceMembership $target, BandSpaceMembership $actor): void
+    {
+        if (!$this->canManage($target, $actor)) {
+            throw new AccessDeniedHttpException('Vous ne pouvez gérer que vos propres indisponibilités');
+        }
+    }
+}

--- a/src/Service/BandSpace/AgendaAggregator.php
+++ b/src/Service/BandSpace/AgendaAggregator.php
@@ -7,12 +7,14 @@ use App\Entity\BandSpace\AgendaEntry;
 use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\BandSpace\FinanceEntry;
+use App\Entity\BandSpace\MemberAbsence;
 use App\Entity\BandSpace\Task;
 use App\Entity\User;
 use App\Enum\BandSpace\AgendaRecurrenceFrequency;
 use App\Enum\BandSpace\AgendaRecurrenceMonthlyMode;
 use App\Repository\BandSpace\AgendaEntryRepository;
 use App\Repository\BandSpace\FinanceEntryRepository;
+use App\Repository\BandSpace\MemberAbsenceRepository;
 use App\Repository\BandSpace\TaskRepository;
 use App\Service\Builder\User\UserProfilePictureUrlBuilder;
 use DateInterval;
@@ -32,6 +34,7 @@ readonly class AgendaAggregator
         private AgendaEntryRepository $agendaEntryRepository,
         private TaskRepository $taskRepository,
         private FinanceEntryRepository $financeEntryRepository,
+        private MemberAbsenceRepository $memberAbsenceRepository,
         private UserProfilePictureUrlBuilder $profilePictureUrlBuilder,
     ) {
     }
@@ -63,6 +66,7 @@ readonly class AgendaAggregator
             ...$manualItems,
             ...array_map(fn(Task $t): AgendaItem => $this->buildTask($bandSpace, $t), $this->taskRepository->findUpcomingForBand($bandSpace, $from, $to)),
             ...array_map(fn(FinanceEntry $f): AgendaItem => $this->buildFinance($bandSpace, $f), $this->financeEntryRepository->findUpcomingForBand($bandSpace, $viewer, $from, $to)),
+            ...array_map(fn(MemberAbsence $a): AgendaItem => $this->buildAbsence($bandSpace, $a), $this->memberAbsenceRepository->findOverlappingForBand($bandSpace, $from, $to)),
         ];
 
         usort(
@@ -410,6 +414,49 @@ readonly class AgendaAggregator
         return $item;
     }
 
+    /**
+     * A member's unavailability, as an all day band rather than an appointment: it is context for
+     * the dates around it, not something anybody attends.
+     *
+     * The range is a pair of calendar dates and carries no instant, so both ends are pinned to
+     * midnight UTC the way an all day entry is - see AgendaEntryCreateProcessor for why that pin
+     * matters, and assets/js/utils/agendaDate.js for how the front end unpins it.
+     */
+    private function buildAbsence(BandSpace $bandSpace, MemberAbsence $absence): AgendaItem
+    {
+        $displayName = $absence->member->displayName();
+
+        $item = new AgendaItem();
+        $item->id = 'absence-' . $absence->id;
+        $item->bandSpaceId = (string) $bandSpace->id;
+        $item->source = 'absence';
+        $item->sourceId = (string) $absence->id;
+        $item->datetime = $this->pinToUtcMidnight($absence->startDate);
+        $item->endDatetime = $this->pinToUtcMidnight($absence->endDate);
+        $item->isAllDay = true;
+        $item->title = $displayName . ' indisponible';
+        $item->description = $absence->reason;
+        // Only what a consumer reads. The member's name is already in the title, and the reason is
+        // already the description, which is where both the list row and the calendar chip read it.
+        $item->metadata = ['member_id' => (string) $absence->member->id];
+
+        return $item;
+    }
+
+    /**
+     * A date-only column as an ATOM instant at midnight UTC, which is how every all day item on the
+     * agenda is carried - see AgendaEntryCreateProcessor for why the pin matters, and
+     * assets/js/utils/agendaDate.js for how the front end takes it back off.
+     *
+     * Built by concatenation rather than by parsing: ATOM on a +00:00 date is
+     * `Y-m-d\TH:i:s+00:00`, so constructing a DateTimeImmutable only to format it again would
+     * return the string it was handed.
+     */
+    private function pinToUtcMidnight(DateTimeInterface $date): string
+    {
+        return $date->format('Y-m-d') . 'T00:00:00+00:00';
+    }
+
     private function buildFinance(BandSpace $bandSpace, FinanceEntry $entry): AgendaItem
     {
         $item = new AgendaItem();
@@ -417,7 +464,7 @@ readonly class AgendaAggregator
         $item->bandSpaceId = (string) $bandSpace->id;
         $item->source = 'finance';
         $item->sourceId = (string) $entry->id;
-        $item->datetime = DateTimeImmutable::createFromInterface($entry->date)->setTime(0, 0)->format(DateTimeInterface::ATOM);
+        $item->datetime = $this->pinToUtcMidnight($entry->date);
         $item->endDatetime = null;
         $item->isAllDay = false;
         $item->title = $entry->label;

--- a/src/Service/Builder/BandSpace/MemberAbsenceBuilder.php
+++ b/src/Service/Builder/BandSpace/MemberAbsenceBuilder.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\Builder\BandSpace;
+
+use App\ApiResource\BandSpace\MemberAbsenceResource;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\BandSpace\MemberAbsence;
+use App\Security\BandSpace\MemberAbsenceChecker;
+use App\Service\Builder\User\UserProfilePictureUrlBuilder;
+
+readonly class MemberAbsenceBuilder
+{
+    public function __construct(
+        private MemberAbsenceChecker $memberAbsenceChecker,
+        private UserProfilePictureUrlBuilder $profilePictureUrlBuilder,
+    ) {
+    }
+
+    /**
+     * @param MemberAbsence[] $entities
+     * @return MemberAbsenceResource[]
+     */
+    public function buildFromList(array $entities, BandSpaceMembership $viewer): array
+    {
+        return array_map(
+            fn(MemberAbsence $entity): MemberAbsenceResource => $this->buildItem($entity, $viewer),
+            $entities
+        );
+    }
+
+    public function buildItem(MemberAbsence $entity, BandSpaceMembership $viewer): MemberAbsenceResource
+    {
+        $dto = new MemberAbsenceResource();
+        $dto->id = (string) $entity->id;
+        $dto->bandSpaceId = (string) $entity->member->bandSpace->id;
+        $dto->memberId = (string) $entity->member->id;
+        $dto->displayName = $entity->member->displayName();
+        $dto->profilePictureUrl = $this->profilePictureUrlBuilder->build($entity->member->user);
+        $dto->startDate = $entity->startDate->format('Y-m-d');
+        $dto->endDate = $entity->endDate->format('Y-m-d');
+        $dto->reason = $entity->reason;
+        $dto->canManage = $this->memberAbsenceChecker->canManage($entity->member, $viewer);
+        $dto->creationDatetime = $entity->creationDatetime;
+
+        return $dto;
+    }
+}

--- a/src/Service/Builder/BandSpace/MemberAbsenceBuilder.php
+++ b/src/Service/Builder/BandSpace/MemberAbsenceBuilder.php
@@ -36,8 +36,8 @@ readonly class MemberAbsenceBuilder
         $dto->memberId = (string) $entity->member->id;
         $dto->displayName = $entity->member->displayName();
         $dto->profilePictureUrl = $this->profilePictureUrlBuilder->build($entity->member->user);
-        $dto->startDate = $entity->startDate->format('Y-m-d');
-        $dto->endDate = $entity->endDate->format('Y-m-d');
+        $dto->startDate = $entity->startDate;
+        $dto->endDate = $entity->endDate;
         $dto->reason = $entity->reason;
         $dto->canManage = $this->memberAbsenceChecker->canManage($entity->member, $viewer);
         $dto->creationDatetime = $entity->creationDatetime;

--- a/src/State/Processor/BandSpace/MemberAbsenceCreateProcessor.php
+++ b/src/State/Processor/BandSpace/MemberAbsenceCreateProcessor.php
@@ -52,17 +52,36 @@ readonly class MemberAbsenceCreateProcessor implements ProcessorInterface
         $target = $this->resolveTarget($data->memberId, $bandSpace, $actor);
         $this->memberAbsenceChecker->assertCanManage($target, $actor);
 
+        // NotNull has already run, so neither date can be null by the time a processor is reached.
+        // The guard is what says so to a reader and to the analyser, and it degrades to a 422 rather
+        // than a TypeError if the operation is ever wired without validation.
+        if (!$data->startDate instanceof DateTimeImmutable || !$data->endDate instanceof DateTimeImmutable) {
+            throw new UnprocessableEntityHttpException('Veuillez spécifier les dates de l\'indisponibilité');
+        }
+
         $absence = new MemberAbsence();
         $absence->member = $target;
-        // ValidAbsenceRange has already accepted both dates as a strict Y-m-d, so parsing cannot fail.
-        $absence->startDate = new DateTimeImmutable($data->startDate);
-        $absence->endDate = new DateTimeImmutable($data->endDate);
+        $absence->startDate = $this->pinToWrittenDay($data->startDate);
+        $absence->endDate = $this->pinToWrittenDay($data->endDate);
         $absence->reason = $data->reason;
 
         $this->entityManager->persist($absence);
         $this->entityManager->flush();
 
         return $this->memberAbsenceBuilder->buildItem($absence, $actor);
+    }
+
+    /**
+     * The caller's own written day, pinned to midnight UTC.
+     *
+     * The DTO is denormalized by the loose parser, so an offset the caller sent is still attached and
+     * `2026-08-10T23:00:00-04:00` is the 11th in UTC while its wall clock says the 10th. The wall
+     * clock wins, because that is the day the member typed. Same rule and same reason as
+     * AgendaEntryCreateProcessor's all day branch.
+     */
+    private function pinToWrittenDay(DateTimeImmutable $date): DateTimeImmutable
+    {
+        return new DateTimeImmutable($date->format('Y-m-d') . 'T00:00:00+00:00');
     }
 
     /**

--- a/src/State/Processor/BandSpace/MemberAbsenceCreateProcessor.php
+++ b/src/State/Processor/BandSpace/MemberAbsenceCreateProcessor.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\MemberAbsenceCreate;
+use App\ApiResource\BandSpace\MemberAbsenceResource;
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\BandSpace\MemberAbsence;
+use App\Entity\User;
+use App\Enum\BandSpace\MembershipStatus;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\MemberAbsenceChecker;
+use App\Service\Builder\BandSpace\MemberAbsenceBuilder;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * @implements ProcessorInterface<MemberAbsenceCreate, MemberAbsenceResource>
+ */
+readonly class MemberAbsenceCreateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private MemberAbsenceChecker $memberAbsenceChecker,
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private MemberAbsenceBuilder $memberAbsenceBuilder,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param MemberAbsenceCreate $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): MemberAbsenceResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $actor] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $target = $this->resolveTarget($data->memberId, $bandSpace, $actor);
+        $this->memberAbsenceChecker->assertCanManage($target, $actor);
+
+        $absence = new MemberAbsence();
+        $absence->member = $target;
+        // ValidAbsenceRange has already accepted both dates as a strict Y-m-d, so parsing cannot fail.
+        $absence->startDate = new DateTimeImmutable($data->startDate);
+        $absence->endDate = new DateTimeImmutable($data->endDate);
+        $absence->reason = $data->reason;
+
+        $this->entityManager->persist($absence);
+        $this->entityManager->flush();
+
+        return $this->memberAbsenceBuilder->buildItem($absence, $actor);
+    }
+
+    /**
+     * The membership the absence is recorded for: the one named, or the caller's own when nothing is.
+     * Whether the caller is allowed to name somebody else is the checker's call, made right after.
+     */
+    private function resolveTarget(?string $memberId, BandSpace $bandSpace, BandSpaceMembership $actor): BandSpaceMembership
+    {
+        if ($memberId === null || $memberId === '') {
+            return $actor;
+        }
+
+        $target = $this->bandSpaceMembershipRepository->findOneByIdAndBandSpace($memberId, $bandSpace);
+        if (!$target instanceof BandSpaceMembership) {
+            throw new NotFoundHttpException('Membre introuvable');
+        }
+
+        // A former member keeps the absences they recorded while they were here, as history, but
+        // nobody records a new one for them.
+        if ($target->status !== MembershipStatus::Active) {
+            throw new UnprocessableEntityHttpException('Ce membre ne fait plus partie du Band Space');
+        }
+
+        return $target;
+    }
+}

--- a/src/State/Processor/BandSpace/MemberAbsenceDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/MemberAbsenceDeleteProcessor.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\MemberAbsenceResource;
+use App\Entity\BandSpace\MemberAbsence;
+use App\Entity\User;
+use App\Repository\BandSpace\MemberAbsenceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\MemberAbsenceChecker;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<MemberAbsenceResource, void>
+ */
+readonly class MemberAbsenceDeleteProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private MemberAbsenceChecker $memberAbsenceChecker,
+        private MemberAbsenceRepository $memberAbsenceRepository,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param MemberAbsenceResource $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $actor] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $absence = $this->memberAbsenceRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$absence instanceof MemberAbsence) {
+            throw new NotFoundHttpException('Indisponibilité introuvable');
+        }
+
+        $this->memberAbsenceChecker->assertCanManage($absence->member, $actor);
+
+        $this->entityManager->remove($absence);
+        $this->entityManager->flush();
+    }
+}

--- a/src/State/Processor/BandSpace/MemberAbsenceUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/MemberAbsenceUpdateProcessor.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\MemberAbsenceResource;
+use App\Entity\BandSpace\MemberAbsence;
+use App\Entity\User;
+use App\Repository\BandSpace\MemberAbsenceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Security\BandSpace\MemberAbsenceChecker;
+use App\Service\Builder\BandSpace\MemberAbsenceBuilder;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<MemberAbsenceResource, MemberAbsenceResource>
+ */
+readonly class MemberAbsenceUpdateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceMemberChecker $memberChecker,
+        private MemberAbsenceChecker $memberAbsenceChecker,
+        private MemberAbsenceRepository $memberAbsenceRepository,
+        private MemberAbsenceBuilder $memberAbsenceBuilder,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * The member an absence belongs to is deliberately not patchable: moving one to somebody else is
+     * a delete plus a create, which keeps a second authorization branch out of this path.
+     *
+     * @param MemberAbsenceResource $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): MemberAbsenceResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $actor] = $this->memberChecker->checkMemberForWrite((string) $uriVariables['bandSpaceId'], $user);
+
+        $absence = $this->memberAbsenceRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$absence instanceof MemberAbsence) {
+            throw new NotFoundHttpException('Indisponibilité introuvable');
+        }
+
+        $this->memberAbsenceChecker->assertCanManage($absence->member, $actor);
+
+        // $data is the stored resource with the patch body merged over it, so a field the caller
+        // left out already carries its stored value and needs no payload lookup. Comparing before
+        // assigning also skips the write when a client resends an unchanged date.
+        // ValidAbsenceRange and the property constraints have run against that merged pair, so both
+        // dates are a strict Y-m-d here.
+        if ($data->startDate !== $absence->startDate->format('Y-m-d')) {
+            $absence->startDate = new DateTimeImmutable($data->startDate);
+        }
+
+        if ($data->endDate !== $absence->endDate->format('Y-m-d')) {
+            $absence->endDate = new DateTimeImmutable($data->endDate);
+        }
+
+        // An identical string is ===, which Doctrine's change set computation skips on its own.
+        $absence->reason = $data->reason;
+
+        $this->entityManager->flush();
+
+        return $this->memberAbsenceBuilder->buildItem($absence, $actor);
+    }
+}

--- a/src/State/Processor/BandSpace/MemberAbsenceUpdateProcessor.php
+++ b/src/State/Processor/BandSpace/MemberAbsenceUpdateProcessor.php
@@ -54,17 +54,15 @@ readonly class MemberAbsenceUpdateProcessor implements ProcessorInterface
 
         $this->memberAbsenceChecker->assertCanManage($absence->member, $actor);
 
-        // $data is the stored resource with the patch body merged over it, so a field the caller
-        // left out already carries its stored value and needs no payload lookup. Comparing before
-        // assigning also skips the write when a client resends an unchanged date.
-        // ValidAbsenceRange and the property constraints have run against that merged pair, so both
-        // dates are a strict Y-m-d here.
-        if ($data->startDate !== $absence->startDate->format('Y-m-d')) {
-            $absence->startDate = new DateTimeImmutable($data->startDate);
+        // $data is the stored resource with the patch body merged over it, so a field the caller left
+        // out already carries its stored value and assigning it back is a no-op Doctrine skips. The
+        // instanceof is the null guard the nullable DTO needs, not a "was it sent" check.
+        if ($data->startDate instanceof DateTimeImmutable) {
+            $absence->startDate = $this->pinToWrittenDay($data->startDate);
         }
 
-        if ($data->endDate !== $absence->endDate->format('Y-m-d')) {
-            $absence->endDate = new DateTimeImmutable($data->endDate);
+        if ($data->endDate instanceof DateTimeImmutable) {
+            $absence->endDate = $this->pinToWrittenDay($data->endDate);
         }
 
         // An identical string is ===, which Doctrine's change set computation skips on its own.
@@ -73,5 +71,18 @@ readonly class MemberAbsenceUpdateProcessor implements ProcessorInterface
         $this->entityManager->flush();
 
         return $this->memberAbsenceBuilder->buildItem($absence, $actor);
+    }
+
+    /**
+     * The caller's own written day, pinned to midnight UTC.
+     *
+     * The DTO is denormalized by the loose parser, so an offset the caller sent is still attached and
+     * `2026-08-10T23:00:00-04:00` is the 11th in UTC while its wall clock says the 10th. The wall
+     * clock wins, because that is the day the member typed. Same rule and same reason as
+     * AgendaEntryCreateProcessor's all day branch.
+     */
+    private function pinToWrittenDay(DateTimeImmutable $date): DateTimeImmutable
+    {
+        return new DateTimeImmutable($date->format('Y-m-d') . 'T00:00:00+00:00');
     }
 }

--- a/src/State/Provider/BandSpace/MemberAbsenceCollectionProvider.php
+++ b/src/State/Provider/BandSpace/MemberAbsenceCollectionProvider.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\MemberAbsenceResource;
+use App\Entity\User;
+use App\Repository\BandSpace\MemberAbsenceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\MemberAbsenceBuilder;
+use DateTimeImmutable;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * @implements ProviderInterface<object>
+ */
+readonly class MemberAbsenceCollectionProvider implements ProviderInterface
+{
+    private const int DEFAULT_WINDOW_DAYS = 30;
+
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private MemberAbsenceRepository $memberAbsenceRepository,
+        private MemberAbsenceBuilder $memberAbsenceBuilder,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * Every member's absences, not just the reader's: shared visibility is the whole point, and a
+     * band that hides availability from itself gains nothing. There is deliberately no member filter
+     * either - a band is a handful of people, so both consumers narrow client side off one response.
+     *
+     * @return MemberAbsenceResource[]
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): array
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+
+        $filters = $context['filters'] ?? [];
+        $from = $this->parseDate($filters['from'] ?? null) ?? new DateTimeImmutable('today');
+        $to = $this->parseDate($filters['to'] ?? null) ?? $from->modify('+' . self::DEFAULT_WINDOW_DAYS . ' days');
+
+        return $this->memberAbsenceBuilder->buildFromList(
+            $this->memberAbsenceRepository->findOverlappingForBand($bandSpace, $from, $to),
+            $viewer,
+        );
+    }
+
+    /**
+     * Anything but a usable date string reads as absent, so the caller falls back to its default
+     * window. `?from[]=x` arrives as an array and would otherwise be a TypeError, so a 500 for what
+     * is really a malformed request.
+     */
+    private function parseDate(mixed $value): ?DateTimeImmutable
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            // The column is a DATE, so the window is compared day to day: any time on the value is
+            // dropped rather than letting an afternoon `to` exclude that same day's absences.
+            return (new DateTimeImmutable($value))->setTime(0, 0);
+        } catch (\Exception) {
+            throw new BadRequestHttpException('Date invalide');
+        }
+    }
+}

--- a/src/State/Provider/BandSpace/MemberAbsenceCollectionProvider.php
+++ b/src/State/Provider/BandSpace/MemberAbsenceCollectionProvider.php
@@ -56,9 +56,10 @@ readonly class MemberAbsenceCollectionProvider implements ProviderInterface
     }
 
     /**
-     * Anything but a usable date string reads as absent, so the caller falls back to its default
-     * window. `?from[]=x` arrives as an array and would otherwise be a TypeError, so a 500 for what
-     * is really a malformed request.
+     * A string that is not a date is a 400. Anything that is not a string at all falls back to the
+     * default window instead: `?from[]=x` arrives as an array, and the point of the guard is that it
+     * no longer reaches a `?string` parameter and dies as a TypeError, so a 500 for a nonsensical
+     * filter nobody meant to send.
      */
     private function parseDate(mixed $value): ?DateTimeImmutable
     {

--- a/src/State/Provider/BandSpace/MemberAbsenceItemProvider.php
+++ b/src/State/Provider/BandSpace/MemberAbsenceItemProvider.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\MemberAbsenceResource;
+use App\Entity\BandSpace\MemberAbsence;
+use App\Entity\User;
+use App\Repository\BandSpace\MemberAbsenceRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\MemberAbsenceBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProviderInterface<object>
+ */
+readonly class MemberAbsenceItemProvider implements ProviderInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private MemberAbsenceRepository $memberAbsenceRepository,
+        private MemberAbsenceBuilder $memberAbsenceBuilder,
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): MemberAbsenceResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $viewer] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+
+        $absence = $this->memberAbsenceRepository->findOneByIdAndBandSpace((string) $uriVariables['id'], $bandSpace);
+        if (!$absence instanceof MemberAbsence) {
+            throw new NotFoundHttpException('Indisponibilité introuvable');
+        }
+
+        return $this->memberAbsenceBuilder->buildItem($absence, $viewer);
+    }
+}

--- a/src/Validator/BandSpace/Agenda/ValidAbsenceRange.php
+++ b/src/Validator/BandSpace/Agenda/ValidAbsenceRange.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\BandSpace\Agenda;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class-level constraint capping how long an absence may run.
+ *
+ * The two dates are validated individually by `Assert\Date` and `Assert\GreaterThanOrEqual` on the
+ * DTOs, the way FinanceRecurrenceCreate already validates the same `Y-m-d` string pair. Only the
+ * span needs both values at once, which is the one thing a property constraint cannot express.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ValidAbsenceRange extends Constraint
+{
+    public const string RANGE_TOO_LONG_CODE = 'music_all_7a476a56-6bab-4114-82bd-3cff1ec6a8a2';
+
+    /** A generous year, so one bad input cannot paint the whole calendar. */
+    public const int MAX_DAYS = 366;
+
+    public string $rangeTooLongMessage = 'Une indisponibilité ne peut pas dépasser 366 jours.';
+
+    public function getTargets(): string|array
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/BandSpace/Agenda/ValidAbsenceRange.php
+++ b/src/Validator/BandSpace/Agenda/ValidAbsenceRange.php
@@ -9,9 +9,10 @@ use Symfony\Component\Validator\Constraint;
 /**
  * Class-level constraint capping how long an absence may run.
  *
- * The two dates are validated individually by `Assert\Date` and `Assert\GreaterThanOrEqual` on the
- * DTOs, the way FinanceRecurrenceCreate already validates the same `Y-m-d` string pair. Only the
- * span needs both values at once, which is the one thing a property constraint cannot express.
+ * The dates themselves are the serializer's business: they are typed `DateTimeImmutable` and carry a
+ * strict `!Y-m-d` denormalization format, so a malformed value or an instant never reaches here.
+ * `NotNull` covers absence and `GreaterThanOrEqual` covers the ordering. Only the span needs both
+ * values at once, which is the one thing a property constraint cannot express.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class ValidAbsenceRange extends Constraint

--- a/src/Validator/BandSpace/Agenda/ValidAbsenceRangeValidator.php
+++ b/src/Validator/BandSpace/Agenda/ValidAbsenceRangeValidator.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\BandSpace\Agenda;
+
+use DateTimeImmutable;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class ValidAbsenceRangeValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidAbsenceRange) {
+            throw new UnexpectedTypeException($constraint, ValidAbsenceRange::class);
+        }
+
+        if ($value === null) {
+            return;
+        }
+
+        $start = $this->parseDate($value, 'startDate');
+        $end = $this->parseDate($value, 'endDate');
+
+        // Anything the property constraints already rejected - missing, not a date, out of order -
+        // has its own violation. Saying "too long" on top of it would be noise, and the span of a
+        // pair that does not parse is not a question worth answering.
+        if (!$start instanceof DateTimeImmutable || !$end instanceof DateTimeImmutable || $end < $start) {
+            return;
+        }
+
+        // Inclusive on both ends, so a single day counts as one.
+        $days = (int) $start->diff($end)->days + 1;
+        if ($days > ValidAbsenceRange::MAX_DAYS) {
+            $this->context->buildViolation($constraint->rangeTooLongMessage)
+                ->atPath('endDate')
+                ->setCode(ValidAbsenceRange::RANGE_TOO_LONG_CODE)
+                ->addViolation();
+        }
+    }
+
+    /**
+     * The property as a real date, or null when it is absent or not a `Y-m-d` calendar day.
+     *
+     * isset() rather than a bare read: an omitted date leaves the typed property uninitialized on
+     * the create DTO, and touching it would fatal before NotBlank ever runs. The format is checked
+     * by round-trip so `2026-02-31`, which DateTimeImmutable would happily read as 3 March, is not
+     * mistaken for a span this constraint can measure.
+     */
+    private function parseDate(object $value, string $property): ?DateTimeImmutable
+    {
+        $raw = property_exists($value, $property) && isset($value->{$property}) ? $value->{$property} : null;
+        if (!is_string($raw)) {
+            return null;
+        }
+
+        $date = DateTimeImmutable::createFromFormat('!Y-m-d', $raw);
+
+        return $date !== false && $date->format('Y-m-d') === $raw ? $date : null;
+    }
+}

--- a/src/Validator/BandSpace/Agenda/ValidAbsenceRangeValidator.php
+++ b/src/Validator/BandSpace/Agenda/ValidAbsenceRangeValidator.php
@@ -21,12 +21,12 @@ class ValidAbsenceRangeValidator extends ConstraintValidator
             return;
         }
 
-        $start = $this->parseDate($value, 'startDate');
-        $end = $this->parseDate($value, 'endDate');
+        $start = $this->readDate($value, 'startDate');
+        $end = $this->readDate($value, 'endDate');
 
-        // Anything the property constraints already rejected - missing, not a date, out of order -
-        // has its own violation. Saying "too long" on top of it would be noise, and the span of a
-        // pair that does not parse is not a question worth answering.
+        // A missing date has its own NotNull violation, and an out of order pair its own
+        // GreaterThanOrEqual one. Adding "too long" on top would be noise, and the span of a pair
+        // that is not a pair is not a question worth answering.
         if (!$start instanceof DateTimeImmutable || !$end instanceof DateTimeImmutable || $end < $start) {
             return;
         }
@@ -42,22 +42,18 @@ class ValidAbsenceRangeValidator extends ConstraintValidator
     }
 
     /**
-     * The property as a real date, or null when it is absent or not a `Y-m-d` calendar day.
-     *
-     * isset() rather than a bare read: an omitted date leaves the typed property uninitialized on
-     * the create DTO, and touching it would fatal before NotBlank ever runs. The format is checked
-     * by round-trip so `2026-02-31`, which DateTimeImmutable would happily read as 3 March, is not
-     * mistaken for a span this constraint can measure.
+     * The serializer has already parsed and rejected anything malformed, so this only has to cope
+     * with the field being absent. isset() rather than a bare read, because a property the caller
+     * omitted may be uninitialized rather than null.
      */
-    private function parseDate(object $value, string $property): ?DateTimeImmutable
+    private function readDate(object $value, string $property): ?DateTimeImmutable
     {
-        $raw = property_exists($value, $property) && isset($value->{$property}) ? $value->{$property} : null;
-        if (!is_string($raw)) {
+        if (!property_exists($value, $property) || !isset($value->{$property})) {
             return null;
         }
 
-        $date = DateTimeImmutable::createFromFormat('!Y-m-d', $raw);
+        $date = $value->{$property};
 
-        return $date !== false && $date->format('Y-m-d') === $raw ? $date : null;
+        return $date instanceof DateTimeImmutable ? $date : null;
     }
 }

--- a/tests/Api/BandSpace/Absence/MemberAbsenceCreateTest.php
+++ b/tests/Api/BandSpace/Absence/MemberAbsenceCreateTest.php
@@ -11,8 +11,9 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\User\UserFactory;
 use App\Validator\BandSpace\Agenda\ValidAbsenceRange;
-use Symfony\Component\Validator\Constraints\Date;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -362,89 +363,53 @@ class MemberAbsenceCreateTest extends ApiTestCase
         ]);
     }
 
-    public function test_a_date_that_is_not_a_real_calendar_day_is_rejected(): void
+    public function test_an_impossible_calendar_day_rolls_over_rather_than_being_rejected(): void
     {
+        // The documented cost of typing the dates as DateTimeImmutable: PHP's date parsing does no
+        // calendar check, so 31 February becomes 3 March, and by validation time the original string
+        // is gone so nothing can tell the two apart. Assert\Date's checkdate did catch this when the
+        // property was a string. Recorded as a test so the behaviour is visible rather than a
+        // surprise, and so a future fix has something to flip.
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
 
         $this->client->loginUser($user);
         $this->client->jsonRequest(
             'POST',
             '/api/band_spaces/' . $bandSpace->id . '/absences',
-            // 31 February: DateTimeImmutable would happily read this as 3 March, which is why the
-            // constraint parses strictly instead.
-            ['startDate' => '2026-02-31', 'endDate' => '2026-03-02'],
+            ['startDate' => '2026-02-31', 'endDate' => '2026-03-05'],
             ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
         );
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
-        $this->assertJsonEquals([
-            '@context' => '/api/contexts/ConstraintViolation',
-            '@id' => '/api/validation_errors/' . Date::INVALID_DATE_ERROR,
-            '@type' => 'ConstraintViolation',
-            'status' => 422,
-            'violations' => [
-                [
-                    'propertyPath' => 'start_date',
-                    'message' => 'Le format de la date est invalide (attendu : AAAA-MM-JJ)',
-                    'code' => Date::INVALID_DATE_ERROR,
-                ],
-            ],
-            'detail' => 'start_date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
-            'type' => '/validation_errors/' . Date::INVALID_DATE_ERROR,
-            'title' => 'An error occurred',
-            'description' => 'start_date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
-        ]);
-    }
-
-    public function test_a_reason_longer_than_the_column_is_rejected(): void
-    {
-        $user = UserFactory::new()->asBaseUser()->create();
-        $bandSpace = BandSpaceFactory::new()->create();
-        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
-
-        $this->client->loginUser($user);
-        $this->client->jsonRequest(
-            'POST',
-            '/api/band_spaces/' . $bandSpace->id . '/absences',
-            [
-                'startDate' => '2026-08-10',
-                'endDate' => '2026-08-12',
-                // One over the 120 character column, which would otherwise be a database error.
-                'reason' => str_repeat('a', 121),
-            ],
-            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
-        );
-
-        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
-        $this->assertJsonEquals([
-            '@context' => '/api/contexts/ConstraintViolation',
-            '@id' => '/api/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
-            '@type' => 'ConstraintViolation',
-            'status' => 422,
-            'violations' => [
-                [
-                    'propertyPath' => 'reason',
-                    'message' => 'Le motif ne peut pas dépasser 120 caractères',
-                    'code' => 'd94b19cc-114f-4f44-9cc4-4138e80a87b9',
-                ],
-            ],
-            'detail' => 'reason: Le motif ne peut pas dépasser 120 caractères',
-            'type' => '/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
-            'title' => 'An error occurred',
-            'description' => 'reason: Le motif ne peut pas dépasser 120 caractères',
-        ]);
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $repository = self::getContainer()->get(MemberAbsenceRepository::class);
-        $this->assertCount(0, $repository->findAll());
+        $absence = $repository->findAll()[0];
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $membership->id,
+            'display_name' => $user->username,
+            'profile_picture_url' => null,
+            'start_date' => '2026-03-03',
+            'end_date' => '2026-03-05',
+            'reason' => null,
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
     }
 
     public function test_a_whitespace_only_date_is_rejected_rather_than_read_as_today(): void
     {
-        // NotBlank passes a whitespace string (empty('   ') is false) and DateTimeImmutable('   ')
-        // returns the current timestamp, so anything that lets this through does not fail loudly -
-        // it silently records an absence starting today. Assert\Date is what closes that.
+        // DateTimeImmutable('   ') returns the current timestamp, so anything that lets this through
+        // silently records an absence starting today. The serializer refuses to denormalize it, and
+        // collectDenormalizationErrors turns that refusal into a 422 naming the field rather than a
+        // bare 400 the form cannot attach to an input.
         $user = UserFactory::new()->asBaseUser()->create();
         $bandSpace = BandSpaceFactory::new()->create();
         BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
@@ -460,20 +425,62 @@ class MemberAbsenceCreateTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertJsonEquals([
             '@context' => '/api/contexts/ConstraintViolation',
-            '@id' => '/api/validation_errors/' . Date::INVALID_FORMAT_ERROR,
+            '@id' => '/api/validation_errors/' . Type::INVALID_TYPE_ERROR,
             '@type' => 'ConstraintViolation',
             'status' => 422,
             'violations' => [
                 [
                     'propertyPath' => 'start_date',
-                    'message' => 'Le format de la date est invalide (attendu : AAAA-MM-JJ)',
-                    'code' => Date::INVALID_FORMAT_ERROR,
+                    'message' => 'Cette valeur doit être de type string|null.',
+                    'code' => Type::INVALID_TYPE_ERROR,
+                    // The serializer's own English wording, passed through untranslated. Asserted so
+                    // it is a visible part of the contract rather than a surprise in a client.
+                    'hint' => 'The data is either not an string, an empty string, or null; you should pass a string that can be parsed with the passed format or a valid DateTime string.',
                 ],
             ],
-            'detail' => 'start_date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
-            'type' => '/validation_errors/' . Date::INVALID_FORMAT_ERROR,
+            'detail' => 'start_date: Cette valeur doit être de type string|null.',
+            'type' => '/validation_errors/' . Type::INVALID_TYPE_ERROR,
             'title' => 'An error occurred',
-            'description' => 'start_date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+            'description' => 'start_date: Cette valeur doit être de type string|null.',
+        ]);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertCount(0, $repository->findAll());
+    }
+
+    public function test_an_omitted_start_date_is_reported_rather_than_left_uninitialized(): void
+    {
+        // The typed property stays uninitialized, which both the class constraint and
+        // GreaterThanOrEqual's property path have to survive without touching it.
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            ['endDate' => '2026-08-12'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . NotNull::IS_NULL_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'start_date',
+                    'message' => 'Veuillez spécifier une date de début',
+                    'code' => NotNull::IS_NULL_ERROR,
+                ],
+            ],
+            'detail' => 'start_date: Veuillez spécifier une date de début',
+            'type' => '/validation_errors/' . NotNull::IS_NULL_ERROR,
+            'title' => 'An error occurred',
+            'description' => 'start_date: Veuillez spécifier une date de début',
         ]);
 
         $repository = self::getContainer()->get(MemberAbsenceRepository::class);

--- a/tests/Api/BandSpace/Absence/MemberAbsenceCreateTest.php
+++ b/tests/Api/BandSpace/Absence/MemberAbsenceCreateTest.php
@@ -1,0 +1,508 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Absence;
+
+use App\Enum\BandSpace\MembershipStatus;
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\MemberAbsenceRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use App\Validator\BandSpace\Agenda\ValidAbsenceRange;
+use Symfony\Component\Validator\Constraints\Date;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class MemberAbsenceCreateTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_a_member_records_their_own_absence(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            [
+                'startDate' => '2026-08-10',
+                'endDate' => '2026-08-12',
+                'reason' => 'Vacances',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $absences = $repository->findAll();
+        $this->assertCount(1, $absences);
+        $absence = $absences[0];
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $membership->id,
+            'display_name' => $user->username,
+            'profile_picture_url' => null,
+            'start_date' => '2026-08-10',
+            'end_date' => '2026-08-12',
+            'reason' => 'Vacances',
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_a_single_day_absence_is_a_range_that_starts_and_ends_the_same_day(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            ['startDate' => '2026-08-22', 'endDate' => '2026-08-22'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $absence = $repository->findAll()[0];
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $membership->id,
+            'display_name' => $user->username,
+            'profile_picture_url' => null,
+            'start_date' => '2026-08-22',
+            'end_date' => '2026-08-22',
+            'reason' => null,
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_an_admin_records_an_absence_for_another_member(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $bandMate,
+            'stageName' => 'Jo la Basse',
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            [
+                'memberId' => (string) $bandMateMembership->id,
+                'startDate' => '2026-09-01',
+                'endDate' => '2026-09-05',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $absence = $repository->findAll()[0];
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $bandMateMembership->id,
+            'display_name' => 'Jo la Basse',
+            'profile_picture_url' => null,
+            'start_date' => '2026-09-01',
+            'end_date' => '2026-09-05',
+            'reason' => null,
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_a_member_may_name_their_own_membership_explicitly(): void
+    {
+        // The other half of resolveTarget: naming yourself is the same as leaving memberId out, so
+        // the front end may send it unconditionally without needing to know the caller's role.
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            [
+                'memberId' => (string) $membership->id,
+                'startDate' => '2026-08-10',
+                'endDate' => '2026-08-12',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $absence = $repository->findAll()[0];
+
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $membership->id,
+            'display_name' => $user->username,
+            'profile_picture_url' => null,
+            'start_date' => '2026-08-10',
+            'end_date' => '2026-08-12',
+            'reason' => null,
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_a_member_cannot_record_an_absence_for_someone_else(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bandMate])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            [
+                'memberId' => (string) $bandMateMembership->id,
+                'startDate' => '2026-09-01',
+                'endDate' => '2026-09-05',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous ne pouvez gérer que vos propres indisponibilités',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous ne pouvez gérer que vos propres indisponibilités',
+        ]);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertCount(0, $repository->findAll());
+    }
+
+    public function test_an_admin_cannot_record_an_absence_for_a_member_who_has_left(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $formerMember = UserFactory::new()->create(['username' => 'former_member', 'email' => 'former_member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $formerMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $formerMember,
+            'status' => MembershipStatus::Left,
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            [
+                'memberId' => (string) $formerMembership->id,
+                'startDate' => '2026-09-01',
+                'endDate' => '2026-09-05',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/422',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Ce membre ne fait plus partie du Band Space',
+            'status' => 422,
+            'type' => '/errors/422',
+            'description' => 'Ce membre ne fait plus partie du Band Space',
+        ]);
+    }
+
+    public function test_an_admin_gets_a_404_for_a_member_of_another_band_space(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $stranger = UserFactory::new()->create(['username' => 'stranger_user', 'email' => 'stranger@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $strangerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $otherBandSpace, 'user' => $stranger])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            [
+                'memberId' => (string) $strangerMembership->id,
+                'startDate' => '2026-09-01',
+                'endDate' => '2026-09-05',
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Membre introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Membre introuvable',
+        ]);
+    }
+
+    public function test_an_end_date_before_the_start_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            ['startDate' => '2026-08-12', 'endDate' => '2026-08-10'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . GreaterThanOrEqual::TOO_LOW_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'end_date',
+                    'message' => 'La date de fin doit être postérieure ou égale à la date de début.',
+                    'code' => GreaterThanOrEqual::TOO_LOW_ERROR,
+                ],
+            ],
+            'detail' => 'end_date: La date de fin doit être postérieure ou égale à la date de début.',
+            'type' => '/validation_errors/' . GreaterThanOrEqual::TOO_LOW_ERROR,
+            'title' => 'An error occurred',
+            'description' => 'end_date: La date de fin doit être postérieure ou égale à la date de début.',
+        ]);
+    }
+
+    public function test_a_range_longer_than_a_year_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            ['startDate' => '2026-01-01', 'endDate' => '2027-01-02'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . ValidAbsenceRange::RANGE_TOO_LONG_CODE,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'end_date',
+                    'message' => 'Une indisponibilité ne peut pas dépasser 366 jours.',
+                    'code' => ValidAbsenceRange::RANGE_TOO_LONG_CODE,
+                ],
+            ],
+            'detail' => 'end_date: Une indisponibilité ne peut pas dépasser 366 jours.',
+            'type' => '/validation_errors/' . ValidAbsenceRange::RANGE_TOO_LONG_CODE,
+            'title' => 'An error occurred',
+            'description' => 'end_date: Une indisponibilité ne peut pas dépasser 366 jours.',
+        ]);
+    }
+
+    public function test_a_date_that_is_not_a_real_calendar_day_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            // 31 February: DateTimeImmutable would happily read this as 3 March, which is why the
+            // constraint parses strictly instead.
+            ['startDate' => '2026-02-31', 'endDate' => '2026-03-02'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . Date::INVALID_DATE_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'start_date',
+                    'message' => 'Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+                    'code' => Date::INVALID_DATE_ERROR,
+                ],
+            ],
+            'detail' => 'start_date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+            'type' => '/validation_errors/' . Date::INVALID_DATE_ERROR,
+            'title' => 'An error occurred',
+            'description' => 'start_date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+        ]);
+    }
+
+    public function test_a_reason_longer_than_the_column_is_rejected(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            [
+                'startDate' => '2026-08-10',
+                'endDate' => '2026-08-12',
+                // One over the 120 character column, which would otherwise be a database error.
+                'reason' => str_repeat('a', 121),
+            ],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'reason',
+                    'message' => 'Le motif ne peut pas dépasser 120 caractères',
+                    'code' => 'd94b19cc-114f-4f44-9cc4-4138e80a87b9',
+                ],
+            ],
+            'detail' => 'reason: Le motif ne peut pas dépasser 120 caractères',
+            'type' => '/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            'title' => 'An error occurred',
+            'description' => 'reason: Le motif ne peut pas dépasser 120 caractères',
+        ]);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertCount(0, $repository->findAll());
+    }
+
+    public function test_a_whitespace_only_date_is_rejected_rather_than_read_as_today(): void
+    {
+        // NotBlank passes a whitespace string (empty('   ') is false) and DateTimeImmutable('   ')
+        // returns the current timestamp, so anything that lets this through does not fail loudly -
+        // it silently records an absence starting today. Assert\Date is what closes that.
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            ['startDate' => '   ', 'endDate' => '2026-08-12'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . Date::INVALID_FORMAT_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'start_date',
+                    'message' => 'Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+                    'code' => Date::INVALID_FORMAT_ERROR,
+                ],
+            ],
+            'detail' => 'start_date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+            'type' => '/validation_errors/' . Date::INVALID_FORMAT_ERROR,
+            'title' => 'An error occurred',
+            'description' => 'start_date: Le format de la date est invalide (attendu : AAAA-MM-JJ)',
+        ]);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertCount(0, $repository->findAll());
+    }
+
+    public function test_a_non_member_cannot_record_an_absence(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $this->client->loginUser($stranger);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            ['startDate' => '2026-08-10', 'endDate' => '2026-08-12'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/Absence/MemberAbsenceDeleteTest.php
+++ b/tests/Api/BandSpace/Absence/MemberAbsenceDeleteTest.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Absence;
+
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\MemberAbsenceRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\MemberAbsenceFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class MemberAbsenceDeleteTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_a_member_deletes_their_own_absence(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertCount(0, $repository->findAll());
+    }
+
+    public function test_an_admin_deletes_another_member_absence(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bandMate])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $bandMateMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertCount(0, $repository->findAll());
+    }
+
+    public function test_a_member_cannot_delete_another_member_absence(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bandMate])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $bandMateMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous ne pouvez gérer que vos propres indisponibilités',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous ne pouvez gérer que vos propres indisponibilités',
+        ]);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertCount(1, $repository->findAll());
+    }
+
+    public function test_an_absence_of_another_band_space_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $stranger = UserFactory::new()->create(['username' => 'stranger_user', 'email' => 'stranger@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $strangerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $otherBandSpace, 'user' => $stranger])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $strangerMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'DELETE',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Indisponibilité introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Indisponibilité introuvable',
+        ]);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertCount(1, $repository->findAll());
+    }
+}

--- a/tests/Api/BandSpace/Absence/MemberAbsenceGetCollectionTest.php
+++ b/tests/Api/BandSpace/Absence/MemberAbsenceGetCollectionTest.php
@@ -265,6 +265,33 @@ class MemberAbsenceGetCollectionTest extends ApiTestCase
         ]);
     }
 
+    public function test_an_unparseable_window_bound_is_a_bad_request(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/absences?from=not-a-date',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/400',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Date invalide',
+            'status' => 400,
+            'type' => '/errors/400',
+            'description' => 'Date invalide',
+        ]);
+    }
+
     public function test_a_non_member_cannot_read_the_absences(): void
     {
         $stranger = UserFactory::new()->asBaseUser()->create();

--- a/tests/Api/BandSpace/Absence/MemberAbsenceGetCollectionTest.php
+++ b/tests/Api/BandSpace/Absence/MemberAbsenceGetCollectionTest.php
@@ -1,0 +1,293 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Absence;
+
+use App\Enum\BandSpace\Role;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\MemberAbsenceFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class MemberAbsenceGetCollectionTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_a_member_sees_every_member_absence_in_the_window(): void
+    {
+        // Shared visibility is the whole point of the feature: a band that hides availability from
+        // itself gains nothing, so a plain member reads the other members' rows too.
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $bandMate,
+            'stageName' => 'Jo la Basse',
+        ])->create();
+
+        $mine = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+            'reason' => 'Vacances',
+        ])->create();
+        $theirs = MemberAbsenceFactory::new([
+            'member' => $bandMateMembership,
+            'startDate' => new DateTimeImmutable('2026-06-20'),
+            'endDate' => new DateTimeImmutable('2026-06-20'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/absences?from=2026-06-01&to=2026-06-30',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences',
+            '@type' => 'Collection',
+            'totalItems' => 2,
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $mine->id,
+                    '@type' => 'MemberAbsence',
+                    'id' => $mine->id,
+                    'band_space_id' => $bandSpace->id,
+                    'member_id' => $membership->id,
+                    'display_name' => $user->username,
+                    'profile_picture_url' => null,
+                    'start_date' => '2026-06-10',
+                    'end_date' => '2026-06-12',
+                    'reason' => 'Vacances',
+                    'can_manage' => true,
+                    'creation_datetime' => $mine->creationDatetime->format(\DateTimeInterface::ATOM),
+                ],
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $theirs->id,
+                    '@type' => 'MemberAbsence',
+                    'id' => $theirs->id,
+                    'band_space_id' => $bandSpace->id,
+                    'member_id' => $bandMateMembership->id,
+                    'display_name' => 'Jo la Basse',
+                    'profile_picture_url' => null,
+                    'start_date' => '2026-06-20',
+                    'end_date' => '2026-06-20',
+                    'reason' => null,
+                    // Somebody else's absence: readable, not editable.
+                    'can_manage' => false,
+                    'creation_datetime' => $theirs->creationDatetime->format(\DateTimeInterface::ATOM),
+                ],
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences?from=2026-06-01&to=2026-06-30',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_an_admin_may_manage_every_absence(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bandMate])->create();
+
+        $absence = MemberAbsenceFactory::new([
+            'member' => $bandMateMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/absences?from=2026-06-01&to=2026-06-30',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+                    '@type' => 'MemberAbsence',
+                    'id' => $absence->id,
+                    'band_space_id' => $bandSpace->id,
+                    'member_id' => $bandMateMembership->id,
+                    'display_name' => $bandMate->username,
+                    'profile_picture_url' => null,
+                    'start_date' => '2026-06-10',
+                    'end_date' => '2026-06-12',
+                    'reason' => null,
+                    'can_manage' => true,
+                    'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+                ],
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences?from=2026-06-01&to=2026-06-30',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_the_window_keeps_absences_that_only_touch_its_edge_and_drops_the_rest(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        // Ends on the first day asked for: still overlaps, so it is in.
+        $touchingStart = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-05-28'),
+            'endDate' => new DateTimeImmutable('2026-06-01'),
+        ])->create();
+        // Starts on the last day asked for: same.
+        $touchingEnd = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-06-30'),
+            'endDate' => new DateTimeImmutable('2026-07-04'),
+        ])->create();
+        // Entirely before and entirely after: out.
+        MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-05-20'),
+            'endDate' => new DateTimeImmutable('2026-05-31'),
+        ])->create();
+        MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-07-01'),
+            'endDate' => new DateTimeImmutable('2026-07-10'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/absences?from=2026-06-01&to=2026-06-30',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences',
+            '@type' => 'Collection',
+            'totalItems' => 2,
+            'member' => [
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $touchingStart->id,
+                    '@type' => 'MemberAbsence',
+                    'id' => $touchingStart->id,
+                    'band_space_id' => $bandSpace->id,
+                    'member_id' => $membership->id,
+                    'display_name' => $user->username,
+                    'profile_picture_url' => null,
+                    'start_date' => '2026-05-28',
+                    'end_date' => '2026-06-01',
+                    'reason' => null,
+                    'can_manage' => true,
+                    'creation_datetime' => $touchingStart->creationDatetime->format(\DateTimeInterface::ATOM),
+                ],
+                [
+                    '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $touchingEnd->id,
+                    '@type' => 'MemberAbsence',
+                    'id' => $touchingEnd->id,
+                    'band_space_id' => $bandSpace->id,
+                    'member_id' => $membership->id,
+                    'display_name' => $user->username,
+                    'profile_picture_url' => null,
+                    'start_date' => '2026-06-30',
+                    'end_date' => '2026-07-04',
+                    'reason' => null,
+                    'can_manage' => true,
+                    'creation_datetime' => $touchingEnd->creationDatetime->format(\DateTimeInterface::ATOM),
+                ],
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences?from=2026-06-01&to=2026-06-30',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_another_band_space_absences_never_leak(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $stranger = UserFactory::new()->create(['username' => 'stranger_user', 'email' => 'stranger@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $strangerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $otherBandSpace, 'user' => $stranger])->create();
+
+        MemberAbsenceFactory::new([
+            'member' => $strangerMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/absences?from=2026-06-01&to=2026-06-30',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences',
+            '@type' => 'Collection',
+            'totalItems' => 0,
+            'member' => [],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences?from=2026-06-01&to=2026-06-30',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_a_non_member_cannot_read_the_absences(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $this->client->loginUser($stranger);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/Absence/MemberAbsenceGetTest.php
+++ b/tests/Api/BandSpace/Absence/MemberAbsenceGetTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Absence;
+
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\MemberAbsenceFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * The item Get exists so the `@id` every absence payload advertises resolves. The other tests match
+ * that `@id` as a string, which only proves the operation is declared with the right template:
+ * IRI generation is template substitution and never reaches the provider. These two cases are what
+ * prove the route and its authorization actually answer.
+ */
+#[ResetDatabase]
+class MemberAbsenceGetTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_a_member_reads_one_absence_by_its_advertised_iri(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $bandMate,
+            'stageName' => 'Jo la Basse',
+        ])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $bandMateMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+            'reason' => 'Vacances',
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $bandMateMembership->id,
+            'display_name' => 'Jo la Basse',
+            'profile_picture_url' => null,
+            'start_date' => '2026-06-10',
+            'end_date' => '2026-06-12',
+            'reason' => 'Vacances',
+            // Somebody else's absence, and the reader is not an admin.
+            'can_manage' => false,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_a_non_member_cannot_read_one_absence(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create();
+        $member = UserFactory::new()->create(['username' => 'band_member', 'email' => 'band_member@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($stranger);
+        $this->client->request(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            [],
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/Absence/MemberAbsenceUpdateTest.php
+++ b/tests/Api/BandSpace/Absence/MemberAbsenceUpdateTest.php
@@ -1,0 +1,300 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Absence;
+
+use App\Enum\BandSpace\Role;
+use App\Repository\BandSpace\MemberAbsenceRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\MemberAbsenceFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class MemberAbsenceUpdateTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_a_member_moves_their_own_absence(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+            'reason' => 'Vacances',
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            ['startDate' => '2026-06-15', 'endDate' => '2026-06-18', 'reason' => 'Déménagement'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $membership->id,
+            'display_name' => $user->username,
+            'profile_picture_url' => null,
+            'start_date' => '2026-06-15',
+            'end_date' => '2026-06-18',
+            'reason' => 'Déménagement',
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_clearing_the_reason_is_a_real_patch_and_not_a_no_op(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+            'reason' => 'Vacances',
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            ['reason' => null],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $membership->id,
+            'display_name' => $user->username,
+            'profile_picture_url' => null,
+            // The dates were not in the payload, so they are untouched.
+            'start_date' => '2026-06-10',
+            'end_date' => '2026-06-12',
+            'reason' => null,
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_an_admin_edits_another_member_absence(): void
+    {
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $admin, 'role' => Role::Admin])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bandMate])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $bandMateMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            ['endDate' => '2026-06-14'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            'member_id' => $bandMateMembership->id,
+            'display_name' => $bandMate->username,
+            'profile_picture_url' => null,
+            'start_date' => '2026-06-10',
+            'end_date' => '2026-06-14',
+            'reason' => null,
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    public function test_a_member_cannot_edit_another_member_absence(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bandMate])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $bandMateMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            ['endDate' => '2026-06-14'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous ne pouvez gérer que vos propres indisponibilités',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous ne pouvez gérer que vos propres indisponibilités',
+        ]);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertSame('2026-06-12', $repository->findAll()[0]->endDate->format('Y-m-d'));
+    }
+
+    public function test_patching_one_date_is_still_validated_against_the_stored_other_one(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            ['endDate' => '2026-06-01'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/' . GreaterThanOrEqual::TOO_LOW_ERROR,
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'end_date',
+                    'message' => 'La date de fin doit être postérieure ou égale à la date de début.',
+                    'code' => GreaterThanOrEqual::TOO_LOW_ERROR,
+                ],
+            ],
+            'detail' => 'end_date: La date de fin doit être postérieure ou égale à la date de début.',
+            'type' => '/validation_errors/' . GreaterThanOrEqual::TOO_LOW_ERROR,
+            'title' => 'An error occurred',
+            'description' => 'end_date: La date de fin doit être postérieure ou égale à la date de début.',
+        ]);
+    }
+
+    public function test_a_patch_cannot_move_an_absence_to_another_member(): void
+    {
+        // The processor never reads memberId, so an absence stays with whoever it was recorded for:
+        // moving one is a delete plus a create. Asserted rather than left to the docblock, because
+        // this is the one authorization rule in the module with no failing path of its own - a
+        // reassignment would simply be accepted and silently ignored, or silently applied.
+        $admin = UserFactory::new()->asBaseUser()->create();
+        $bandMate = UserFactory::new()->create(['username' => 'band_mate', 'email' => 'band_mate@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $adminMembership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $admin,
+            'role' => Role::Admin,
+        ])->create();
+        $bandMateMembership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $bandMate])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $bandMateMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            ['memberId' => (string) $adminMembership->id, 'endDate' => '2026-06-14'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MemberAbsence',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            '@type' => 'MemberAbsence',
+            'id' => $absence->id,
+            'band_space_id' => $bandSpace->id,
+            // Still the band mate's, not the admin's, even though the payload named the admin.
+            'member_id' => $bandMateMembership->id,
+            'display_name' => $bandMate->username,
+            'profile_picture_url' => null,
+            'start_date' => '2026-06-10',
+            'end_date' => '2026-06-14',
+            'reason' => null,
+            'can_manage' => true,
+            'creation_datetime' => $absence->creationDatetime->format(\DateTimeInterface::ATOM),
+        ]);
+
+        $repository = self::getContainer()->get(MemberAbsenceRepository::class);
+        $this->assertSame((string) $bandMateMembership->id, (string) $repository->findAll()[0]->member->id);
+    }
+
+    public function test_an_absence_of_another_band_space_is_not_found(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $stranger = UserFactory::new()->create(['username' => 'stranger_user', 'email' => 'stranger@test.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $otherBandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        $strangerMembership = BandSpaceMembershipFactory::new(['bandSpace' => $otherBandSpace, 'user' => $stranger])->create();
+        $absence = MemberAbsenceFactory::new([
+            'member' => $strangerMembership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'PATCH',
+            '/api/band_spaces/' . $bandSpace->id . '/absences/' . $absence->id,
+            ['endDate' => '2026-06-14'],
+            ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Indisponibilité introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Indisponibilité introuvable',
+        ]);
+    }
+}

--- a/tests/Api/BandSpace/Absence/MemberAbsenceUpdateTest.php
+++ b/tests/Api/BandSpace/Absence/MemberAbsenceUpdateTest.php
@@ -10,9 +10,9 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\MemberAbsenceFactory;
 use App\Tests\Factory\User\UserFactory;
-use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use DateTimeImmutable;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
 #[ResetDatabase]

--- a/tests/Api/BandSpace/Agenda/AgendaGetCollectionTest.php
+++ b/tests/Api/BandSpace/Agenda/AgendaGetCollectionTest.php
@@ -11,6 +11,7 @@ use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
 use App\Tests\Factory\BandSpace\FinanceEntryFactory;
+use App\Tests\Factory\BandSpace\MemberAbsenceFactory;
 use App\Tests\Factory\BandSpace\TaskFactory;
 use Doctrine\Common\Collections\ArrayCollection;
 use App\Tests\Factory\User\UserFactory;
@@ -719,6 +720,66 @@ class AgendaGetCollectionTest extends ApiTestCase
             ],
             'view' => [
                 '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-01-01&to=2026-01-31',
+                '@type' => 'PartialCollectionView',
+            ],
+        ]);
+    }
+
+    public function test_absences_reach_the_calendar_as_all_day_items(): void
+    {
+        // The fourth aggregated source. It arrives as an ordinary AgendaItem, which is what lets the
+        // existing calendar, list and dashboard widget render it without knowing about absences.
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $user,
+            'stageName' => 'Jo la Basse',
+        ])->create();
+
+        $absence = MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+            'reason' => 'Vacances',
+        ])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'GET',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-06-01&to=2026-06-30',
+            [],
+            ['HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseIsSuccessful();
+        $itemId = 'absence-' . $absence->id;
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaItem',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/agenda_items/id=' . $itemId . ';bandSpaceId=' . $bandSpace->id,
+                    '@type' => 'AgendaItem',
+                    'id' => $itemId,
+                    'band_space_id' => $bandSpace->id,
+                    'source' => 'absence',
+                    'source_id' => $absence->id,
+                    // Both ends pinned to midnight UTC: a range of calendar dates, never an instant.
+                    'datetime' => '2026-06-10T00:00:00+00:00',
+                    'end_datetime' => '2026-06-12T00:00:00+00:00',
+                    'is_all_day' => true,
+                    'title' => 'Jo la Basse indisponible',
+                    'description' => 'Vacances',
+                    // Only the member: the name is already in the title and the reason is already
+                    // the description, so nothing is carried twice.
+                    'metadata' => ['member_id' => $membership->id],
+                ],
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda?from=2026-06-01&to=2026-06-30',
                 '@type' => 'PartialCollectionView',
             ],
         ]);

--- a/tests/Api/BandSpace/BandSpacePendingDeletionWriteBlockTest.php
+++ b/tests/Api/BandSpace/BandSpacePendingDeletionWriteBlockTest.php
@@ -10,6 +10,7 @@ use App\Repository\BandSpace\BandSpaceInvitationRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceNoteRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\BandSpace\MemberAbsenceRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
@@ -109,6 +110,24 @@ class BandSpacePendingDeletionWriteBlockTest extends ApiTestCase
         $this->assertCount(0, self::getContainer()->get(BandSpaceNoteRepository::class)->findByBandSpace($bandSpace));
     }
 
+    public function test_a_member_cannot_record_an_absence(): void
+    {
+        [$admin, $bandSpace] = $this->pendingDeletionSpace();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/absences',
+            ['startDate' => '2026-08-10', 'endDate' => '2026-08-12'],
+            self::HEADERS,
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals(self::EXPECTED_CONFLICT);
+
+        $this->assertCount(0, self::getContainer()->get(MemberAbsenceRepository::class)->findAll());
+    }
+
     /**
      * Joining a condemned space is pointless, and this processor has no checker to hang the guard on, so it
      * gets its own message.
@@ -194,6 +213,7 @@ class BandSpacePendingDeletionWriteBlockTest extends ApiTestCase
         yield 'setlists' => ['setlists'];
         yield 'finance categories' => ['finance/categories'];
         yield 'tech riders' => ['tech_riders'];
+        yield 'absences' => ['absences'];
     }
 
     /**

--- a/tests/Factory/BandSpace/MemberAbsenceFactory.php
+++ b/tests/Factory/BandSpace/MemberAbsenceFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Factory\BandSpace;
+
+use App\Entity\BandSpace\MemberAbsence;
+use DateTimeImmutable;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+
+/**
+ * @extends PersistentObjectFactory<MemberAbsence>
+ */
+final class MemberAbsenceFactory extends PersistentObjectFactory
+{
+    /**
+     * The dates are pinned rather than faked: they decide both the window a test asks for and the
+     * order rows come back in, and faker defaults have flipped sorts in CI before.
+     */
+    protected function defaults(): array
+    {
+        return [
+            'member' => BandSpaceMembershipFactory::new(),
+            'startDate' => new DateTimeImmutable('2026-06-10'),
+            'endDate' => new DateTimeImmutable('2026-06-12'),
+            'reason' => null,
+        ];
+    }
+
+    public static function class(): string
+    {
+        return MemberAbsence::class;
+    }
+}


### PR DESCRIPTION
Closes #777.

A band member records the days they are not available, and the agenda answers "who can actually be there" instead of the question being re-asked in a chat thread every time somebody proposes a date. Prerequisite for #778 (date polls) and for warning when an event lands on a day half the band is away.

## Model

`MemberAbsence` hangs off `BandSpaceMembership` rather than `User`, so a record belongs to this band and a member who later leaves keeps their history here, the way finance splits already do.

Day granularity, not datetime: a single day is a range where start equals end. The two dates are typed `DateTimeImmutable` and serialize as a bare `Y-m-d` in both directions via `#[Context]`, because an absence is a calendar date and never an instant: an ATOM value would have to be unpinned by every reader, which is the bug class `assets/js/utils/agendaDate.js` documents as having come back three times. The processors keep the caller's own written day, so an offset a client happens to send cannot move it, the same rule `AgendaEntryCreateProcessor` already applies to an all day entry.

## API

`GET` / `POST /band_spaces/{bandSpaceId}/absences`, plus `GET` / `PATCH` / `DELETE` on the item.

Reads are open to any member: shared visibility is the whole point, and a band that hides availability from itself gains nothing. Writes go through `MemberAbsenceChecker` - a member manages their own absences, an admin manages anyone's. On create, an optional `member_id` defaults to the caller and is honoured for somebody else only when the caller is an admin; the target must still be an active member. A `PATCH` deliberately cannot move an absence to another member, which is a delete plus a create.

`can_manage` is resolved server side. The client cannot work it out: the security store carries a username and roles, and the band space payload a role, but never the membership id.

## Agenda

`AgendaAggregator` gains a fourth `absence` source, so absences reach the calendar, the list and the dashboard widget through the endpoint those already consume. They render as muted all-day violet bands rather than event chips, since they are context and not appointments, and the existing all-day machinery (`isAllDayItem`, `agendaCalendarEventDates`) needed no changes to carry a multi-day one.

Management lives in a drawer opened from the Agenda toolbar, with a year selector, a member filter and month-grouped rows. Deliberately not a tenth sidebar module: this is an agenda sub-feature, and the agenda is where the answer is needed.

## Scope decisions

- No dashboard prompt when a member has declared nothing: it would nag people who genuinely have nothing to declare, with no way to dismiss it.
- No half-day support. Someone unavailable only in the morning records the day and says so in the free-text motif. Datetimes were rejected because they break the all-day rendering and the day-key grouping and reopen the offset bug class above.
- Absences are not written to `BandSpaceActivity`: high frequency, low signal, and they would drown the activity feed.
- No overlap validation between one member's own absences: a `PATCH` would need a self-excluding query, and two overlapping bands are self-evident in the list.

## Validation

A whitespace-only date used to be stored silently as today: `NotBlank` passes `"   "` because `empty("   ")` is false, and `new DateTimeImmutable("   ")` returns the current timestamp. The serializer now refuses to denormalize it, and `collectDenormalizationErrors: true` on the write operations turns that refusal into a 422 naming the field rather than a bare 400 the form cannot attach to an input. `NotNull` covers absence, `GreaterThanOrEqual` covers the ordering, and the class constraint is left with only the 366 day span, which is the one rule needing both values at once.

Two consequences of the typed property are worth knowing, and neither is new to this branch:

- PHP's date parsing does no calendar check and the original string is gone by validation time, so `2026-02-31` is accepted as 3 March. `Assert\Date` used to reject it. Recorded as a named test so the behaviour is visible rather than a surprise.
- A null byte in the date returns a 500, because `DateTimeNormalizer` parses through `createFromFormat`, which raises a `ValueError`, and the normalizer only catches `Exception`. This already applies to every `DateTime` typed field in the app, `eventDatetime` on `/agenda-entries` included, verified live. Filed as #934 with a one decorator fix that covers every endpoint at once, rather than hardening this resource alone.

## Frontend consolidation

Adding a fourth source meant editing five tables in `Agenda.vue` and a sixth private one in `AgendaWidget.vue` - and the sixth was missed, so the same absence rendered violet on the agenda and grey on the dashboard. Fixed at the root with `assets/js/constants/agendaSources.js`, one row per source, following the existing `fileSources.js` pattern whose docblock records the identical failure mode. A fifth source is now one row plus, if it is clickable, one branch.

## Index

The proposed composite `(member_id, start_date, end_date)` was measured and dropped. MariaDB drives from the membership side on `band_space_id` and then refs into the absence table on the foreign key index, so it never picks the composite while that index exists, and DBAL's `Index::isFulfilledBy` needs an equal column count so the composite cannot absorb it either. At band scale the plans are indistinguishable, so it was pure write cost.

## Verification

- 2463 tests green, including 32 new absence tests. Every request asserts its full JSON body, success and error alike.
- PHPStan level 8 over `src/` clean. Biome clean. 555 frontend tests green. `npm run build` OK.
- Migration applied, rolled back with `migrations:migrate prev`, and re-applied on the migration database, with no residual schema drift.
- Manual pass as an admin and as a plain member: create, edit, delete, month and year views, the source filter toggle, click-through from a calendar band to the drawer, and the dashboard widget colour. Console clean.

## Deploy

One migration, `Version20260830192026`, creating `band_space_member_absence`. No configuration change.

## Follow-ups worth filing separately

- Ten inline "owner or admin" checks across the Band Space processors have drifted into five phrasings of one refusal; a shared `BandSpaceOwnershipChecker` would end that.
- #934, the app wide null byte 500 described above.
- `AgendaItem` advertises an IRI that 404s. It is a projection rather than an addressable resource, so the fix is to stop minting one.

