### PR TITLE
Agenda: iCal feed so band dates can be subscribed in Google, Apple and Outlook calendars

### DIFF
--- a/assets/js/api/bandSpace/band-space-agenda-feed.js
+++ b/assets/js/api/bandSpace/band-space-agenda-feed.js
@@ -1,0 +1,35 @@
+/** global: Routing */
+
+import axios from 'axios'
+import { handleApiError } from '../utils/handleApiError.js'
+
+export default {
+  /**
+   * The caller's own feed for this band, never anyone else's, and never the URL: only the token's
+   * hash is stored, so the address exists once, in the response to generate().
+   */
+  getFeed(bandSpaceId) {
+    return axios
+      .get(Routing.generate('api_band_space_agenda_feed_get', { bandSpaceId }))
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
+  /** Generates the feed, or rotates it: either way the previous URL stops working. */
+  generateFeed(bandSpaceId) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_agenda_feed_post', { bandSpaceId }),
+        {},
+        { headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' } }
+      )
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
+  revokeFeed(bandSpaceId) {
+    return axios
+      .delete(Routing.generate('api_band_space_agenda_feed_delete', { bandSpaceId }))
+      .catch(handleApiError)
+  }
+}

--- a/assets/js/components/BandSpace/Settings/CalendarSyncSection.vue
+++ b/assets/js/components/BandSpace/Settings/CalendarSyncSection.vue
@@ -1,0 +1,286 @@
+<template>
+  <div class="bg-surface-0 dark:bg-surface-900 rounded-2xl p-6">
+    <h2 class="text-lg font-semibold text-surface-800 dark:text-surface-100 mb-2">
+      Synchronisation agenda
+    </h2>
+    <p class="text-sm text-surface-600 dark:text-surface-300 mb-4">
+      Recevez les dates du groupe directement dans Google Agenda, Apple Calendrier ou Outlook. Le
+      lien est personnel : il vous appartient et ne concerne que ce Band Space.
+    </p>
+
+    <Message severity="secondary" :closable="false" class="mb-4">
+      <ul class="list-disc pl-4 text-sm space-y-1">
+        <li>
+          L'agenda du groupe apparaît comme un <strong>calendrier séparé</strong>, en lecture seule,
+          avec sa propre couleur et sa propre case pour l'afficher ou le masquer.
+        </li>
+        <li>
+          Seuls les <strong>événements de l'agenda</strong> sont publiés. Les tâches, les finances
+          et les absences restent dans l'application.
+        </li>
+        <li>
+          Google actualise ce type de calendrier <strong>toutes les 8 à 24 heures</strong> et ne
+          propose aucun bouton pour forcer la mise à jour. Une date ajoutée aujourd'hui peut donc
+          n'apparaître que demain sur votre téléphone.
+        </li>
+      </ul>
+    </Message>
+
+    <div v-if="isLoading" class="flex flex-col gap-2">
+      <Skeleton width="100%" height="3rem" borderRadius="0.5rem" />
+      <Skeleton width="60%" height="2rem" borderRadius="0.5rem" />
+    </div>
+
+    <template v-else>
+      <!-- Shown once, right after generating: the address only exists in that response. -->
+      <div
+        v-if="generatedUrl"
+        class="mb-4 rounded-xl border border-primary-200 dark:border-primary-800 bg-primary-50 dark:bg-primary-950/40 p-4"
+      >
+        <p class="text-sm font-medium text-surface-800 dark:text-surface-100 mb-2">
+          Votre lien d'abonnement
+        </p>
+        <div class="flex flex-col sm:flex-row gap-2 mb-3">
+          <InputText
+            :model-value="generatedUrl"
+            readonly
+            class="flex-1 font-mono text-xs"
+            aria-label="Lien d'abonnement à l'agenda"
+            @focus="selectAll"
+          />
+          <Button
+            :icon="hasCopied ? 'pi pi-check' : 'pi pi-copy'"
+            :label="hasCopied ? 'Copié' : 'Copier'"
+            size="small"
+            @click="copyUrl"
+          />
+        </div>
+
+        <div class="flex flex-wrap gap-2 mb-3">
+          <Button
+            label="Ajouter à Google Agenda"
+            icon="pi pi-google"
+            size="small"
+            severity="secondary"
+            outlined
+            :as="'a'"
+            :href="googleUrl"
+            target="_blank"
+            rel="noopener"
+          />
+          <Button
+            label="Apple Calendrier ou Outlook"
+            icon="pi pi-calendar-plus"
+            size="small"
+            severity="secondary"
+            outlined
+            :as="'a'"
+            :href="webcalUrl"
+          />
+        </div>
+
+        <p class="text-xs text-surface-600 dark:text-surface-400">
+          Conservez ce lien : il ne pourra plus être affiché. Toute personne qui le détient peut lire
+          les dates du groupe, ne le publiez pas.
+        </p>
+      </div>
+
+      <div v-if="feed.is_enabled" class="flex flex-col gap-3">
+        <dl class="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+          <div>
+            <dt class="text-surface-500 dark:text-surface-400">Créé le</dt>
+            <dd class="tabular-nums">{{ formatDateLong(feed.creation_datetime) }}</dd>
+          </div>
+          <div>
+            <dt class="text-surface-500 dark:text-surface-400">Dernier accès</dt>
+            <dd class="tabular-nums">
+              {{ feed.last_access_datetime ? formatDateLong(feed.last_access_datetime) : 'Jamais' }}
+            </dd>
+          </div>
+          <div>
+            <dt class="text-surface-500 dark:text-surface-400">Accès</dt>
+            <dd class="tabular-nums">{{ feed.access_count }}</dd>
+          </div>
+        </dl>
+
+        <div class="flex flex-wrap gap-2">
+          <Button
+            label="Régénérer le lien"
+            icon="pi pi-refresh"
+            size="small"
+            severity="secondary"
+            outlined
+            :loading="isSubmitting"
+            @click="confirmRegenerate"
+          />
+          <Button
+            label="Révoquer"
+            icon="pi pi-trash"
+            size="small"
+            severity="danger"
+            text
+            :loading="isSubmitting"
+            @click="confirmRevoke"
+          />
+        </div>
+      </div>
+
+      <Button
+        v-else
+        label="Générer mon lien d'abonnement"
+        icon="pi pi-calendar-plus"
+        size="small"
+        :loading="isSubmitting"
+        @click="generate"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import Skeleton from 'primevue/skeleton'
+import { useConfirm } from 'primevue/useconfirm'
+import { useToast } from 'primevue/usetoast'
+import { computed, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import agendaFeedApi from '../../../api/bandSpace/band-space-agenda-feed.js'
+import { formatDateLong } from '../../../utils/date.js'
+
+const route = useRoute()
+const confirm = useConfirm()
+const toast = useToast()
+
+const bandSpaceId = route.params.id
+const feed = ref({
+  is_enabled: false,
+  creation_datetime: null,
+  last_access_datetime: null,
+  access_count: 0
+})
+const generatedUrl = ref(null)
+const isLoading = ref(true)
+const isSubmitting = ref(false)
+const hasCopied = ref(false)
+
+/**
+ * Apple Calendar and Outlook desktop open their subscribe dialog on a webcal:// link, and Google
+ * accepts one inside its own cid parameter. An https:// URL in that parameter is not reliably
+ * handled, which is why both buttons start from the same webcal form.
+ */
+const webcalUrl = computed(() =>
+  generatedUrl.value ? generatedUrl.value.replace(/^https?:\/\//, 'webcal://') : null
+)
+
+const googleUrl = computed(() =>
+  webcalUrl.value
+    ? `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(webcalUrl.value)}`
+    : null
+)
+
+onMounted(loadFeed)
+
+async function loadFeed() {
+  isLoading.value = true
+  try {
+    feed.value = await agendaFeedApi.getFeed(bandSpaceId)
+  } catch {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: "Impossible de charger l'état de la synchronisation.",
+      life: 4000
+    })
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function generate() {
+  isSubmitting.value = true
+  try {
+    const created = await agendaFeedApi.generateFeed(bandSpaceId)
+    generatedUrl.value = created.feed_url
+    hasCopied.value = false
+    await loadFeed()
+  } catch {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: 'La génération du lien a échoué.',
+      life: 4000
+    })
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+function confirmRegenerate() {
+  confirm.require({
+    message:
+      "Un nouveau lien sera créé et l'ancien cessera immédiatement de fonctionner. Les calendriers déjà abonnés ne se mettront plus à jour.",
+    header: 'Régénérer le lien',
+    icon: 'pi pi-exclamation-triangle',
+    acceptLabel: 'Régénérer',
+    rejectLabel: 'Annuler',
+    accept: generate
+  })
+}
+
+function confirmRevoke() {
+  confirm.require({
+    message:
+      'Le lien cessera de fonctionner et les calendriers déjà abonnés ne se mettront plus à jour.',
+    header: 'Révoquer le lien',
+    icon: 'pi pi-exclamation-triangle',
+    acceptLabel: 'Révoquer',
+    rejectLabel: 'Annuler',
+    acceptProps: { severity: 'danger' },
+    accept: revoke
+  })
+}
+
+async function revoke() {
+  isSubmitting.value = true
+  try {
+    await agendaFeedApi.revokeFeed(bandSpaceId)
+    generatedUrl.value = null
+    await loadFeed()
+    toast.add({
+      severity: 'success',
+      summary: 'Lien révoqué',
+      detail: "Le flux d'agenda a été désactivé.",
+      life: 3000
+    })
+  } catch {
+    toast.add({
+      severity: 'error',
+      summary: 'Erreur',
+      detail: 'La révocation a échoué.',
+      life: 4000
+    })
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+async function copyUrl() {
+  try {
+    await navigator.clipboard.writeText(generatedUrl.value)
+    hasCopied.value = true
+  } catch {
+    toast.add({
+      severity: 'warn',
+      summary: 'Copie impossible',
+      detail: 'Sélectionnez le lien et copiez-le manuellement.',
+      life: 4000
+    })
+  }
+}
+
+function selectAll(event) {
+  event.target.select()
+}
+</script>

--- a/assets/js/components/BandSpace/Settings/activitySentences.js
+++ b/assets/js/components/BandSpace/Settings/activitySentences.js
@@ -57,6 +57,8 @@ const SENTENCES = {
     a.payload?.to ? "a basculé l'événement en journée entière" : 'a quitté la journée entière',
   'agenda.occurrence_cancelled': (a) =>
     `a annulé l'occurrence du ${a.payload?.occurrence_date ?? '?'} de « ${a.payload?.title ?? 'Sans titre'} »`,
+  'agenda.feed_generated': () => "a généré un lien d'abonnement à l'agenda",
+  'agenda.feed_revoked': () => "a révoqué son lien d'abonnement à l'agenda",
   'agenda.series_truncated': (a) =>
     `a tronqué la série « ${a.payload?.title ?? 'Sans titre'} » à partir du ${a.payload?.from_occurrence_date ?? '?'}`,
 

--- a/assets/js/constants/bandSpace.js
+++ b/assets/js/constants/bandSpace.js
@@ -104,6 +104,7 @@ export const BAND_SPACE_SETTINGS_SECTIONS = Object.freeze([
   { key: 'members', label: 'Membres', adminOnly: false },
   { key: 'activity', label: "Journal d'activité", adminOnly: false },
   { key: 'shares', label: 'Partages actifs', adminOnly: false },
+  { key: 'calendar', label: 'Synchronisation agenda', adminOnly: false },
   { key: 'storage', label: 'Stockage', adminOnly: false },
   { key: 'general', label: 'Général', adminOnly: false },
   { key: 'danger', label: 'Zone de danger', adminOnly: false }

--- a/assets/js/views/BandSpace/Agenda.vue
+++ b/assets/js/views/BandSpace/Agenda.vue
@@ -14,6 +14,21 @@
       </div>
       <div class="flex items-center gap-2">
         <Button
+          as="router-link"
+          :to="{
+            name: BAND_SPACE_ROUTES.PARAMETERS,
+            params: { id: route.params.id },
+            query: { section: 'calendar' }
+          }"
+          icon="pi pi-calendar-plus"
+          label="Synchroniser"
+          size="small"
+          severity="secondary"
+          text
+          :pt="{ label: { class: 'hidden sm:inline' } }"
+          aria-label="Synchroniser l'agenda avec mon calendrier personnel"
+        />
+        <Button
           icon="pi pi-user-minus"
           label="Indisponibilités"
           size="small"
@@ -266,6 +281,7 @@ import {
   agendaSourceFor,
   agendaSourceLabel
 } from '../../constants/agendaSources.js'
+import { BAND_SPACE_ROUTES } from '../../constants/bandSpace.js'
 import { useBandAbsenceStore } from '../../store/bandSpace/bandSpaceAbsence.js'
 import { useBandAgendaStore } from '../../store/bandSpace/bandSpaceAgenda.js'
 import {

--- a/assets/js/views/BandSpace/Settings.vue
+++ b/assets/js/views/BandSpace/Settings.vue
@@ -32,6 +32,7 @@
             <MembersSection v-if="activeSection === 'members'" />
             <ActivitySection v-else-if="activeSection === 'activity'" />
             <ActiveSharesSection v-else-if="activeSection === 'shares'" />
+            <CalendarSyncSection v-else-if="activeSection === 'calendar'" />
             <QuotaIndicator v-else-if="activeSection === 'storage'" />
             <GeneralSection v-else-if="activeSection === 'general'" />
             <DangerZoneSection v-else-if="activeSection === 'danger'" />
@@ -49,6 +50,7 @@ import { useRoute } from 'vue-router'
 import QuotaIndicator from '../../components/BandSpace/Files/QuotaIndicator.vue'
 import ActiveSharesSection from '../../components/BandSpace/Settings/ActiveSharesSection.vue'
 import ActivitySection from '../../components/BandSpace/Settings/ActivitySection.vue'
+import CalendarSyncSection from '../../components/BandSpace/Settings/CalendarSyncSection.vue'
 import ComingSoonSection from '../../components/BandSpace/Settings/ComingSoonSection.vue'
 import DangerZoneSection from '../../components/BandSpace/Settings/DangerZoneSection.vue'
 import GeneralSection from '../../components/BandSpace/Settings/GeneralSection.vue'

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -91,6 +91,24 @@ framework:
             limit: 30
             interval: '1 minute'
             cache_pool: "rate_limiter.cache"
+        # Keyed on the token, not on the caller's address: a calendar client polls from its vendor's
+        # shared fetcher pool, so a per IP bucket would let one band's subscribers throttle another's.
+        # 60 an hour against the most aggressive legitimate configuration there is, Apple Calendar at
+        # its 5 minute minimum, which is 12. Google and Outlook are hours apart, so nobody real gets
+        # close. A 429 here is invisible to the user: the client shows nothing and quietly stops
+        # refreshing, which is why the ceiling sits this far above real use.
+        band_space_agenda_feed_access:
+            policy: sliding_window
+            limit: 60
+            interval: '1 hour'
+            cache_pool: "rate_limiter.cache"
+        # Charged only when the token is unknown, and keyed on the address, which is what stops
+        # someone minting a Valkey bucket per token they invent. A real subscriber never reaches it.
+        band_space_agenda_feed_miss:
+            policy: sliding_window
+            limit: 20
+            interval: '1 hour'
+            cache_pool: "rate_limiter.cache"
         band_space_creation:
             policy: fixed_window
             limit: 2

--- a/migrations/2026/09/Version20260906135456.php
+++ b/migrations/2026/09/Version20260906135456.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260906135456 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add band_space_agenda_feed_token, the secret half of a member iCal subscription URL';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE band_space_agenda_feed_token (id CHAR(36) NOT NULL, membership_id CHAR(36) NOT NULL, token_hash VARCHAR(64) NOT NULL, creation_datetime DATETIME NOT NULL, last_access_datetime DATETIME DEFAULT NULL, access_count INT NOT NULL, UNIQUE INDEX UNIQ_CAA3CA65B3BC57DA (token_hash), UNIQUE INDEX UNIQ_CAA3CA651FB354CD (membership_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
+        $this->addSql('ALTER TABLE band_space_agenda_feed_token ADD CONSTRAINT FK_CAA3CA651FB354CD FOREIGN KEY (membership_id) REFERENCES band_space_membership (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band_space_agenda_feed_token DROP FOREIGN KEY FK_CAA3CA651FB354CD');
+        $this->addSql('DROP TABLE band_space_agenda_feed_token');
+    }
+}

--- a/src/ApiResource/BandSpace/AgendaFeedDownload.php
+++ b/src/ApiResource/BandSpace/AgendaFeedDownload.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Provider\BandSpace\AgendaFeedDownloadProvider;
+
+/**
+ * The public feed itself, fetched by the subscriber's calendar client.
+ *
+ * No `security:` attribute on purpose: a calendar client sends no cookie and no JWT. The token in
+ * the path is the whole credential, and `^/api/shares/` is already PUBLIC_ACCESS in security.yaml,
+ * which is the same door the file share links use.
+ */
+#[ApiResource(
+    shortName: 'AgendaFeedDownload',
+    operations: [
+        new Get(
+            uriTemplate: '/shares/agenda/{token}.ics',
+            openapi: new Operation(tags: ['Band Space Agenda']),
+            output: false,
+            name: 'api_band_space_agenda_feed_download',
+            provider: AgendaFeedDownloadProvider::class,
+        ),
+    ],
+)]
+class AgendaFeedDownload
+{
+    #[ApiProperty(identifier: true)]
+    public string $token;
+}

--- a/src/ApiResource/BandSpace/AgendaFeedGenerated.php
+++ b/src/ApiResource/BandSpace/AgendaFeedGenerated.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace;
+
+/**
+ * The one and only time the plaintext feed token is readable.
+ *
+ * Only its sha256 is stored, so this URL cannot be shown again: losing it means generating a new
+ * one, which retires the old. The section that renders this says so.
+ */
+class AgendaFeedGenerated
+{
+    public string $feedUrl;
+
+    public \DateTimeInterface $creationDatetime;
+}

--- a/src/ApiResource/BandSpace/AgendaFeedResource.php
+++ b/src/ApiResource/BandSpace/AgendaFeedResource.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\AgendaFeedGenerateProcessor;
+use App\State\Processor\BandSpace\AgendaFeedRevokeProcessor;
+use App\State\Provider\BandSpace\AgendaFeedProvider;
+
+/**
+ * A member's own iCal subscription for one band space: whether one exists, and how it is doing.
+ *
+ * Member level rather than admin level, and singular rather than a collection: the feed belongs to
+ * the person, and each membership holds at most one. Nobody, admin included, reads anyone else's.
+ */
+#[ApiResource(
+    shortName: 'AgendaFeed',
+    operations: [
+        new Get(
+            uriTemplate: '/band_spaces/{bandSpaceId}/agenda-feed',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            openapi: new Operation(tags: ['Band Space Agenda']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_agenda_feed_get',
+            provider: AgendaFeedProvider::class,
+        ),
+        new Post(
+            uriTemplate: '/band_spaces/{bandSpaceId}/agenda-feed',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            openapi: new Operation(tags: ['Band Space Agenda']),
+            security: "is_granted('ROLE_USER')",
+            input: false,
+            output: AgendaFeedGenerated::class,
+            name: 'api_band_space_agenda_feed_post',
+            processor: AgendaFeedGenerateProcessor::class,
+        ),
+        new Delete(
+            uriTemplate: '/band_spaces/{bandSpaceId}/agenda-feed',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            openapi: new Operation(tags: ['Band Space Agenda']),
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_agenda_feed_delete',
+            // API Platform reads before it writes on a Delete, and with no provider the default one
+            // finds nothing and answers 404 before the processor is ever reached.
+            provider: AgendaFeedProvider::class,
+            processor: AgendaFeedRevokeProcessor::class,
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+class AgendaFeedResource
+{
+    #[ApiProperty(identifier: true)]
+    public string $bandSpaceId;
+
+    public bool $isEnabled = false;
+
+    /**
+     * Never the URL: only the token's sha256 is stored, so the feed cannot be shown again after the
+     * response that created it.
+     */
+    public ?\DateTimeInterface $creationDatetime = null;
+
+    public ?\DateTimeInterface $lastAccessDatetime = null;
+
+    public int $accessCount = 0;
+}

--- a/src/Entity/BandSpace/AgendaFeedToken.php
+++ b/src/Entity/BandSpace/AgendaFeedToken.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity\BandSpace;
+
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * The secret half of one member's agenda iCal subscription URL.
+ *
+ * Hung off the membership rather than off the band space, so a leaked URL is revoked for one person
+ * in one band. A member of several bands therefore holds several tokens, which their calendar client
+ * renders as several separately coloured, separately toggleable calendars.
+ *
+ * `onDelete: CASCADE` is a safety net, not the revocation mechanism: a membership row survives
+ * leaving and being kicked (it goes to `MembershipStatus::Left` / `Kicked` and keeps a
+ * `leftDatetime`), so the cascade never fires on either. Revocation is the token row being deleted
+ * by the leave and kick processors, backed by the feed provider refusing a membership that is no
+ * longer active.
+ */
+#[ORM\Entity(repositoryClass: AgendaFeedTokenRepository::class)]
+#[ORM\Table(name: 'band_space_agenda_feed_token')]
+class AgendaFeedToken
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    public UuidInterface|string|null $id = null {
+        get {
+            return is_string($this->id) ? $this->id : $this->id?->toString();
+        }
+    }
+
+    /**
+     * Unique, so regenerating rotates the hash in place and a member never holds two live feeds for
+     * the same band.
+     */
+    #[ORM\OneToOne(targetEntity: BandSpaceMembership::class)]
+    #[ORM\JoinColumn(nullable: false, unique: true, onDelete: 'CASCADE')]
+    public BandSpaceMembership $membership;
+
+    /** sha256 of the plaintext token, which is never stored. */
+    #[ORM\Column(type: Types::STRING, length: 64, unique: true)]
+    public string $tokenHash;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    public DateTimeImmutable $creationDatetime;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    public ?DateTimeImmutable $lastAccessDatetime = null;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $accessCount = 0;
+
+    public function __construct()
+    {
+        $this->creationDatetime = new DateTimeImmutable();
+    }
+}

--- a/src/Enum/BandSpace/BandSpaceAgendaActivityType.php
+++ b/src/Enum/BandSpace/BandSpaceAgendaActivityType.php
@@ -14,4 +14,6 @@ enum BandSpaceAgendaActivityType: string
     case IsAllDayChanged = 'is_all_day_changed';
     case OccurrenceCancelled = 'occurrence_cancelled';
     case SeriesTruncated = 'series_truncated';
+    case FeedGenerated = 'feed_generated';
+    case FeedRevoked = 'feed_revoked';
 }

--- a/src/Repository/BandSpace/AgendaFeedTokenRepository.php
+++ b/src/Repository/BandSpace/AgendaFeedTokenRepository.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository\BandSpace;
+
+use App\Entity\BandSpace\AgendaFeedToken;
+use App\Entity\BandSpace\BandSpaceMembership;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<AgendaFeedToken>
+ */
+class AgendaFeedTokenRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AgendaFeedToken::class);
+    }
+
+    /**
+     * The whole aggregate the public feed needs, in one query: the token, the membership behind it
+     * (whose status decides whether the feed is still allowed) and the band space (whose name goes
+     * into X-WR-CALNAME). The endpoint is unauthenticated and polled, so it does no second lookup.
+     */
+    public function findOneByTokenHash(string $tokenHash): ?AgendaFeedToken
+    {
+        return $this->createQueryBuilder('t')
+            ->addSelect('m', 'b')
+            ->innerJoin('t.membership', 'm')
+            ->innerJoin('m.bandSpace', 'b')
+            ->where('t.tokenHash = :hash')
+            ->setParameter('hash', $tokenHash)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findOneByMembership(BandSpaceMembership $membership): ?AgendaFeedToken
+    {
+        return $this->findOneBy(['membership' => $membership]);
+    }
+
+    /**
+     * Kills the feed of a member on their way out, whether they left, were removed by an admin or
+     * deleted their MusicAll account.
+     *
+     * DQL rather than a find and remove because the row is only ever hydrated to be thrown away, and
+     * because the three departure paths would otherwise each carry the same null check. Nothing is
+     * lost by bypassing the ORM here: AgendaFeedToken has no lifecycle callbacks, no upload behind
+     * it and nothing cascading off it, and no departure path holds the entity.
+     *
+     * The read side does not depend on this: AgendaFeedDownloadProvider refuses a membership that is
+     * not active anyway, so a departure that somehow skipped this call still closes the feed.
+     */
+    public function deleteForMembership(BandSpaceMembership $membership): void
+    {
+        $this->getEntityManager()
+            ->createQuery('DELETE FROM App\Entity\BandSpace\AgendaFeedToken t WHERE t.membership = :membership')
+            ->setParameter('membership', $membership)
+            ->execute();
+    }
+}

--- a/src/Service/BandSpace/IcalFeedBuilder.php
+++ b/src/Service/BandSpace/IcalFeedBuilder.php
@@ -1,0 +1,210 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\BandSpace;
+
+use App\ApiResource\BandSpace\AgendaItem;
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * Serialises agenda items into the RFC 5545 document a calendar client subscribes to.
+ *
+ * Occurrences are emitted expanded rather than as an RRULE. AgendaAggregator already expands them,
+ * in civil time and with cancellations applied (#821), and our recurrence model is not a full RRULE,
+ * so deriving one here would be a second source of truth free to disagree with the app.
+ *
+ * Hand rolled rather than pulled from a library: eight properties are emitted, and every library
+ * brings its own event model, so the mapping layer would be most of the code anyway. The risk lives
+ * in the folding and escaping rules, and that is what the unit test covers.
+ */
+final class IcalFeedBuilder
+{
+    /** RFC 5545 3.1: no content line exceeds 75 octets, and every break is a CRLF. */
+    private const int FOLD_OCTETS = 75;
+
+    private const string LINE_BREAK = "\r\n";
+
+    /** The right hand side of a UID, so ours cannot collide with another publisher's. */
+    private const string UID_DOMAIN = '@musicall.com';
+
+    private const string PRODUCT_ID = '-//MusicAll//Band Space Agenda//FR';
+
+    /** What honest clients are asked to wait between polls. Outlook reads X-PUBLISHED-TTL. */
+    private const string REFRESH_INTERVAL = 'PT12H';
+
+    /**
+     * @param AgendaItem[] $items      already narrowed to the sources the feed publishes
+     * @param DateTimeImmutable $generatedAt what every DTSTAMP carries. Passed in rather than read
+     *                                       off the clock so the body is byte identical between two
+     *                                       polls that find nothing changed, which is the whole
+     *                                       basis of the ETag on this endpoint.
+     */
+    public function build(array $items, string $calendarName, DateTimeImmutable $generatedAt): string
+    {
+        $stamp = $this->utcStamp($generatedAt);
+
+        $lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:' . self::PRODUCT_ID,
+            'CALSCALE:GREGORIAN',
+            // Deliberately no METHOD. METHOD:PUBLISH makes Outlook treat the document as a one off
+            // import rather than as a subscription it keeps refreshing.
+            'X-WR-CALNAME:' . $this->escapeText($calendarName),
+            'X-PUBLISHED-TTL:' . self::REFRESH_INTERVAL,
+            'REFRESH-INTERVAL;VALUE=DURATION:' . self::REFRESH_INTERVAL,
+        ];
+
+        foreach ($items as $item) {
+            array_push($lines, ...$this->buildEvent($item, $stamp));
+        }
+
+        $lines[] = 'END:VCALENDAR';
+
+        return implode(self::LINE_BREAK, array_map($this->fold(...), $lines)) . self::LINE_BREAK;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildEvent(AgendaItem $item, string $stamp): array
+    {
+        $lines = [
+            // AgendaItem::$id is already stable across fetches, occurrences included, which is the
+            // property that matters: a UID that moved would have the subscriber's calendar filling
+            // up with a fresh copy of every event on every poll.
+            'UID:' . $item->id . self::UID_DOMAIN,
+            'DTSTAMP:' . $stamp,
+        ];
+
+        array_push($lines, ...($item->isAllDay ? $this->allDayBounds($item) : $this->timedBounds($item)));
+
+        $lines[] = 'SUMMARY:' . $this->escapeText($item->title);
+
+        if ($item->description !== null && $item->description !== '') {
+            $lines[] = 'DESCRIPTION:' . $this->escapeText($item->description);
+        }
+
+        $location = $item->metadata['location'] ?? null;
+        if (is_string($location) && $location !== '') {
+            $lines[] = 'LOCATION:' . $this->escapeText($location);
+        }
+
+        return ['BEGIN:VEVENT', ...$lines, 'END:VEVENT'];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function allDayBounds(AgendaItem $item): array
+    {
+        $firstDay = $this->writtenDay($item->datetime);
+        // Our end is the last day the entry covers; RFC 5545 wants the day after it. That is the
+        // same conversion assets/js/utils/agendaDate.js does for FullCalendar, which reads an all
+        // day end as exclusive too. An entry with no end covers its single day.
+        $lastDay = $item->endDatetime !== null ? $this->writtenDay($item->endDatetime) : $firstDay;
+
+        return [
+            'DTSTART;VALUE=DATE:' . $firstDay->format('Ymd'),
+            'DTEND;VALUE=DATE:' . $lastDay->modify('+1 day')->format('Ymd'),
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function timedBounds(AgendaItem $item): array
+    {
+        $lines = ['DTSTART:' . $this->utcStamp(new DateTimeImmutable($item->datetime))];
+
+        // No DTEND when the entry has none. RFC 5545 reads a DATE-TIME start with no end as an event
+        // ending at its start, which is exactly what the app knows; inventing a duration would put a
+        // length on the subscriber's calendar that nobody typed.
+        if ($item->endDatetime !== null) {
+            $lines[] = 'DTEND:' . $this->utcStamp(new DateTimeImmutable($item->endDatetime));
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The day an all day item was written for, read off the front of the string rather than parsed
+     * and converted.
+     *
+     * All day items reach here pinned to midnight UTC by the aggregator. Converting that pin instead
+     * of reading it is what #877 and #912 were about: west of UTC the day moves back one, and the
+     * event lands in the wrong cell of the subscriber's calendar rather than merely showing an odd
+     * hour.
+     */
+    private function writtenDay(string $atom): DateTimeImmutable
+    {
+        return new DateTimeImmutable(substr($atom, 0, 10) . ' 00:00:00', new DateTimeZone('UTC'));
+    }
+
+    /**
+     * A UTC instant, with the trailing Z that saves the document from carrying a VTIMEZONE block.
+     */
+    private function utcStamp(DateTimeImmutable $moment): string
+    {
+        return $moment->setTimezone(new DateTimeZone('UTC'))->format('Ymd\THis\Z');
+    }
+
+    /**
+     * RFC 5545 3.3.11.
+     *
+     * The backslash pass runs first, so a backslash the user typed is doubled before this method
+     * starts adding its own and doubling those too.
+     *
+     * Control characters are dropped rather than escaped, because TEXT has no representation for
+     * them. Removing them by byte is safe on the accented titles this app is full of: none of the
+     * removed values can appear inside a UTF-8 sequence, whose bytes are all >= 0x80. It also
+     * disposes of the null byte, which this project has met before (#934).
+     */
+    private function escapeText(string $value): string
+    {
+        $withoutControls = (string) preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $value);
+
+        return str_replace(
+            ['\\', "\r\n", "\n", "\r", ';', ','],
+            ['\\\\', '\\n', '\\n', '\\n', '\\;', '\\,'],
+            $withoutControls,
+        );
+    }
+
+    /**
+     * RFC 5545 3.1.
+     *
+     * The 75 counts octets, and the leading space of a continuation counts toward its own 75. The
+     * part worth being careful about is that a fold must never land inside a UTF-8 sequence:
+     * splitting « Répétition » mid character is the bug this app would actually hit, and it produces
+     * a calendar the client refuses rather than a cosmetic glitch.
+     */
+    private function fold(string $line): string
+    {
+        if (strlen($line) <= self::FOLD_OCTETS) {
+            return $line;
+        }
+
+        $characters = preg_split('//u', $line, -1, PREG_SPLIT_NO_EMPTY);
+        if ($characters === false) {
+            // Not valid UTF-8, so there is no safe place to cut. An over long line is a lesser
+            // failure than a truncated one.
+            return $line;
+        }
+
+        $folded = [];
+        $current = '';
+
+        foreach ($characters as $character) {
+            if (strlen($current) + strlen($character) > self::FOLD_OCTETS) {
+                $folded[] = $current;
+                $current = ' ';
+            }
+            $current .= $character;
+        }
+
+        $folded[] = $current;
+
+        return implode(self::LINE_BREAK, $folded);
+    }
+}

--- a/src/Service/BandSpace/ShareTokenService.php
+++ b/src/Service/BandSpace/ShareTokenService.php
@@ -1,8 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace App\Service\BandSpace\File;
+namespace App\Service\BandSpace;
 
-final class FileShareTokenService
+/**
+ * Mints the secret half of a public Band Space URL, for the file share links and for the agenda
+ * iCal feed.
+ *
+ * Only the sha256 is ever stored, so a database dump does not hand over working links. The plaintext
+ * token exists once, in the response that created it, which is why both callers surface it to the
+ * user immediately and never read it back.
+ */
+final class ShareTokenService
 {
     private const int TOKEN_BYTES = 32;
 

--- a/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
+++ b/src/Service/Procedure/BandSpace/WithdrawUserFromBandSpacesProcedure.php
@@ -11,6 +11,7 @@ use App\Enum\BandSpace\BandSpaceSettingsActivityType;
 use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\BandSpace\Role;
 use App\Event\BandSpaceMemberRoleChangedEvent;
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\BandSpace\BandSpaceDeletionScheduler;
@@ -64,6 +65,7 @@ readonly class WithdrawUserFromBandSpacesProcedure
         private BandSpaceDeletionScheduler $bandSpaceDeletionScheduler,
         private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
         private TaskAssignmentRevoker $taskAssignmentRevoker,
+        private AgendaFeedTokenRepository $agendaFeedTokenRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
     ) {
     }
@@ -104,6 +106,7 @@ readonly class WithdrawUserFromBandSpacesProcedure
 
         $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
         $this->taskAssignmentRevoker->revokeForMember($membership, $user);
+        $this->agendaFeedTokenRepository->deleteForMembership($membership);
 
         $this->bandSpaceActivityRecorder->record(
             bandSpace: $bandSpace,

--- a/src/State/Processor/BandSpace/AgendaFeedGenerateProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaFeedGenerateProcessor.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\AgendaFeedGenerated;
+use App\Entity\BandSpace\AgendaFeedToken;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceAgendaActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use App\Service\BandSpace\ShareTokenService;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Mints, or rotates, the caller's iCal subscription URL for one band space.
+ *
+ * @implements ProcessorInterface<mixed, AgendaFeedGenerated>
+ */
+readonly class AgendaFeedGenerateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private AgendaFeedTokenRepository $feedTokenRepository,
+        private ShareTokenService $tokenService,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private EntityManagerInterface $entityManager,
+        private UrlGeneratorInterface $urlGenerator,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): AgendaFeedGenerated
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $membership] = $this->memberChecker->checkMemberForWrite(
+            (string) $uriVariables['bandSpaceId'],
+            $user,
+        );
+
+        $tokenPair = $this->tokenService->generate();
+
+        // One row per membership, so a second call rotates the hash in place rather than leaving two
+        // live URLs behind. That is also what makes this the revoke-and-replace action the UI calls
+        // « Régénérer »: the previous URL stops working the moment this returns.
+        $feedToken = $this->feedTokenRepository->findOneByMembership($membership) ?? new AgendaFeedToken();
+        $feedToken->membership = $membership;
+        $feedToken->tokenHash = $tokenPair['hash'];
+        // Every counter on the row describes a URL, and the URL has just changed, so they are reset
+        // with it. Carried over, a link generated seconds ago would report itself as created last
+        // month and already fetched forty times, which is the retired one's history.
+        $feedToken->creationDatetime = new DateTimeImmutable();
+        $feedToken->accessCount = 0;
+        $feedToken->lastAccessDatetime = null;
+
+        $this->entityManager->persist($feedToken);
+
+        $this->activityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Agenda,
+            type: BandSpaceAgendaActivityType::FeedGenerated,
+            actor: $user,
+        );
+
+        $this->entityManager->flush();
+
+        $generated = new AgendaFeedGenerated();
+        $generated->feedUrl = $this->urlGenerator->generate(
+            'api_band_space_agenda_feed_download',
+            ['token' => $tokenPair['token']],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+        $generated->creationDatetime = $feedToken->creationDatetime;
+
+        return $generated;
+    }
+}

--- a/src/State/Processor/BandSpace/AgendaFeedRevokeProcessor.php
+++ b/src/State/Processor/BandSpace/AgendaFeedRevokeProcessor.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\BandSpace\AgendaFeedToken;
+use App\Entity\User;
+use App\Enum\BandSpace\BandSpaceAgendaActivityType;
+use App\Enum\BandSpace\BandSpaceModule;
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\BandSpace\BandSpaceActivityRecorder;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProcessorInterface<mixed, null>
+ */
+readonly class AgendaFeedRevokeProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private AgendaFeedTokenRepository $feedTokenRepository,
+        private BandSpaceActivityRecorder $activityRecorder,
+        private EntityManagerInterface $entityManager,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): null
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        [$bandSpace, $membership] = $this->memberChecker->checkMemberForWrite(
+            (string) $uriVariables['bandSpaceId'],
+            $user,
+        );
+
+        $feedToken = $this->feedTokenRepository->findOneByMembership($membership);
+        if (!$feedToken instanceof AgendaFeedToken) {
+            throw new NotFoundHttpException('Aucun flux à révoquer');
+        }
+
+        // Deleted rather than flagged. There is at most one row per membership and nobody reads a
+        // dead one, so a revocation datetime would only buy the 410 that a file share needs for the
+        // human on its landing page. A calendar client has no human to read it.
+        $this->entityManager->remove($feedToken);
+
+        $this->activityRecorder->record(
+            bandSpace: $bandSpace,
+            module: BandSpaceModule::Agenda,
+            type: BandSpaceAgendaActivityType::FeedRevoked,
+            actor: $user,
+        );
+
+        $this->entityManager->flush();
+
+        return null;
+    }
+}

--- a/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceLeaveProcessor.php
@@ -10,6 +10,7 @@ use App\Enum\BandSpace\BandSpaceSettingsActivityType;
 use App\Enum\BandSpace\MembershipStatus;
 use App\Enum\BandSpace\Role;
 use App\Event\BandSpaceMemberLeftEvent;
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
@@ -34,6 +35,7 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
         private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
         private TaskAssignmentRevoker $taskAssignmentRevoker,
+        private AgendaFeedTokenRepository $agendaFeedTokenRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
         private EventDispatcherInterface $eventDispatcher,
@@ -69,6 +71,7 @@ readonly class BandSpaceLeaveProcessor implements ProcessorInterface
 
             $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
             $this->taskAssignmentRevoker->revokeForMember($membership, $user);
+            $this->agendaFeedTokenRepository->deleteForMembership($membership);
 
             $this->bandSpaceActivityRecorder->record(
                 bandSpace: $bandSpace,

--- a/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceMemberDeleteProcessor.php
@@ -10,6 +10,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Enum\BandSpace\BandSpaceSettingsActivityType;
 use App\Enum\BandSpace\MembershipStatus;
 use App\Event\BandSpaceMemberRemovedEvent;
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Security\BandSpace\BandSpaceAdminChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
@@ -33,6 +34,7 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
         private PersonalRecurrenceDeactivator $personalRecurrenceDeactivator,
         private TaskAssignmentRevoker $taskAssignmentRevoker,
+        private AgendaFeedTokenRepository $agendaFeedTokenRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
         private EventDispatcherInterface $eventDispatcher,
@@ -72,6 +74,7 @@ readonly class BandSpaceMemberDeleteProcessor implements ProcessorInterface
 
             $this->personalRecurrenceDeactivator->deactivateForMember($membership, $user);
             $this->taskAssignmentRevoker->revokeForMember($membership, $user);
+            $this->agendaFeedTokenRepository->deleteForMembership($membership);
 
             $this->bandSpaceActivityRecorder->record(
                 bandSpace: $bandSpace,

--- a/src/State/Processor/BandSpace/File/BandSpaceFileShareCreateProcessor.php
+++ b/src/State/Processor/BandSpace/File/BandSpaceFileShareCreateProcessor.php
@@ -13,7 +13,7 @@ use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Security\BandSpace\BandSpaceAdminChecker;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
-use App\Service\BandSpace\File\FileShareTokenService;
+use App\Service\BandSpace\ShareTokenService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -33,7 +33,7 @@ readonly class BandSpaceFileShareCreateProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceAdminChecker $adminChecker,
         private BandSpaceFileRepository $fileRepository,
-        private FileShareTokenService $tokenService,
+        private ShareTokenService $tokenService,
         private PasswordHasherFactoryInterface $passwordHasherFactory,
         private BandSpaceActivityRecorder $activityRecorder,
         private RequestStack $requestStack,

--- a/src/State/Provider/BandSpace/AgendaFeedDownloadProvider.php
+++ b/src/State/Provider/BandSpace/AgendaFeedDownloadProvider.php
@@ -1,0 +1,161 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\AgendaItem;
+use App\Entity\BandSpace\AgendaFeedToken;
+use App\Enum\BandSpace\MembershipStatus;
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
+use App\Service\BandSpace\AgendaAggregator;
+use App\Service\BandSpace\IcalFeedBuilder;
+use App\Service\BandSpace\ShareTokenService;
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Target;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * Serves one member's agenda as an RFC 5545 document to whatever calendar client holds their token.
+ *
+ * @implements ProviderInterface<Response>
+ */
+readonly class AgendaFeedDownloadProvider implements ProviderInterface
+{
+    /**
+     * Manual entries only. Tasks, finance rows and absences are context for the agenda screen, which
+     * has filter chips and per source colours; a subscribed calendar has neither, and dropping four
+     * sources into one uncoloured calendar is how a subscription gets deleted. A second source, if
+     * ever asked for, becomes its own URL so the client can colour and hide it on its own.
+     */
+    private const string PUBLISHED_SOURCE = 'manual';
+
+    private const string WINDOW_START = '-12 months';
+
+    private const string WINDOW_END = '+24 months';
+
+    public function __construct(
+        private AgendaFeedTokenRepository $feedTokenRepository,
+        private ShareTokenService $tokenService,
+        private AgendaAggregator $agendaAggregator,
+        private IcalFeedBuilder $icalFeedBuilder,
+        private EntityManagerInterface $entityManager,
+        private RequestStack $requestStack,
+        #[Target('band_space_agenda_feed_access')]
+        private RateLimiterFactoryInterface $feedAccessLimiter,
+        #[Target('band_space_agenda_feed_miss')]
+        private RateLimiterFactoryInterface $feedMissLimiter,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): Response
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $feedToken = $this->feedTokenRepository->findOneByTokenHash(
+            $this->tokenService->hashOf((string) $uriVariables['token']),
+        );
+
+        // The lookup comes before either limiter on purpose. Keying the access limiter on the token
+        // is what makes it safe for a feed, since a calendar client's requests arrive from its
+        // vendor's shared fetcher pool and a per IP bucket would let one band's polling throttle
+        // another's. But a bucket per token asked for would let anyone mint unbounded keys in
+        // Valkey, so an unknown token is charged to the caller's own address instead.
+        if (!$feedToken instanceof AgendaFeedToken) {
+            $this->consume($this->feedMissLimiter, $request?->getClientIp() ?? 'unknown');
+
+            throw new NotFoundHttpException('Flux introuvable');
+        }
+
+        $this->consume($this->feedAccessLimiter, $feedToken->tokenHash);
+
+        $membership = $feedToken->membership;
+        // The token outlives the membership: a row goes to Left or Kicked and keeps its
+        // leftDatetime, it is never deleted, so the FK's onDelete CASCADE never fires. Without this
+        // line somebody thrown out of the band would keep reading its dates indefinitely. The leave
+        // and kick processors drop the token too; this is the check that does not depend on them.
+        if ($membership->status !== MembershipStatus::Active) {
+            throw new NotFoundHttpException('Flux introuvable');
+        }
+
+        // Snapped to midnight rather than computed to the second, so two polls on the same day
+        // expand the same occurrences and produce the same bytes. Without that the ETag below would
+        // change on every request and never save anything.
+        $today = new DateTimeImmutable('today', new DateTimeZone('UTC'));
+        $bandSpace = $membership->bandSpace;
+
+        $items = array_filter(
+            $this->agendaAggregator->aggregate(
+                $bandSpace,
+                $membership,
+                $today->modify(self::WINDOW_START),
+                $today->modify(self::WINDOW_END),
+            ),
+            static fn(AgendaItem $item): bool => $item->source === self::PUBLISHED_SOURCE,
+        );
+
+        $body = $this->icalFeedBuilder->build($items, $bandSpace->name, $today);
+
+        $feedToken->accessCount += 1;
+        $feedToken->lastAccessDatetime = new DateTimeImmutable();
+        $this->entityManager->flush();
+
+        return $this->respond($body, $request);
+    }
+
+    /**
+     * The document, or a 304 when the client already holds it.
+     *
+     * The ETag saves the transfer, not the aggregation: it is computed from the body, so the work
+     * has already happened by the time we know the client is up to date. That is the right trade for
+     * now, since the expansion is a handful of queries while a feed of a busy year is tens of
+     * kilobytes fetched by every member's client. The body only varies by band space and by day, so
+     * that pair is where a Valkey cache would key if one is ever measured to be worth it.
+     */
+    private function respond(string $body, ?Request $request): Response
+    {
+        $response = new Response($body, Response::HTTP_OK, [
+            'Content-Type' => 'text/calendar; charset=utf-8',
+            // The body is member authored, so it is served the way BandSpaceFileDownloadProvider
+            // serves an upload. No browser promotes an explicit text/calendar to text/html today,
+            // which makes this defence in depth rather than a fix.
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+        $response->setEtag(hash('xxh128', $body));
+        $response->setPrivate();
+        $response->setMaxAge(3600);
+
+        if ($request instanceof Request) {
+            // Turns the response into a bodyless 304 when If-None-Match matches.
+            $response->isNotModified($request);
+        }
+
+        return $response;
+    }
+
+    /**
+     * A 429 carrying Retry-After.
+     *
+     * The bare RateLimitExceededException maps to a 429 with no header, which is worse than usual
+     * here: a calendar client shows the user nothing and quietly stops refreshing, so a stale
+     * calendar is the only symptom. Telling it when to come back is the least we can do.
+     */
+    private function consume(RateLimiterFactoryInterface $limiterFactory, string $key): void
+    {
+        $limit = $limiterFactory->create($key)->consume();
+        if ($limit->isAccepted()) {
+            return;
+        }
+
+        throw new TooManyRequestsHttpException(
+            max(1, $limit->getRetryAfter()->getTimestamp() - time()),
+            'Trop de requêtes sur ce flux',
+        );
+    }
+}

--- a/src/State/Provider/BandSpace/AgendaFeedProvider.php
+++ b/src/State/Provider/BandSpace/AgendaFeedProvider.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\AgendaFeedResource;
+use App\Entity\BandSpace\AgendaFeedToken;
+use App\Entity\User;
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @implements ProviderInterface<AgendaFeedResource>
+ */
+readonly class AgendaFeedProvider implements ProviderInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private AgendaFeedTokenRepository $feedTokenRepository,
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): AgendaFeedResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $bandSpaceId = (string) $uriVariables['bandSpaceId'];
+        [, $membership] = $this->memberChecker->checkMember($bandSpaceId, $user);
+
+        $resource = new AgendaFeedResource();
+        $resource->bandSpaceId = $bandSpaceId;
+
+        // The caller's own feed, looked up by their membership: there is no reading of anyone else's,
+        // for an admin no more than for anyone. And no URL, because only the hash was ever stored.
+        $feedToken = $this->feedTokenRepository->findOneByMembership($membership);
+        if ($feedToken instanceof AgendaFeedToken) {
+            $resource->isEnabled = true;
+            $resource->creationDatetime = $feedToken->creationDatetime;
+            $resource->lastAccessDatetime = $feedToken->lastAccessDatetime;
+            $resource->accessCount = $feedToken->accessCount;
+        }
+
+        return $resource;
+    }
+}

--- a/src/State/Provider/BandSpace/File/BandSpaceFilePublicShareDownloadProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFilePublicShareDownloadProvider.php
@@ -9,7 +9,7 @@ use App\Enum\BandSpace\BandSpaceFileActivityType;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\BandSpaceFileShareRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
-use App\Service\BandSpace\File\FileShareTokenService;
+use App\Service\BandSpace\ShareTokenService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -29,7 +29,7 @@ readonly class BandSpaceFilePublicShareDownloadProvider implements ProviderInter
     public function __construct(
         private EntityManagerInterface $entityManager,
         private BandSpaceFileShareRepository $shareRepository,
-        private FileShareTokenService $tokenService,
+        private ShareTokenService $tokenService,
         private PasswordHasherFactoryInterface $passwordHasherFactory,
         private BandSpaceActivityRecorder $activityRecorder,
         private StorageInterface $vichStorage,

--- a/src/State/Provider/BandSpace/File/BandSpaceFilePublicShareMetadataProvider.php
+++ b/src/State/Provider/BandSpace/File/BandSpaceFilePublicShareMetadataProvider.php
@@ -6,7 +6,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\BandSpace\File\BandSpaceFilePublicShareMetadata;
 use App\Repository\BandSpace\BandSpaceFileShareRepository;
-use App\Service\BandSpace\File\FileShareTokenService;
+use App\Service\BandSpace\ShareTokenService;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\GoneHttpException;
@@ -20,7 +20,7 @@ readonly class BandSpaceFilePublicShareMetadataProvider implements ProviderInter
 {
     public function __construct(
         private BandSpaceFileShareRepository $shareRepository,
-        private FileShareTokenService $tokenService,
+        private ShareTokenService $tokenService,
         private RequestStack $requestStack,
         #[Target('band_space_file_share_access')]
         private RateLimiterFactoryInterface $shareAccessLimiter,

--- a/tests/Api/BandSpace/Agenda/AgendaFeedTest.php
+++ b/tests/Api/BandSpace/Agenda/AgendaFeedTest.php
@@ -1,0 +1,453 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Agenda;
+
+use App\Entity\BandSpace\AgendaFeedToken;
+use App\Enum\BandSpace\MembershipStatus;
+use App\Enum\BandSpace\TaskPriority;
+use App\Enum\BandSpace\TaskStatus;
+use App\Repository\BandSpace\AgendaFeedTokenRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\AgendaEntryFactory;
+use App\Tests\Factory\BandSpace\AgendaFeedTokenFactory;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\BandSpace\FinanceCategoryFactory;
+use App\Tests\Factory\BandSpace\FinanceEntryFactory;
+use App\Tests\Factory\BandSpace\MemberAbsenceFactory;
+use App\Tests\Factory\BandSpace\TaskFactory;
+use App\Tests\Factory\User\UserFactory;
+use DateTimeImmutable;
+use DateTimeZone;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class AgendaFeedTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const string KNOWN_TOKEN = 'a-token-only-this-test-knows';
+
+    public function test_a_member_generates_a_feed_and_only_the_hash_is_stored(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-feed',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $response = $this->getResponseAsArray();
+
+        // The token is random, so the URL cannot be asserted whole. What matters is its shape and
+        // that the row behind it holds the hash of the token the caller was just handed.
+        $this->assertMatchesRegularExpression(
+            '#^https?://[^/]+/api/shares/agenda/[A-Za-z0-9_\-]+\.ics$#',
+            $response['feed_url'],
+        );
+
+        $tokens = $this->feedTokenRepository()->findBy(['membership' => $membership]);
+        $this->assertCount(1, $tokens);
+        $this->assertSame(hash('sha256', $this->tokenFromUrl($response['feed_url'])), $tokens[0]->tokenHash);
+        $this->assertSame(0, $tokens[0]->accessCount);
+        $this->assertNull($tokens[0]->lastAccessDatetime);
+        $this->assertSame(
+            $tokens[0]->creationDatetime->format(\DateTimeInterface::ATOM),
+            $response['creation_datetime'],
+        );
+    }
+
+    public function test_generating_twice_rotates_the_token_in_place(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership])->withPlainToken(self::KNOWN_TOKEN)->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/agenda-feed',
+            [],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        // A member holds one feed per band, never two: the old URL is dead the moment a new one is
+        // handed out, which is what makes this the revoke and replace action the UI offers.
+        $tokens = $this->feedTokenRepository()->findBy(['membership' => $membership]);
+        $this->assertCount(1, $tokens);
+        $this->assertNotSame(hash('sha256', self::KNOWN_TOKEN), $tokens[0]->tokenHash);
+        // The counters described the URL that has just been retired, so they go with it. Kept, a
+        // link minted a second ago would report itself as already fetched nine times.
+        $this->assertSame(0, $tokens[0]->accessCount);
+        $this->assertNull($tokens[0]->lastAccessDatetime);
+        $this->assertGreaterThan(
+            new DateTimeImmutable('-1 hour'),
+            $tokens[0]->creationDatetime,
+        );
+    }
+
+    public function test_a_non_member_cannot_generate_a_feed(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $this->client->loginUser($stranger);
+        $this->client->jsonRequest('POST', '/api/band_spaces/' . $bandSpace->id . '/agenda-feed', [], [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'status' => 403,
+            'type' => '/errors/403',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+        ]);
+        $this->assertCount(0, $this->feedTokenRepository()->findAll());
+    }
+
+    public function test_a_non_member_cannot_revoke_a_feed(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create();
+        $stranger = UserFactory::new()->asBaseUser()->create([
+            'username' => 'a_stranger',
+            'email' => 'a_stranger@email.com',
+        ]);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $member])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership])->withPlainToken(self::KNOWN_TOKEN)->create();
+
+        $this->client->loginUser($stranger);
+        $this->client->jsonRequest('DELETE', '/api/band_spaces/' . $bandSpace->id . '/agenda-feed', [], [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'status' => 403,
+            'type' => '/errors/403',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+        ]);
+        // The member's feed is untouched: a stranger cannot cut off someone else's subscription.
+        $this->assertCount(1, $this->feedTokenRepository()->findBy(['membership' => $membership]));
+    }
+
+    public function test_revoking_when_there_is_no_feed_is_a_404(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('DELETE', '/api/band_spaces/' . $bandSpace->id . '/agenda-feed', [], [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'status' => 404,
+            'type' => '/errors/404',
+            'title' => 'An error occurred',
+            'detail' => 'Aucun flux à révoquer',
+            'description' => 'Aucun flux à révoquer',
+        ]);
+    }
+
+    public function test_the_state_endpoint_reports_an_existing_feed(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        AgendaFeedTokenFactory::new([
+            'membership' => $membership,
+            'creationDatetime' => new DateTimeImmutable('2026-09-01 10:00:00', new DateTimeZone('UTC')),
+            'lastAccessDatetime' => new DateTimeImmutable('2026-09-05 08:30:00', new DateTimeZone('UTC')),
+            'accessCount' => 7,
+        ])->withPlainToken(self::KNOWN_TOKEN)->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/agenda-feed', [], [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaFeed',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-feed',
+            '@type' => 'AgendaFeed',
+            'band_space_id' => (string) $bandSpace->id,
+            'is_enabled' => true,
+            // Never the URL: only the hash was stored, so it cannot be shown again.
+            'creation_datetime' => '2026-09-01T10:00:00+00:00',
+            'last_access_datetime' => '2026-09-05T08:30:00+00:00',
+            'access_count' => 7,
+        ]);
+    }
+
+    public function test_the_state_endpoint_reports_no_feed(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/agenda-feed', [], [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/AgendaFeed',
+            '@id' => '/api/band_spaces/' . $bandSpace->id . '/agenda-feed',
+            '@type' => 'AgendaFeed',
+            'band_space_id' => (string) $bandSpace->id,
+            'is_enabled' => false,
+            'creation_datetime' => null,
+            'last_access_datetime' => null,
+            'access_count' => 0,
+        ]);
+    }
+
+    public function test_a_non_member_cannot_read_the_feed_state(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $this->client->loginUser($stranger);
+        $this->client->jsonRequest('GET', '/api/band_spaces/' . $bandSpace->id . '/agenda-feed', [], [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_revoking_deletes_the_token(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership])->withPlainToken(self::KNOWN_TOKEN)->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('DELETE', '/api/band_spaces/' . $bandSpace->id . '/agenda-feed', [], [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertCount(0, $this->feedTokenRepository()->findBy(['membership' => $membership]));
+    }
+
+    public function test_leaving_the_band_kills_the_feed(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $other = UserFactory::new()->asBaseUser()->create([
+            'username' => 'second_member',
+            'email' => 'second_member@email.com',
+        ]);
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        // A second admin, so leaving is not refused for emptying the band of admins.
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $other,
+            'role' => \App\Enum\BandSpace\Role::Admin,
+        ])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership])->withPlainToken(self::KNOWN_TOKEN)->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', '/api/band_spaces/' . $bandSpace->id . '/leave', [], [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertCount(0, $this->feedTokenRepository()->findBy(['membership' => $membership]));
+    }
+
+    public function test_the_feed_publishes_manual_entries_and_nothing_else(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new(['name' => 'Les Copains'])->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership])->withPlainToken(self::KNOWN_TOKEN)->create();
+
+        AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Répétition générale',
+            'description' => 'Préparer le set',
+            'location' => 'Studio B',
+            'eventDatetime' => new DateTimeImmutable('+10 days 20:00:00', new DateTimeZone('UTC')),
+            'endDatetime' => new DateTimeImmutable('+10 days 23:00:00', new DateTimeZone('UTC')),
+        ])->create();
+
+        TaskFactory::new([
+            'bandSpace' => $bandSpace,
+            'createdBy' => $user,
+            'title' => 'Acheter des cordes',
+            'status' => TaskStatus::Todo,
+            'priority' => TaskPriority::High,
+            'dueDate' => new DateTimeImmutable('+12 days 12:00:00', new DateTimeZone('UTC')),
+        ])->create();
+
+        $financeCategory = FinanceCategoryFactory::new(['bandSpace' => $bandSpace, 'name' => 'Logistique'])->create();
+        FinanceEntryFactory::new([
+            'category' => $financeCategory,
+            'label' => 'Location salle',
+            'date' => new \DateTime('+13 days', new DateTimeZone('UTC')),
+        ])->create();
+
+        MemberAbsenceFactory::new([
+            'member' => $membership,
+            'startDate' => new DateTimeImmutable('+14 days', new DateTimeZone('UTC')),
+            'endDate' => new DateTimeImmutable('+15 days', new DateTimeZone('UTC')),
+        ])->create();
+
+        $this->client->request('GET', '/api/shares/agenda/' . self::KNOWN_TOKEN . '.ics');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('Content-Type', 'text/calendar; charset=utf-8');
+        $this->assertResponseHeaderSame('X-Content-Type-Options', 'nosniff');
+
+        $feed = (string) $this->client->getResponse()->getContent();
+        $this->assertStringContainsString('BEGIN:VCALENDAR', $feed);
+        $this->assertStringContainsString("X-WR-CALNAME:Les Copains\r\n", $feed);
+        $this->assertStringContainsString("SUMMARY:Répétition générale\r\n", $feed);
+        $this->assertStringContainsString("LOCATION:Studio B\r\n", $feed);
+        $this->assertSame(1, substr_count($feed, 'BEGIN:VEVENT'));
+
+        // The three sources a personal calendar has no use for. A subscribed calendar has no filter
+        // chips and one colour, so they would be noise the subscriber deletes the feed over.
+        $this->assertStringNotContainsString('Acheter des cordes', $feed);
+        $this->assertStringNotContainsString('Location salle', $feed);
+        $this->assertStringNotContainsString('indisponible', $feed);
+    }
+
+    public function test_fetching_the_feed_records_the_access(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership, 'accessCount' => 4])
+            ->withPlainToken(self::KNOWN_TOKEN)
+            ->create();
+
+        $this->client->request('GET', '/api/shares/agenda/' . self::KNOWN_TOKEN . '.ics');
+
+        $this->assertResponseIsSuccessful();
+
+        $tokens = $this->feedTokenRepository()->findBy(['membership' => $membership]);
+        $this->assertSame(5, $tokens[0]->accessCount);
+        $this->assertInstanceOf(DateTimeImmutable::class, $tokens[0]->lastAccessDatetime);
+    }
+
+    public function test_a_matching_etag_is_answered_with_a_304(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership])->withPlainToken(self::KNOWN_TOKEN)->create();
+        AgendaEntryFactory::new([
+            'bandSpace' => $bandSpace,
+            'creator' => $user,
+            'title' => 'Concert',
+            'eventDatetime' => new DateTimeImmutable('+10 days 20:00:00', new DateTimeZone('UTC')),
+        ])->create();
+
+        $this->client->request('GET', '/api/shares/agenda/' . self::KNOWN_TOKEN . '.ics');
+        $this->assertResponseIsSuccessful();
+        $etag = $this->client->getResponse()->getEtag();
+        $this->assertNotNull($etag);
+
+        $this->client->request('GET', '/api/shares/agenda/' . self::KNOWN_TOKEN . '.ics', [], [], [
+            'HTTP_IF_NONE_MATCH' => $etag,
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_MODIFIED);
+        $this->assertEmpty($this->client->getResponse()->getContent());
+    }
+
+    public function test_an_unknown_token_is_a_404(): void
+    {
+        $this->client->request('GET', '/api/shares/agenda/nobody-minted-this.ics');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonContains(['detail' => 'Flux introuvable']);
+    }
+
+    public function test_a_kicked_member_keeps_no_feed(): void
+    {
+        // The FK cascade never fires here: a membership row survives being kicked, it only changes
+        // status. Without the provider's own check the URL would keep serving the band's dates.
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $user,
+            'status' => MembershipStatus::Kicked,
+        ])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership])->withPlainToken(self::KNOWN_TOKEN)->create();
+
+        $this->client->request('GET', '/api/shares/agenda/' . self::KNOWN_TOKEN . '.ics');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonContains(['detail' => 'Flux introuvable']);
+    }
+
+    public function test_the_feed_needs_no_authentication(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+        $bandSpace = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new(['bandSpace' => $bandSpace, 'user' => $user])->create();
+        AgendaFeedTokenFactory::new(['membership' => $membership])->withPlainToken(self::KNOWN_TOKEN)->create();
+
+        // No loginUser: a calendar client sends neither a cookie nor a JWT, so a 401 here would mean
+        // the endpoint is unusable by the only callers it has.
+        $this->client->request('GET', '/api/shares/agenda/' . self::KNOWN_TOKEN . '.ics');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    private function feedTokenRepository(): AgendaFeedTokenRepository
+    {
+        /** @var AgendaFeedTokenRepository $repository */
+        $repository = self::getContainer()->get(AgendaFeedTokenRepository::class);
+
+        return $repository;
+    }
+
+    private function tokenFromUrl(string $feedUrl): string
+    {
+        return basename(parse_url($feedUrl, PHP_URL_PATH) ?: '', '.ics');
+    }
+}

--- a/tests/Factory/BandSpace/AgendaFeedTokenFactory.php
+++ b/tests/Factory/BandSpace/AgendaFeedTokenFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Tests\Factory\BandSpace;
+
+use App\Entity\BandSpace\AgendaFeedToken;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+
+/**
+ * @extends PersistentObjectFactory<AgendaFeedToken>
+ */
+final class AgendaFeedTokenFactory extends PersistentObjectFactory
+{
+    protected function defaults(): array
+    {
+        return [
+            'membership' => BandSpaceMembershipFactory::new(),
+            'tokenHash' => hash('sha256', self::faker()->uuid()),
+            'creationDatetime' => new \DateTimeImmutable(),
+        ];
+    }
+
+    /**
+     * Seeds the row a plaintext token unlocks, so a test can call the public feed without first
+     * going through the authenticated generate endpoint. Only the hash is ever stored, which is why
+     * the plaintext has to be chosen by the caller rather than read back.
+     */
+    public function withPlainToken(string $token): static
+    {
+        return $this->with(['tokenHash' => hash('sha256', $token)]);
+    }
+
+    public static function class(): string
+    {
+        return AgendaFeedToken::class;
+    }
+}

--- a/tests/Unit/Service/BandSpace/IcalFeedBuilderTest.php
+++ b/tests/Unit/Service/BandSpace/IcalFeedBuilderTest.php
@@ -1,0 +1,257 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\BandSpace;
+
+use App\ApiResource\BandSpace\AgendaItem;
+use App\Service\BandSpace\IcalFeedBuilder;
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+
+class IcalFeedBuilderTest extends TestCase
+{
+    private IcalFeedBuilder $builder;
+
+    private DateTimeImmutable $generatedAt;
+
+    protected function setUp(): void
+    {
+        $this->builder = new IcalFeedBuilder();
+        $this->generatedAt = new DateTimeImmutable('2026-09-06 00:00:00', new DateTimeZone('UTC'));
+    }
+
+    public function test_empty_feed_is_a_valid_calendar(): void
+    {
+        $feed = $this->builder->build([], 'Les Copains', $this->generatedAt);
+
+        $this->assertSame(
+            "BEGIN:VCALENDAR\r\n"
+            . "VERSION:2.0\r\n"
+            . "PRODID:-//MusicAll//Band Space Agenda//FR\r\n"
+            . "CALSCALE:GREGORIAN\r\n"
+            . "X-WR-CALNAME:Les Copains\r\n"
+            . "X-PUBLISHED-TTL:PT12H\r\n"
+            . "REFRESH-INTERVAL;VALUE=DURATION:PT12H\r\n"
+            . "END:VCALENDAR\r\n",
+            $feed,
+        );
+    }
+
+    public function test_method_is_never_emitted(): void
+    {
+        // METHOD:PUBLISH makes Outlook treat the document as a one off import instead of a
+        // subscription it keeps refreshing.
+        $feed = $this->builder->build([$this->timedItem()], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringNotContainsString('METHOD:', $feed);
+    }
+
+    public function test_a_timed_event_is_serialised_in_utc(): void
+    {
+        $item = $this->timedItem();
+        $item->datetime = '2026-08-01T22:00:00+02:00';
+        $item->endDatetime = '2026-08-02T01:30:00+02:00';
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringContainsString("DTSTART:20260801T200000Z\r\n", $feed);
+        $this->assertStringContainsString("DTEND:20260801T233000Z\r\n", $feed);
+        $this->assertStringContainsString("DTSTAMP:20260906T000000Z\r\n", $feed);
+    }
+
+    public function test_a_timed_event_without_an_end_emits_no_dtend(): void
+    {
+        $item = $this->timedItem();
+        $item->endDatetime = null;
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringNotContainsString('DTEND', $feed);
+    }
+
+    public function test_an_all_day_event_uses_dates_and_an_exclusive_end(): void
+    {
+        // Two days covered, 1 and 2 August, so RFC 5545 wants the 3rd. Getting this wrong is the
+        // classic off by one that shows a festival ending the day before it does.
+        $item = $this->allDayItem();
+        $item->datetime = '2026-08-01T00:00:00+00:00';
+        $item->endDatetime = '2026-08-02T00:00:00+00:00';
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringContainsString("DTSTART;VALUE=DATE:20260801\r\n", $feed);
+        $this->assertStringContainsString("DTEND;VALUE=DATE:20260803\r\n", $feed);
+        // The timed forms, which would put the entry at 02:00 on the subscriber's calendar.
+        $this->assertStringNotContainsString('DTSTART:', $feed);
+        $this->assertStringNotContainsString('DTEND:', $feed);
+    }
+
+    public function test_a_single_all_day_event_still_covers_one_day(): void
+    {
+        $item = $this->allDayItem();
+        $item->datetime = '2026-08-01T00:00:00+00:00';
+        $item->endDatetime = null;
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringContainsString("DTSTART;VALUE=DATE:20260801\r\n", $feed);
+        $this->assertStringContainsString("DTEND;VALUE=DATE:20260802\r\n", $feed);
+    }
+
+    public function test_an_all_day_date_is_read_as_written_and_never_converted(): void
+    {
+        // The pin is midnight UTC by convention. A builder that parsed and converted instead of
+        // reading would move the day west of UTC, which is what #877 and #912 were about.
+        $item = $this->allDayItem();
+        $item->datetime = '2026-08-01T00:00:00+00:00';
+
+        $previous = date_default_timezone_get();
+        date_default_timezone_set('America/New_York');
+
+        try {
+            $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+        } finally {
+            date_default_timezone_set($previous);
+        }
+
+        $this->assertStringContainsString("DTSTART;VALUE=DATE:20260801\r\n", $feed);
+    }
+
+    public function test_uid_is_stable_and_carries_our_domain(): void
+    {
+        $item = $this->timedItem();
+        $item->id = 'manual-3f1c-20260801-2300';
+
+        $first = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+        $second = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringContainsString("UID:manual-3f1c-20260801-2300@musicall.com\r\n", $first);
+        $this->assertSame($first, $second);
+    }
+
+    public function test_text_values_are_escaped(): void
+    {
+        $item = $this->timedItem();
+        $item->title = 'Concert; back\\slash, comma';
+        $item->description = "Ligne 1\nLigne 2";
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringContainsString("SUMMARY:Concert\\; back\\\\slash\\, comma\r\n", $feed);
+        $this->assertStringContainsString("DESCRIPTION:Ligne 1\\nLigne 2\r\n", $feed);
+    }
+
+    public function test_control_characters_including_a_null_byte_are_dropped(): void
+    {
+        $item = $this->timedItem();
+        $item->title = "Concert\0 au \x07Bataclan";
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringContainsString("SUMMARY:Concert au Bataclan\r\n", $feed);
+    }
+
+    public function test_location_comes_from_the_metadata(): void
+    {
+        $item = $this->timedItem();
+        $item->metadata = ['location' => 'Le Botanique, Bruxelles'];
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringContainsString("LOCATION:Le Botanique\\, Bruxelles\r\n", $feed);
+    }
+
+    public function test_an_empty_location_or_description_is_omitted(): void
+    {
+        $item = $this->timedItem();
+        $item->description = '';
+        $item->metadata = ['location' => null];
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertStringNotContainsString('DESCRIPTION', $feed);
+        $this->assertStringNotContainsString('LOCATION', $feed);
+    }
+
+    public function test_no_line_exceeds_seventy_five_octets(): void
+    {
+        $item = $this->timedItem();
+        $item->title = str_repeat('Concert de rentree ', 20);
+        $item->description = str_repeat('Une description assez longue pour forcer le pliage. ', 10);
+
+        $feed = $this->builder->build([$item], str_repeat('Nom de groupe ', 12), $this->generatedAt);
+
+        foreach (explode("\r\n", $feed) as $line) {
+            $this->assertLessThanOrEqual(75, strlen($line), sprintf('Line over 75 octets: %s', $line));
+        }
+    }
+
+    public function test_folding_never_splits_a_multibyte_character(): void
+    {
+        // The whole reason to fold by character rather than by byte: this app is full of accents, and
+        // a cut inside a UTF-8 sequence produces a calendar the client refuses outright.
+        $item = $this->timedItem();
+        $item->title = str_repeat('Répétition générale à Liège ', 6);
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        $this->assertSame($feed, mb_convert_encoding($feed, 'UTF-8', 'UTF-8'));
+        foreach (explode("\r\n", $feed) as $line) {
+            $this->assertLessThanOrEqual(75, strlen($line));
+            $this->assertTrue(mb_check_encoding($line, 'UTF-8'), sprintf('Broken UTF-8 on: %s', $line));
+        }
+    }
+
+    public function test_a_folded_line_unfolds_back_to_its_value(): void
+    {
+        $item = $this->timedItem();
+        $item->title = str_repeat('Répétition générale ', 8);
+
+        $feed = $this->builder->build([$item], 'Les Copains', $this->generatedAt);
+
+        // RFC 5545 3.1: unfolding removes each CRLF and the single whitespace that follows it.
+        $unfolded = str_replace("\r\n ", '', $feed);
+
+        $this->assertStringContainsString('SUMMARY:' . $item->title . "\r\n", $unfolded);
+    }
+
+    public function test_every_event_is_wrapped_and_ordered_as_given(): void
+    {
+        $first = $this->timedItem();
+        $first->id = 'manual-aaa';
+        $first->title = 'Premier';
+
+        $second = $this->timedItem();
+        $second->id = 'manual-bbb';
+        $second->title = 'Second';
+
+        $feed = $this->builder->build([$first, $second], 'Les Copains', $this->generatedAt);
+
+        $this->assertSame(2, substr_count($feed, "BEGIN:VEVENT\r\n"));
+        $this->assertSame(2, substr_count($feed, "END:VEVENT\r\n"));
+        $this->assertLessThan(strpos($feed, 'Second'), (int) strpos($feed, 'Premier'));
+    }
+
+    private function timedItem(): AgendaItem
+    {
+        $item = new AgendaItem();
+        $item->id = 'manual-3f1c';
+        $item->bandSpaceId = 'b1';
+        $item->source = 'manual';
+        $item->sourceId = '3f1c';
+        $item->datetime = '2026-08-01T20:00:00+00:00';
+        $item->endDatetime = '2026-08-01T23:00:00+00:00';
+        $item->isAllDay = false;
+        $item->title = 'Concert';
+
+        return $item;
+    }
+
+    private function allDayItem(): AgendaItem
+    {
+        $item = $this->timedItem();
+        $item->isAllDay = true;
+
+        return $item;
+    }
+}


### PR DESCRIPTION
Closes #779.

Publishes a band space agenda as an iCal feed a member can subscribe to in Google Agenda, Apple Calendrier, Outlook or anything else that speaks RFC 5545. Read only, one way, no OAuth and no vendor lock: the calendar client polls a secret URL.

## What is published

Manual agenda entries only, recurrence occurrences expanded, cancellations applied. Tasks, finance rows and absences stay in the app: a subscribed calendar has no filter chips and one colour, so the other three sources are noise the subscriber deletes the feed over. If a second source is ever wanted it becomes a second URL rather than a flag, because the client already gives per calendar colour and show/hide for free, and a server side toggle would be invisible for up to 24 hours on Google.

## Token

One per membership, so a leaked URL is revoked for one person in one band, and a member of several bands gets several separately coloured calendars. Minted with the hardened path (`ShareTokenService`, 32 CSPRNG bytes, sha256 stored, plaintext shown once), which is why `FileShareTokenService` moved out of the `File` namespace rather than being copied.

A `BandSpaceMembership` row survives leaving and being kicked, so the FK cascade never fires on either. Revocation is therefore two guards: the token row is deleted by all three departure paths, and the feed provider refuses a membership that is not active.

## Caching and limits

`ETag` with a `304`, which needed the body to be byte identical between two unchanged polls: `DTSTAMP` comes from stored data and the rolling window is snapped to midnight rather than computed to the second. The access limiter is keyed on the token, not the caller's address, because a calendar client polls from its vendor's shared fetcher pool and a per IP bucket would let one band's subscribers throttle another's. An unknown token is charged to the address instead, so nobody can mint a Valkey bucket per token they invent.

## Verification

Full suite green (2634). PHPStan level 8 clean, Biome clean, build clean. The migration was applied on the migration database and round tripped through `down` and `up`.

Checked against real seeded data on the dev site: 20 events including expanded weekly occurrences, longest line exactly 75 octets, no fold split an accent, two fetches byte identical, `304` on a conditional GET, `404` after revoking, `429` with `Retry-After` on the 61st fetch in an hour while a different token was unaffected.

Google has to reach the URL from the public internet, so the subscribe flow itself could not be exercised locally. The `cid=webcal://` deep link wants a manual check after deploy.
