### PR TITLE
Feedback: send a short report from inside the app, with the page and module prefilled

### DIFF
--- a/assets/js/App.vue
+++ b/assets/js/App.vue
@@ -1,6 +1,9 @@
 <template>
     <router-view/>
     <ConfirmDialog />
+    <!-- Mounted here rather than in a layout so the trigger works from every route, the layout-less
+         live setlist view included. -->
+    <FeedbackDrawer />
 </template>
 
 <script setup>
@@ -8,6 +11,7 @@ import { storeToRefs } from 'pinia'
 import ConfirmDialog from 'primevue/confirmdialog'
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import FeedbackDrawer from './components/Feedback/FeedbackDrawer.vue'
 import { useUserSecurityStore } from './store/user/security.js'
 import { resolveUnauthenticatedRedirect } from './utils/unauthenticatedRedirect.js'
 

--- a/assets/js/api/admin/feedback.js
+++ b/assets/js/api/admin/feedback.js
@@ -1,0 +1,24 @@
+/** global: Routing */
+
+import axios from 'axios'
+
+export default {
+  list({ page = 1, status = null, module = null, type = null } = {}) {
+    const params = new URLSearchParams({ page: String(page) })
+    if (status) params.append('status', status)
+    if (module) params.append('module', module)
+    if (type) params.append('type', type)
+
+    return axios
+      .get(`${Routing.generate('api_admin_feedbacks_list')}?${params.toString()}`)
+      .then((resp) => resp.data)
+  },
+
+  updateStatus(id, status) {
+    return axios.post(
+      Routing.generate('api_admin_feedbacks_status_update', { id }),
+      { status },
+      { headers: { 'Content-Type': 'application/ld+json' } }
+    )
+  }
+}

--- a/assets/js/api/feedback/feedback.js
+++ b/assets/js/api/feedback/feedback.js
@@ -1,0 +1,22 @@
+/** global: Routing */
+
+import axios from 'axios'
+
+export default {
+  send({ type, module, message, email, pageUrl, bandSpaceId }) {
+    return axios
+      .post(
+        Routing.generate('api_feedback_post'),
+        {
+          type,
+          module,
+          message,
+          email,
+          page_url: pageUrl,
+          band_space_id: bandSpaceId
+        },
+        { headers: { 'Content-Type': 'application/ld+json' } }
+      )
+      .then((resp) => resp.data)
+  }
+}

--- a/assets/js/components/Admin/AdminSidebar.vue
+++ b/assets/js/components/Admin/AdminSidebar.vue
@@ -32,6 +32,11 @@
           :value="publicationsBadgeCount"
           severity="warn"
         />
+        <Badge
+          v-if="module.key === 'feedback' && notificationStore.newFeedbacks > 0"
+          :value="notificationStore.newFeedbacks"
+          severity="warn"
+        />
       </RouterLink>
     </div>
   </nav>

--- a/assets/js/components/AppNavbarUserCluster.vue
+++ b/assets/js/components/AppNavbarUserCluster.vue
@@ -19,6 +19,20 @@
           <i v-else class="pi pi-envelope text-xl text-surface-600 dark:text-surface-300" aria-hidden="true" />
         </RouterLink>
         <NotificationBell @navigate="emit('navigate')" />
+        <!-- Admins only, and only while something is waiting: an always-on icon would be permanent
+             clutter for the one or two people who see it. Replaces the email notification the
+             feedback module would otherwise need. -->
+        <RouterLink
+          v-if="userSecurityStore.isAdmin && notificationStore.newFeedbacks > 0"
+          :to="{ name: 'admin_feedbacks_index' }"
+          class="flex items-center justify-center w-10 h-10 rounded-full hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors"
+          :aria-label="`Retours utilisateurs (${notificationStore.newFeedbacks} à traiter)`"
+          @click="emit('navigate')"
+        >
+          <OverlayBadge :value="notificationStore.newFeedbacks" severity="warn" size="small">
+            <i class="pi pi-comment text-xl text-surface-600 dark:text-surface-300" aria-hidden="true" />
+          </OverlayBadge>
+        </RouterLink>
         <Avatar
           v-if="userSecurityStore.profilePictureUrl"
           :image="userSecurityStore.profilePictureUrl"

--- a/assets/js/components/BandSpace/BandSidebar.vue
+++ b/assets/js/components/BandSpace/BandSidebar.vue
@@ -32,6 +32,20 @@
       class="mt-auto pt-3 border-t border-surface-200 dark:border-surface-700"
     >
       <slot name="above-settings" />
+      <!-- Inside the component rather than passed through the slot above, because AppBandLayout
+           renders this sidebar twice (the desktop aside and the mobile drawer) and only the mobile
+           one fills slots. -->
+      <button
+        type="button"
+        :disabled="disabled"
+        :class="linkClasses(false)"
+        aria-label="Envoyer un retour"
+        v-tooltip.right="tooltipFor('Un retour ?')"
+        @click="handleFeedbackClick"
+      >
+        <i class="pi pi-comment text-base shrink-0" aria-hidden="true"></i>
+        <span v-if="!collapsed" class="font-medium truncate">Un retour ?</span>
+      </button>
       <RouterLink
         :to="{ name: settingsItem.route, params: { id: currentSpaceId } }"
         custom
@@ -74,6 +88,7 @@
 import { computed } from 'vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
 import { BAND_SPACE_ROUTES, NAVIGATION_ITEMS } from '../../constants/bandSpace.js'
+import { useFeedbackStore } from '../../store/feedback.js'
 import { useUserSecurityStore } from '../../store/user/security.js'
 
 const props = defineProps({
@@ -87,6 +102,14 @@ const emit = defineEmits(['navigate'])
 
 const { currentSpaceId } = useBandSpaceNavigation()
 const userSecurityStore = useUserSecurityStore()
+const feedbackStore = useFeedbackStore()
+
+function handleFeedbackClick() {
+  // Closes the mobile drawer the same way a navigation does, otherwise the drawer sits on top of
+  // the panel that just opened.
+  emit('navigate')
+  feedbackStore.openDrawer()
+}
 
 // `superAdminOnly` marks a module that is merged but not yet announced and is dropped when it is
 // released. Membership role is deliberately not a gate: « Paramètres » is where a member quits the

--- a/assets/js/components/Feedback/FeedbackDrawer.vue
+++ b/assets/js/components/Feedback/FeedbackDrawer.vue
@@ -1,0 +1,197 @@
+<template>
+  <Drawer
+    v-model:visible="visible"
+    position="right"
+    class="w-full sm:!w-[28rem]"
+    header="Un retour à nous faire ?"
+    @hide="handleHide"
+  >
+    <div v-if="isSent" class="flex flex-col items-center text-center gap-4 py-8">
+      <i class="pi pi-check-circle text-5xl text-green-600 dark:text-green-400" aria-hidden="true" />
+      <p class="text-lg text-surface-700 dark:text-surface-300">Merci, votre retour est bien arrivé.</p>
+      <Button label="Fermer" severity="secondary" outlined @click="visible = false" />
+    </div>
+
+    <form v-else class="flex flex-col gap-5" novalidate @submit.prevent="handleSubmit">
+      <p class="text-surface-600 dark:text-surface-400 text-sm">
+        Un bug, une idée, une question ? Quelques mots suffisent. La page et la section sont
+        pré-remplies, corrigez-les si besoin.
+      </p>
+
+      <Message v-if="errorMessage" severity="error" :closable="false">{{ errorMessage }}</Message>
+
+      <div class="flex flex-col gap-2">
+        <label for="feedback-type" class="font-medium text-surface-700 dark:text-surface-300">
+          Type de retour
+        </label>
+        <Select
+          id="feedback-type"
+          v-model="type"
+          :options="FEEDBACK_TYPE_OPTIONS"
+          option-label="label"
+          option-value="value"
+          fluid
+        />
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label for="feedback-module" class="font-medium text-surface-700 dark:text-surface-300">
+          Section concernée
+        </label>
+        <Select
+          id="feedback-module"
+          v-model="module"
+          :options="FEEDBACK_MODULE_GROUPS"
+          option-label="label"
+          option-value="value"
+          option-group-label="label"
+          option-group-children="items"
+          fluid
+        />
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label for="feedback-message" class="font-medium text-surface-700 dark:text-surface-300">
+          Votre message
+        </label>
+        <Textarea
+          id="feedback-message"
+          v-model="message"
+          rows="6"
+          :maxlength="MESSAGE_MAX_LENGTH"
+          :invalid="submitted && !isMessageLongEnough"
+          aria-describedby="feedback-message-help"
+          placeholder="Décrivez ce que vous avez vu, et ce que vous attendiez."
+        />
+        <small id="feedback-message-help" class="text-surface-500 dark:text-surface-400">
+          {{ message.trim().length }} / {{ MESSAGE_MAX_LENGTH }} caractères, {{ MESSAGE_MIN_LENGTH }} minimum
+        </small>
+      </div>
+
+      <div v-if="!userSecurityStore.isAuthenticated" class="flex flex-col gap-2">
+        <label for="feedback-email" class="font-medium text-surface-700 dark:text-surface-300">
+          Votre email <span class="font-normal text-surface-500">(facultatif)</span>
+        </label>
+        <InputText id="feedback-email" v-model="email" type="email" aria-describedby="feedback-email-help" />
+        <small id="feedback-email-help" class="text-surface-500 dark:text-surface-400">
+          Laissez-le si vous souhaitez une réponse.
+        </small>
+      </div>
+
+      <p class="text-xs text-surface-500 dark:text-surface-400">
+        La page « {{ pageUrl }} » est envoyée avec votre message.
+      </p>
+
+      <div class="flex justify-end gap-2">
+        <Button label="Annuler" severity="secondary" text :disabled="feedbackStore.isSending" @click="visible = false" />
+        <Button
+          type="submit"
+          label="Envoyer"
+          icon="pi pi-send"
+          :loading="feedbackStore.isSending"
+          :disabled="!isMessageLongEnough || feedbackStore.isSending"
+        />
+      </div>
+    </form>
+  </Drawer>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Drawer from 'primevue/drawer'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import Select from 'primevue/select'
+import Textarea from 'primevue/textarea'
+import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { handleApiError } from '../../api/utils/handleApiError.js'
+import {
+  FEEDBACK_MODULE_GROUPS,
+  FEEDBACK_TYPE_OPTIONS,
+  MESSAGE_MAX_LENGTH,
+  MESSAGE_MIN_LENGTH
+} from '../../constants/feedback.js'
+import { useFeedbackStore } from '../../store/feedback.js'
+import { useUserSecurityStore } from '../../store/user/security.js'
+import { resolveFeedbackModule } from '../../utils/feedbackModule.js'
+
+const feedbackStore = useFeedbackStore()
+const userSecurityStore = useUserSecurityStore()
+const route = useRoute()
+
+const visible = computed({
+  get: () => feedbackStore.isDrawerOpen,
+  set: (value) => (value ? feedbackStore.openDrawer() : feedbackStore.closeDrawer())
+})
+
+const type = ref('bug')
+const module = ref('other')
+const message = ref('')
+const email = ref('')
+const submitted = ref(false)
+const isSent = ref(false)
+const errorMessage = ref('')
+
+// Read when the drawer opens rather than as a computed, so the values stay put if a background
+// navigation happens while the user is typing.
+const pageUrl = ref('/')
+const bandSpaceId = ref(null)
+
+const isMessageLongEnough = computed(() => message.value.trim().length >= MESSAGE_MIN_LENGTH)
+
+watch(
+  () => feedbackStore.isDrawerOpen,
+  (isOpen) => {
+    if (isOpen) {
+      resetForm()
+    }
+  }
+)
+
+function resetForm() {
+  type.value = 'bug'
+  module.value = resolveFeedbackModule(route.name)
+  message.value = ''
+  email.value = ''
+  submitted.value = false
+  isSent.value = false
+  errorMessage.value = ''
+  pageUrl.value = route.fullPath
+  // The live setlist view names it differently, and it is the only Band Space route outside the
+  // band layout.
+  bandSpaceId.value = route.params.id || route.params.bandSpaceId || null
+}
+
+function handleHide() {
+  // A drawer dismissed by the mask or Escape never runs the cancel button, so the sent state has to
+  // be cleared here too or reopening shows the thank-you panel.
+  isSent.value = false
+}
+
+async function handleSubmit() {
+  submitted.value = true
+  errorMessage.value = ''
+  if (!isMessageLongEnough.value) {
+    return
+  }
+
+  try {
+    await feedbackStore.send({
+      type: type.value,
+      module: module.value,
+      message: message.value.trim(),
+      email: email.value.trim() || null,
+      pageUrl: pageUrl.value,
+      bandSpaceId: bandSpaceId.value
+    })
+    isSent.value = true
+  } catch (error) {
+    if (error.response?.status === 429) {
+      errorMessage.value = 'Vous avez envoyé plusieurs retours récemment. Réessayez dans un moment.'
+      return
+    }
+    errorMessage.value = handleApiError(error).message
+  }
+}
+</script>

--- a/assets/js/constants/admin.js
+++ b/assets/js/constants/admin.js
@@ -32,6 +32,14 @@ export const ADMIN_MODULES = [
     color: '#f59e0b'
   },
   {
+    key: 'feedback',
+    label: 'Retours',
+    icon: 'pi-comment',
+    route: 'admin_feedbacks_index',
+    description: 'Retours envoyés depuis le site et les Band Spaces',
+    color: '#f97316'
+  },
+  {
     key: 'users',
     label: 'Utilisateurs',
     icon: 'pi-users',

--- a/assets/js/constants/feedback.js
+++ b/assets/js/constants/feedback.js
@@ -1,0 +1,54 @@
+import { FEEDBACK_MODULES } from '../utils/feedbackModule.js'
+
+/**
+ * Mirrors `App\ApiResource\Feedback\FeedbackResource`. The picker disables the send button below it,
+ * so the user is told before the round trip rather than by a 422.
+ */
+export const MESSAGE_MIN_LENGTH = 10
+export const MESSAGE_MAX_LENGTH = 2000
+
+/** Mirrors `App\Enum\Feedback\FeedbackType`, labels included. */
+export const FEEDBACK_TYPE_OPTIONS = Object.freeze([
+  { value: 'bug', label: 'Bug' },
+  { value: 'suggestion', label: 'Suggestion' },
+  { value: 'question', label: 'Question' },
+  { value: 'other', label: 'Autre' }
+])
+
+/**
+ * Mirrors `App\Enum\Feedback\FeedbackModule`, split into the Band Space modules and the rest of
+ * the site. The grouping is presentation only, which is why it lives here and not on the PHP enum.
+ *
+ * Seventeen options is a lot for a dropdown, which is why the drawer prefills it from the route:
+ * most people never open this list, and the ones who do are correcting a wrong guess.
+ */
+export const FEEDBACK_MODULE_GROUPS = Object.freeze([
+  {
+    label: 'Band Space',
+    items: [
+      { value: FEEDBACK_MODULES.DASHBOARD, label: 'Dashboard du Band Space' },
+      { value: FEEDBACK_MODULES.AGENDA, label: 'Agenda' },
+      { value: FEEDBACK_MODULES.NOTES, label: 'Notes' },
+      { value: FEEDBACK_MODULES.FILE, label: 'Fichiers' },
+      { value: FEEDBACK_MODULES.SETLIST, label: 'Setlists' },
+      { value: FEEDBACK_MODULES.RIDER, label: 'Tech riders' },
+      { value: FEEDBACK_MODULES.TASK, label: 'Tâches' },
+      { value: FEEDBACK_MODULES.FINANCE, label: 'Finances' },
+      { value: FEEDBACK_MODULES.SETTINGS, label: 'Paramètres du Band Space' }
+    ]
+  },
+  {
+    label: 'Le site',
+    items: [
+      { value: FEEDBACK_MODULES.FORUM, label: 'Forum' },
+      { value: FEEDBACK_MODULES.PUBLICATION, label: 'Publications' },
+      { value: FEEDBACK_MODULES.GALLERY, label: 'Galeries photo' },
+      { value: FEEDBACK_MODULES.DIRECTORY, label: 'Annuaire et recherche' },
+      { value: FEEDBACK_MODULES.COURSE, label: 'Cours' },
+      { value: FEEDBACK_MODULES.MESSAGE, label: 'Messagerie' },
+      { value: FEEDBACK_MODULES.NOTIFICATION, label: 'Notifications' },
+      { value: FEEDBACK_MODULES.ACCOUNT, label: 'Mon compte' },
+      { value: FEEDBACK_MODULES.OTHER, label: 'Autre' }
+    ]
+  }
+])

--- a/assets/js/constants/feedback.test.js
+++ b/assets/js/constants/feedback.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { FEEDBACK_MODULES } from '../utils/feedbackModule.js'
+import { FEEDBACK_MODULE_GROUPS, FEEDBACK_TYPE_OPTIONS } from './feedback.js'
+
+const moduleValues = Object.values(FEEDBACK_MODULES)
+const pickerOptions = FEEDBACK_MODULE_GROUPS.flatMap((group) => group.items)
+
+describe('FEEDBACK_MODULE_GROUPS', () => {
+  // Asserted here rather than in the PHP mirror test, which could only count
+  // `FEEDBACK_MODULES.SOMETHING` identifiers in the source: a typo resolves to undefined at runtime
+  // without throwing, so the count stayed right while the option was broken.
+  it('gives every option a value that really exists on FEEDBACK_MODULES', () => {
+    for (const option of pickerOptions) {
+      assert.ok(
+        moduleValues.includes(option.value),
+        `Option « ${option.label} » has value ${JSON.stringify(option.value)}, which is not a FEEDBACK_MODULES value`
+      )
+    }
+  })
+
+  it('offers every module, so no route can prefill an option the user cannot see', () => {
+    const offered = pickerOptions.map((option) => option.value).sort()
+    assert.deepEqual(offered, [...moduleValues].sort())
+  })
+
+  it('labels every option', () => {
+    for (const option of pickerOptions) {
+      assert.equal(typeof option.label, 'string')
+      assert.ok(option.label.length > 0)
+    }
+  })
+})
+
+describe('FEEDBACK_TYPE_OPTIONS', () => {
+  it('gives every option a non-empty value and label', () => {
+    for (const option of FEEDBACK_TYPE_OPTIONS) {
+      assert.equal(typeof option.value, 'string')
+      assert.ok(option.value.length > 0)
+      assert.equal(typeof option.label, 'string')
+      assert.ok(option.label.length > 0)
+    }
+  })
+})

--- a/assets/js/router/admin.js
+++ b/assets/js/router/admin.js
@@ -49,6 +49,11 @@ export default {
       component: () => import('../views/Admin/Forum/Index.vue')
     },
     {
+      name: 'admin_feedbacks_index',
+      path: 'retours',
+      component: () => import('../views/Admin/Feedback/Index.vue')
+    },
+    {
       name: 'admin_band_space_coming_soon',
       path: 'band-spaces',
       component: () => import('../views/Admin/ComingSoonPage.vue'),

--- a/assets/js/store/feedback.js
+++ b/assets/js/store/feedback.js
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+import { readonly, ref } from 'vue'
+import feedbackApi from '../api/feedback/feedback.js'
+
+/**
+ * The drawer is mounted once in App.vue, so opening it is a store flag rather than a prop threaded
+ * through every layout. Same shape as the Band Space create modal.
+ */
+export const useFeedbackStore = defineStore('feedback', () => {
+  const isDrawerOpen = ref(false)
+  const isSending = ref(false)
+
+  function openDrawer() {
+    isDrawerOpen.value = true
+  }
+
+  function closeDrawer() {
+    isDrawerOpen.value = false
+  }
+
+  async function send(payload) {
+    isSending.value = true
+    try {
+      return await feedbackApi.send(payload)
+    } finally {
+      isSending.value = false
+    }
+  }
+
+  return {
+    isDrawerOpen,
+    isSending: readonly(isSending),
+    openDrawer,
+    closeDrawer,
+    send
+  }
+})

--- a/assets/js/store/notification/notification.js
+++ b/assets/js/store/notification/notification.js
@@ -6,6 +6,7 @@ export const useNotificationStore = defineStore('notification', () => {
   const unreadMessages = ref(0)
   const pendingPublications = ref(0)
   const pendingGalleries = ref(0)
+  const newFeedbacks = ref(0)
 
   async function loadNotifications() {
     try {
@@ -13,6 +14,7 @@ export const useNotificationStore = defineStore('notification', () => {
       unreadMessages.value = data.unread_messages || 0
       pendingPublications.value = data.pending_publications || 0
       pendingGalleries.value = data.pending_galleries || 0
+      newFeedbacks.value = data.new_feedbacks || 0
     } catch (e) {
       console.error('Failed to load notifications:', e)
     }
@@ -22,6 +24,7 @@ export const useNotificationStore = defineStore('notification', () => {
     unreadMessages: readonly(unreadMessages),
     pendingPublications: readonly(pendingPublications),
     pendingGalleries: readonly(pendingGalleries),
+    newFeedbacks: readonly(newFeedbacks),
     loadNotifications
   }
 })

--- a/assets/js/utils/feedbackModule.js
+++ b/assets/js/utils/feedbackModule.js
@@ -1,0 +1,107 @@
+import { BAND_SPACE_ROUTES } from '../constants/bandSpace.js'
+
+/**
+ * Mirrors `App\Enum\Feedback\FeedbackModule`. The API refuses anything else, so a value added here
+ * without its PHP counterpart is a 422 rather than a silent miss.
+ */
+export const FEEDBACK_MODULES = Object.freeze({
+  AGENDA: 'agenda',
+  NOTES: 'notes',
+  FILE: 'file',
+  TASK: 'task',
+  FINANCE: 'finance',
+  SETLIST: 'setlist',
+  RIDER: 'rider',
+  SETTINGS: 'settings',
+  DASHBOARD: 'dashboard',
+  FORUM: 'forum',
+  PUBLICATION: 'publication',
+  GALLERY: 'gallery',
+  DIRECTORY: 'directory',
+  COURSE: 'course',
+  MESSAGE: 'message',
+  NOTIFICATION: 'notification',
+  ACCOUNT: 'account',
+  OTHER: 'other'
+})
+
+/**
+ * Route name to module. The Band Space half reads from BAND_SPACE_ROUTES rather than retyping the
+ * names, so renaming a route there cannot silently drop a mapping here.
+ *
+ * A route absent from this map falls back to OTHER, which is why the map does not have to enumerate
+ * every route in the app: only the ones whose module is worth prefilling.
+ */
+const ROUTE_TO_MODULE = Object.freeze({
+  [BAND_SPACE_ROUTES.AGENDA]: FEEDBACK_MODULES.AGENDA,
+  [BAND_SPACE_ROUTES.NOTES]: FEEDBACK_MODULES.NOTES,
+  [BAND_SPACE_ROUTES.FILES]: FEEDBACK_MODULES.FILE,
+  [BAND_SPACE_ROUTES.TASKS]: FEEDBACK_MODULES.TASK,
+  [BAND_SPACE_ROUTES.FINANCE]: FEEDBACK_MODULES.FINANCE,
+  [BAND_SPACE_ROUTES.SETLIST]: FEEDBACK_MODULES.SETLIST,
+  app_band_setlist_live: FEEDBACK_MODULES.SETLIST,
+  [BAND_SPACE_ROUTES.RIDER]: FEEDBACK_MODULES.RIDER,
+  [BAND_SPACE_ROUTES.PARAMETERS]: FEEDBACK_MODULES.SETTINGS,
+  [BAND_SPACE_ROUTES.DASHBOARD]: FEEDBACK_MODULES.DASHBOARD,
+  [BAND_SPACE_ROUTES.INDEX]: FEEDBACK_MODULES.DASHBOARD,
+
+  app_forum_index: FEEDBACK_MODULES.FORUM,
+  app_forum_my_topics: FEEDBACK_MODULES.FORUM,
+  forum_topic_list: FEEDBACK_MODULES.FORUM,
+  forum_topic_item: FEEDBACK_MODULES.FORUM,
+
+  app_publications: FEEDBACK_MODULES.PUBLICATION,
+  app_publications_by_category: FEEDBACK_MODULES.PUBLICATION,
+  app_publication_show: FEEDBACK_MODULES.PUBLICATION,
+  app_publication_tag: FEEDBACK_MODULES.PUBLICATION,
+  app_user_publications: FEEDBACK_MODULES.PUBLICATION,
+  app_user_publication_edit: FEEDBACK_MODULES.PUBLICATION,
+  app_user_publication_preview: FEEDBACK_MODULES.PUBLICATION,
+
+  app_gallery_show: FEEDBACK_MODULES.GALLERY,
+  app_user_galleries: FEEDBACK_MODULES.GALLERY,
+  app_user_gallery_edit: FEEDBACK_MODULES.GALLERY,
+  app_user_gallery_preview: FEEDBACK_MODULES.GALLERY,
+
+  app_search_musician: FEEDBACK_MODULES.DIRECTORY,
+  app_search_guitarist: FEEDBACK_MODULES.DIRECTORY,
+  app_search_bassist: FEEDBACK_MODULES.DIRECTORY,
+  app_search_drummer: FEEDBACK_MODULES.DIRECTORY,
+  app_search_pianist: FEEDBACK_MODULES.DIRECTORY,
+  app_search_singer: FEEDBACK_MODULES.DIRECTORY,
+  app_search_teacher: FEEDBACK_MODULES.DIRECTORY,
+  app_user_announces: FEEDBACK_MODULES.DIRECTORY,
+  app_user_public_profile: FEEDBACK_MODULES.DIRECTORY,
+  app_user_musician_profile: FEEDBACK_MODULES.DIRECTORY,
+  app_user_teacher_profile: FEEDBACK_MODULES.DIRECTORY,
+
+  app_course: FEEDBACK_MODULES.COURSE,
+  app_course_by_category: FEEDBACK_MODULES.COURSE,
+  app_course_show: FEEDBACK_MODULES.COURSE,
+  app_user_courses: FEEDBACK_MODULES.COURSE,
+
+  app_messages: FEEDBACK_MODULES.MESSAGE,
+  app_notifications_index: FEEDBACK_MODULES.NOTIFICATION,
+
+  app_login: FEEDBACK_MODULES.ACCOUNT,
+  app_register: FEEDBACK_MODULES.ACCOUNT,
+  app_forgot_password: FEEDBACK_MODULES.ACCOUNT,
+  app_reset_password: FEEDBACK_MODULES.ACCOUNT,
+  app_verify_email: FEEDBACK_MODULES.ACCOUNT
+})
+
+/**
+ * The module to preselect for the page the user is on.
+ *
+ * Settings routes are matched by prefix rather than listed: there are eight of them, they all share
+ * one module, and new ones keep appearing.
+ */
+export function resolveFeedbackModule(routeName) {
+  if (typeof routeName !== 'string' || routeName === '') {
+    return FEEDBACK_MODULES.OTHER
+  }
+  if (routeName.startsWith('app_user_settings')) {
+    return FEEDBACK_MODULES.ACCOUNT
+  }
+  return ROUTE_TO_MODULE[routeName] ?? FEEDBACK_MODULES.OTHER
+}

--- a/assets/js/utils/feedbackModule.test.js
+++ b/assets/js/utils/feedbackModule.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { BAND_SPACE_ROUTES } from '../constants/bandSpace.js'
+import { FEEDBACK_MODULES, resolveFeedbackModule } from './feedbackModule.js'
+
+describe('resolveFeedbackModule', () => {
+  it('maps every Band Space route to its own module', () => {
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.AGENDA), FEEDBACK_MODULES.AGENDA)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.NOTES), FEEDBACK_MODULES.NOTES)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.FILES), FEEDBACK_MODULES.FILE)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.TASKS), FEEDBACK_MODULES.TASK)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.FINANCE), FEEDBACK_MODULES.FINANCE)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.SETLIST), FEEDBACK_MODULES.SETLIST)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.RIDER), FEEDBACK_MODULES.RIDER)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.PARAMETERS), FEEDBACK_MODULES.SETTINGS)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.DASHBOARD), FEEDBACK_MODULES.DASHBOARD)
+  })
+
+  // The live view sits outside both layouts, so it is the one Band Space route that cannot be
+  // reached from BAND_SPACE_ROUTES and has to be listed by hand.
+  it('maps the standalone setlist live route to the setlist module', () => {
+    assert.equal(resolveFeedbackModule('app_band_setlist_live'), FEEDBACK_MODULES.SETLIST)
+  })
+
+  it('maps the site sections', () => {
+    assert.equal(resolveFeedbackModule('forum_topic_item'), FEEDBACK_MODULES.FORUM)
+    assert.equal(resolveFeedbackModule('app_publication_show'), FEEDBACK_MODULES.PUBLICATION)
+    assert.equal(resolveFeedbackModule('app_gallery_show'), FEEDBACK_MODULES.GALLERY)
+    assert.equal(resolveFeedbackModule('app_search_drummer'), FEEDBACK_MODULES.DIRECTORY)
+    assert.equal(resolveFeedbackModule('app_course_show'), FEEDBACK_MODULES.COURSE)
+    assert.equal(resolveFeedbackModule('app_messages'), FEEDBACK_MODULES.MESSAGE)
+  })
+
+  // Matched by prefix: there are eight of them today and the list keeps growing.
+  it('folds every settings route into the account module', () => {
+    assert.equal(resolveFeedbackModule('app_user_settings'), FEEDBACK_MODULES.ACCOUNT)
+    assert.equal(resolveFeedbackModule('app_user_settings_notifications'), FEEDBACK_MODULES.ACCOUNT)
+    assert.equal(
+      resolveFeedbackModule('app_user_settings_profile_teacher'),
+      FEEDBACK_MODULES.ACCOUNT
+    )
+  })
+
+  it('falls back to other for an unmapped route', () => {
+    assert.equal(resolveFeedbackModule('app_home'), FEEDBACK_MODULES.OTHER)
+    assert.equal(resolveFeedbackModule('not_found'), FEEDBACK_MODULES.OTHER)
+  })
+
+  // The drawer can open before the router has settled, and a null route name must not throw.
+  it('falls back to other when there is no route name', () => {
+    assert.equal(resolveFeedbackModule(null), FEEDBACK_MODULES.OTHER)
+    assert.equal(resolveFeedbackModule(undefined), FEEDBACK_MODULES.OTHER)
+    assert.equal(resolveFeedbackModule(''), FEEDBACK_MODULES.OTHER)
+  })
+})

--- a/assets/js/views/Admin/Feedback/Index.vue
+++ b/assets/js/views/Admin/Feedback/Index.vue
@@ -1,0 +1,225 @@
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-semibold">Retours utilisateurs</h1>
+      <Tag v-if="totalItems > 0" :value="`${totalItems} retour(s)`" severity="secondary" />
+    </div>
+
+    <div class="flex flex-wrap gap-3 mb-6">
+      <Select
+        v-model="statusFilter"
+        :options="STATUS_FILTER_OPTIONS"
+        option-label="label"
+        option-value="value"
+        aria-label="Filtrer par statut"
+        class="w-48"
+      />
+      <Select
+        v-model="typeFilter"
+        :options="TYPE_FILTER_OPTIONS"
+        option-label="label"
+        option-value="value"
+        aria-label="Filtrer par type"
+        class="w-48"
+      />
+      <Select
+        v-model="moduleFilter"
+        :options="MODULE_FILTER_OPTIONS"
+        option-label="label"
+        option-value="value"
+        aria-label="Filtrer par section"
+        class="w-56"
+      />
+    </div>
+
+    <div v-if="isLoading && !feedbacks.length" class="space-y-3">
+      <div v-for="i in 5" :key="i" class="h-16 bg-surface-100 dark:bg-surface-800 animate-pulse rounded" />
+    </div>
+
+    <DataTable v-else :value="feedbacks" stripedRows class="text-sm">
+      <Column field="creation_datetime" header="Reçu le" :style="{ width: '10rem' }">
+        <template #body="{ data }">{{ formatDate(data.creation_datetime) }}</template>
+      </Column>
+      <Column field="type_label" header="Type" :style="{ width: '8rem' }">
+        <template #body="{ data }">
+          <Tag :value="data.type_label" :severity="TYPE_SEVERITY[data.type] ?? 'secondary'" />
+        </template>
+      </Column>
+      <Column field="module_label" header="Section" :style="{ width: '12rem' }" />
+      <Column field="message" header="Message">
+        <template #body="{ data }">
+          <p class="whitespace-pre-line">{{ data.message }}</p>
+          <p class="text-xs text-surface-500 dark:text-surface-400 mt-1">
+            <span>{{ data.username ?? 'Visiteur anonyme' }}</span>
+            <span v-if="data.email"> &middot; {{ data.email }}</span>
+            <span v-if="data.band_space_name"> &middot; {{ data.band_space_name }}</span>
+            <span> &middot; </span>
+            <RouterLink :to="data.page_url" class="underline">{{ data.page_url }}</RouterLink>
+          </p>
+        </template>
+      </Column>
+      <Column header="Statut" :style="{ width: '11rem' }">
+        <template #body="{ data }">
+          <Select
+            :model-value="data.status"
+            :options="STATUS_OPTIONS"
+            option-label="label"
+            option-value="value"
+            :loading="updatingId === data.id"
+            :disabled="updatingId === data.id"
+            :aria-label="`Statut du retour du ${formatDate(data.creation_datetime)}`"
+            fluid
+            @update:model-value="(status) => handleStatusChange(data, status)"
+          />
+        </template>
+      </Column>
+      <template #empty>
+        <div class="text-center py-8 text-surface-500 dark:text-surface-400">
+          Aucun retour pour le moment.
+        </div>
+      </template>
+    </DataTable>
+
+    <Paginator
+      v-if="totalItems > ROWS_PER_PAGE"
+      :rows="ROWS_PER_PAGE"
+      :totalRecords="totalItems"
+      :first="(page - 1) * ROWS_PER_PAGE"
+      class="mt-4"
+      @page="handlePageChange"
+    />
+  </div>
+</template>
+
+<script setup>
+import { useTitle } from '@vueuse/core'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import Paginator from 'primevue/paginator'
+import Select from 'primevue/select'
+import Tag from 'primevue/tag'
+import { useToast } from 'primevue/usetoast'
+import { onMounted, ref, watch } from 'vue'
+import feedbackApi from '../../../api/admin/feedback.js'
+import { FEEDBACK_MODULE_GROUPS, FEEDBACK_TYPE_OPTIONS } from '../../../constants/feedback.js'
+import { useNotificationStore } from '../../../store/notification/notification.js'
+import { formatDate } from '../../../utils/date.js'
+
+// Mirrors paginationItemsPerPage on the GetCollection. Server side paging, unlike the other admin
+// tables: this one is never drained.
+const ROWS_PER_PAGE = 25
+
+// A sentinel rather than null, because PrimeVue reads a null model value as "nothing selected" and
+// renders the field blank instead of showing the "all" option. Translated back to "send no filter"
+// in load().
+const ALL = 'all'
+
+const STATUS_OPTIONS = [
+  { value: 'new', label: 'Nouveau' },
+  { value: 'in_progress', label: 'En cours' },
+  { value: 'done', label: 'Traité' }
+]
+
+const STATUS_FILTER_OPTIONS = [{ value: ALL, label: 'Tous les statuts' }, ...STATUS_OPTIONS]
+
+const TYPE_FILTER_OPTIONS = [{ value: ALL, label: 'Tous les types' }, ...FEEDBACK_TYPE_OPTIONS]
+
+// Flat, unlike the drawer's grouped picker: PrimeVue needs every option inside a group once any
+// group exists, so the "all" entry would need a group of its own and render an empty header above
+// it. Grouping earns its place when someone is classifying their own report, not when an admin is
+// narrowing a table.
+const MODULE_FILTER_OPTIONS = [
+  { value: ALL, label: 'Toutes les sections' },
+  ...FEEDBACK_MODULE_GROUPS.flatMap((group) => group.items)
+]
+
+const TYPE_SEVERITY = {
+  bug: 'danger',
+  suggestion: 'info',
+  question: 'warn',
+  other: 'secondary'
+}
+
+useTitle('Retours - Admin - MusicAll')
+
+const notificationStore = useNotificationStore()
+const toast = useToast()
+
+const feedbacks = ref([])
+const totalItems = ref(0)
+const page = ref(1)
+const isLoading = ref(false)
+const updatingId = ref(null)
+
+const statusFilter = ref(ALL)
+const typeFilter = ref(ALL)
+const moduleFilter = ref(ALL)
+
+/** The API has no "all" value: an unfiltered axis is an absent parameter. */
+function asFilter(value) {
+  return value === ALL ? null : value
+}
+
+async function load() {
+  isLoading.value = true
+  try {
+    const data = await feedbackApi.list({
+      page: page.value,
+      status: asFilter(statusFilter.value),
+      type: asFilter(typeFilter.value),
+      module: asFilter(moduleFilter.value)
+    })
+    feedbacks.value = data.member
+    totalItems.value = data.totalItems
+  } catch (e) {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: e?.response?.data?.detail || 'Impossible de charger les retours.',
+      life: 4000
+    })
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// Filtering resets to the first page: staying on page 4 of a narrower result set shows an empty
+// table and looks like a bug.
+watch([statusFilter, typeFilter, moduleFilter], () => {
+  page.value = 1
+  load()
+})
+
+function handlePageChange(event) {
+  page.value = event.page + 1
+  load()
+}
+
+async function handleStatusChange(feedback, status) {
+  if (status === feedback.status) {
+    return
+  }
+  const previousStatus = feedback.status
+  updatingId.value = feedback.id
+  try {
+    await feedbackApi.updateStatus(feedback.id, status)
+    feedback.status = status
+    // The navbar badge counts untriaged reports, so it has to follow a change made here rather than
+    // wait for the next page load.
+    await notificationStore.loadNotifications()
+    toast.add({ severity: 'success', summary: 'Statut mis à jour', life: 2000 })
+  } catch (e) {
+    feedback.status = previousStatus
+    toast.add({
+      severity: 'error',
+      summary: 'Action impossible',
+      detail: e?.response?.data?.detail || 'Une erreur est survenue.',
+      life: 4000
+    })
+  } finally {
+    updatingId.value = null
+  }
+}
+
+onMounted(load)
+</script>

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -96,3 +96,11 @@ framework:
             limit: 2
             interval: '1 day'
             cache_pool: "rate_limiter.cache"
+        # Higher than contact_form (3/hour): feedback is meant to be sent the moment something
+        # is noticed, so a user filing three small reports while walking through a module is normal
+        # use rather than abuse.
+        feedback_submit:
+            policy: sliding_window
+            limit: 5
+            interval: '1 hour'
+            cache_pool: "rate_limiter.cache"

--- a/migrations/2026/09/Version20260905140131.php
+++ b/migrations/2026/09/Version20260905140131.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * In app feedback: a short report carrying the page and the module it was sent from.
+ */
+final class Version20260905140131 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create the feedback table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE feedback (id CHAR(36) NOT NULL, type VARCHAR(20) NOT NULL, module VARCHAR(20) NOT NULL, message LONGTEXT NOT NULL, email VARCHAR(255) DEFAULT NULL, page_url VARCHAR(255) NOT NULL, user_agent VARCHAR(255) DEFAULT NULL, status VARCHAR(20) NOT NULL, creation_datetime DATETIME NOT NULL, user_id CHAR(36) DEFAULT NULL, band_space_id CHAR(36) DEFAULT NULL, INDEX IDX_D2294458A76ED395 (user_id), INDEX IDX_D2294458E31C124A (band_space_id), INDEX idx_feedback_triage (status, creation_datetime), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE feedback ADD CONSTRAINT FK_D2294458A76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE feedback ADD CONSTRAINT FK_D2294458E31C124A FOREIGN KEY (band_space_id) REFERENCES band_space (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE feedback DROP FOREIGN KEY FK_D2294458A76ED395');
+        $this->addSql('ALTER TABLE feedback DROP FOREIGN KEY FK_D2294458E31C124A');
+        $this->addSql('DROP TABLE feedback');
+    }
+}

--- a/src/ApiResource/Admin/Feedback/AdminFeedback.php
+++ b/src/ApiResource/Admin/Feedback/AdminFeedback.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\Admin\Feedback;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Enum\Feedback\FeedbackType;
+use App\State\Provider\Admin\Feedback\AdminFeedbackCollectionProvider;
+use App\State\Provider\Admin\Feedback\AdminFeedbackItemProvider;
+use DateTimeInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * The triage list.
+ *
+ * Paginated in the database, unlike every other admin collection, which is `paginationEnabled: false`
+ * with a client side DataTable. Those list a queue that moderation drains; this one is the only admin
+ * table nothing prunes, so it only grows.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            uriTemplate: '/admin/feedbacks',
+            openapi: new Operation(tags: ['Admin Feedback']),
+            paginationEnabled: true,
+            paginationItemsPerPage: 25,
+            security: 'is_granted("ROLE_ADMIN")',
+            name: 'api_admin_feedbacks_list',
+            provider: AdminFeedbackCollectionProvider::class,
+            // Declared rather than parsed in the provider, so an unknown value is a 422 naming the
+            // parameter before the provider runs and the filters can be trusted. `values()` cannot go
+            // in a `schema` here: an attribute argument has to be a constant expression, and a static
+            // call is not one.
+            parameters: [
+                'status' => new QueryParameter(key: 'status', constraints: [new Assert\Choice(callback: [FeedbackStatus::class, 'values'], message: 'Statut inconnu')]),
+                'module' => new QueryParameter(key: 'module', constraints: [new Assert\Choice(callback: [FeedbackModule::class, 'values'], message: 'Section inconnue')]),
+                'type' => new QueryParameter(key: 'type', constraints: [new Assert\Choice(callback: [FeedbackType::class, 'values'], message: 'Type de retour inconnu')]),
+            ],
+        ),
+        // Exists so the item IRI the collection advertises resolves. Without it API Platform still
+        // emits an @id per row, built from the short name, pointing at a route that does not exist.
+        new Get(
+            uriTemplate: '/admin/feedbacks/{id}',
+            openapi: new Operation(tags: ['Admin Feedback']),
+            security: 'is_granted("ROLE_ADMIN")',
+            name: 'api_admin_feedbacks_get',
+            provider: AdminFeedbackItemProvider::class,
+        ),
+    ],
+)]
+class AdminFeedback
+{
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    public string $type;
+    public string $typeLabel;
+    public string $module;
+    public string $moduleLabel;
+    public string $message;
+    public ?string $email = null;
+    public ?string $username = null;
+    public ?string $bandSpaceName = null;
+    public string $pageUrl;
+    public ?string $userAgent = null;
+    public string $status;
+    public string $statusLabel;
+    public DateTimeInterface $creationDatetime;
+}

--- a/src/ApiResource/Admin/Feedback/AdminFeedbackStatusUpdate.php
+++ b/src/ApiResource/Admin/Feedback/AdminFeedbackStatusUpdate.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\Admin\Feedback;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\Enum\Feedback\FeedbackStatus;
+use App\State\Processor\Admin\Feedback\AdminFeedbackStatusUpdateProcessor;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Moving one report through triage.
+ *
+ * A Post rather than a Patch because nothing under src/ApiResource/Admin/ uses Patch: a status
+ * change is modelled as its own single purpose resource returning 204.
+ */
+#[Post(
+    uriTemplate: '/admin/feedbacks/{id}/status',
+    status: Response::HTTP_NO_CONTENT,
+    openapi: new Operation(tags: ['Admin Feedback']),
+    security: 'is_granted("ROLE_ADMIN")',
+    name: 'api_admin_feedbacks_status_update',
+    processor: AdminFeedbackStatusUpdateProcessor::class,
+)]
+class AdminFeedbackStatusUpdate
+{
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    #[Assert\NotBlank(message: 'Veuillez choisir un statut')]
+    #[Assert\Choice(callback: [FeedbackStatus::class, 'values'], message: 'Statut inconnu')]
+    public string $status;
+}

--- a/src/ApiResource/Feedback/FeedbackResource.php
+++ b/src/ApiResource/Feedback/FeedbackResource.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\Feedback;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackType;
+use App\State\Processor\Feedback\FeedbackProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Sending a short report from wherever the user is standing.
+ *
+ * Declares no `security:` expression on purpose. The api firewall is `lazy: true` and forces
+ * nothing, so an anonymous visitor posts here exactly as they do to /api/contact, while a logged in
+ * one is still resolved from their token and attached by the processor.
+ */
+#[ApiResource(
+    shortName: 'Feedback',
+    operations: [
+        new Post(
+            uriTemplate: '/feedbacks',
+            openapi: false,
+            name: 'api_feedback_post',
+            processor: FeedbackProcessor::class,
+        ),
+        // Carries no identifier of its own, so without an item operation API Platform falls back to
+        // a random .well-known/genid IRI on the response. Declared exactly as Contact does, for the
+        // same reason. shortName sits on the resource rather than the operations so @type and
+        // @context agree.
+        new Get(openapi: false),
+    ],
+)]
+class FeedbackResource
+{
+    /** Mirrored by assets/js/constants/feedback.js, pinned by FeedbackClientMirrorTest. */
+    final public const int MESSAGE_MIN_LENGTH = 10;
+    final public const int MESSAGE_MAX_LENGTH = 2000;
+
+    #[Assert\NotBlank(message: 'Veuillez choisir un type de retour')]
+    #[Assert\Choice(callback: [FeedbackType::class, 'values'], message: 'Type de retour inconnu')]
+    public string $type;
+
+    #[Assert\NotBlank(message: 'Veuillez choisir une section')]
+    #[Assert\Choice(callback: [FeedbackModule::class, 'values'], message: 'Section inconnue')]
+    public string $module;
+
+    #[Assert\NotBlank(message: 'Veuillez écrire votre message')]
+    #[Assert\Length(
+        min: self::MESSAGE_MIN_LENGTH,
+        max: self::MESSAGE_MAX_LENGTH,
+        minMessage: 'Votre message doit contenir au minimum {{ limit }} caractères',
+        maxMessage: 'Votre message ne peut pas dépasser {{ limit }} caractères',
+    )]
+    public string $message;
+
+    /**
+     * Optional even without an account: a report carrying a section and a page is actionable without
+     * a way to reply, and demanding one costs us the quick report this feature exists for.
+     */
+    #[Assert\Email(message: "L'email est invalide")]
+    #[Assert\Length(max: 255, maxMessage: "L'email ne peut pas dépasser {{ limit }} caractères")]
+    public ?string $email = null;
+
+    /**
+     * A path, never an absolute URL. An admin clicks this from the triage table, so accepting a full
+     * URL would make the admin list an open redirect with a human in the loop.
+     *
+     * A leading slash is not enough on its own. `//evil.com` and `/\evil.com` are protocol relative:
+     * the browser resolves both to another origin, and vue-router passes any string starting with a
+     * slash through to the rendered href untouched, so a middle click, a ctrl click or just hovering
+     * for the status bar leaves the site. Hence the lookahead refusing a second slash or a backslash,
+     * and the backslash excluded from the body as well.
+     *
+     * Anchored with \z rather than $, which also matches before a trailing newline. The backslash is
+     * written \x5C rather than escaped: in a single quoted PHP string a literal `\\` reaches PCRE as
+     * one backslash, which escapes the `]` and leaves a regex that fails to compile, and a regex that
+     * fails to compile rejects every value including the valid ones.
+     */
+    #[Assert\NotBlank(message: 'La page est obligatoire')]
+    #[Assert\Length(max: 255, maxMessage: "L'adresse de la page est trop longue")]
+    #[Assert\Regex(pattern: '#^/(?![/\x5C])[^\s\x5C]*\z#', message: "L'adresse de la page est invalide")]
+    public string $pageUrl;
+
+    /**
+     * Attached by the processor only when the sender is an active member of that space, so a report
+     * cannot be pinned onto somebody else's Band Space.
+     */
+    #[Assert\Uuid(message: 'Identifiant de Band Space invalide')]
+    public ?string $bandSpaceId = null;
+}

--- a/src/ApiResource/Notification/Notification.php
+++ b/src/ApiResource/Notification/Notification.php
@@ -18,4 +18,7 @@ class Notification
     public ?int $pendingGalleries = null;
 
     public ?int $pendingPublications = null;
+
+    /** Untriaged feedback. Null for anyone but an admin, like the two counts above. */
+    public ?int $newFeedbacks = null;
 }

--- a/src/Entity/Feedback/Feedback.php
+++ b/src/Entity/Feedback/Feedback.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity\Feedback;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\User;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Enum\Feedback\FeedbackType;
+use App\Repository\Feedback\FeedbackRepository;
+use DateTime;
+use DateTimeInterface;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity(repositoryClass: FeedbackRepository::class)]
+#[ORM\Table(name: 'feedback')]
+#[ORM\Index(name: 'idx_feedback_triage', columns: ['status', 'creation_datetime'])]
+class Feedback
+{
+    #[ORM\Id]
+    #[ORM\Column(type: "uuid", unique: true)]
+    #[ORM\GeneratedValue(strategy: "CUSTOM")]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    public UuidInterface|string|null $id = null {
+        get {
+            return is_string($this->id) ? $this->id : $this->id?->toString();
+        }
+    }
+
+    #[ORM\Column(type: Types::STRING, length: 20, enumType: FeedbackType::class)]
+    public FeedbackType $type;
+
+    #[ORM\Column(type: Types::STRING, length: 20, enumType: FeedbackModule::class)]
+    public FeedbackModule $module;
+
+    #[ORM\Column(type: Types::TEXT)]
+    public string $message;
+
+    /**
+     * Optional even for an anonymous sender. A report carrying a module and a page is actionable
+     * without one, and requiring it would cost us the drive by report that is the whole point.
+     */
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    public ?string $email = null;
+
+    /**
+     * Set from the security token, never from the request body. Accounts are anonymized rather than
+     * removed (see DeleteAccountProcedure), so this never dangles; SET NULL is belt and braces.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    public ?User $user = null;
+
+    /**
+     * Survives the purge of the space it came from, because the report is still worth reading once
+     * the space is gone.
+     */
+    #[ORM\ManyToOne(targetEntity: BandSpace::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    public ?BandSpace $bandSpace = null;
+
+    /**
+     * A path, never an absolute URL. An admin clicks these from the triage table, so accepting an
+     * absolute URL would turn the admin list into an open redirect with a human in the loop.
+     */
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    public string $pageUrl;
+
+    /** Read from the request, never from the body. Truncated to fit rather than rejected. */
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    public ?string $userAgent = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, enumType: FeedbackStatus::class)]
+    public FeedbackStatus $status = FeedbackStatus::New;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    public DateTimeInterface $creationDatetime;
+
+    public function __construct()
+    {
+        $this->creationDatetime = new DateTime();
+    }
+}

--- a/src/Enum/Feedback/FeedbackModule.php
+++ b/src/Enum/Feedback/FeedbackModule.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace App\Enum\Feedback;
+
+/**
+ * Where in the app a piece of feedback came from.
+ *
+ * Distinct from {@see \App\Enum\BandSpace\BandSpaceModule}, which is band scoped and whose values
+ * are a persisted contract for BandSpaceActivity rows: adding a site wide case there would widen a
+ * column that a different feature depends on. The Band Space cases here carry the same string values
+ * as their BandSpaceModule counterparts on purpose, so the two can be compared without a mapping
+ * table, but the two enums are free to diverge.
+ *
+ * The client prefills this from the current route, so a case only earns its place if a user can
+ * actually be standing on it. `Other` is the fallback for a route the map does not know, which is
+ * also what an anonymous caller posting by hand gets.
+ */
+enum FeedbackModule: string
+{
+    // Band Space, mirroring BandSpaceModule's values.
+    case Agenda = 'agenda';
+    case Notes = 'notes';
+    case File = 'file';
+    case Task = 'task';
+    case Finance = 'finance';
+    case Setlist = 'setlist';
+    case Rider = 'rider';
+    case Settings = 'settings';
+    case Dashboard = 'dashboard';
+
+    // The rest of the site.
+    case Forum = 'forum';
+    case Publication = 'publication';
+    case Gallery = 'gallery';
+    case Directory = 'directory';
+    case Course = 'course';
+    case Message = 'message';
+    case Notification = 'notification';
+    case Account = 'account';
+    case Other = 'other';
+
+    /** @return list<string> for Assert\Choice, which cannot take an enum directly here. */
+    public static function values(): array
+    {
+        return array_map(static fn (self $case): string => $case->value, self::cases());
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Agenda => 'Agenda',
+            self::Notes => 'Notes',
+            self::File => 'Fichiers',
+            self::Task => 'Tâches',
+            self::Finance => 'Finances',
+            self::Setlist => 'Setlists',
+            self::Rider => 'Tech riders',
+            self::Settings => 'Paramètres du Band Space',
+            self::Dashboard => 'Dashboard du Band Space',
+            self::Forum => 'Forum',
+            self::Publication => 'Publications',
+            self::Gallery => 'Galeries photo',
+            self::Directory => 'Annuaire et recherche',
+            self::Course => 'Cours',
+            self::Message => 'Messagerie',
+            self::Notification => 'Notifications',
+            self::Account => 'Mon compte',
+            self::Other => 'Autre',
+        };
+    }
+}

--- a/src/Enum/Feedback/FeedbackStatus.php
+++ b/src/Enum/Feedback/FeedbackStatus.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace App\Enum\Feedback;
+
+/**
+ * Where a piece of feedback sits in the triage queue.
+ *
+ * `New` is the count the admin badge shows, so it means "nobody has looked at this yet" rather than
+ * "recently created": reading a report and deciding it needs nothing still moves it to `Done`.
+ */
+enum FeedbackStatus: string
+{
+    case New = 'new';
+    case InProgress = 'in_progress';
+    case Done = 'done';
+
+    /** @return list<string> for Assert\Choice, which cannot take an enum directly here. */
+    public static function values(): array
+    {
+        return array_map(static fn (self $case): string => $case->value, self::cases());
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::New => 'Nouveau',
+            self::InProgress => 'En cours',
+            self::Done => 'Traité',
+        };
+    }
+}

--- a/src/Enum/Feedback/FeedbackType.php
+++ b/src/Enum/Feedback/FeedbackType.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace App\Enum\Feedback;
+
+/**
+ * What a piece of feedback is, which decides how it is triaged rather than where it came from.
+ *
+ * Kept deliberately short. A longer list pushes the cost of classifying onto the person reporting,
+ * who is already doing us a favour, and every extra case is one more way for the same report to
+ * land in two different buckets.
+ */
+enum FeedbackType: string
+{
+    case Bug = 'bug';
+    case Suggestion = 'suggestion';
+    case Question = 'question';
+    case Other = 'other';
+
+    /** @return list<string> for Assert\Choice, which cannot take an enum directly here. */
+    public static function values(): array
+    {
+        return array_map(static fn (self $case): string => $case->value, self::cases());
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Bug => 'Bug',
+            self::Suggestion => 'Suggestion',
+            self::Question => 'Question',
+            self::Other => 'Autre',
+        };
+    }
+}

--- a/src/Repository/Feedback/FeedbackRepository.php
+++ b/src/Repository/Feedback/FeedbackRepository.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository\Feedback;
+
+use App\Entity\Feedback\Feedback;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Enum\Feedback\FeedbackType;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<Feedback>
+ */
+class FeedbackRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Feedback::class);
+    }
+
+    /**
+     * Looked up through a QueryBuilder rather than find(), which coerces the id through the uuid
+     * field type and throws on a malformed one. The id here is a URI path segment, so nothing has
+     * validated it before it arrives, and a stray character has to be a 404 rather than a 500.
+     */
+    public function findOneById(string $id): ?Feedback
+    {
+        if (!Uuid::isValid($id)) {
+            return null;
+        }
+
+        return $this->createQueryBuilder('f')
+            ->where('f.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * The number the admin badge shows. Counts untriaged reports rather than recent ones, so reading
+     * one and deciding it needs nothing still clears it.
+     */
+    public function countNew(): int
+    {
+        return $this->count(['status' => FeedbackStatus::New]);
+    }
+
+    /**
+     * The admin triage list, newest first.
+     *
+     * Paginated in the database rather than in the browser, unlike the other admin collections: this
+     * is the one admin table nothing prunes, so it only ever grows.
+     *
+     * Joins the author and the band space eagerly because the list renders both on every row, and a
+     * lazy proxy per row would be a pair of N+1s.
+     *
+     * @return Paginator<Feedback>
+     */
+    public function findForAdmin(
+        ?FeedbackStatus $status,
+        ?FeedbackModule $module,
+        ?FeedbackType $type,
+        int $offset,
+        int $limit,
+    ): Paginator {
+        $queryBuilder = $this->createQueryBuilder('f')
+            ->leftJoin('f.user', 'u')->addSelect('u')
+            ->leftJoin('f.bandSpace', 'bs')->addSelect('bs')
+            ->orderBy('f.creationDatetime', 'DESC')
+            ->addOrderBy('f.id', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit);
+
+        if ($status instanceof FeedbackStatus) {
+            $queryBuilder->andWhere('f.status = :status')->setParameter('status', $status);
+        }
+        if ($module instanceof FeedbackModule) {
+            $queryBuilder->andWhere('f.module = :module')->setParameter('module', $module);
+        }
+        if ($type instanceof FeedbackType) {
+            $queryBuilder->andWhere('f.type = :type')->setParameter('type', $type);
+        }
+
+        return new Paginator($queryBuilder->getQuery(), fetchJoinCollection: false);
+    }
+}

--- a/src/Service/Builder/Admin/Feedback/AdminFeedbackBuilder.php
+++ b/src/Service/Builder/Admin/Feedback/AdminFeedbackBuilder.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\Builder\Admin\Feedback;
+
+use App\ApiResource\Admin\Feedback\AdminFeedback;
+use App\Entity\Feedback\Feedback;
+
+/**
+ * Shared by the triage list and the single report view, so the two can never disagree about what a
+ * report looks like.
+ */
+readonly class AdminFeedbackBuilder
+{
+    public function buildFromEntity(Feedback $feedback): AdminFeedback
+    {
+        $resource = new AdminFeedback();
+        $resource->id = (string) $feedback->id;
+        $resource->type = $feedback->type->value;
+        $resource->typeLabel = $feedback->type->label();
+        $resource->module = $feedback->module->value;
+        $resource->moduleLabel = $feedback->module->label();
+        $resource->message = $feedback->message;
+        $resource->email = $feedback->email;
+        $resource->username = $feedback->user?->username;
+        $resource->bandSpaceName = $feedback->bandSpace?->name;
+        $resource->pageUrl = $feedback->pageUrl;
+        $resource->userAgent = $feedback->userAgent;
+        $resource->status = $feedback->status->value;
+        $resource->statusLabel = $feedback->status->label();
+        $resource->creationDatetime = $feedback->creationDatetime;
+
+        return $resource;
+    }
+
+    /**
+     * @param list<Feedback> $feedbacks
+     *
+     * @return list<AdminFeedback>
+     */
+    public function buildFromEntities(array $feedbacks): array
+    {
+        return array_map($this->buildFromEntity(...), $feedbacks);
+    }
+}

--- a/src/State/Processor/Admin/Feedback/AdminFeedbackStatusUpdateProcessor.php
+++ b/src/State/Processor/Admin/Feedback/AdminFeedbackStatusUpdateProcessor.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\Admin\Feedback;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Admin\Feedback\AdminFeedbackStatusUpdate;
+use App\Entity\Feedback\Feedback;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Repository\Feedback\FeedbackRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<AdminFeedbackStatusUpdate, null>
+ */
+readonly class AdminFeedbackStatusUpdateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private FeedbackRepository $feedbackRepository,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): null
+    {
+        $feedback = $this->feedbackRepository->findOneById((string) $uriVariables['id']);
+        if (!$feedback instanceof Feedback) {
+            throw new NotFoundHttpException('Retour introuvable');
+        }
+
+        // Idempotent on purpose: setting the status it already has is a no-op rather than a 400, so a
+        // double click in the triage table cannot fail.
+        $feedback->status = FeedbackStatus::from($data->status);
+        $this->entityManager->flush();
+
+        return null;
+    }
+}

--- a/src/State/Processor/Feedback/FeedbackProcessor.php
+++ b/src/State/Processor/Feedback/FeedbackProcessor.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\Feedback;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Feedback\FeedbackResource;
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\Feedback\Feedback;
+use App\Entity\User;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackType;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Target;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * @implements ProcessorInterface<FeedbackResource, FeedbackResource>
+ */
+readonly class FeedbackProcessor implements ProcessorInterface
+{
+    private const int USER_AGENT_MAX_LENGTH = 255;
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private BandSpaceRepository $bandSpaceRepository,
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private Security $security,
+        #[Target('feedback_submit')]
+        private RateLimiterFactoryInterface $feedbackSubmitLimiter,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): FeedbackResource
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $this->feedbackSubmitLimiter->create($request?->getClientIp() ?? 'unknown')->consume()->ensureAccepted();
+
+        $user = $this->security->getUser();
+
+        $feedback = new Feedback();
+        $feedback->type = FeedbackType::from($data->type);
+        $feedback->module = FeedbackModule::from($data->module);
+        $feedback->message = $data->message;
+        $feedback->email = $data->email;
+        $feedback->pageUrl = $data->pageUrl;
+        $feedback->userAgent = $this->readUserAgent($request?->headers->get('User-Agent'));
+        $feedback->user = $user instanceof User ? $user : null;
+        $feedback->bandSpace = $this->resolveBandSpace($data->bandSpaceId, $feedback->user);
+
+        $this->entityManager->persist($feedback);
+        $this->entityManager->flush();
+
+        return $data;
+    }
+
+    /**
+     * Truncated rather than rejected: a browser we have never seen is not a reason to lose the
+     * report, and the column is only ever read by a human trying to reproduce a bug.
+     */
+    private function readUserAgent(?string $userAgent): ?string
+    {
+        if ($userAgent === null || trim($userAgent) === '') {
+            return null;
+        }
+
+        return mb_substr($userAgent, 0, self::USER_AGENT_MAX_LENGTH);
+    }
+
+    /**
+     * Dropped silently rather than refused when the sender is not an active member, so a stranger
+     * cannot pin a report onto a space they have nothing to do with. Silence rather than a 403
+     * because the id is filled in by the client from the current route: a mismatch means a stale tab
+     * or a space just left, and losing the association is a better outcome than losing the report.
+     */
+    private function resolveBandSpace(?string $bandSpaceId, ?User $user): ?BandSpace
+    {
+        if ($bandSpaceId === null || !$user instanceof User) {
+            return null;
+        }
+
+        $bandSpace = $this->bandSpaceRepository->find($bandSpaceId);
+        if (!$bandSpace instanceof BandSpace) {
+            return null;
+        }
+
+        $membership = $this->bandSpaceMembershipRepository->findMembership($bandSpace, $user);
+
+        return $membership instanceof BandSpaceMembership ? $bandSpace : null;
+    }
+}

--- a/src/State/Provider/Admin/Feedback/AdminFeedbackCollectionProvider.php
+++ b/src/State/Provider/Admin/Feedback/AdminFeedbackCollectionProvider.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\Admin\Feedback;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Pagination\TraversablePaginator;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Admin\Feedback\AdminFeedback;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Enum\Feedback\FeedbackType;
+use App\Repository\Feedback\FeedbackRepository;
+use App\Service\Builder\Admin\Feedback\AdminFeedbackBuilder;
+use ArrayIterator;
+
+/**
+ * @implements ProviderInterface<AdminFeedback>
+ */
+readonly class AdminFeedbackCollectionProvider implements ProviderInterface
+{
+    public function __construct(
+        private FeedbackRepository $feedbackRepository,
+        private AdminFeedbackBuilder $builder,
+        private Pagination $pagination,
+    ) {
+    }
+
+    /**
+     * @return TraversablePaginator<AdminFeedback>
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): TraversablePaginator
+    {
+        $page = $this->pagination->getPage($context);
+        $itemsPerPage = $this->pagination->getLimit($operation, $context);
+        $offset = $this->pagination->getOffset($operation, $context);
+
+        $filters = $context['filters'] ?? [];
+
+        $paginator = $this->feedbackRepository->findForAdmin(
+            FeedbackStatus::tryFrom(self::readFilter($filters, 'status')),
+            FeedbackModule::tryFrom(self::readFilter($filters, 'module')),
+            FeedbackType::tryFrom(self::readFilter($filters, 'type')),
+            $offset,
+            $itemsPerPage,
+        );
+
+        $resources = $this->builder->buildFromEntities(array_values(iterator_to_array($paginator)));
+
+        return new TraversablePaginator(new ArrayIterator($resources), $page, $itemsPerPage, count($paginator));
+    }
+
+    /**
+     * No defensive parsing: ParameterValidatorProvider has already turned an unknown value into a
+     * 422 before this runs, so all that is left is "was it sent at all". The string check survives
+     * `?status[]=x`, which reaches here as an array rather than a string.
+     *
+     * @param array<string, mixed> $filters
+     */
+    private static function readFilter(array $filters, string $key): string
+    {
+        $value = $filters[$key] ?? null;
+
+        return is_string($value) ? $value : '';
+    }
+}

--- a/src/State/Provider/Admin/Feedback/AdminFeedbackItemProvider.php
+++ b/src/State/Provider/Admin/Feedback/AdminFeedbackItemProvider.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\Admin\Feedback;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Admin\Feedback\AdminFeedback;
+use App\Entity\Feedback\Feedback;
+use App\Repository\Feedback\FeedbackRepository;
+use App\Service\Builder\Admin\Feedback\AdminFeedbackBuilder;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProviderInterface<AdminFeedback>
+ */
+readonly class AdminFeedbackItemProvider implements ProviderInterface
+{
+    public function __construct(
+        private FeedbackRepository $feedbackRepository,
+        private AdminFeedbackBuilder $builder,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): AdminFeedback
+    {
+        $feedback = $this->feedbackRepository->findOneById((string) $uriVariables['id']);
+        if (!$feedback instanceof Feedback) {
+            throw new NotFoundHttpException('Retour introuvable');
+        }
+
+        return $this->builder->buildFromEntity($feedback);
+    }
+}

--- a/src/State/Provider/Notification/NotificationProvider.php
+++ b/src/State/Provider/Notification/NotificationProvider.php
@@ -7,6 +7,7 @@ use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\Notification\Notification;
 use App\Entity\Gallery;
 use App\Entity\Publication;
+use App\Repository\Feedback\FeedbackRepository;
 use App\Repository\GalleryRepository;
 use App\Repository\Message\MessageThreadMetaRepository;
 use App\Repository\PublicationRepository;
@@ -22,7 +23,8 @@ readonly class NotificationProvider implements ProviderInterface
         private Security                    $security,
         private MessageThreadMetaRepository $messageThreadMetaRepository,
         private GalleryRepository           $galleryRepository,
-        private PublicationRepository       $publicationRepository
+        private PublicationRepository       $publicationRepository,
+        private FeedbackRepository          $feedbackRepository
     ) {
     }
 
@@ -38,6 +40,7 @@ readonly class NotificationProvider implements ProviderInterface
         if ($this->security->isGranted('ROLE_ADMIN')) {
             $notification->pendingGalleries = $this->galleryRepository->count(['status' => Gallery::STATUS_PENDING]);
             $notification->pendingPublications = $this->publicationRepository->count(['status' => Publication::STATUS_PENDING]);
+            $notification->newFeedbacks = $this->feedbackRepository->countNew();
 
             return $notification;
         }

--- a/tests/Api/Admin/Feedback/AdminFeedbackListTest.php
+++ b/tests/Api/Admin/Feedback/AdminFeedbackListTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Admin\Feedback;
+
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Enum\Feedback\FeedbackType;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\Feedback\FeedbackFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class AdminFeedbackListTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_not_logged(): void
+    {
+        $this->client->request('GET', '/api/admin/feedbacks');
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function test_base_user_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/admin/feedbacks');
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_admin_lists_feedback_newest_first(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $author = UserFactory::new()->asBaseUser()->create(['username' => 'reporter', 'email' => 'reporter@email.com']);
+
+        $older = FeedbackFactory::new()->create([
+            'creationDatetime' => new \DateTime('2026-09-01 09:00:00'),
+            'message' => 'Le plus ancien des deux retours.',
+        ]);
+        $newer = FeedbackFactory::new()->create([
+            'creationDatetime' => new \DateTime('2026-09-02 09:00:00'),
+            'type' => FeedbackType::Suggestion,
+            'module' => FeedbackModule::Forum,
+            'message' => 'Le plus récent des deux retours.',
+            'pageUrl' => '/forum',
+            'email' => 'reporter@email.com',
+            'user' => $author,
+        ]);
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/feedbacks');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminFeedback',
+            '@id' => '/api/admin/feedbacks',
+            '@type' => 'Collection',
+            'totalItems' => 2,
+            'member' => [
+                [
+                    '@id' => '/api/admin/feedbacks/' . $newer->id,
+                    '@type' => 'AdminFeedback',
+                    'id' => (string) $newer->id,
+                    'type' => 'suggestion',
+                    'type_label' => 'Suggestion',
+                    'module' => 'forum',
+                    'module_label' => 'Forum',
+                    'message' => 'Le plus récent des deux retours.',
+                    'email' => 'reporter@email.com',
+                    'username' => 'reporter',
+                    'page_url' => '/forum',
+                    'status' => 'new',
+                    'status_label' => 'Nouveau',
+                    'creation_datetime' => '2026-09-02T09:00:00+00:00',
+                ],
+                [
+                    '@id' => '/api/admin/feedbacks/' . $older->id,
+                    '@type' => 'AdminFeedback',
+                    'id' => (string) $older->id,
+                    'type' => 'bug',
+                    'type_label' => 'Bug',
+                    'module' => 'file',
+                    'module_label' => 'Fichiers',
+                    'message' => 'Le plus ancien des deux retours.',
+                    'page_url' => '/band/space-id/fichiers',
+                    'status' => 'new',
+                    'status_label' => 'Nouveau',
+                    'creation_datetime' => '2026-09-01T09:00:00+00:00',
+                ],
+            ],
+            'search' => [
+                '@type' => 'IriTemplate',
+                'template' => '/api/admin/feedbacks{?status,module,type}',
+                'variableRepresentation' => 'BasicRepresentation',
+                'mapping' => [
+                    ['@type' => 'IriTemplateMapping', 'variable' => 'status', 'property' => 'status', 'required' => false],
+                    ['@type' => 'IriTemplateMapping', 'variable' => 'module', 'property' => 'module', 'required' => false],
+                    ['@type' => 'IriTemplateMapping', 'variable' => 'type', 'property' => 'type', 'required' => false],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_admin_filters_by_status(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        FeedbackFactory::new()->create(['message' => 'Un retour encore à trier.']);
+        $triaged = FeedbackFactory::new()->asTriaged()->create([
+            'creationDatetime' => new \DateTime('2026-09-03 09:00:00'),
+            'message' => 'Un retour déjà traité.',
+        ]);
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/feedbacks?status=done');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminFeedback',
+            '@id' => '/api/admin/feedbacks',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/admin/feedbacks/' . $triaged->id,
+                    '@type' => 'AdminFeedback',
+                    'id' => (string) $triaged->id,
+                    'type' => 'bug',
+                    'type_label' => 'Bug',
+                    'module' => 'file',
+                    'module_label' => 'Fichiers',
+                    'message' => 'Un retour déjà traité.',
+                    'page_url' => '/band/space-id/fichiers',
+                    'status' => 'done',
+                    'status_label' => 'Traité',
+                    'creation_datetime' => '2026-09-03T09:00:00+00:00',
+                ],
+            ],
+            'view' => [
+                '@id' => '/api/admin/feedbacks?status=done',
+                '@type' => 'PartialCollectionView',
+            ],
+            'search' => [
+                '@type' => 'IriTemplate',
+                'template' => '/api/admin/feedbacks{?status,module,type}',
+                'variableRepresentation' => 'BasicRepresentation',
+                'mapping' => [
+                    ['@type' => 'IriTemplateMapping', 'variable' => 'status', 'property' => 'status', 'required' => false],
+                    ['@type' => 'IriTemplateMapping', 'variable' => 'module', 'property' => 'module', 'required' => false],
+                    ['@type' => 'IriTemplateMapping', 'variable' => 'type', 'property' => 'type', 'required' => false],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_an_unknown_status_filter_is_refused(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/feedbacks?status=bogus');
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_an_array_status_filter_is_refused_rather_than_a_500(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/feedbacks?status[]=new');
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function test_the_untriaged_count_ignores_handled_feedback(): void
+    {
+        FeedbackFactory::new()->create();
+        FeedbackFactory::new()->create();
+        FeedbackFactory::new()->asTriaged()->create();
+
+        $repository = static::getContainer()->get(\App\Repository\Feedback\FeedbackRepository::class);
+        $this->assertSame(2, $repository->countNew());
+        $this->assertSame(FeedbackStatus::New, FeedbackStatus::from('new'));
+    }
+}

--- a/tests/Api/Admin/Feedback/AdminFeedbackStatusUpdateTest.php
+++ b/tests/Api/Admin/Feedback/AdminFeedbackStatusUpdateTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Admin\Feedback;
+
+use App\Entity\Feedback\Feedback;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\Feedback\FeedbackFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class AdminFeedbackStatusUpdateTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    public function test_not_logged(): void
+    {
+        $feedback = FeedbackFactory::new()->create();
+
+        $this->client->jsonRequest('POST', '/api/admin/feedbacks/' . $feedback->id . '/status', ['status' => 'done'], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function test_base_user_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $feedback = FeedbackFactory::new()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', '/api/admin/feedbacks/' . $feedback->id . '/status', ['status' => 'done'], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_admin_moves_a_report_to_done(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $feedback = FeedbackFactory::new()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/feedbacks/' . $feedback->id . '/status', ['status' => 'done'], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertSame('', $this->client->getResponse()->getContent());
+
+        $this->assertSame(FeedbackStatus::Done, $this->reload((string) $feedback->id)->status);
+    }
+
+    public function test_setting_the_status_it_already_has_is_a_no_op(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $feedback = FeedbackFactory::new()->asTriaged()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/feedbacks/' . $feedback->id . '/status', ['status' => 'done'], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $this->assertSame(FeedbackStatus::Done, $this->reload((string) $feedback->id)->status);
+    }
+
+    public function test_an_unknown_status_is_refused(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $feedback = FeedbackFactory::new()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/feedbacks/' . $feedback->id . '/status', ['status' => 'archived'], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'status',
+                    'message' => 'Statut inconnu',
+                    'code' => '8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+                ],
+            ],
+            'detail' => 'status: Statut inconnu',
+            'type' => '/validation_errors/8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+            'title' => 'An error occurred',
+            'description' => 'status: Statut inconnu',
+        ]);
+
+        $this->assertSame(FeedbackStatus::New, $this->reload((string) $feedback->id)->status);
+    }
+
+    /**
+     * The id is a URI path segment, so nothing validates it before the processor. find() would coerce
+     * it through the uuid field type and throw, which is a 500 rather than a 404.
+     */
+    public function test_a_malformed_id_is_a_404_rather_than_a_500(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/feedbacks/not-a-uuid/status', ['status' => 'done'], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function test_an_unknown_id_is_a_404(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/feedbacks/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/status', ['status' => 'done'], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    private function reload(string $id): Feedback
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->clear();
+
+        $feedback = $entityManager->getRepository(Feedback::class)->find($id);
+        $this->assertInstanceOf(Feedback::class, $feedback);
+
+        return $feedback;
+    }
+}

--- a/tests/Api/Feedback/FeedbackPostTest.php
+++ b/tests/Api/Feedback/FeedbackPostTest.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Feedback;
+
+use App\Entity\Feedback\Feedback;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Enum\Feedback\FeedbackType;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class FeedbackPostTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    public function test_anonymous_can_send_feedback(): void
+    {
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'file',
+            'message' => "Le téléversement échoue sans message d'erreur.",
+            'page_url' => '/band/abc/fichiers',
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Feedback',
+            '@id' => '/api/feedback',
+            '@type' => 'Feedback',
+            'type' => 'bug',
+            'module' => 'file',
+            'message' => "Le téléversement échoue sans message d'erreur.",
+            'page_url' => '/band/abc/fichiers',
+        ]);
+
+        $feedback = $this->latestFeedback();
+        $this->assertSame(FeedbackType::Bug, $feedback->type);
+        $this->assertSame(FeedbackModule::File, $feedback->module);
+        $this->assertSame(FeedbackStatus::New, $feedback->status);
+        $this->assertNull($feedback->user);
+        $this->assertNull($feedback->email);
+        $this->assertNull($feedback->bandSpace);
+    }
+
+    public function test_anonymous_can_leave_an_email(): void
+    {
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'suggestion',
+            'module' => 'forum',
+            'message' => 'Il manque un filtre par tag sur le forum.',
+            'page_url' => '/forum',
+            'email' => 'visiteur@email.com',
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Feedback',
+            '@id' => '/api/feedback',
+            '@type' => 'Feedback',
+            'type' => 'suggestion',
+            'module' => 'forum',
+            'message' => 'Il manque un filtre par tag sur le forum.',
+            'page_url' => '/forum',
+            'email' => 'visiteur@email.com',
+        ]);
+
+        $this->assertSame('visiteur@email.com', $this->latestFeedback()->email);
+    }
+
+    public function test_logged_in_user_is_attached_with_their_band_space(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create(['name' => 'Les Cactus']);
+        BandSpaceMembershipFactory::new()->create(['bandSpace' => $bandSpace, 'user' => $user]);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'finance',
+            'message' => 'Le total annuel ne correspond pas à la somme des lignes.',
+            'page_url' => '/band/' . $bandSpace->id . '/finances',
+            'band_space_id' => (string) $bandSpace->id,
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Feedback',
+            '@id' => '/api/feedback',
+            '@type' => 'Feedback',
+            'type' => 'bug',
+            'module' => 'finance',
+            'message' => 'Le total annuel ne correspond pas à la somme des lignes.',
+            'page_url' => '/band/' . $bandSpace->id . '/finances',
+            'band_space_id' => (string) $bandSpace->id,
+        ]);
+
+        $feedback = $this->latestFeedback();
+        $this->assertNotNull($feedback->user);
+        $this->assertSame($user->username, $feedback->user->username);
+        $this->assertNotNull($feedback->bandSpace);
+        $this->assertSame('Les Cactus', $feedback->bandSpace->name);
+    }
+
+    public function test_band_space_is_dropped_when_the_sender_is_not_a_member(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $someoneElsesSpace = BandSpaceFactory::new()->create(['name' => 'Pas la mienne']);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'agenda',
+            'message' => 'Un message parfaitement valide envoyé par un non membre.',
+            'page_url' => '/band/' . $someoneElsesSpace->id . '/agenda',
+            'band_space_id' => (string) $someoneElsesSpace->id,
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $feedback = $this->latestFeedback();
+        $this->assertNotNull($feedback->user);
+        $this->assertNull($feedback->bandSpace, 'A non member must not be able to pin a report onto a space');
+    }
+
+    public function test_band_space_is_dropped_for_an_anonymous_sender(): void
+    {
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'agenda',
+            'message' => 'Un message parfaitement valide envoyé sans être connecté.',
+            'page_url' => '/band/' . $bandSpace->id . '/agenda',
+            'band_space_id' => (string) $bandSpace->id,
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertNull($this->latestFeedback()->bandSpace);
+    }
+
+    public function test_a_short_message_is_refused(): void
+    {
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'file',
+            'message' => 'trop bref',
+            'page_url' => '/band/abc/fichiers',
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'message',
+                    'message' => 'Votre message doit contenir au minimum 10 caractères',
+                    'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
+                ],
+            ],
+            'detail' => 'message: Votre message doit contenir au minimum 10 caractères',
+            'type' => '/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
+            'title' => 'An error occurred',
+            'description' => 'message: Votre message doit contenir au minimum 10 caractères',
+        ]);
+
+        $this->assertSame(0, $this->feedbackCount());
+    }
+
+    public function test_an_unknown_module_is_refused(): void
+    {
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'trombone',
+            'message' => 'Un message parfaitement valide sur une section inventée.',
+            'page_url' => '/band/abc/fichiers',
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'module',
+                    'message' => 'Section inconnue',
+                    'code' => '8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+                ],
+            ],
+            'detail' => 'module: Section inconnue',
+            'type' => '/validation_errors/8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+            'title' => 'An error occurred',
+            'description' => 'module: Section inconnue',
+        ]);
+
+        $this->assertSame(0, $this->feedbackCount());
+    }
+
+    public function test_an_absolute_page_url_is_refused(): void
+    {
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'file',
+            'message' => 'Un message parfaitement valide avec une URL absolue.',
+            'page_url' => 'https://evil.example.com/phishing',
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/de1e3db3-5ed4-4941-aae4-59f3667cc3a3',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'page_url',
+                    'message' => "L'adresse de la page est invalide",
+                    'code' => 'de1e3db3-5ed4-4941-aae4-59f3667cc3a3',
+                ],
+            ],
+            'detail' => "page_url: L'adresse de la page est invalide",
+            'type' => '/validation_errors/de1e3db3-5ed4-4941-aae4-59f3667cc3a3',
+            'title' => 'An error occurred',
+            'description' => "page_url: L'adresse de la page est invalide",
+        ]);
+
+        $this->assertSame(0, $this->feedbackCount());
+    }
+
+    /**
+     * A leading slash alone is not enough. These all resolve to another origin in a browser, and
+     * vue-router hands any slash-prefixed string straight to the rendered href, so a middle click or
+     * a hover in the admin triage table would leave the site. An anonymous caller can plant one.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function offSitePageUrlProvider(): iterable
+    {
+        yield 'protocol relative' => ['//evil.example.com/phishing'];
+        yield 'protocol relative, extra slash' => ['///evil.example.com'];
+        yield 'backslash after the leading slash' => ['/\\evil.example.com'];
+        yield 'backslash further in' => ['/band/\\evil.example.com'];
+    }
+
+    #[DataProvider('offSitePageUrlProvider')]
+    public function test_an_off_site_page_url_is_refused(string $pageUrl): void
+    {
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'file',
+            'message' => 'Un message parfaitement valide avec une URL hors du site.',
+            'page_url' => $pageUrl,
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/de1e3db3-5ed4-4941-aae4-59f3667cc3a3',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'page_url',
+                    'message' => "L'adresse de la page est invalide",
+                    'code' => 'de1e3db3-5ed4-4941-aae4-59f3667cc3a3',
+                ],
+            ],
+            'detail' => "page_url: L'adresse de la page est invalide",
+            'type' => '/validation_errors/de1e3db3-5ed4-4941-aae4-59f3667cc3a3',
+            'title' => 'An error occurred',
+            'description' => "page_url: L'adresse de la page est invalide",
+        ]);
+
+        $this->assertSame(0, $this->feedbackCount());
+    }
+
+    public function test_the_submission_is_rate_limited(): void
+    {
+        // Burn the whole 5/hour budget for this IP up front; the test client is always 127.0.0.1.
+        /** @var RateLimiterFactoryInterface $limiter */
+        $limiter = self::getContainer()->get('limiter.feedback_submit');
+        $limiter->create('127.0.0.1')->consume(5);
+
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'file',
+            'message' => 'Un message parfaitement valide, mais un de trop.',
+            'page_url' => '/band/abc/fichiers',
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_TOO_MANY_REQUESTS);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/429',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Rate Limit Exceeded',
+            'status' => 429,
+            'type' => '/errors/429',
+            'description' => 'Rate Limit Exceeded',
+        ]);
+
+        $this->assertSame(0, $this->feedbackCount());
+    }
+
+    public function test_a_malformed_band_space_id_is_refused(): void
+    {
+        $this->client->jsonRequest('POST', '/api/feedbacks', [
+            'type' => 'bug',
+            'module' => 'file',
+            'message' => 'Un message parfaitement valide avec un identifiant cassé.',
+            'page_url' => '/band/abc/fichiers',
+            'band_space_id' => 'not-a-uuid',
+        ], self::HEADERS);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/51120b12-a2bc-41bf-aa53-cd73daf330d0',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'band_space_id',
+                    'message' => 'Identifiant de Band Space invalide',
+                    'code' => '51120b12-a2bc-41bf-aa53-cd73daf330d0',
+                ],
+            ],
+            'detail' => 'band_space_id: Identifiant de Band Space invalide',
+            'type' => '/validation_errors/51120b12-a2bc-41bf-aa53-cd73daf330d0',
+            'title' => 'An error occurred',
+            'description' => 'band_space_id: Identifiant de Band Space invalide',
+        ]);
+
+        $this->assertSame(0, $this->feedbackCount());
+    }
+
+    private function latestFeedback(): Feedback
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->clear();
+
+        $feedback = $entityManager->getRepository(Feedback::class)->findOneBy([], ['creationDatetime' => 'DESC']);
+        $this->assertInstanceOf(Feedback::class, $feedback);
+
+        return $feedback;
+    }
+
+    private function feedbackCount(): int
+    {
+        return static::getContainer()->get(EntityManagerInterface::class)->getRepository(Feedback::class)->count([]);
+    }
+}

--- a/tests/Api/Notification/NotificationGetTest.php
+++ b/tests/Api/Notification/NotificationGetTest.php
@@ -6,6 +6,7 @@ use App\Entity\Gallery;
 use App\Entity\Publication;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
+use App\Tests\Factory\Feedback\FeedbackFactory;
 use App\Tests\Factory\Message\MessageThreadFactory;
 use App\Tests\Factory\Message\MessageThreadMetaFactory;
 use App\Tests\Factory\Publication\GalleryFactory;
@@ -67,6 +68,8 @@ class NotificationGetTest extends ApiTestCase
         GalleryFactory::new(['status' => Gallery::STATUS_PENDING])->create();
         GalleryFactory::new(['status' => Gallery::STATUS_DRAFT])->create();// not taken into count
         GalleryFactory::new(['status' => Gallery::STATUS_ONLINE])->create();// not taken into count
+        FeedbackFactory::new()->create();
+        FeedbackFactory::new()->asTriaged()->create(); // not taken into count
 
         $this->client->loginUser($user1);
         $this->client->request('GET', '/api/notifications');
@@ -78,6 +81,7 @@ class NotificationGetTest extends ApiTestCase
             'unread_messages'      => 1,
             'pending_galleries'    => 1,
             'pending_publications' => 1,
+            'new_feedbacks'        => 1,
         ]);
     }
 
@@ -98,6 +102,7 @@ class NotificationGetTest extends ApiTestCase
             'unread_messages'      => 1,
             'pending_galleries'    => 0,
             'pending_publications' => 0,
+            'new_feedbacks'        => 0,
         ]);
     }
 }

--- a/tests/Factory/Feedback/FeedbackFactory.php
+++ b/tests/Factory/Feedback/FeedbackFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Factory\Feedback;
+
+use App\Entity\Feedback\Feedback;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackStatus;
+use App\Enum\Feedback\FeedbackType;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+
+/**
+ * @extends PersistentObjectFactory<Feedback>
+ */
+final class FeedbackFactory extends PersistentObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [
+            'type' => FeedbackType::Bug,
+            'module' => FeedbackModule::File,
+            'message' => 'Le bouton de téléversement ne répond pas.',
+            'pageUrl' => '/band/space-id/fichiers',
+            'status' => FeedbackStatus::New,
+            // Pinned rather than faked: the admin list orders on it, and faker ties have flipped
+            // sort order in CI before.
+            'creationDatetime' => new \DateTime('2026-09-01 10:00:00'),
+        ];
+    }
+
+    public function asTriaged(): static
+    {
+        return $this->with(['status' => FeedbackStatus::Done]);
+    }
+
+    public static function class(): string
+    {
+        return Feedback::class;
+    }
+}

--- a/tests/Unit/Enum/Feedback/FeedbackClientMirrorTest.php
+++ b/tests/Unit/Enum/Feedback/FeedbackClientMirrorTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Enum\Feedback;
+
+use App\ApiResource\Feedback\FeedbackResource;
+use App\Enum\Feedback\FeedbackModule;
+use App\Enum\Feedback\FeedbackType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The drawer prefills the section from the current route and disables its send button below the
+ * minimum length, so the module list and the length bound exist in JavaScript as well as in PHP. If
+ * the two drift, a user gets a picker offering a value the API refuses, or a send button that
+ * enables just before a 422.
+ *
+ * Same approach as TechRiderDuplicateNameLimitsTest: the duplication is deliberate, and this is the
+ * contract between the two copies.
+ *
+ * Only the literal values live here. Whether the picker actually offers every module is asserted in
+ * assets/js/constants/feedback.test.js instead: from PHP the options are `FEEDBACK_MODULES.NAME`
+ * identifiers, and a typo in one resolves to undefined at runtime without throwing, so counting them
+ * from the source would keep passing while an option was broken.
+ */
+class FeedbackClientMirrorTest extends TestCase
+{
+    private const string MODULES_PATH = 'assets/js/utils/feedbackModule.js';
+    private const string CONSTANTS_PATH = 'assets/js/constants/feedback.js';
+
+    public function test_the_client_module_list_matches_the_enum(): void
+    {
+        preg_match_all("/^  [A-Z_]+: '([a-z_]+)'/m", $this->read(self::MODULES_PATH), $matches);
+        self::assertNotEmpty($matches[1], sprintf('No FEEDBACK_MODULES entries found in %s.', self::MODULES_PATH));
+
+        $expected = FeedbackModule::values();
+        sort($expected);
+        $actual = $matches[1];
+        sort($actual);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_the_client_type_list_matches_the_enum(): void
+    {
+        preg_match_all("/\{ value: '([a-z_]+)', label:/", $this->read(self::CONSTANTS_PATH), $matches);
+        self::assertNotEmpty($matches[1], sprintf('No FEEDBACK_TYPE_OPTIONS entries found in %s.', self::CONSTANTS_PATH));
+
+        $this->assertSame(FeedbackType::values(), $matches[1]);
+    }
+
+    public function test_the_client_minimum_message_length_matches_the_resource(): void
+    {
+        preg_match('/export const MESSAGE_MIN_LENGTH = (\d+)/', $this->read(self::CONSTANTS_PATH), $matches);
+        self::assertNotEmpty($matches, sprintf('No MESSAGE_MIN_LENGTH export found in %s.', self::CONSTANTS_PATH));
+
+        $this->assertSame(FeedbackResource::MESSAGE_MIN_LENGTH, (int) $matches[1]);
+    }
+
+    public function test_the_client_maximum_message_length_matches_the_resource(): void
+    {
+        preg_match('/export const MESSAGE_MAX_LENGTH = (\d+)/', $this->read(self::CONSTANTS_PATH), $matches);
+        self::assertNotEmpty($matches, sprintf('No MESSAGE_MAX_LENGTH export found in %s.', self::CONSTANTS_PATH));
+
+        $this->assertSame(FeedbackResource::MESSAGE_MAX_LENGTH, (int) $matches[1]);
+    }
+
+    private function read(string $relativePath): string
+    {
+        // tests/Unit/Enum/Feedback -> project root
+        $path = \dirname(__DIR__, 4) . '/' . $relativePath;
+        self::assertFileExists($path);
+
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+}


### PR DESCRIPTION
Closes #938.

A user, logged in or not, sends a short message from wherever they are. The page path and the
section are prefilled from the current route, so a report arrives already classified.

Until now the only channel was `/contact`: a full page linked from the footer, fire and forget,
with no persistence, no page context and no triage. That is why the first beta return arrived as a
batch that had to be turned into issues by hand (#731-740).

v1 puts the trigger in the Band Space sidebar only. The API, the module list and the admin screen
are app wide already, so exposing it elsewhere later is a template change.

## Backend

`Feedback` is a persisted entity rather than an email, because feedback is the input to issues here
and has to be countable, filterable by section and triageable.

- `POST /api/feedbacks` declares no `security:` expression, so the lazy api firewall lets an
  anonymous visitor through exactly as it does for `/api/contact`, while a logged in one is still
  resolved from their token. `user` and `userAgent` come from the security token and the request,
  never from the body; the DTO does not even carry those properties.
- New `feedback_submit` rate limiter, 5 per hour by IP. Higher than `contact_form` (3): filing three
  small reports while walking through a module is normal use, not abuse.
- A band space is attached only when the sender is an active member of it, and dropped silently
  otherwise, so nobody can pin a report onto a space they have nothing to do with. Silence rather
  than a 403 because the id is filled in by the client from the route: a mismatch means a stale tab,
  and losing the association beats losing the report.

## The page URL is a path, and only a path

An admin clicks these from the triage table, so the column has to be an origin the site controls.
A leading slash is not enough on its own: `//evil.com` and `/\evil.com` are protocol relative, the
browser resolves both to another origin, and vue-router passes any slash-prefixed string through to
the rendered href untouched. A plain left click stays internal, but a middle click, a ctrl click,
"open in new tab" and even a hover for the status bar all use the raw href. Since the endpoint is
anonymous, anyone could have planted one. The pattern refuses a second slash or a backslash after
the leading one, and backslashes anywhere; four vectors are covered by tests.

The backslash is written `\x5C` rather than escaped, because in a single quoted PHP string a literal
`\\` reaches PCRE as one backslash, escapes the `]` and leaves a pattern that fails to compile, and
a pattern that fails to compile rejects every value including the valid ones.

## Admin

Two conventions pull in opposite directions here, and this change follows each where it applies.

- **Server side pagination, unlike every other admin collection.** The others are
  `paginationEnabled: false` with a client side DataTable, because they list a queue moderation
  drains. This is the one admin table nothing prunes, so it only grows.
- **A `Post` for the status change, like every other admin write.** There is no `Patch` anywhere
  under `src/ApiResource/Admin/`; a status change is its own single purpose resource returning 204.

The item operation exists so the IRI the collection advertises resolves: without it API Platform
still emits an `@id` per row, built from the short name, pointing at a route that does not exist.

## Notification: a badge, not an email

`NotificationProvider` gains a `newFeedbacks` count, admin only like `pendingGalleries`, shown as an
icon with a badge next to the messages envelope and on the new Retours tile. The admin list
refreshes the count after a status change, so the badge follows the triage rather than the page load.

## Frontend

- `FeedbackDrawer.vue` is mounted once in `App.vue` and opened from a store flag, following the
  Band Space create modal.
- The trigger lives inside `BandSidebar.vue` rather than in its `#above-settings` slot, because
  `AppBandLayout` renders that sidebar twice, for the desktop aside and the mobile drawer, and only
  the mobile one fills slots. One edit covers both.
- `resolveFeedbackModule()` maps `route.name` to a section, reusing `BAND_SPACE_ROUTES` rather than
  retyping route names. Putting the map in route `meta` was considered and dropped: it scatters it
  across seven router files and cannot be pinned by one test.

The module list and the message bounds exist in JavaScript as well as in PHP, so
`FeedbackClientMirrorTest` pins the literal values, and `constants/feedback.test.js` checks every
picker option resolves to a real module. That second check has to live in JavaScript: from PHP the
options are `FEEDBACK_MODULES.NAME` identifiers, and a typo resolves to undefined at runtime without
throwing, so counting them from the source would keep passing while an option was broken.

## Out of scope, deliberately

Screenshot attachment, threaded replies, filing issues automatically, per user notification
preferences. A feedback box that turns into a ticketing system is the failure mode.

## Checks

Suite 2569 green, PHPStan level 8 clean, Biome clean, `npm run build` clean, 565 JS tests green.
The migration was applied, rolled back and reapplied on the migration database, not only the
Foundry one.

Exercised in the running app: anonymous submission stored with no user; a logged in submission
carrying the author and the space; the sixth call in an hour refused with a 429; a protocol relative
and a backslash page URL both refused with a 422 and no row written; a status change moving the
navbar and sidebar badges together. No console errors.
