### PR TITLE
Admin: find a user, see a summary, and grant roles

### DIFF
--- a/assets/js/api/admin/user.js
+++ b/assets/js/api/admin/user.js
@@ -1,0 +1,25 @@
+/** global: Routing */
+
+import axios from 'axios'
+
+export default {
+  search({ search, page = 1 }) {
+    const params = new URLSearchParams({ search, page: String(page) })
+
+    return axios
+      .get(`${Routing.generate('api_admin_users_search')}?${params.toString()}`)
+      .then((resp) => resp.data)
+  },
+
+  get(id) {
+    return axios.get(Routing.generate('api_admin_users_get', { id })).then((resp) => resp.data)
+  },
+
+  updateRoles(id, roles) {
+    return axios.post(
+      Routing.generate('api_admin_users_roles_update', { id }),
+      { roles },
+      { headers: { 'Content-Type': 'application/ld+json' } }
+    )
+  }
+}

--- a/assets/js/components/Admin/UserSearchPanel.vue
+++ b/assets/js/components/Admin/UserSearchPanel.vue
@@ -1,0 +1,142 @@
+<template>
+  <Panel header="Rechercher un utilisateur">
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-2">
+        <label for="admin-user-search" class="font-medium text-surface-700 dark:text-surface-300">
+          Nom d'utilisateur ou email
+        </label>
+        <div class="flex gap-2">
+          <InputText
+            id="admin-user-search"
+            v-model="term"
+            class="flex-1"
+            placeholder="Ex : jean_michel, jean@email.com"
+            aria-describedby="admin-user-search-help"
+            @keyup.enter="handleSearch"
+          />
+          <Button
+            label="Rechercher"
+            icon="pi pi-search"
+            :loading="isLoading"
+            :disabled="!isTermLongEnough || isLoading"
+            @click="handleSearch"
+          />
+        </div>
+        <small id="admin-user-search-help" class="text-surface-500 dark:text-surface-400">
+          {{ USER_SEARCH_MIN_LENGTH }} caractères minimum. Les comptes fermés restent visibles.
+        </small>
+      </div>
+
+      <Message v-if="errorMessage" severity="error" :closable="false">{{ errorMessage }}</Message>
+
+      <DataTable v-if="hasSearched" :value="users" stripedRows class="text-sm">
+        <Column field="username" header="Utilisateur">
+          <template #body="{ data }">
+            <RouterLink
+              :to="{ name: 'admin_users_show', params: { id: data.id } }"
+              class="font-medium underline"
+            >
+              {{ data.username }}
+            </RouterLink>
+            <Tag v-if="data.is_deleted" value="Compte fermé" severity="danger" class="ml-2" />
+          </template>
+        </Column>
+        <Column field="email" header="Email" class="hidden md:table-cell" />
+        <Column header="Rôles">
+          <template #body="{ data }">
+            <span v-if="!data.roles.length" class="text-surface-500 dark:text-surface-400">Aucun</span>
+            <Tag
+              v-for="role in data.roles"
+              :key="role"
+              :value="roleLabel(role)"
+              severity="secondary"
+              class="mr-1"
+            />
+          </template>
+        </Column>
+        <Column field="creation_datetime" header="Inscription">
+          <template #body="{ data }">{{ formatDate(data.creation_datetime) }}</template>
+        </Column>
+        <template #empty>
+          <div class="text-center py-6 text-surface-500 dark:text-surface-400">
+            Aucun compte ne correspond à « {{ lastTerm }} ».
+          </div>
+        </template>
+      </DataTable>
+
+      <Paginator
+        v-if="totalItems > ROWS_PER_PAGE"
+        :rows="ROWS_PER_PAGE"
+        :totalRecords="totalItems"
+        :first="(page - 1) * ROWS_PER_PAGE"
+        @page="handlePageChange"
+      />
+    </div>
+  </Panel>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import Paginator from 'primevue/paginator'
+import Panel from 'primevue/panel'
+import Tag from 'primevue/tag'
+import { computed, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import adminUserApi from '../../api/admin/user.js'
+import {
+  GRANTABLE_ROLES,
+  USER_SEARCH_MIN_LENGTH,
+  USER_SEARCH_ROWS_PER_PAGE
+} from '../../constants/adminUser.js'
+import { formatDate } from '../../utils/date.js'
+
+const ROWS_PER_PAGE = USER_SEARCH_ROWS_PER_PAGE
+
+const term = ref('')
+const lastTerm = ref('')
+const users = ref([])
+const totalItems = ref(0)
+const page = ref(1)
+const isLoading = ref(false)
+const hasSearched = ref(false)
+const errorMessage = ref('')
+
+const isTermLongEnough = computed(() => term.value.trim().length >= USER_SEARCH_MIN_LENGTH)
+
+function roleLabel(role) {
+  return GRANTABLE_ROLES.find((candidate) => candidate.value === role)?.label ?? role
+}
+
+async function load() {
+  isLoading.value = true
+  errorMessage.value = ''
+  try {
+    const data = await adminUserApi.search({ search: lastTerm.value, page: page.value })
+    users.value = data.member
+    totalItems.value = data.totalItems
+    hasSearched.value = true
+  } catch (e) {
+    errorMessage.value = e?.response?.data?.detail || 'La recherche a échoué.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function handleSearch() {
+  if (!isTermLongEnough.value) return
+  // Pinned when the search runs rather than read live, so paging through results is not thrown off
+  // by someone still typing in the box.
+  lastTerm.value = term.value.trim()
+  page.value = 1
+  load()
+}
+
+function handlePageChange(event) {
+  page.value = event.page + 1
+  load()
+}
+</script>

--- a/assets/js/constants/adminUser.js
+++ b/assets/js/constants/adminUser.js
@@ -1,0 +1,33 @@
+import { ROLE_ADMIN, ROLE_TESTER } from '../utils/roles.js'
+
+/**
+ * Mirrors `AdminUserRoleUpdate::GRANTABLE_ROLES`, pinned by
+ * tests/Unit/Security/AdminUserRolesClientMirrorTest.php. Anything else is a 422, so a role added
+ * here without its PHP counterpart is a dead toggle.
+ *
+ * The order is deliberate: the harmless one first. ROLE_TESTER grants no permission at all, it only
+ * reveals modules that are merged but not yet announced. ROLE_ADMIN hands over the whole back
+ * office, which is why it is the one that asks before it applies.
+ */
+export const GRANTABLE_ROLES = Object.freeze([
+  {
+    value: ROLE_TESTER,
+    label: 'Testeur',
+    description:
+      "Voit les modules terminés mais pas encore annoncés. N'accorde aucune permission supplémentaire.",
+    requiresConfirmation: false
+  },
+  {
+    value: ROLE_ADMIN,
+    label: 'Administrateur',
+    description:
+      "Accès complet à l'administration : modération, utilisateurs, retours et publications.",
+    requiresConfirmation: true
+  }
+])
+
+/** Mirrors `AdminUser::SEARCH_MIN_LENGTH`, the Assert\Length on the search query parameter. */
+export const USER_SEARCH_MIN_LENGTH = 2
+
+/** Mirrors `AdminUser::ITEMS_PER_PAGE`, so the paginator agrees with what the API returns. */
+export const USER_SEARCH_ROWS_PER_PAGE = 20

--- a/assets/js/router/admin.js
+++ b/assets/js/router/admin.js
@@ -14,6 +14,11 @@ export default {
       component: () => import('../views/Admin/UserDashboard.vue')
     },
     {
+      name: 'admin_users_show',
+      path: 'users/:id',
+      component: () => import('../views/Admin/User/Show.vue')
+    },
+    {
       name: 'admin_publications_index',
       path: 'publications',
       component: () => import('../views/Admin/Publications/Index.vue')

--- a/assets/js/router/admin.test.js
+++ b/assets/js/router/admin.test.js
@@ -17,33 +17,50 @@ const router = createRouter({
   routes: [{ path: '/', children: [adminRoute] }]
 })
 
-const adminRouteNames = adminRoute.children.map((child) => child.name)
+/**
+ * A child with a required param cannot be resolved by name alone, so each one gets a placeholder.
+ * Derived from the path rather than listed, so a future admin route with params needs no change
+ * here.
+ */
+function paramsFor(path) {
+  const names = [...String(path).matchAll(/:(\w+)/g)].map(([, name]) => name)
+
+  return Object.fromEntries(names.map((name) => [name, 'placeholder']))
+}
+
+const adminPages = adminRoute.children.map((child) => ({
+  name: child.name,
+  params: paramsFor(child.path)
+}))
 
 describe('the admin route tree', () => {
   it('has children to protect', () => {
-    assert.ok(adminRouteNames.length > 0)
+    assert.ok(adminPages.length > 0)
   })
 
   it('requires admin on every page, not just the index', () => {
-    for (const name of adminRouteNames) {
-      const resolved = router.resolve({ name })
+    for (const page of adminPages) {
       assert.equal(
-        resolved.meta.isAdminRequired,
+        router.resolve(page).meta.isAdminRequired,
         true,
-        `${name} does not inherit isAdminRequired, so the guard never fires for it`
+        `${page.name} does not inherit isAdminRequired, so the guard never fires for it`
       )
     }
   })
 
   it('still requires authentication on every page', () => {
-    for (const name of adminRouteNames) {
-      assert.equal(router.resolve({ name }).meta.isAuthRequired, true)
+    for (const page of adminPages) {
+      assert.equal(
+        router.resolve(page).meta.isAuthRequired,
+        true,
+        `${page.name} lost isAuthRequired`
+      )
     }
   })
 
   it('puts every admin page under /admin', () => {
-    for (const name of adminRouteNames) {
-      assert.match(router.resolve({ name }).path, /^\/admin(\/|$)/)
+    for (const page of adminPages) {
+      assert.match(router.resolve(page).path, /^\/admin(\/|$)/, `${page.name} escaped the prefix`)
     }
   })
 })

--- a/assets/js/views/Admin/User/Show.vue
+++ b/assets/js/views/Admin/User/Show.vue
@@ -1,0 +1,283 @@
+<template>
+  <div class="flex flex-col gap-6">
+    <div class="flex items-center gap-3">
+      <Button
+        icon="pi pi-arrow-left"
+        severity="secondary"
+        text
+        rounded
+        aria-label="Retour à la gestion des utilisateurs"
+        @click="router.push({ name: 'admin_users_dashboard' })"
+      />
+      <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-100">
+        {{ user?.username ?? 'Utilisateur' }}
+      </h1>
+      <Tag v-if="user?.is_deleted" value="Compte fermé" severity="danger" />
+    </div>
+
+    <div v-if="isLoading" class="flex justify-center py-8">
+      <ProgressSpinner style="width: 50px; height: 50px" />
+    </div>
+
+    <Message v-else-if="errorMessage" severity="error" :closable="false">{{ errorMessage }}</Message>
+
+    <Tabs v-else v-model:value="activeTab">
+      <TabList>
+        <Tab value="summary">Résumé</Tab>
+        <Tab value="roles">Rôles</Tab>
+        <Tab value="moderation">
+          Modération
+          <ComingSoonBadge class="ml-2" />
+        </Tab>
+      </TabList>
+
+      <TabPanels>
+        <TabPanel value="summary">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Panel header="Identité">
+              <dl class="flex flex-col gap-2 text-sm">
+                <div v-for="row in identityRows" :key="row.label" class="flex justify-between gap-4">
+                  <dt class="text-surface-500 dark:text-surface-400">{{ row.label }}</dt>
+                  <dd class="text-right">{{ row.value }}</dd>
+                </div>
+              </dl>
+            </Panel>
+
+            <Panel header="Dates">
+              <dl class="flex flex-col gap-2 text-sm">
+                <div v-for="row in dateRows" :key="row.label" class="flex justify-between gap-4">
+                  <dt class="text-surface-500 dark:text-surface-400">{{ row.label }}</dt>
+                  <dd class="text-right">{{ row.value }}</dd>
+                </div>
+              </dl>
+            </Panel>
+
+            <Panel header="Contenus publiés" class="md:col-span-2">
+              <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
+                <div v-for="count in activityCounts" :key="count.label" class="text-center">
+                  <p class="text-2xl font-semibold">{{ count.value }}</p>
+                  <p class="text-sm text-surface-500 dark:text-surface-400">{{ count.label }}</p>
+                </div>
+              </div>
+            </Panel>
+          </div>
+        </TabPanel>
+
+        <TabPanel value="roles">
+          <Panel header="Rôles attribués">
+            <Message v-if="isSelf" severity="warn" :closable="false" class="mb-4">
+              Vous ne pouvez pas modifier vos propres rôles. Demandez à un autre administrateur.
+            </Message>
+            <Message v-if="roleError" severity="error" :closable="false" class="mb-4">{{ roleError }}</Message>
+
+            <div class="flex flex-col gap-5">
+              <div
+                v-for="role in GRANTABLE_ROLES"
+                :key="role.value"
+                class="flex items-start justify-between gap-4"
+              >
+                <div>
+                  <label :for="`role-${role.value}`" class="font-medium">{{ role.label }}</label>
+                  <p class="text-sm text-surface-500 dark:text-surface-400">{{ role.description }}</p>
+                </div>
+                <ToggleSwitch
+                  :inputId="`role-${role.value}`"
+                  :modelValue="roleSwitches[role.value]"
+                  :disabled="isSelf || isSavingRoles"
+                  @update:modelValue="(granted) => handleRoleToggle(role, granted)"
+                />
+              </div>
+            </div>
+          </Panel>
+        </TabPanel>
+
+        <TabPanel value="moderation">
+          <Panel header="Modération">
+            <div class="text-center py-10 flex flex-col items-center gap-3">
+              <i class="pi pi-shield text-4xl text-surface-400" aria-hidden="true" />
+              <p class="text-surface-600 dark:text-surface-400 max-w-lg">
+                Suspendre un compte ou restreindre ses actions arrivera ici. Rien n'est encore
+                décidé sur ce que « suspendu » veut dire, ni sur ce qu'il advient des contenus déjà
+                publiés, donc rien n'est encore construit.
+              </p>
+            </div>
+          </Panel>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+
+    <ConfirmDialog group="admin-user-role" />
+  </div>
+</template>
+
+<script setup>
+import { useTitle } from '@vueuse/core'
+import Button from 'primevue/button'
+import ConfirmDialog from 'primevue/confirmdialog'
+import Message from 'primevue/message'
+import Panel from 'primevue/panel'
+import ProgressSpinner from 'primevue/progressspinner'
+import Tab from 'primevue/tab'
+import TabList from 'primevue/tablist'
+import TabPanel from 'primevue/tabpanel'
+import TabPanels from 'primevue/tabpanels'
+import Tabs from 'primevue/tabs'
+import Tag from 'primevue/tag'
+import ToggleSwitch from 'primevue/toggleswitch'
+import { useConfirm } from 'primevue/useconfirm'
+import { useToast } from 'primevue/usetoast'
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import adminUserApi from '../../../api/admin/user.js'
+import ComingSoonBadge from '../../../components/Admin/ComingSoonBadge.vue'
+import { GRANTABLE_ROLES } from '../../../constants/adminUser.js'
+import { useUserSecurityStore } from '../../../store/user/security.js'
+import { formatDate } from '../../../utils/date.js'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+const confirm = useConfirm()
+const userSecurityStore = useUserSecurityStore()
+
+const user = ref(null)
+const isLoading = ref(true)
+const errorMessage = ref('')
+const roleError = ref('')
+const isSavingRoles = ref(false)
+const activeTab = ref('summary')
+
+/**
+ * The switch positions, held here rather than read straight off `user.roles`.
+ *
+ * PrimeVue's ToggleSwitch keeps its own visual state once clicked, and it only resyncs when the
+ * bound value actually changes. Binding it to `user.roles` meant that cancelling the confirmation
+ * left the prop on the value it already had, so nothing resynced and the switch sat there claiming
+ * the account was an administrator when it was not. Moving the flip here and putting it back makes
+ * the revert a real change, which is the only thing the component reacts to.
+ */
+const roleSwitches = ref({})
+
+function syncSwitchesFromUser() {
+  roleSwitches.value = Object.fromEntries(
+    GRANTABLE_ROLES.map((role) => [role.value, user.value?.roles?.includes(role.value) ?? false])
+  )
+}
+
+useTitle(() => `${user.value?.username ?? 'Utilisateur'} - Admin - MusicAll`)
+
+// The API refuses it anyway; the UI disables the switches so the refusal is not a surprise.
+const isSelf = computed(() => user.value?.username === userSecurityStore.user?.username)
+
+const identityRows = computed(() => [
+  { label: "Nom d'utilisateur", value: user.value.username },
+  { label: 'Email', value: user.value.email },
+  { label: 'Email confirmé', value: user.value.is_email_confirmed ? 'Oui' : 'Non' },
+  { label: 'Profil musicien', value: user.value.has_musician_profile ? 'Oui' : 'Non' },
+  { label: 'Profil professeur', value: user.value.has_teacher_profile ? 'Oui' : 'Non' },
+  { label: 'Identifiant', value: user.value.id }
+])
+
+const dateRows = computed(() => [
+  { label: 'Inscription', value: formatOrDash(user.value.creation_datetime) },
+  { label: 'Dernière connexion', value: formatOrDash(user.value.last_login_datetime) },
+  { label: 'Dernière activité', value: formatOrDash(user.value.last_activity_datetime) },
+  { label: 'Email confirmé le', value: formatOrDash(user.value.confirmation_datetime) },
+  {
+    label: "Nom d'utilisateur changé le",
+    value: formatOrDash(user.value.username_changed_datetime)
+  },
+  { label: 'Compte fermé le', value: formatOrDash(user.value.deletion_datetime) }
+])
+
+const activityCounts = computed(() => [
+  { label: 'Publications', value: user.value.activity?.publications ?? 0 },
+  { label: 'Commentaires', value: user.value.activity?.comments ?? 0 },
+  { label: 'Messages forum', value: user.value.activity?.forum_posts ?? 0 },
+  { label: 'Annonces', value: user.value.activity?.musician_announces ?? 0 },
+  { label: 'Band Spaces', value: user.value.activity?.band_spaces ?? 0 }
+])
+
+function formatOrDash(value) {
+  return value ? formatDate(value) : '-'
+}
+
+function handleRoleToggle(role, granted) {
+  // Follow the click straight away, so the switch does not feel stuck while the confirmation is up.
+  roleSwitches.value[role.value] = granted
+
+  if (!granted || !role.requiresConfirmation) {
+    saveRoles(nextRoles(role.value, granted))
+    return
+  }
+
+  confirm.require({
+    group: 'admin-user-role',
+    header: 'Confirmation',
+    message: `Donner le rôle « ${role.label} » à ${user.value.username} ? Cela donne un accès complet à l'administration.`,
+    icon: 'pi pi-exclamation-triangle',
+    rejectLabel: 'Annuler',
+    acceptLabel: 'Confirmer',
+    acceptClass: 'p-button-danger',
+    accept: () => saveRoles(nextRoles(role.value, true)),
+    // reject covers the Annuler button, onHide the close icon and Escape. Both are wired because a
+    // dismissal that does not put the switch back leaves the screen claiming the account is an
+    // administrator when it is not. onHide runs after accept too, which is harmless: by then the
+    // save has refreshed the user and the switches follow it.
+    reject: () => syncSwitchesFromUser(),
+    onHide: () => syncSwitchesFromUser()
+  })
+}
+
+/**
+ * The whole grantable set is sent, so the request states what the roles should be rather than how
+ * they changed. Roles the account holds that this screen cannot grant are preserved server side.
+ */
+function nextRoles(role, granted) {
+  const grantable = GRANTABLE_ROLES.map((candidate) => candidate.value)
+  const kept = user.value.roles.filter((held) => grantable.includes(held) && held !== role)
+
+  return granted ? [...kept, role] : kept
+}
+
+async function saveRoles(roles) {
+  isSavingRoles.value = true
+  roleError.value = ''
+  try {
+    await adminUserApi.updateRoles(user.value.id, roles)
+  } catch (e) {
+    roleError.value = e?.response?.data?.detail || 'La mise à jour des rôles a échoué.'
+    syncSwitchesFromUser()
+    isSavingRoles.value = false
+
+    return
+  }
+
+  // The save landed. A failure from here on is a stale display, not a failed change, and saying
+  // otherwise would send an admin back to re-grant a role they already granted.
+  try {
+    user.value = await adminUserApi.get(user.value.id)
+    syncSwitchesFromUser()
+    toast.add({ severity: 'success', summary: 'Rôles mis à jour', life: 3000 })
+  } catch {
+    roleError.value =
+      "Les rôles ont bien été enregistrés, mais l'affichage n'a pas pu être actualisé. Rechargez la page."
+  } finally {
+    isSavingRoles.value = false
+  }
+}
+
+onMounted(async () => {
+  try {
+    user.value = await adminUserApi.get(route.params.id)
+    syncSwitchesFromUser()
+  } catch (e) {
+    errorMessage.value =
+      e?.response?.status === 404
+        ? 'Utilisateur introuvable.'
+        : e?.response?.data?.detail || 'Impossible de charger cet utilisateur.'
+  } finally {
+    isLoading.value = false
+  }
+})
+</script>

--- a/assets/js/views/Admin/UserDashboard.vue
+++ b/assets/js/views/Admin/UserDashboard.vue
@@ -12,6 +12,8 @@
       />
     </div>
 
+    <UserSearchPanel />
+
     <!-- Loading State -->
     <div v-if="dashboardStore.isLoadingUsers" class="flex justify-center py-8">
       <ProgressSpinner style="width: 50px; height: 50px" />
@@ -500,6 +502,7 @@ import { computed, onMounted, ref } from 'vue'
 import ComingSoonBadge from '../../components/Admin/ComingSoonBadge.vue'
 import DateRangePicker from '../../components/Admin/DateRangePicker.vue'
 import TimeSeriesChart from '../../components/Admin/TimeSeriesChart.vue'
+import UserSearchPanel from '../../components/Admin/UserSearchPanel.vue'
 import { useAdminDashboardStore } from '../../store/admin/dashboard.js'
 
 const dashboardStore = useAdminDashboardStore()

--- a/src/ApiResource/Admin/User/AdminUser.php
+++ b/src/ApiResource/Admin/User/AdminUser.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\Admin\User;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Provider\Admin\User\AdminUserCollectionProvider;
+use App\State\Provider\Admin\User\AdminUserItemProvider;
+use DateTimeInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Looking one account up, and seeing enough about it to make a decision.
+ *
+ * Email is searchable on purpose: it is often the only thing you have when somebody writes in about
+ * their own account. That is also why the collection refuses to answer without a search term, so it
+ * cannot become a way to page through the whole user base.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            uriTemplate: '/admin/users',
+            openapi: new Operation(tags: ['Admin Users']),
+            paginationEnabled: true,
+            paginationItemsPerPage: self::ITEMS_PER_PAGE,
+            security: 'is_granted("ROLE_ADMIN")',
+            name: 'api_admin_users_search',
+            provider: AdminUserCollectionProvider::class,
+            parameters: [
+                'search' => new QueryParameter(
+                    key: 'search',
+                    constraints: [new Assert\Length(min: self::SEARCH_MIN_LENGTH, minMessage: 'Saisissez au moins {{ limit }} caractères')],
+                ),
+            ],
+        ),
+        new Get(
+            uriTemplate: '/admin/users/{id}',
+            openapi: new Operation(tags: ['Admin Users']),
+            security: 'is_granted("ROLE_ADMIN")',
+            name: 'api_admin_users_get',
+            provider: AdminUserItemProvider::class,
+        ),
+    ],
+)]
+class AdminUser
+{
+    /** Both mirrored by assets/js/constants/adminUser.js, pinned by AdminUserRolesClientMirrorTest. */
+    final public const int SEARCH_MIN_LENGTH = 2;
+    final public const int ITEMS_PER_PAGE = 20;
+
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    public string $username;
+    public string $email;
+
+    /**
+     * The roles as stored, not as resolved. User::getRoles() adds ROLE_USER to everyone and the
+     * hierarchy is applied server side, so showing the resolved set would show a row nobody wrote
+     * and that the roles screen cannot turn off.
+     *
+     * @var list<string>
+     */
+    public array $roles = [];
+
+    public DateTimeInterface $creationDatetime;
+    public ?DateTimeInterface $lastLoginDatetime = null;
+    public ?DateTimeInterface $lastActivityDatetime = null;
+    public ?DateTimeInterface $confirmationDatetime = null;
+    public ?DateTimeInterface $usernameChangedDatetime = null;
+
+    /** Soft delete: the account is anonymised rather than removed, so the row is still here. */
+    public ?DateTimeInterface $deletionDatetime = null;
+
+    public bool $isDeleted = false;
+    public bool $isEmailConfirmed = false;
+    public bool $hasMusicianProfile = false;
+    public bool $hasTeacherProfile = false;
+    public ?string $profilePictureUrl = null;
+
+    /**
+     * Null on the collection, which answers who rather than what.
+     *
+     * genId: false because this is an embedded value rather than a resource of its own. Without it
+     * API Platform mints a random .well-known/genid IRI for it on every request, which is both
+     * meaningless and unassertable.
+     */
+    #[ApiProperty(genId: false)]
+    public ?AdminUserActivity $activity = null;
+}

--- a/src/ApiResource/Admin/User/AdminUserActivity.php
+++ b/src/ApiResource/Admin/User/AdminUserActivity.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\Admin\User;
+
+/**
+ * What an account has produced, which is the part of the summary a moderation decision rests on.
+ *
+ * Its own object rather than five more fields on AdminUser, so the collection can leave it null and
+ * mean it: the list answers "which account is this", the item answers "what have they done", and
+ * counting five tables per row would make a search page pay for a question it is not asking.
+ */
+class AdminUserActivity
+{
+    public int $publications = 0;
+    public int $comments = 0;
+    public int $forumPosts = 0;
+    public int $musicianAnnounces = 0;
+    public int $bandSpaces = 0;
+}

--- a/src/ApiResource/Admin/User/AdminUserRoleUpdate.php
+++ b/src/ApiResource/Admin/User/AdminUserRoleUpdate.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\Admin\User;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\Admin\User\AdminUserRoleUpdateProcessor;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Setting which of the grantable roles an account holds.
+ *
+ * A Post rather than a Patch, like every other admin write: nothing under src/ApiResource/Admin/
+ * uses Patch. The whole grantable set is sent rather than one toggle at a time, so the request says
+ * what the roles should be and repeating it changes nothing.
+ *
+ * This is the one screen that hands out privilege, so it is deliberately narrow:
+ *
+ *  - only the two roles below can be written, anything else is a 422, and a role the account holds
+ *    that is not in this list is preserved untouched rather than silently dropped
+ *  - an admin cannot change their own roles, enforced in the processor. That stops somebody
+ *    removing their own ROLE_ADMIN and locking themselves out of the back office, and it removes
+ *    the simplest self escalation path
+ *  - ROLE_USER is absent because User::getRoles() gives it to everyone already
+ */
+#[Post(
+    uriTemplate: '/admin/users/{id}/roles',
+    status: Response::HTTP_NO_CONTENT,
+    openapi: new Operation(tags: ['Admin Users']),
+    security: 'is_granted("ROLE_ADMIN")',
+    name: 'api_admin_users_roles_update',
+    processor: AdminUserRoleUpdateProcessor::class,
+)]
+class AdminUserRoleUpdate
+{
+    /**
+     * ROLE_TESTER reveals modules that are merged but not yet announced and grants no permission of
+     * its own, so it is the low stakes one. ROLE_ADMIN is the one worth a confirmation in the UI.
+     *
+     * @var list<string>
+     */
+    final public const array GRANTABLE_ROLES = ['ROLE_ADMIN', 'ROLE_TESTER'];
+
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    /**
+     * @var list<string>
+     */
+    // Count first: Assert\Unique scans the array for each element, so without a bound a payload of
+    // thousands of junk strings burns CPU quadratically before anything rejects it. Only an
+    // authenticated admin can reach this, so it is self inflicted rather than a way in, but the
+    // whole list can only ever hold two values and saying so costs one line.
+    #[Assert\Count(max: 2, maxMessage: 'Trop de rôles envoyés')]
+    #[Assert\Unique(message: 'Un rôle est répété')]
+    #[Assert\All([
+        new Assert\Choice(choices: self::GRANTABLE_ROLES, message: 'Rôle inconnu ou non attribuable'),
+    ])]
+    public array $roles = [];
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -7,6 +7,8 @@ use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\User;
 use App\Enum\BandSpace\MembershipStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Ramsey\Uuid\Uuid;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
@@ -100,6 +102,53 @@ class UserRepository extends ServiceEntityRepository implements UserLoaderInterf
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * Looked up through a QueryBuilder rather than find(), which coerces the id through the uuid
+     * field type and throws on a malformed one. The id arrives as a URI path segment, so nothing has
+     * validated it, and a stray character has to be a 404 rather than a 500 (see #934).
+     */
+    public function findOneById(string $id): ?User
+    {
+        if (!Uuid::isValid($id)) {
+            return null;
+        }
+
+        return $this->createQueryBuilder('u')
+            ->where('u.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * Admin lookup by username or email, for the back office user screen.
+     *
+     * Includes deleted accounts, unlike searchByUserName above: an admin looking into a report needs
+     * to find an account that has since been closed, and DeleteAccountProcedure anonymises rather
+     * than removing, so the row is still there to find.
+     *
+     * The search term has its LIKE wildcards escaped, or a lone `%` would list the whole user base
+     * through an endpoint that is meant to answer a question about one person.
+     *
+     * @return Paginator<User>
+     */
+    public function searchForAdmin(string $search, int $offset, int $limit): Paginator
+    {
+        $queryBuilder = $this->createQueryBuilder('u')
+            // profilePicture is the owning side of a nullable OneToOne, so it is genuinely lazy and
+            // every row would otherwise fetch its own when the builder reads the avatar. To-one, so
+            // the join multiplies nothing.
+            ->select('u, profilePicture')
+            ->leftJoin('u.profilePicture', 'profilePicture')
+            ->where('u.username LIKE :search OR u.email LIKE :search')
+            ->setParameter('search', '%' . addcslashes($search, '%_\\') . '%')
+            ->orderBy('u.username', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit);
+
+        return new Paginator($queryBuilder->getQuery(), fetchJoinCollection: false);
     }
 
     /**

--- a/src/Service/Builder/Admin/User/AdminUserBuilder.php
+++ b/src/Service/Builder/Admin/User/AdminUserBuilder.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\Builder\Admin\User;
+
+use App\ApiResource\Admin\User\AdminUser;
+use App\ApiResource\Admin\User\AdminUserActivity;
+use App\Entity\Comment\Comment;
+use App\Entity\Forum\ForumPost;
+use App\Entity\Image\UserProfilePicture;
+use App\Entity\Musician\MusicianAnnounce;
+use App\Entity\Publication;
+use App\Entity\User;
+use App\Enum\BandSpace\MembershipStatus;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Repository\Comment\CommentRepository;
+use App\Repository\Forum\ForumPostRepository;
+use App\Repository\Musician\MusicianAnnounceRepository;
+use App\Repository\PublicationRepository;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
+
+/**
+ * Shared by the search list and the user page, so the two cannot disagree about who an account is.
+ */
+readonly class AdminUserBuilder
+{
+    public function __construct(
+        private UploaderHelper $uploaderHelper,
+        private CacheManager $cacheManager,
+        private PublicationRepository $publicationRepository,
+        private CommentRepository $commentRepository,
+        private ForumPostRepository $forumPostRepository,
+        private MusicianAnnounceRepository $musicianAnnounceRepository,
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+    ) {
+    }
+
+    public function buildFromEntity(User $user): AdminUser
+    {
+        $resource = new AdminUser();
+        $resource->id = $user->id;
+        $resource->username = $user->username;
+        $resource->email = $user->email;
+        // The stored roles, not getRoles(): that one adds ROLE_USER to everyone, and showing a role
+        // the roles screen cannot turn off would be a lie about what is written down.
+        $resource->roles = array_values($user->roles);
+        $resource->creationDatetime = $user->creationDatetime;
+        $resource->lastLoginDatetime = $user->lastLoginDatetime;
+        $resource->lastActivityDatetime = $user->lastActivityDatetime;
+        $resource->confirmationDatetime = $user->confirmationDatetime;
+        $resource->usernameChangedDatetime = $user->usernameChangedDatetime;
+        $resource->deletionDatetime = $user->deletionDatetime;
+        $resource->isDeleted = $user->isDeleted();
+        $resource->isEmailConfirmed = $user->confirmationDatetime instanceof \DateTimeInterface;
+        $resource->hasMusicianProfile = $user->musicianProfile !== null;
+        $resource->hasTeacherProfile = $user->teacherProfile !== null;
+        $resource->profilePictureUrl = $this->buildProfilePictureUrl($user);
+
+        return $resource;
+    }
+
+    /**
+     * @param list<User> $users
+     *
+     * @return list<AdminUser>
+     */
+    public function buildFromEntities(array $users): array
+    {
+        return array_map($this->buildFromEntity(...), $users);
+    }
+
+    /**
+     * The user page only. Five counts per row would make the search page pay for a question it is
+     * not asking.
+     */
+    public function buildWithActivity(User $user): AdminUser
+    {
+        $resource = $this->buildFromEntity($user);
+
+        $activity = new AdminUserActivity();
+        $activity->publications = $this->publicationRepository->count(['author' => $user]);
+        $activity->comments = $this->commentRepository->count(['author' => $user]);
+        $activity->forumPosts = $this->forumPostRepository->count(['creator' => $user]);
+        $activity->musicianAnnounces = $this->musicianAnnounceRepository->count(['author' => $user]);
+        $activity->bandSpaces = $this->bandSpaceMembershipRepository->count([
+            'user' => $user,
+            'status' => MembershipStatus::Active,
+        ]);
+
+        $resource->activity = $activity;
+
+        return $resource;
+    }
+
+    private function buildProfilePictureUrl(User $user): ?string
+    {
+        $profilePicture = $user->profilePicture;
+        if (!$profilePicture instanceof UserProfilePicture) {
+            return null;
+        }
+        if (!$path = $this->uploaderHelper->asset($profilePicture, 'imageFile')) {
+            return null;
+        }
+
+        return $this->cacheManager->getBrowserPath($path, 'user_profile_picture_small');
+    }
+}

--- a/src/State/Processor/Admin/User/AdminUserRoleUpdateProcessor.php
+++ b/src/State/Processor/Admin/User/AdminUserRoleUpdateProcessor.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\Admin\User;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\Admin\User\AdminUserRoleUpdate;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<AdminUserRoleUpdate, null>
+ */
+readonly class AdminUserRoleUpdateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserRepository $userRepository,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): null
+    {
+        $user = $this->userRepository->findOneById((string) $uriVariables['id']);
+        if (!$user instanceof User) {
+            throw new NotFoundHttpException('Utilisateur introuvable');
+        }
+
+        $currentUser = $this->security->getUser();
+        // Nobody edits their own roles. It stops an admin dropping their own ROLE_ADMIN and locking
+        // themselves out of a back office only another admin could let them back into, and it takes
+        // the simplest self escalation path off the table.
+        if ($currentUser instanceof User && $currentUser->id === $user->id) {
+            throw new AccessDeniedHttpException('Vous ne pouvez pas modifier vos propres rôles');
+        }
+
+        // A role the account holds that is not grantable here is kept rather than silently dropped:
+        // this endpoint owns the grantable set, not the whole column.
+        $preserved = array_diff($user->roles, AdminUserRoleUpdate::GRANTABLE_ROLES);
+        $user->roles = array_values(array_unique([...$preserved, ...$data->roles]));
+
+        $this->entityManager->flush();
+
+        return null;
+    }
+}

--- a/src/State/Provider/Admin/User/AdminUserCollectionProvider.php
+++ b/src/State/Provider/Admin/User/AdminUserCollectionProvider.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\Admin\User;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Pagination\TraversablePaginator;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Admin\User\AdminUser;
+use App\Repository\UserRepository;
+use App\Service\Builder\Admin\User\AdminUserBuilder;
+use ArrayIterator;
+
+/**
+ * @implements ProviderInterface<AdminUser>
+ */
+readonly class AdminUserCollectionProvider implements ProviderInterface
+{
+    public function __construct(
+        private UserRepository $userRepository,
+        private AdminUserBuilder $builder,
+        private Pagination $pagination,
+    ) {
+    }
+
+    /**
+     * @return TraversablePaginator<AdminUser>
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): TraversablePaginator
+    {
+        $page = $this->pagination->getPage($context);
+        $itemsPerPage = $this->pagination->getLimit($operation, $context);
+
+        $search = $context['filters']['search'] ?? null;
+        // No search term, no answer. This endpoint exists to look one person up, and returning
+        // everyone by default would turn it into a way to page through the whole user base.
+        if (!is_string($search) || trim($search) === '') {
+            return new TraversablePaginator(new ArrayIterator([]), $page, $itemsPerPage, 0);
+        }
+
+        $paginator = $this->userRepository->searchForAdmin(
+            trim($search),
+            $this->pagination->getOffset($operation, $context),
+            $itemsPerPage,
+        );
+
+        $resources = $this->builder->buildFromEntities(array_values(iterator_to_array($paginator)));
+
+        return new TraversablePaginator(new ArrayIterator($resources), $page, $itemsPerPage, count($paginator));
+    }
+}

--- a/src/State/Provider/Admin/User/AdminUserItemProvider.php
+++ b/src/State/Provider/Admin/User/AdminUserItemProvider.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\Admin\User;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Admin\User\AdminUser;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\Builder\Admin\User\AdminUserBuilder;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProviderInterface<AdminUser>
+ */
+readonly class AdminUserItemProvider implements ProviderInterface
+{
+    public function __construct(
+        private UserRepository $userRepository,
+        private AdminUserBuilder $builder,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): AdminUser
+    {
+        $user = $this->userRepository->findOneById((string) $uriVariables['id']);
+        if (!$user instanceof User) {
+            throw new NotFoundHttpException('Utilisateur introuvable');
+        }
+
+        // A deleted account is still shown: it is anonymised rather than removed, and an admin
+        // looking into a report needs to see it rather than get a 404.
+        return $this->builder->buildWithActivity($user);
+    }
+}

--- a/tests/Api/Admin/User/AdminUserGetTest.php
+++ b/tests/Api/Admin/User/AdminUserGetTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Admin\User;
+
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\Publication\PublicationFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class AdminUserGetTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_not_logged(): void
+    {
+        $target = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->request('GET', '/api/admin/users/' . $target->id);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
+    }
+
+    public function test_base_user_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/admin/users/' . $user->id);
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+        ]);
+    }
+
+    public function test_admin_sees_the_summary_and_the_activity_counts(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create([
+            'username' => 'jean_michel',
+            'email' => 'jm@email.com',
+            'roles' => ['ROLE_TESTER'],
+            'creationDatetime' => new \DateTime('2026-01-15 09:00:00'),
+            'lastLoginDatetime' => new \DateTime('2026-09-01 08:00:00'),
+            'confirmationDatetime' => new \DateTime('2026-01-15 09:30:00'),
+        ]);
+        PublicationFactory::new()->create(['author' => $target, 'slug' => 'une-publication']);
+        PublicationFactory::new()->create(['author' => $target, 'slug' => 'une-autre-publication']);
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users/' . $target->id);
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminUser',
+            '@id' => '/api/admin/users/' . $target->id,
+            '@type' => 'AdminUser',
+            'id' => (string) $target->id,
+            'username' => 'jean_michel',
+            'email' => 'jm@email.com',
+            'roles' => ['ROLE_TESTER'],
+            'creation_datetime' => '2026-01-15T09:00:00+00:00',
+            'last_login_datetime' => '2026-09-01T08:00:00+00:00',
+            'confirmation_datetime' => '2026-01-15T09:30:00+00:00',
+            'is_deleted' => false,
+            'is_email_confirmed' => true,
+            'has_musician_profile' => false,
+            'has_teacher_profile' => false,
+            'activity' => [
+                '@type' => 'AdminUserActivity',
+                'publications' => 2,
+                'comments' => 0,
+                'forum_posts' => 0,
+                'musician_announces' => 0,
+                'band_spaces' => 0,
+            ],
+        ]);
+    }
+
+    /**
+     * Closing an account anonymises it rather than removing the row, so an admin following up on a
+     * report has to be able to reach it instead of getting a 404.
+     */
+    public function test_a_deleted_account_is_still_visible(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create([
+            'username' => 'compte_ferme',
+            'email' => 'ferme@email.com',
+            'roles' => [],
+            'creationDatetime' => new \DateTime('2026-01-15 09:00:00'),
+            'lastLoginDatetime' => new \DateTime('2026-02-01 08:00:00'),
+            'deletionDatetime' => new \DateTimeImmutable('2026-08-01 10:00:00'),
+        ]);
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users/' . $target->id);
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminUser',
+            '@id' => '/api/admin/users/' . $target->id,
+            '@type' => 'AdminUser',
+            'id' => (string) $target->id,
+            'username' => 'compte_ferme',
+            'email' => 'ferme@email.com',
+            'roles' => [],
+            'creation_datetime' => '2026-01-15T09:00:00+00:00',
+            'last_login_datetime' => '2026-02-01T08:00:00+00:00',
+            'deletion_datetime' => '2026-08-01T10:00:00+00:00',
+            'is_deleted' => true,
+            'is_email_confirmed' => false,
+            'has_musician_profile' => false,
+            'has_teacher_profile' => false,
+            'activity' => [
+                '@type' => 'AdminUserActivity',
+                'publications' => 0,
+                'comments' => 0,
+                'forum_posts' => 0,
+                'musician_announces' => 0,
+                'band_spaces' => 0,
+            ],
+        ]);
+    }
+
+    public function test_a_malformed_id_is_a_404_rather_than_a_500(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users/not-a-uuid');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Utilisateur introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Utilisateur introuvable',
+        ]);
+    }
+
+    public function test_an_unknown_id_is_a_404(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Utilisateur introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Utilisateur introuvable',
+        ]);
+    }
+}

--- a/tests/Api/Admin/User/AdminUserRoleUpdateTest.php
+++ b/tests/Api/Admin/User/AdminUserRoleUpdateTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Admin\User;
+
+use App\Entity\User;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class AdminUserRoleUpdateTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const array HEADERS = ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'];
+
+    public function test_not_logged(): void
+    {
+        $target = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $target->id . '/roles', ['roles' => ['ROLE_TESTER']], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
+    }
+
+    public function test_base_user_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $target = UserFactory::new()->create(['username' => 'target', 'email' => 'target@email.com']);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $target->id . '/roles', ['roles' => ['ROLE_TESTER']], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+        ]);
+
+        $this->assertSame([], $this->reload((string) $target->id)->roles);
+    }
+
+    public function test_admin_grants_the_tester_role(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create(['username' => 'target', 'email' => 'target@email.com', 'roles' => []]);
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $target->id . '/roles', ['roles' => ['ROLE_TESTER']], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $this->assertSame(['ROLE_TESTER'], $this->reload((string) $target->id)->roles);
+    }
+
+    public function test_sending_an_empty_list_revokes_everything_grantable(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create([
+            'username' => 'target',
+            'email' => 'target@email.com',
+            'roles' => ['ROLE_TESTER', 'ROLE_ADMIN'],
+        ]);
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $target->id . '/roles', ['roles' => []], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $this->assertSame([], $this->reload((string) $target->id)->roles);
+    }
+
+    /**
+     * The endpoint owns the grantable set, not the whole column, so a role it cannot hand out is
+     * not something it may quietly take away either.
+     */
+    public function test_a_role_outside_the_grantable_set_is_preserved(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create([
+            'username' => 'target',
+            'email' => 'target@email.com',
+            'roles' => ['ROLE_LEGACY_SOMETHING', 'ROLE_TESTER'],
+        ]);
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $target->id . '/roles', ['roles' => ['ROLE_ADMIN']], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $this->assertSame(['ROLE_LEGACY_SOMETHING', 'ROLE_ADMIN'], $this->reload((string) $target->id)->roles);
+    }
+
+    /**
+     * The guardrail that matters: an admin dropping their own ROLE_ADMIN would lock themselves out
+     * of a back office only another admin could let them back into.
+     */
+    public function test_an_admin_cannot_change_their_own_roles(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $admin->id . '/roles', ['roles' => []], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous ne pouvez pas modifier vos propres rôles',
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => 'Vous ne pouvez pas modifier vos propres rôles',
+        ]);
+
+        $this->assertSame(['ROLE_ADMIN'], $this->reload((string) $admin->id)->roles);
+    }
+
+    public function test_an_ungrantable_role_is_refused(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create(['username' => 'target', 'email' => 'target@email.com', 'roles' => []]);
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $target->id . '/roles', ['roles' => ['ROLE_SUPER_ADMIN']], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'roles[0]',
+                    'message' => 'Rôle inconnu ou non attribuable',
+                    'code' => '8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+                ],
+            ],
+            'detail' => 'roles[0]: Rôle inconnu ou non attribuable',
+            'type' => '/validation_errors/8e179f1b-97aa-4560-a02f-2a8b42e49df7',
+            'title' => 'An error occurred',
+            'description' => 'roles[0]: Rôle inconnu ou non attribuable',
+        ]);
+
+        $this->assertSame([], $this->reload((string) $target->id)->roles);
+    }
+
+    public function test_a_malformed_id_is_a_404_rather_than_a_500(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/users/not-a-uuid/roles', ['roles' => []], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Utilisateur introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+            'description' => 'Utilisateur introuvable',
+        ]);
+    }
+
+    public function test_duplicate_roles_are_refused(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create(['username' => 'target', 'email' => 'target@email.com', 'roles' => []]);
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $target->id . '/roles', ['roles' => ['ROLE_TESTER', 'ROLE_TESTER']], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/7911c98d-b845-4da0-94b7-a8dac36bc55a',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'roles',
+                    'message' => 'Un rôle est répété',
+                    'code' => '7911c98d-b845-4da0-94b7-a8dac36bc55a',
+                ],
+            ],
+            'detail' => 'roles: Un rôle est répété',
+            'type' => '/validation_errors/7911c98d-b845-4da0-94b7-a8dac36bc55a',
+            'title' => 'An error occurred',
+            'description' => 'roles: Un rôle est répété',
+        ]);
+
+        $this->assertSame([], $this->reload((string) $target->id)->roles);
+    }
+
+    /**
+     * Assert\Unique scans the array once per element, so an unbounded payload would burn CPU
+     * quadratically before anything rejected it.
+     */
+    public function test_too_many_roles_are_refused(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create(['username' => 'target', 'email' => 'target@email.com', 'roles' => []]);
+
+        $this->client->loginUser($admin);
+        $this->client->jsonRequest('POST', '/api/admin/users/' . $target->id . '/roles', [
+            'roles' => ['ROLE_TESTER', 'ROLE_ADMIN', 'ROLE_AUTRE'],
+        ], self::HEADERS);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $this->assertSame([], $this->reload((string) $target->id)->roles);
+    }
+
+    private function reload(string $id): User
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->clear();
+
+        $user = $entityManager->getRepository(User::class)->find($id);
+        $this->assertInstanceOf(User::class, $user);
+
+        return $user;
+    }
+}

--- a/tests/Api/Admin/User/AdminUserSearchTest.php
+++ b/tests/Api/Admin/User/AdminUserSearchTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Admin\User;
+
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\User\UserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class AdminUserSearchTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_not_logged(): void
+    {
+        $this->client->request('GET', '/api/admin/users?search=someone');
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
+    }
+
+    public function test_base_user_is_refused(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/admin/users?search=someone');
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+            'status' => 403,
+            'type' => '/errors/403',
+            'description' => "Access Denied. The user doesn't have ROLE_ADMIN.",
+        ]);
+    }
+
+    public function test_admin_finds_by_username(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create([
+            'username' => 'jean_michel',
+            'email' => 'jm@email.com',
+            'roles' => [],
+            'creationDatetime' => new \DateTime('2026-01-15 09:00:00'),
+            'lastLoginDatetime' => null,
+        ]);
+        UserFactory::new()->create(['username' => 'autre_personne', 'email' => 'autre@email.com']);
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users?search=jean');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminUser',
+            '@id' => '/api/admin/users',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/admin/users/' . $target->id,
+                    '@type' => 'AdminUser',
+                    'id' => (string) $target->id,
+                    'username' => 'jean_michel',
+                    'email' => 'jm@email.com',
+                    'roles' => [],
+                    'creation_datetime' => '2026-01-15T09:00:00+00:00',
+                    'is_deleted' => false,
+                    'is_email_confirmed' => false,
+                    'has_musician_profile' => false,
+                    'has_teacher_profile' => false,
+                ],
+            ],
+            'view' => ['@id' => '/api/admin/users?search=jean', '@type' => 'PartialCollectionView'],
+        ], 'The search list carries no activity block: it answers who, not what');
+    }
+
+    public function test_admin_finds_by_email(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create([
+            'username' => 'jean_michel',
+            'email' => 'contact.utile@email.com',
+            'roles' => [],
+            'creationDatetime' => new \DateTime('2026-01-15 09:00:00'),
+            'lastLoginDatetime' => null,
+        ]);
+        UserFactory::new()->create(['username' => 'autre_personne', 'email' => 'autre@email.com']);
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users?search=contact.utile');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminUser',
+            '@id' => '/api/admin/users',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/admin/users/' . $target->id,
+                    '@type' => 'AdminUser',
+                    'id' => (string) $target->id,
+                    'username' => 'jean_michel',
+                    'email' => 'contact.utile@email.com',
+                    'roles' => [],
+                    'creation_datetime' => '2026-01-15T09:00:00+00:00',
+                    'is_deleted' => false,
+                    'is_email_confirmed' => false,
+                    'has_musician_profile' => false,
+                    'has_teacher_profile' => false,
+                ],
+            ],
+            'view' => ['@id' => '/api/admin/users?search=contact.utile', '@type' => 'PartialCollectionView'],
+        ]);
+    }
+
+    /**
+     * The endpoint answers a question about one person. Without a term it would page through the
+     * whole user base instead, which is a different feature and not one anybody asked for.
+     */
+    public function test_no_search_term_lists_nobody(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        UserFactory::new()->many(3)->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminUser',
+            '@id' => '/api/admin/users',
+            '@type' => 'Collection',
+            'totalItems' => 0,
+            'member' => [],
+        ]);
+    }
+
+    /**
+     * A LIKE wildcard in the term would otherwise turn the search into the listing the test above
+     * refuses to be: unescaped, `%%` matches every row and `__` matches every name of two
+     * characters or more.
+     *
+     * Usernames are pinned rather than faked so neither term can match one by accident.
+     */
+    #[DataProvider('likeWildcardProvider')]
+    public function test_a_like_wildcard_is_not_a_way_to_list_everyone(string $encodedTerm): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        UserFactory::new()->create(['username' => 'premier', 'email' => 'premier@email.com']);
+        UserFactory::new()->create(['username' => 'deuxieme', 'email' => 'deuxieme@email.com']);
+        UserFactory::new()->create(['username' => 'troisieme', 'email' => 'troisieme@email.com']);
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users?search=' . $encodedTerm);
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminUser',
+            '@id' => '/api/admin/users',
+            '@type' => 'Collection',
+            'totalItems' => 0,
+            'member' => [],
+            'view' => ['@id' => '/api/admin/users?search=' . $encodedTerm, '@type' => 'PartialCollectionView'],
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function likeWildcardProvider(): iterable
+    {
+        yield 'percent matches every row' => ['%25%25'];
+        yield 'underscore matches every name' => ['__'];
+    }
+
+    public function test_a_deleted_account_is_still_findable(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+        $target = UserFactory::new()->create([
+            'username' => 'compte_ferme',
+            'email' => 'ferme@email.com',
+            'roles' => [],
+            'creationDatetime' => new \DateTime('2026-01-15 09:00:00'),
+            'lastLoginDatetime' => null,
+            'deletionDatetime' => new \DateTimeImmutable('2026-08-01 10:00:00'),
+        ]);
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users?search=compte_ferme');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AdminUser',
+            '@id' => '/api/admin/users',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                [
+                    '@id' => '/api/admin/users/' . $target->id,
+                    '@type' => 'AdminUser',
+                    'id' => (string) $target->id,
+                    'username' => 'compte_ferme',
+                    'email' => 'ferme@email.com',
+                    'roles' => [],
+                    'creation_datetime' => '2026-01-15T09:00:00+00:00',
+                    'deletion_datetime' => '2026-08-01T10:00:00+00:00',
+                    'is_deleted' => true,
+                    'is_email_confirmed' => false,
+                    'has_musician_profile' => false,
+                    'has_teacher_profile' => false,
+                ],
+            ],
+            'view' => ['@id' => '/api/admin/users?search=compte_ferme', '@type' => 'PartialCollectionView'],
+        ]);
+    }
+
+    public function test_a_short_search_term_is_refused(): void
+    {
+        $admin = UserFactory::new()->asAdminUser()->create();
+
+        $this->client->loginUser($admin);
+        $this->client->request('GET', '/api/admin/users?search=a');
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'search',
+                    'message' => 'Saisissez au moins 2 caractères',
+                    'code' => '9ff3fdc4-b214-49db-8718-39c315e33d45',
+                ],
+            ],
+            'detail' => 'search: Saisissez au moins 2 caractères',
+            'type' => '/validation_errors/9ff3fdc4-b214-49db-8718-39c315e33d45',
+            'title' => 'An error occurred',
+            'description' => 'search: Saisissez au moins 2 caractères',
+        ]);
+    }
+}

--- a/tests/Unit/Security/AdminUserRolesClientMirrorTest.php
+++ b/tests/Unit/Security/AdminUserRolesClientMirrorTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\ApiResource\Admin\User\AdminUser;
+use App\ApiResource\Admin\User\AdminUserRoleUpdate;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Count;
+
+/**
+ * The roles screen offers a toggle per grantable role, so the list exists in JavaScript as well as
+ * in PHP. The API refuses anything outside its own list with a 422, so a role offered by the client
+ * and unknown to the server is a switch that does nothing but produce an error.
+ *
+ * The reverse matters more: a role the server will grant and the client never offers is a
+ * permission with no way to see or revoke it from the back office.
+ *
+ * Same approach as RoleHierarchyClientMirrorTest and FeedbackClientMirrorTest.
+ */
+class AdminUserRolesClientMirrorTest extends TestCase
+{
+    private const string CONSTANTS_PATH = 'assets/js/constants/adminUser.js';
+
+    public function test_the_client_offers_exactly_the_grantable_roles(): void
+    {
+        preg_match_all('/value: (ROLE_[A-Z_]+)/', $this->read(), $matches);
+        self::assertNotEmpty($matches[1], sprintf('No GRANTABLE_ROLES entries found in %s.', self::CONSTANTS_PATH));
+
+        // The client refers to them through the constants exported by utils/roles.js, which are named
+        // after the role they hold and whose values RoleHierarchyClientMirrorTest already pins, so
+        // comparing the identifiers is enough here.
+        $expected = AdminUserRoleUpdate::GRANTABLE_ROLES;
+        sort($expected);
+        $actual = array_values(array_unique($matches[1]));
+        sort($actual);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * ROLE_USER is added to everyone by User::getRoles(), so a toggle for it would be a switch that
+     * cannot be turned off.
+     */
+    public function test_role_user_is_not_grantable(): void
+    {
+        $this->assertNotContains('ROLE_USER', AdminUserRoleUpdate::GRANTABLE_ROLES);
+        $this->assertStringNotContainsString('value: ROLE_USER', $this->read());
+    }
+
+    /**
+     * The count bound cannot be written as count(GRANTABLE_ROLES): an attribute argument has to be a
+     * constant expression and a function call is not one. So it is a literal, and this is what stops
+     * it drifting if a third role is ever added.
+     */
+    public function test_the_count_bound_matches_the_grantable_set(): void
+    {
+        $roles = new \ReflectionProperty(AdminUserRoleUpdate::class, 'roles');
+        $counts = array_values(array_filter(
+            $roles->getAttributes(),
+            static fn (\ReflectionAttribute $attribute): bool => $attribute->getName() === Count::class,
+        ));
+
+        self::assertCount(1, $counts, 'roles must carry exactly one Assert\\Count.');
+        $this->assertSame(
+            count(AdminUserRoleUpdate::GRANTABLE_ROLES),
+            $counts[0]->newInstance()->max,
+            'The bound has to admit every grantable role and nothing beyond.',
+        );
+    }
+
+    public function test_the_client_search_limits_match_the_resource(): void
+    {
+        $source = $this->read();
+
+        preg_match('/export const USER_SEARCH_MIN_LENGTH = (\d+)/', $source, $minLength);
+        self::assertNotEmpty($minLength, sprintf('No USER_SEARCH_MIN_LENGTH export found in %s.', self::CONSTANTS_PATH));
+        $this->assertSame(AdminUser::SEARCH_MIN_LENGTH, (int) $minLength[1]);
+
+        preg_match('/export const USER_SEARCH_ROWS_PER_PAGE = (\d+)/', $source, $rows);
+        self::assertNotEmpty($rows, sprintf('No USER_SEARCH_ROWS_PER_PAGE export found in %s.', self::CONSTANTS_PATH));
+        $this->assertSame(AdminUser::ITEMS_PER_PAGE, (int) $rows[1]);
+    }
+
+    private function read(): string
+    {
+        // tests/Unit/Security -> project root
+        $path = \dirname(__DIR__, 3) . '/' . self::CONSTANTS_PATH;
+        self::assertFileExists($path);
+
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+}


### PR DESCRIPTION
Closes #943.

Granting `ROLE_TESTER` was a manual database update after #942, which is the friction that stops a
preview flag from ever being used. Rather than a bare toggle, this is a small user administration
screen: find an account, see enough about it to decide, and grant the two roles that exist.

## Finding an account

Search by username **or** email, admin only, as a panel on the existing « Gestion des utilisateurs »
page, which already carried the right title but was a metrics dashboard with no way to look anyone up.

Email is searchable on purpose: it is often the only thing you have when somebody writes in about
their own account. Two things keep that from becoming a way to enumerate the user base: the endpoint
answers nothing without a search term, and the term has its LIKE wildcards escaped. Both are tested,
the second with a data provider covering `%%` and `__`, which without escaping return every row.

Closed accounts stay findable. They are anonymised rather than removed, and an admin following up on
a report needs to reach one instead of getting a 404.

## The user page, in tabs

**Résumé** answers "who is this" without needing three other screens: identity, the dates that
matter, which profiles they hold, and what they have published. The five content counts run on the
item only; the search list deliberately does not pay for them, which is asserted.

**Rôles** is the one screen that hands out privilege, so it is deliberately narrow:

- **Nobody edits their own roles.** This is the important one. It stops an admin dropping their own
  `ROLE_ADMIN` and locking themselves out of a back office only another admin could let them back
  into, and it closes the simplest self escalation path. The API answers 403 and the UI disables the
  switches and says why.
- **Only `ROLE_ADMIN` and `ROLE_TESTER` are writable.** Anything else is a 422. A role the account
  holds outside that set is preserved rather than dropped: this endpoint owns the grantable set, not
  the whole column.
- **`ROLE_USER` is not offered**, because `User::getRoles()` gives it to everyone already.

`ROLE_TESTER` grants no permission at all, so it toggles freely. `ROLE_ADMIN` asks first.

**Modération** is a placeholder, on purpose. There is no ban, suspend or restrict concept anywhere in
the codebase: no field, no enum, no endpoint. Guessing at one now would be worse than marking the
space, so the tab carries the existing coming soon badge and #943 records what it needs before it is
built: what "banned" means, whether it expires, what happens to already published content, and an
audit trail, which the site does not have today.

## A bug worth naming, found by clicking through it

Cancelling the « grant Administrateur » confirmation left the switch visually **on** while the role
was never granted, so the screen claimed somebody was an administrator when they were not.

PrimeVue's ToggleSwitch keeps its own visual state once clicked and only resyncs when the bound value
actually changes, so binding it straight to `user.roles` made the revert a no-op: the prop was
already false. The positions now live in state the component owns, and go back on dismissal.
`onHide` alone did not fire for the Annuler button, so `reject` is wired too.

## Notes

- `searchForAdmin` joins `profilePicture`, which is the owning side of a nullable `OneToOne` and so
  genuinely lazy, unlike the inverse-side profiles. Without the join every row fetched its own.
- `findOneById` guards `Uuid::isValid` because the User id is a uuid column and `find()` throws on a
  malformed one, which is a 500 rather than a 404 (#934).
- `Assert\Count(max: 2)` bounds the roles array, because `Assert\Unique` scans once per element and
  an unbounded payload burns CPU quadratically before anything rejects it. The literal cannot be
  `count(GRANTABLE_ROLES)`, since an attribute argument has to be a constant expression, so a
  reflection test pins the two together.
- `assets/js/router/admin.test.js` needed a change: it is from #940 and resolved every admin route by
  name, which throws once a route has a required `:id`. It now derives placeholder params from the
  path, so future parameterised admin routes need no change, and it still fails when the meta is
  dropped.

## Checks

Suite 2602 green, PHPStan level 8 clean, Biome clean, `npm run build` clean, 585 JS tests green.

Exercised in the running app: search by username and by email, the detail page and its tabs, revoking
and re-granting `ROLE_TESTER` with both persisting, the `ROLE_ADMIN` confirmation, cancelling it and
confirming the switch reverts with nothing granted, and the self-edit guard on the admin's own page.
