### PR TITLE
Dashboard: the « Agenda à venir » widget asks for calendar days, not a wall clock

### DIFF
--- a/assets/js/components/BandSpace/Dashboard/AgendaWidget.vue
+++ b/assets/js/components/BandSpace/Dashboard/AgendaWidget.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-import { addDays, format, isToday, isTomorrow, parseISO, startOfDay } from 'date-fns'
+import { format, isToday, isTomorrow, parseISO } from 'date-fns'
 import { fr } from 'date-fns/locale'
 import { onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
@@ -38,6 +38,7 @@ import bandSpaceAgendaApi from '../../../api/bandSpace/band-space-agenda.js'
 import { agendaSourceFor } from '../../../constants/agendaSources.js'
 import { toAgendaDate } from '../../../utils/agendaDate.js'
 import { isAllDayItem } from '../../../utils/agendaItem.js'
+import { upcomingAgendaWindow } from '../../../utils/agendaRange.js'
 import DashboardWidget from './DashboardWidget.vue'
 
 const WINDOW_DAYS = 7
@@ -53,9 +54,7 @@ const error = ref(null)
 
 onMounted(async () => {
   try {
-    const today = startOfDay(new Date())
-    const from = format(today, "yyyy-MM-dd'T'00:00:00")
-    const to = format(addDays(today, WINDOW_DAYS), "yyyy-MM-dd'T'23:59:59")
+    const { from, to } = upcomingAgendaWindow(new Date(), WINDOW_DAYS)
     const data = await bandSpaceAgendaApi.getAgenda(props.bandSpaceId, { from, to })
     items.value = [...data].sort((a, b) => a.datetime.localeCompare(b.datetime)).slice(0, MAX_ITEMS)
   } catch {

--- a/assets/js/utils/agendaRange.js
+++ b/assets/js/utils/agendaRange.js
@@ -1,13 +1,17 @@
-import { endOfMonth, format, startOfMonth } from 'date-fns'
+import { addDays, endOfMonth, format, startOfMonth } from 'date-fns'
 import { toAgendaDate } from './agendaDate.js'
 
 /**
- * Which period the band space agenda has to show once an entry has been saved.
+ * Which period of the band space agenda is on screen, and which one has to be.
  *
  * This lives outside Agenda.vue because it is the rule that decides whether a save is visible:
  * get it wrong and the agenda refreshes into a period that does not contain the entry, which
  * reads as a failed save and gets the user to save again. It is pure date arithmetic, so it is
  * unit tested without a browser (npm test).
+ *
+ * It is also where a period gets turned into the pair of bounds the API takes, so that rule has one
+ * home rather than a copy in every caller. That is what #944 was: the dashboard widget kept its own
+ * copy, #935 changed the rule, and only the copy in Agenda.vue was updated.
  */
 
 /** Local calendar day: the period is day granular, its bounds are 00:00:00 and 23:59:59. */
@@ -63,4 +67,16 @@ export function agendaViewForSavedEntry(entry, from, to) {
   if (isEntryVisibleInRange(entry, from, to)) return null
 
   return { from: startOfMonth(span.start), to: endOfMonth(span.start), focusDate: span.start }
+}
+
+/**
+ * The bounds the dashboard's « Agenda à venir » widget asks for: today, and the next `days` days.
+ *
+ * Bare calendar days, never a wall clock. The API's `from` and `to` are `Assert\Date`, an anchored
+ * `^\d{4}-\d{2}-\d{2}$`, so a `2026-09-06T00:00:00` is a 422 rather than a narrower window. It
+ * also widens `to` to the end of its day itself, so appending `T23:59:59` here would put that rule
+ * in two places for no gain (#935).
+ */
+export function upcomingAgendaWindow(today, days) {
+  return { from: dayKey(today), to: dayKey(addDays(today, days)) }
 }

--- a/assets/js/utils/agendaRange.test.js
+++ b/assets/js/utils/agendaRange.test.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
-import { agendaViewForSavedEntry, isEntryVisibleInRange } from './agendaRange.js'
+import { after, before, describe, it } from 'node:test'
+import {
+  agendaViewForSavedEntry,
+  isEntryVisibleInRange,
+  upcomingAgendaWindow
+} from './agendaRange.js'
 
 /**
  * The rule that keeps a just saved event on screen. Datetimes are written without a UTC offset on
@@ -167,5 +171,55 @@ describe('all day entries, which the API pins to UTC midnight', () => {
       agendaViewForSavedEntry(ALL_DAY_FIRST_OF_SEPTEMBER, SEPTEMBER_FROM, SEPTEMBER_TO),
       null
     )
+  })
+})
+
+describe('upcomingAgendaWindow', () => {
+  // CI runs at TZ=UTC, so the local-versus-UTC assertion below is structurally blind there: a
+  // regression to `toISOString().slice(0, 10)` passes under UTC and only fails on a developer's
+  // machine. Pinning an offset timezone for this block is what makes the guarantee real where the
+  // suite actually runs. V8 re-reads process.env.TZ per call, so setting it here is enough.
+  const originalTz = process.env.TZ
+  before(() => {
+    process.env.TZ = 'Europe/Paris'
+  })
+  after(() => {
+    if (originalTz === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = originalTz
+    }
+  })
+
+  // #944. The API's from/to are Assert\Date, an anchored ^\d{4}-\d{2}-\d{2}$, so a wall clock is
+  // a 422 and the widget showed « Impossible de charger l'agenda. » on every dashboard. The shape
+  // is the whole bug, so it is what gets asserted.
+  it('asks for bare calendar days, never a wall clock', () => {
+    const { from, to } = upcomingAgendaWindow(new Date(2026, 8, 6), 7)
+
+    assert.equal(from, '2026-09-06')
+    assert.equal(to, '2026-09-13')
+    assert.match(from, /^\d{4}-\d{2}-\d{2}$/)
+    assert.match(to, /^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('spans the window inclusively, because the API widens `to` to the end of its day', () => {
+    const { from, to } = upcomingAgendaWindow(new Date(2026, 8, 6), 0)
+
+    assert.equal(from, '2026-09-06')
+    assert.equal(to, '2026-09-06')
+  })
+
+  it('crosses a month boundary', () => {
+    assert.deepEqual(upcomingAgendaWindow(new Date(2026, 8, 28), 7), {
+      from: '2026-09-28',
+      to: '2026-10-05'
+    })
+  })
+
+  // Formatted from local getters, so a band in Paris asking on the 6th gets the 6th rather than
+  // the 5th, which is what a UTC-based format would hand them before 02:00.
+  it('reads the local calendar day rather than the UTC one', () => {
+    assert.equal(upcomingAgendaWindow(new Date(2026, 8, 6, 0, 30), 1).from, '2026-09-06')
   })
 })


### PR DESCRIPTION
Closes #944.

The « Agenda à venir » widget on every Band Space dashboard has shown
« Impossible de charger l'agenda. » since #935 merged. Its request 422s every time.

The widget built its range as an offset-less wall clock, `2026-09-06T00:00:00`, while
`AgendaItem.php` validates `from` and `to` with `Assert\Date`, an anchored `^\d{4}-\d{2}-\d{2}$`.

#935 converged the full Agenda view onto bare calendar days on 2026-09-05 and left a comment there
about not duplicating the rule "in a second place". The dashboard widget was that second place: its
last commit is `a3a86cf5`, from before the convergence.

## The fix

Rather than correcting the two lines in place, the window moved into `agendaRange.js` as
`upcomingAgendaWindow(today, days)`, reusing the private `dayKey()` that already owned the
calendar-day format rule in that file. A third copy of the rule is what produced this bug, so the
rule now has one home. `dayKey` stays private; only intention-named functions are exported.

The API widens `to` to the end of its day itself, so the window is unchanged.

## Verified

585 JS tests green, Biome clean, `npm run build` clean. No PHP touched; suite 2573 and PHPStan run
green anyway.

Restoring the wall clock fails the new tests, so they pin the bug rather than describe it.

Behaviourally in the running app, with three entries created to probe the window's edges:

- today at 18:00, shown
- **22:30 on the last day of the window, shown.** This is the one worth having: it proves the server
  really does widen `to` to the end of its day, so the final evening is not silently dropped, which
  is the exact failure mode #935 called out.
- day 8, correctly absent from the widget while still visible in the activity feed

Test data removed afterwards.

## A test that could not fail, found in review

The « reads the local calendar day » assertion was structurally blind where it matters. CI runs at
`TZ=UTC`, and under UTC a regression of `dayKey()` to `toISOString().slice(0, 10)` passes silently:
it only fails on a developer machine in an offset zone. The block now pins
`process.env.TZ = 'Europe/Paris'` and restores it afterwards, which V8 honours per call. With the
UTC regression in place that block now fails four tests **under `TZ=UTC`**, and the whole suite is
green in both zones when the code is right.

Worth knowing beyond this PR: any `node --test` assertion about local versus UTC days is blind in CI
unless the timezone is pinned.
