### PR TITLE
Admin SPA: gate it on the admin role, and stop hiding it from super admins

### DIFF
--- a/assets/js/App.vue
+++ b/assets/js/App.vue
@@ -20,7 +20,7 @@ const router = useRouter()
 
 onMounted(async () => {
   await userSecurityStore.checkAuthInfo()
-  const { isAuthenticated, isSuperAdmin } = storeToRefs(userSecurityStore)
+  const { isAuthenticated, isAdmin, isSuperAdmin } = storeToRefs(userSecurityStore)
 
   router.beforeResolve((to) => {
     // Where an unauthenticated visitor lands, and whether the destination is told where they were
@@ -33,6 +33,13 @@ onMounted(async () => {
       return resolveUnauthenticatedRedirect(to)
     }
     if (to.meta.isGuestOnly && isAuthenticated.value) {
+      return { name: 'app_home' }
+    }
+    // The admin SPA used to be gated by isAuthRequired alone, so any logged-in account rendered the
+    // whole back office. Nothing leaked, because every admin endpoint answers 403, but the views
+    // turned that 403 into their empty state: a non admin was shown a plausible, entirely fictional
+    // admin panel (#940).
+    if (to.meta.isAdminRequired && !isAdmin.value) {
       return { name: 'app_home' }
     }
     // Hides modules that are merged but not yet announced. The API stays open, so this

--- a/assets/js/router/admin.test.js
+++ b/assets/js/router/admin.test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import adminRoute from './admin.js'
+
+/**
+ * #940 was not a missing check, it was a check that could never fire: the admin parent declared
+ * `isAdminRequired` and the guard in App.vue read `isAuthRequired` only, so every logged-in account
+ * rendered the back office.
+ *
+ * Guarding the parent is worth nothing if `meta` does not reach the children, and "the page loaded
+ * for an admin" cannot tell the two apart: an inherited flag that passes and a flag that never
+ * arrived look identical from the browser. So this resolves the real route table instead.
+ */
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', children: [adminRoute] }]
+})
+
+const adminRouteNames = adminRoute.children.map((child) => child.name)
+
+describe('the admin route tree', () => {
+  it('has children to protect', () => {
+    assert.ok(adminRouteNames.length > 0)
+  })
+
+  it('requires admin on every page, not just the index', () => {
+    for (const name of adminRouteNames) {
+      const resolved = router.resolve({ name })
+      assert.equal(
+        resolved.meta.isAdminRequired,
+        true,
+        `${name} does not inherit isAdminRequired, so the guard never fires for it`
+      )
+    }
+  })
+
+  it('still requires authentication on every page', () => {
+    for (const name of adminRouteNames) {
+      assert.equal(router.resolve({ name }).meta.isAuthRequired, true)
+    }
+  })
+
+  it('puts every admin page under /admin', () => {
+    for (const name of adminRouteNames) {
+      assert.match(router.resolve({ name }).path, /^\/admin(\/|$)/)
+    }
+  })
+})

--- a/assets/js/store/user/security.js
+++ b/assets/js/store/user/security.js
@@ -6,6 +6,7 @@ import { computed, readonly, ref } from 'vue'
 import securityApi from '../../api/user/security.js'
 import router from '../../router/index.js'
 import { isSafeReturnUrl } from '../../utils/returnUrl.js'
+import { grantsAdmin, grantsSuperAdmin } from '../../utils/roles.js'
 
 // Refresh token promise cache to prevent race conditions
 let refreshPromise = null
@@ -154,24 +155,23 @@ export const useUserSecurityStore = defineStore('userSecurity', () => {
     return userProfile.value?.profile_picture?.small || null
   })
 
-  const isAdmin = computed(() => {
-    return userProfile.value?.roles?.includes('ROLE_ADMIN') || false
-  })
-
   /**
-   * Gates features that are merged but not yet announced. Presentation only: the API
-   * stays open, so this hides a module rather than protecting it.
+   * Both admin flags read the JWT claim rather than userProfile, because a route guard needs the
+   * answer immediately: checkAuthInfo() fills `user` from the token and then calls
+   * fetchUserProfile() WITHOUT awaiting it, so userProfile is still empty on the first navigation.
+   * Reading it in a guard bounces a legitimate admin whenever they load a gated URL directly or hit
+   * reload.
    *
-   * Reads the JWT claim rather than userProfile, unlike isAdmin above, because a route
-   * guard needs the answer immediately: checkAuthInfo() fills `user` from the token and
-   * then calls fetchUserProfile() WITHOUT awaiting it, so userProfile is still empty on
-   * the first navigation. Reading it there bounced legitimate super admins to the
-   * dashboard whenever they loaded a gated URL directly or hit reload. isAdmin gets away
-   * with the late source because it only drives UI that re-renders when the profile lands.
+   * They go through grantsAdmin/grantsSuperAdmin rather than includes() because roles arrive
+   * unexpanded from both sources: a super admin is stored as ["ROLE_SUPER_ADMIN"] and carries no
+   * ROLE_ADMIN, so an includes('ROLE_ADMIN') check answered false for the most privileged account
+   * on the site and hid the whole back office from it (#940).
    */
-  const isSuperAdmin = computed(() => {
-    return user.value?.roles?.includes('ROLE_SUPER_ADMIN') || false
-  })
+  const isAdmin = computed(() => grantsAdmin(user.value?.roles))
+
+  /** Also gates modules that are merged but not yet announced, which is presentation only: the API
+   * stays open, so that hides a module rather than protecting it. */
+  const isSuperAdmin = computed(() => grantsSuperAdmin(user.value?.roles))
 
   function isTokenExpired(decodedJwt) {
     // Refresh if token expires within buffer time

--- a/assets/js/utils/roles.js
+++ b/assets/js/utils/roles.js
@@ -1,0 +1,51 @@
+export const ROLE_USER = 'ROLE_USER'
+export const ROLE_ADMIN = 'ROLE_ADMIN'
+export const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN'
+
+/**
+ * The role hierarchy from `config/packages/security.yaml`, as a map from a role to everything it
+ * also grants. Pinned against the YAML by tests/Unit/Security/RoleHierarchyClientMirrorTest.php.
+ *
+ * The client needs its own copy because neither source of roles is expanded. `User::getRoles()`
+ * returns the stored roles plus ROLE_USER and nothing else, and that is what lands both in the JWT
+ * claim and in the /api/users/self payload. So a super admin, stored as ["ROLE_SUPER_ADMIN"],
+ * arrives carrying no ROLE_ADMIN at all: an `includes('ROLE_ADMIN')` check answers false for the
+ * most privileged account on the site.
+ */
+const GRANTS = Object.freeze({
+  [ROLE_ADMIN]: [ROLE_USER],
+  [ROLE_SUPER_ADMIN]: [ROLE_ADMIN]
+})
+
+/**
+ * Every role a list of roles grants, following the hierarchy transitively, so ROLE_SUPER_ADMIN
+ * reaches ROLE_USER through ROLE_ADMIN.
+ */
+function expand(roles) {
+  const granted = new Set()
+  const pending = [...(Array.isArray(roles) ? roles : [])]
+
+  while (pending.length > 0) {
+    const role = pending.pop()
+    if (typeof role !== 'string' || granted.has(role)) {
+      continue
+    }
+    granted.add(role)
+    pending.push(...(GRANTS[role] ?? []))
+  }
+
+  return granted
+}
+
+/** Whether this role list reaches `role` through the hierarchy. */
+export function grantsRole(roles, role) {
+  return expand(roles).has(role)
+}
+
+export function grantsAdmin(roles) {
+  return grantsRole(roles, ROLE_ADMIN)
+}
+
+export function grantsSuperAdmin(roles) {
+  return grantsRole(roles, ROLE_SUPER_ADMIN)
+}

--- a/assets/js/utils/roles.test.js
+++ b/assets/js/utils/roles.test.js
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  grantsAdmin,
+  grantsRole,
+  grantsSuperAdmin,
+  ROLE_ADMIN,
+  ROLE_SUPER_ADMIN,
+  ROLE_USER
+} from './roles.js'
+
+describe('grantsAdmin', () => {
+  it('accepts an admin', () => {
+    assert.equal(grantsAdmin([ROLE_ADMIN, ROLE_USER]), true)
+  })
+
+  // The whole point of #940. Roles arrive unexpanded from both the JWT and /api/users/self, so a
+  // super admin carries no ROLE_ADMIN and a plain includes() locked the most privileged account on
+  // the site out of the back office.
+  it('accepts a super admin, who never carries ROLE_ADMIN', () => {
+    assert.equal([ROLE_SUPER_ADMIN, ROLE_USER].includes(ROLE_ADMIN), false)
+    assert.equal(grantsAdmin([ROLE_SUPER_ADMIN, ROLE_USER]), true)
+  })
+
+  it('refuses an ordinary user', () => {
+    assert.equal(grantsAdmin([ROLE_USER]), false)
+  })
+})
+
+describe('grantsSuperAdmin', () => {
+  it('accepts only a super admin', () => {
+    assert.equal(grantsSuperAdmin([ROLE_SUPER_ADMIN]), true)
+    assert.equal(grantsSuperAdmin([ROLE_ADMIN, ROLE_USER]), false)
+    assert.equal(grantsSuperAdmin([ROLE_USER]), false)
+  })
+})
+
+describe('grantsRole', () => {
+  it('walks the hierarchy transitively', () => {
+    assert.equal(grantsRole([ROLE_SUPER_ADMIN], ROLE_USER), true)
+  })
+
+  it('does not walk it upwards', () => {
+    assert.equal(grantsRole([ROLE_USER], ROLE_ADMIN), false)
+  })
+
+  // The guard runs before the store has necessarily settled, and an expired or malformed token
+  // leaves `user` null, so none of these may throw.
+  it('treats a missing or malformed role list as granting nothing', () => {
+    for (const value of [null, undefined, 'ROLE_ADMIN', {}, 42, [null], [undefined], [{}]]) {
+      assert.equal(grantsAdmin(value), false, `${JSON.stringify(value)} must not grant admin`)
+    }
+  })
+
+  it('tolerates a role that is not in the hierarchy at all', () => {
+    assert.equal(grantsAdmin(['ROLE_SOMETHING_ELSE']), false)
+    assert.equal(grantsRole(['ROLE_SOMETHING_ELSE'], 'ROLE_SOMETHING_ELSE'), true)
+  })
+})

--- a/tests/Unit/Security/RoleHierarchyClientMirrorTest.php
+++ b/tests/Unit/Security/RoleHierarchyClientMirrorTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * The router guard has to answer "is this an admin" before the profile request comes back, so it
+ * reads the JWT claim, and neither the claim nor /api/users/self is hierarchy expanded:
+ * User::getRoles() returns the stored roles plus ROLE_USER and nothing else. The client therefore
+ * carries its own copy of the hierarchy, and this is the contract between the two.
+ *
+ * The drift this catches already happened once: a super admin, stored as ["ROLE_SUPER_ADMIN"],
+ * carries no ROLE_ADMIN, so the old `includes('ROLE_ADMIN')` check hid the entire back office from
+ * the most privileged account on the site (#940).
+ *
+ * Same approach as TechRiderDuplicateNameLimitsTest and FeedbackClientMirrorTest.
+ */
+class RoleHierarchyClientMirrorTest extends TestCase
+{
+    private const string ROLES_PATH = 'assets/js/utils/roles.js';
+    private const string SECURITY_PATH = 'config/packages/security.yaml';
+
+    public function test_the_client_hierarchy_matches_security_yaml(): void
+    {
+        $this->assertSame($this->hierarchyFromSecurityYaml(), $this->hierarchyFromClient());
+    }
+
+    /**
+     * Every role named on either side of the hierarchy is exported as a constant, so the client
+     * cannot refer to one by a string literal that nothing checks.
+     */
+    public function test_every_role_in_the_hierarchy_is_exported_by_the_client(): void
+    {
+        $source = $this->read(self::ROLES_PATH);
+
+        $roles = [];
+        foreach ($this->hierarchyFromSecurityYaml() as $role => $granted) {
+            $roles[] = $role;
+            $roles = [...$roles, ...$granted];
+        }
+
+        foreach (array_unique($roles) as $role) {
+            $this->assertMatchesRegularExpression(
+                sprintf("/export const [A-Z_]+ = '%s'/", preg_quote($role, '/')),
+                $source,
+                sprintf('%s is in the hierarchy but %s exports no constant for it.', $role, self::ROLES_PATH),
+            );
+        }
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function hierarchyFromSecurityYaml(): array
+    {
+        $security = Yaml::parse($this->read(self::SECURITY_PATH));
+        $hierarchy = $security['security']['role_hierarchy'] ?? [];
+        self::assertNotEmpty($hierarchy, 'No role_hierarchy found in ' . self::SECURITY_PATH);
+
+        $normalized = [];
+        foreach ($hierarchy as $role => $granted) {
+            $normalized[$role] = is_array($granted) ? array_values($granted) : [$granted];
+        }
+        ksort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function hierarchyFromClient(): array
+    {
+        $source = $this->read(self::ROLES_PATH);
+
+        // The GRANTS map, read as `[ROLE_X]: [ROLE_Y, ...]` entries with the constant names resolved
+        // back to their values through the exports above them.
+        preg_match_all("/export const ([A-Z_]+) = '([A-Z_]+)'/", $source, $constants, PREG_SET_ORDER);
+        $byName = [];
+        foreach ($constants as $constant) {
+            $byName[$constant[1]] = $constant[2];
+        }
+        self::assertNotEmpty($byName, 'No role constants found in ' . self::ROLES_PATH);
+
+        preg_match('/const GRANTS = Object\.freeze\(\{(.+?)\}\)/s', $source, $block);
+        self::assertNotEmpty($block, 'No GRANTS map found in ' . self::ROLES_PATH);
+
+        preg_match_all('/\[([A-Z_]+)\]:\s*\[([^\]]*)\]/', $block[1], $entries, PREG_SET_ORDER);
+        self::assertNotEmpty($entries, 'No GRANTS entries found in ' . self::ROLES_PATH);
+
+        $hierarchy = [];
+        foreach ($entries as $entry) {
+            $role = $byName[$entry[1]] ?? $entry[1];
+            $granted = array_values(array_filter(array_map(
+                static fn (string $name): string => $byName[trim($name)] ?? trim($name),
+                explode(',', $entry[2]),
+            )));
+            $hierarchy[$role] = $granted;
+        }
+        ksort($hierarchy);
+
+        return $hierarchy;
+    }
+
+    private function read(string $relativePath): string
+    {
+        // tests/Unit/Security -> project root
+        $path = \dirname(__DIR__, 3) . '/' . $relativePath;
+        self::assertFileExists($path);
+
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+}


### PR DESCRIPTION
Closes #940.

Two bugs with one root cause, which had to be fixed together.

## 1. The admin SPA rendered for anyone logged in

`assets/js/router/admin.js` declared `meta: { isAuthRequired: true, isAdminRequired: true }`, but
nothing read `isAdminRequired`: the global guard in `App.vue` read `isAuthRequired`, `isGuestOnly`
and `superAdminOnly` only. So `isAuthRequired` was the whole gate, and any account passed it.

Nothing leaked, because every admin endpoint answers 403. The problem was what a non admin saw
instead: the views turn that 403 into their empty state, so `/admin/retours` said
« Aucun retour pour le moment. », which reads as "there is no feedback" rather than "you should not
be here". A plausible, entirely fictional admin panel, badge counts and all.

## 2. A super admin could not see the admin UI at all

`User::getRoles()` returns the stored roles plus `ROLE_USER` and nothing else, with no hierarchy
expansion, and that is what lands both in the JWT claim and in `/api/users/self`
(`UserSelfBuilder` calls the same method). `user_super_admin` is stored as `["ROLE_SUPER_ADMIN"]`,
so `roles.includes('ROLE_ADMIN')` was **false for the most privileged account on the site**. The
« Administration » entry was missing from its avatar menu, along with the admin controls in the
forum topic view and the gallery and publication previews.

This is why the two go together: gating `/admin` on a check that answers false for a super admin
would have taken away their only remaining way in, which was typing the URL.

## What changed

- **`assets/js/utils/roles.js`** (new): the hierarchy from `security.yaml` as data, plus
  `grantsRole` / `grantsAdmin` / `grantsSuperAdmin`. It walks the hierarchy transitively, terminates
  on a cycle, and treats a null or malformed role list as granting nothing, because the guard runs
  before the store has necessarily settled.
- **`store/user/security.js`**: `isAdmin` now reads the JWT claim through `grantsAdmin`, the way
  `isSuperAdmin` already did. `checkAuthInfo()` sets `user.roles` and `isAuthenticated` together and
  synchronously, then calls `fetchUserProfile()` **without awaiting it**, so the profile is empty on
  the first navigation and could never have driven a guard.
- **`App.vue`**: the guard reads `to.meta.isAdminRequired` and sends a non admin to `app_home`,
  matching the sibling `isGuestOnly` and `superAdminOnly` branches.

The profile-derived `isAdmin` was replaced rather than joined by a second computed. Same roles,
available earlier, and it fixes the super admin in all five consumers at once. It is not a
staleness trade-off either: `refreshUserProfile()` is only called on username and avatar changes,
never on a role change, since roles are not self-service, so the profile was never fresher than the
token for this data.

## Pins

The hierarchy now exists in two languages, so both copies are held to the config.

- `tests/Unit/Security/RoleHierarchyClientMirrorTest.php` parses `role_hierarchy` out of
  `security.yaml` and compares it to the client's map, and checks every role in it is exported as a
  constant. Verified it fails when the SUPER_ADMIN link is dropped and when ADMIN is pointed at the
  wrong role. Same approach as `FeedbackClientMirrorTest` and `TechRiderDuplicateNameLimitsTest`.
- `assets/js/utils/roles.test.js` covers the hierarchy, the super admin case that names the bug, and
  malformed input.
- `assets/js/router/admin.test.js` resolves the real route table and asserts every admin child
  inherits both flags and sits under `/admin`. Guarding the parent is worth nothing if `meta` does
  not reach the children, and "the page loaded for an admin" cannot tell an inherited flag that
  passes from a flag that never arrived, which is precisely what this issue was. It fails when the
  parent's `isAdminRequired` is dropped and when a child escapes the prefix.

## Checks

Suite 2571 green, PHPStan clean, Biome clean, `npm run build` clean, 577 JS tests green.

Exercised in the running app with three accounts:

- `user_base` at `/admin` is redirected to `/`, with no admin chrome rendered.
- `user_super_admin` reaches `/admin` and now has « Administration » in the avatar menu.
- `user_admin` stays on `/admin/retours` through a direct URL load **and** a cache-busting hard
  reload, which is the regression a profile-derived check would have caused.

No console errors.

## Note

This is presentation only. The server side gate is unchanged and remains the real boundary: every
admin operation carries `security: 'is_granted("ROLE_ADMIN")'` and the `^/api/admin` access_control
rule, and Symfony expands the hierarchy there, so a super admin was always authorized by the API.
