### PR TITLE
Replace ROLE_SUPER_ADMIN with a flat ROLE_TESTER: a feature flag, not a rank

### DIFF
--- a/assets/js/App.vue
+++ b/assets/js/App.vue
@@ -20,7 +20,7 @@ const router = useRouter()
 
 onMounted(async () => {
   await userSecurityStore.checkAuthInfo()
-  const { isAuthenticated, isAdmin, isSuperAdmin } = storeToRefs(userSecurityStore)
+  const { isAuthenticated, isAdmin, isTester } = storeToRefs(userSecurityStore)
 
   router.beforeResolve((to) => {
     // Where an unauthenticated visitor lands, and whether the destination is told where they were
@@ -44,7 +44,7 @@ onMounted(async () => {
     }
     // Hides modules that are merged but not yet announced. The API stays open, so this
     // keeps the URL from being walkable, it does not protect anything.
-    if (to.meta.superAdminOnly && !isSuperAdmin.value) {
+    if (to.meta.testerOnly && !isTester.value) {
       return to.params.id
         ? { name: 'app_band_dashboard', params: { id: to.params.id } }
         : { name: 'app_home' }

--- a/assets/js/components/BandSpace/BandSidebar.vue
+++ b/assets/js/components/BandSpace/BandSidebar.vue
@@ -111,12 +111,12 @@ function handleFeedbackClick() {
   feedbackStore.openDrawer()
 }
 
-// `superAdminOnly` marks a module that is merged but not yet announced and is dropped when it is
+// `testerOnly` marks a module that is merged but not yet announced and is dropped when it is
 // released. Membership role is deliberately not a gate: « Paramètres » is where a member quits the
 // space and sets their stage name and instruments, so every member gets the entry, and the page
 // itself hides whatever is admin only.
 const visibleItems = computed(() =>
-  NAVIGATION_ITEMS.filter((item) => !item.superAdminOnly || userSecurityStore.isSuperAdmin)
+  NAVIGATION_ITEMS.filter((item) => !item.testerOnly || userSecurityStore.isTester)
 )
 
 const workItems = computed(() =>

--- a/assets/js/constants/bandSpace.js
+++ b/assets/js/constants/bandSpace.js
@@ -18,14 +18,18 @@ export const BAND_SPACE_ROUTES = {
 export const LAST_TECH_RIDER_KEY = 'lastTechRiderId'
 
 /**
- * Tech riders are merged but not yet announced, so the module is hidden from everyone
- * except super admins.
+ * Tech riders are merged but not yet announced, so the module is hidden from everyone except
+ * accounts carrying ROLE_TESTER.
  *
  * RELEASING THE MODULE IS THIS ONE FLIP: set it to false. Both the sidebar entry and the
  * route guard read it, so nothing else needs touching. It is presentation only, the API
  * has always been open, so this is a curtain rather than a permission.
+ *
+ * A tester is an ordinary user with a flag, not a rank, so the preview can go to a band member
+ * without also handing them the back office. An admin does not see the module unless they are also
+ * a tester (#942).
  */
-export const RIDER_SUPER_ADMIN_ONLY = true
+export const RIDER_TESTER_ONLY = true
 
 /**
  * The modules a Band Space is described by, shared between the public presentation page and the
@@ -33,7 +37,7 @@ export const RIDER_SUPER_ADMIN_ONLY = true
  *
  * Distinct from NAVIGATION_ITEMS, which is the in-app sidebar: this list sells the module, that one
  * routes to it. Dashboard is absent because nobody joins for a dashboard, and tech riders are absent
- * because RIDER_SUPER_ADMIN_ONLY still hides the module from members. Never advertise what a visitor
+ * because RIDER_TESTER_ONLY still hides the module from members. Never advertise what a visitor
  * would not find after signing up.
  *
  * Each description says what stops being scattered, which is the whole argument for the module.
@@ -140,7 +144,7 @@ export const NAVIGATION_ITEMS = Object.freeze([
     label: 'Tech riders',
     route: BAND_SPACE_ROUTES.RIDER,
     icon: 'pi-sliders-h',
-    superAdminOnly: RIDER_SUPER_ADMIN_ONLY
+    testerOnly: RIDER_TESTER_ONLY
   },
   { label: 'Tâches', route: BAND_SPACE_ROUTES.TASKS, icon: 'pi-check-square' },
   { label: 'Finances', route: BAND_SPACE_ROUTES.FINANCE, icon: 'pi-wallet' },

--- a/assets/js/constants/bandSpace.test.js
+++ b/assets/js/constants/bandSpace.test.js
@@ -5,6 +5,7 @@ import {
   BAND_SPACE_SETTINGS_SECTIONS,
   filterSectionsByRole,
   NAVIGATION_ITEMS,
+  RIDER_TESTER_ONLY,
   resolveSettingsSection,
   visibleSettingsSections
 } from './bandSpace.js'
@@ -24,7 +25,29 @@ describe('the Paramètres sidebar entry', () => {
     const parameters = NAVIGATION_ITEMS.find((item) => item.route === BAND_SPACE_ROUTES.PARAMETERS)
 
     assert.ok(parameters)
-    assert.equal(parameters.superAdminOnly, undefined)
+    assert.equal(parameters.testerOnly, undefined)
+  })
+})
+
+describe('the Tech Riders curtain', () => {
+  // The constant's comment promises releasing the module is one flip, because the sidebar entry and
+  // the route guard both read it. That only holds while the entry actually reads it: gating the
+  // route alone would leave a dead sidebar link, and gating the entry alone would leave the URL
+  // walkable, which is what the curtain exists to prevent.
+  it('gates the sidebar entry on the shared flag, so one flip releases the module', () => {
+    const rider = NAVIGATION_ITEMS.find((item) => item.route === BAND_SPACE_ROUTES.RIDER)
+
+    assert.ok(rider)
+    assert.equal(rider.testerOnly, RIDER_TESTER_ONLY)
+  })
+
+  it('gates nothing else, so the flip cannot take another module with it', () => {
+    const gated = NAVIGATION_ITEMS.filter((item) => item.testerOnly !== undefined)
+
+    assert.deepEqual(
+      gated.map((item) => item.route),
+      [BAND_SPACE_ROUTES.RIDER]
+    )
   })
 })
 

--- a/assets/js/router/index.js
+++ b/assets/js/router/index.js
@@ -1,5 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import { RIDER_SUPER_ADMIN_ONLY } from '../constants/bandSpace.js'
+import { RIDER_TESTER_ONLY } from '../constants/bandSpace.js'
 import admin from './admin.js'
 import course from './course.js'
 import forum from './forum.js'
@@ -102,7 +102,7 @@ const routes = [
         path: ':id/tech-riders',
         name: 'app_band_rider',
         component: () => import('../views/BandSpace/TechRider.vue'),
-        meta: { superAdminOnly: RIDER_SUPER_ADMIN_ONLY }
+        meta: { testerOnly: RIDER_TESTER_ONLY }
       },
       {
         path: ':id/parametres',

--- a/assets/js/store/user/security.js
+++ b/assets/js/store/user/security.js
@@ -6,7 +6,7 @@ import { computed, readonly, ref } from 'vue'
 import securityApi from '../../api/user/security.js'
 import router from '../../router/index.js'
 import { isSafeReturnUrl } from '../../utils/returnUrl.js'
-import { grantsAdmin, grantsSuperAdmin } from '../../utils/roles.js'
+import { grantsAdmin, grantsTester } from '../../utils/roles.js'
 
 // Refresh token promise cache to prevent race conditions
 let refreshPromise = null
@@ -156,22 +156,25 @@ export const useUserSecurityStore = defineStore('userSecurity', () => {
   })
 
   /**
-   * Both admin flags read the JWT claim rather than userProfile, because a route guard needs the
-   * answer immediately: checkAuthInfo() fills `user` from the token and then calls
-   * fetchUserProfile() WITHOUT awaiting it, so userProfile is still empty on the first navigation.
-   * Reading it in a guard bounces a legitimate admin whenever they load a gated URL directly or hit
-   * reload.
+   * Both flags read the JWT claim rather than userProfile, because a route guard needs the answer
+   * immediately: checkAuthInfo() fills `user` from the token and then calls fetchUserProfile()
+   * WITHOUT awaiting it, so userProfile is still empty on the first navigation. Reading it in a
+   * guard bounces a legitimate admin whenever they load a gated URL directly or hit reload.
    *
-   * They go through grantsAdmin/grantsSuperAdmin rather than includes() because roles arrive
-   * unexpanded from both sources: a super admin is stored as ["ROLE_SUPER_ADMIN"] and carries no
-   * ROLE_ADMIN, so an includes('ROLE_ADMIN') check answered false for the most privileged account
-   * on the site and hid the whole back office from it (#940).
+   * isAdmin goes through grantsAdmin rather than includes() because roles arrive unexpanded from
+   * both sources, so anything the server hierarchy would have added has to be added client side
+   * (#940).
    */
   const isAdmin = computed(() => grantsAdmin(user.value?.roles))
 
-  /** Also gates modules that are merged but not yet announced, which is presentation only: the API
-   * stays open, so that hides a module rather than protecting it. */
-  const isSuperAdmin = computed(() => grantsSuperAdmin(user.value?.roles))
+  /**
+   * Sees modules that are merged but not yet announced. Presentation only: the APIs behind them
+   * stay open, so this draws a curtain rather than protecting anything.
+   *
+   * Independent of isAdmin, deliberately. A tester is an ordinary account with a flag, so a preview
+   * can go to a band member without also giving them the back office (#942).
+   */
+  const isTester = computed(() => grantsTester(user.value?.roles))
 
   function isTokenExpired(decodedJwt) {
     // Refresh if token expires within buffer time
@@ -272,7 +275,7 @@ export const useUserSecurityStore = defineStore('userSecurity', () => {
     userProfile: readonly(userProfile),
     profilePictureUrl,
     isAdmin,
-    isSuperAdmin,
+    isTester,
     isAuthenticated: readonly(isAuthenticated),
     isAuthenticatedLoading: readonly(isAuthenticatedLoading),
     loginErrors: readonly(loginErrors),

--- a/assets/js/utils/roles.js
+++ b/assets/js/utils/roles.js
@@ -1,6 +1,6 @@
 export const ROLE_USER = 'ROLE_USER'
 export const ROLE_ADMIN = 'ROLE_ADMIN'
-export const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN'
+export const ROLE_TESTER = 'ROLE_TESTER'
 
 /**
  * The role hierarchy from `config/packages/security.yaml`, as a map from a role to everything it
@@ -8,18 +8,20 @@ export const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN'
  *
  * The client needs its own copy because neither source of roles is expanded. `User::getRoles()`
  * returns the stored roles plus ROLE_USER and nothing else, and that is what lands both in the JWT
- * claim and in the /api/users/self payload. So a super admin, stored as ["ROLE_SUPER_ADMIN"],
- * arrives carrying no ROLE_ADMIN at all: an `includes('ROLE_ADMIN')` check answers false for the
- * most privileged account on the site.
+ * claim and in the /api/users/self payload, so anything the hierarchy would have added has to be
+ * added here instead.
+ *
+ * ROLE_TESTER is absent on purpose, and that absence is the point: it is a feature flag rather than
+ * a rank, so it grants nothing and nothing grants it. Its predecessor ROLE_SUPER_ADMIN sat above
+ * ROLE_ADMIN, which meant handing someone a preview also handed them the back office (#942).
  */
 const GRANTS = Object.freeze({
-  [ROLE_ADMIN]: [ROLE_USER],
-  [ROLE_SUPER_ADMIN]: [ROLE_ADMIN]
+  [ROLE_ADMIN]: [ROLE_USER]
 })
 
 /**
- * Every role a list of roles grants, following the hierarchy transitively, so ROLE_SUPER_ADMIN
- * reaches ROLE_USER through ROLE_ADMIN.
+ * Every role a list of roles grants, following the hierarchy transitively, so a role two levels up
+ * still reaches the bottom. A role absent from the map, like ROLE_TESTER, grants exactly itself.
  */
 function expand(roles) {
   const granted = new Set()
@@ -46,6 +48,10 @@ export function grantsAdmin(roles) {
   return grantsRole(roles, ROLE_ADMIN)
 }
 
-export function grantsSuperAdmin(roles) {
-  return grantsRole(roles, ROLE_SUPER_ADMIN)
+/**
+ * Whether this account sees modules that are merged but not yet announced. Presentation only: the
+ * APIs behind those modules stay open, so this draws a curtain rather than enforcing anything.
+ */
+export function grantsTester(roles) {
+  return grantsRole(roles, ROLE_TESTER)
 }

--- a/assets/js/utils/roles.test.js
+++ b/assets/js/utils/roles.test.js
@@ -3,9 +3,9 @@ import { describe, it } from 'node:test'
 import {
   grantsAdmin,
   grantsRole,
-  grantsSuperAdmin,
+  grantsTester,
   ROLE_ADMIN,
-  ROLE_SUPER_ADMIN,
+  ROLE_TESTER,
   ROLE_USER
 } from './roles.js'
 
@@ -14,30 +14,36 @@ describe('grantsAdmin', () => {
     assert.equal(grantsAdmin([ROLE_ADMIN, ROLE_USER]), true)
   })
 
-  // The whole point of #940. Roles arrive unexpanded from both the JWT and /api/users/self, so a
-  // super admin carries no ROLE_ADMIN and a plain includes() locked the most privileged account on
-  // the site out of the back office.
-  it('accepts a super admin, who never carries ROLE_ADMIN', () => {
-    assert.equal([ROLE_SUPER_ADMIN, ROLE_USER].includes(ROLE_ADMIN), false)
-    assert.equal(grantsAdmin([ROLE_SUPER_ADMIN, ROLE_USER]), true)
-  })
-
   it('refuses an ordinary user', () => {
     assert.equal(grantsAdmin([ROLE_USER]), false)
   })
+
+  // #942: the flag must not be a rank. A tester is an ordinary account, so handing someone a
+  // preview must not hand them the back office, which is exactly what its predecessor did.
+  it('refuses a tester, who is an ordinary user with a flag', () => {
+    assert.equal(grantsAdmin([ROLE_TESTER, ROLE_USER]), false)
+  })
 })
 
-describe('grantsSuperAdmin', () => {
-  it('accepts only a super admin', () => {
-    assert.equal(grantsSuperAdmin([ROLE_SUPER_ADMIN]), true)
-    assert.equal(grantsSuperAdmin([ROLE_ADMIN, ROLE_USER]), false)
-    assert.equal(grantsSuperAdmin([ROLE_USER]), false)
+describe('grantsTester', () => {
+  it('accepts a tester', () => {
+    assert.equal(grantsTester([ROLE_TESTER, ROLE_USER]), true)
+  })
+
+  it('refuses an ordinary user', () => {
+    assert.equal(grantsTester([ROLE_USER]), false)
+  })
+
+  // The other half of keeping the flag orthogonal: being an admin does not enrol you in previews.
+  // ROLE_SUPER_ADMIN used to grant both directions at once, which is why neither now does.
+  it('refuses an admin who is not also a tester', () => {
+    assert.equal(grantsTester([ROLE_ADMIN, ROLE_USER]), false)
   })
 })
 
 describe('grantsRole', () => {
-  it('walks the hierarchy transitively', () => {
-    assert.equal(grantsRole([ROLE_SUPER_ADMIN], ROLE_USER), true)
+  it('walks the hierarchy downwards', () => {
+    assert.equal(grantsRole([ROLE_ADMIN], ROLE_USER), true)
   })
 
   it('does not walk it upwards', () => {

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -10,9 +10,12 @@ security:
             entity:
                 class: App\Entity\User
 
+    # ROLE_TESTER is deliberately absent: it is a feature flag, not a rank. It reveals modules that
+    # are merged but not yet announced, grants no permission of its own, and is held by ordinary
+    # users, so putting it here would make every tester an admin (which is what ROLE_SUPER_ADMIN
+    # used to do, see #942).
     role_hierarchy:
-        ROLE_ADMIN:       ROLE_USER
-        ROLE_SUPER_ADMIN: ROLE_ADMIN
+        ROLE_ADMIN: ROLE_USER
 
     firewalls:
         dev:

--- a/src/Fixtures/BandSpace/BandSpaceStory.php
+++ b/src/Fixtures/BandSpace/BandSpaceStory.php
@@ -21,6 +21,7 @@ class BandSpaceStory extends Story
     {
         $adminUser = UserStory::get(UserStory::ADMIN_USER);
         $baseUser = UserStory::get(UserStory::BASE_USER);
+        $testerUser = UserStory::get(UserStory::TESTER_USER);
 
         // Admin's band space (admin is creator)
         $adminBand = BandSpaceFactory::new()
@@ -67,6 +68,17 @@ class BandSpaceStory extends Story
             ->with([
                 'bandSpace' => $collaborativeBand,
                 'user' => $baseUser,
+                'role' => Role::User
+            ])
+            ->create();
+
+        // The tester is a plain member, not an admin: ROLE_TESTER reveals modules that are merged
+        // but not yet announced, and those live inside a band space, so an account holding the flag
+        // with nowhere to use it cannot actually reach them (#942).
+        BandSpaceMembershipFactory::new()
+            ->with([
+                'bandSpace' => $collaborativeBand,
+                'user' => $testerUser,
                 'role' => Role::User
             ])
             ->create();

--- a/src/Fixtures/Factory/User/UserFactory.php
+++ b/src/Fixtures/Factory/User/UserFactory.php
@@ -63,18 +63,21 @@ final class UserFactory extends PersistentObjectFactory
     }
 
     /**
-     * ROLE_SUPER_ADMIN was only a line in the role hierarchy until now, granted to nobody.
-     * It gates features that are merged but not yet announced, so there has to be an
-     * account that can actually reach them in dev.
+     * ROLE_TESTER reveals features that are merged but not yet announced, so dev needs an account
+     * that can actually reach them.
+     *
+     * Deliberately an ordinary user carrying nothing else. That is the whole point of the role
+     * (#942): it is a feature flag rather than a rank, so the fixtures have to prove a non admin
+     * reaches the module, and that user_admin does not reach it by virtue of being an admin.
      */
-    public function asSuperAdminUser(): static
+    public function asTesterUser(): static
     {
         return $this->with([
             'creationDatetime' => \DateTime::createFromFormat(\DateTimeInterface::ATOM, '1990-01-02T02:03:04+00:00'),
-            'email' => 'user_super_admin@email.com',
+            'email' => 'user_tester@email.com',
             'password' => self::DEFAULT_PASSWORD,
-            'roles' => ['ROLE_SUPER_ADMIN'],
-            'username' => 'user_super_admin',
+            'roles' => ['ROLE_TESTER'],
+            'username' => 'user_tester',
         ]);
     }
 

--- a/src/Fixtures/User/UserStory.php
+++ b/src/Fixtures/User/UserStory.php
@@ -12,14 +12,14 @@ class UserStory extends Story
 {
     const string ADMIN_USER = 'admin_user';
     const string BASE_USER = 'base_user';
-    const string SUPER_ADMIN_USER = 'super_admin_user';
+    const string TESTER_USER = 'tester_user';
     const string POOL_USERS = 'pool_user';
 
     public function build(): void
     {
         $this->addState(self::ADMIN_USER, UserFactory::new()->asAdminUser());
         $this->addState(self::BASE_USER, UserFactory::new()->asBaseUser());
-        $this->addState(self::SUPER_ADMIN_USER, UserFactory::new()->asSuperAdminUser());
+        $this->addState(self::TESTER_USER, UserFactory::new()->asTesterUser());
         $this->addToPool(self::POOL_USERS, UserFactory::new()->many(20));
     }
 }

--- a/tests/Unit/Security/RoleHierarchyClientMirrorTest.php
+++ b/tests/Unit/Security/RoleHierarchyClientMirrorTest.php
@@ -12,8 +12,9 @@ use Symfony\Component\Yaml\Yaml;
  * carries its own copy of the hierarchy, and this is the contract between the two.
  *
  * The drift this catches already happened once: a super admin, stored as ["ROLE_SUPER_ADMIN"],
- * carries no ROLE_ADMIN, so the old `includes('ROLE_ADMIN')` check hid the entire back office from
- * the most privileged account on the site (#940).
+ * carried no ROLE_ADMIN, so the old `includes('ROLE_ADMIN')` check hid the entire back office from
+ * the most privileged account on the site (#940). That role is gone (#942), and the tests below
+ * keep its replacement from repeating the mistake.
  *
  * Same approach as TechRiderDuplicateNameLimitsTest and FeedbackClientMirrorTest.
  */
@@ -21,6 +22,8 @@ class RoleHierarchyClientMirrorTest extends TestCase
 {
     private const string ROLES_PATH = 'assets/js/utils/roles.js';
     private const string SECURITY_PATH = 'config/packages/security.yaml';
+    private const string FIXTURE_PATH = 'src/Fixtures/Factory/User/UserFactory.php';
+    private const string TESTER_ROLE = 'ROLE_TESTER';
 
     public function test_the_client_hierarchy_matches_security_yaml(): void
     {
@@ -102,6 +105,39 @@ class RoleHierarchyClientMirrorTest extends TestCase
         ksort($hierarchy);
 
         return $hierarchy;
+    }
+
+    /**
+     * The invariant #942 exists for. ROLE_TESTER is a feature flag: it reveals modules that are
+     * merged but not yet announced, and grants no permission of its own. Putting it in the
+     * hierarchy, in either direction, breaks that: above ROLE_ADMIN it turns every tester into an
+     * admin, which is what ROLE_SUPER_ADMIN did, and below it enrols every admin into previews they
+     * did not ask for.
+     */
+    public function test_the_tester_role_is_not_a_rank(): void
+    {
+        foreach ($this->hierarchyFromSecurityYaml() as $role => $granted) {
+            $this->assertNotSame(self::TESTER_ROLE, $role, 'ROLE_TESTER must grant nothing.');
+            $this->assertNotContains(self::TESTER_ROLE, $granted, sprintf('%s must not grant ROLE_TESTER.', $role));
+        }
+    }
+
+    /**
+     * ROLE_TESTER is outside the hierarchy, so the mirror above cannot vouch for it. The string
+     * still has to match on both sides, or the flag silently stops working.
+     */
+    public function test_the_client_tester_role_matches_the_one_the_fixtures_grant(): void
+    {
+        $this->assertMatchesRegularExpression(
+            sprintf("/export const ROLE_TESTER = '%s'/", self::TESTER_ROLE),
+            $this->read(self::ROLES_PATH),
+            sprintf('%s must export ROLE_TESTER as %s, or the curtain never lifts for a tester.', self::ROLES_PATH, self::TESTER_ROLE),
+        );
+        $this->assertStringContainsString(
+            sprintf("'roles' => ['%s']", self::TESTER_ROLE),
+            $this->read(self::FIXTURE_PATH),
+            sprintf('%s must grant exactly %s, or dev has no account that can reach an unannounced module.', self::FIXTURE_PATH, self::TESTER_ROLE),
+        );
     }
 
     private function read(string $relativePath): string


### PR DESCRIPTION
Closes #942.

`ROLE_SUPER_ADMIN` was never a privilege tier. It gated nothing on the backend, not one
`is_granted("ROLE_SUPER_ADMIN")` in `src/`, and its only job was hiding the Tech Riders module while
it is merged but not yet announced. `src/Fixtures/Factory/User/UserFactory.php` said as much in its
own comment: granted to nobody, gating features that are not yet announced.

Because it sat above `ROLE_ADMIN` in `role_hierarchy`, **making someone a tester made them a full
admin**. The rider preview could not be handed to a band member without also handing them the back
office and moderation powers. It is now a flat `ROLE_TESTER` carried by ordinary users.

No production account held `ROLE_SUPER_ADMIN`, so there is no data migration.

## The invariant this rests on

`ROLE_TESTER` is deliberately **absent from `role_hierarchy`, in both directions**. Above
`ROLE_ADMIN` it recreates the bug being deleted; below it, every admin is enrolled into previews
they did not ask for. `RoleHierarchyClientMirrorTest::test_the_tester_role_is_not_a_rank` fails on
either, and I checked it by putting `ROLE_TESTER: ROLE_ADMIN` back and watching it break.

It also removes a whole class of bug for this role: the second half of #940 happened because
`ROLE_SUPER_ADMIN` sat in a hierarchy the client did not expand. A flat role has nothing to expand.

## Behaviour change worth knowing before merging

**An admin no longer inherits the preview.** That is the point of the change, but it means an admin
account needs `ROLE_TESTER` added to keep seeing the Tech Riders module. Until #943 lands that is a
manual database update.

## Fixtures

`user_super_admin` becomes `user_tester`: a plain user carrying only `ROLE_TESTER`, which is what
makes the fixture prove something rather than just rename a string. It is also now a member of the
Collaborators band space, because the modules the flag reveals live *inside* a band space, so an
account holding the flag with nowhere to use it cannot reach them.

## Checks

Suite 2573 green, PHPStan clean, Biome clean, `npm run build` clean, 581 JS tests green.

In the running app, both directions of the orthogonality:

- `user_tester`, an ordinary user carrying only `ROLE_TESTER`, sees the Tech riders sidebar entry and
  opens `/band/{id}/tech-riders`.
- `user_admin` sees neither the entry nor the page, and is bounced back to the dashboard.

Beyond the PHP invariant, `roles.test.js` pins both halves directly:
`grantsAdmin([ROLE_TESTER, ROLE_USER])` is false and `grantsTester([ROLE_ADMIN, ROLE_USER])` is
false. `bandSpace.test.js` pins that the curtain gates the rider sidebar entry through the shared
constant and gates nothing else, so releasing the module stays the one flip its comment promises.

## Unrelated, found while verifying

The dashboard « Agenda à venir » widget has been failing since #935 merged. Filed as #944, not
touched here.
