### PR TITLE
Mercure: enable the FrankenPHP hub and publish from Symfony

### DIFF
--- a/.docker/frankenphp/Caddyfile
+++ b/.docker/frankenphp/Caddyfile
@@ -34,6 +34,36 @@
 
 	{$CADDY_SERVER_EXTRA_DIRECTIVES}
 
+	# The Mercure hub is part of the FrankenPHP binary, so realtime needs no extra container, unit
+	# or deploy target. The directive orders itself (after `encode`) and hands every path that is
+	# not under /.well-known/mercure straight on to php_server, so nothing else is affected.
+	#
+	# Production runs the same binary but its Caddyfile lives on the server, outside this
+	# repository, so this block has to be reproduced there by hand.
+	mercure {
+		# Bolt is the default transport and its default path is Caddy's own data directory,
+		# /data/caddy/mercure.db here: writable by the container user, inside the caddy_data
+		# volume, and on the server outside the release directory, so a deploy does not lose it.
+		# History is a bonus rather than a contract - the design publishes a signal and lets the
+		# client refetch - but it means a reconnect after the deploy restart can replay what it
+		# missed, which is the one moment every subscriber reconnects at once.
+		#
+		# Bounded because that is the only thing standing between a per-notification signal and a
+		# file that grows for the lifetime of the server. Both settings are needed: the transport
+		# prunes nothing unless size and cleanup_frequency are both non-zero. A thousand updates is
+		# far more than a reconnect ever walks back through.
+		transport bolt {
+			size 1000
+			cleanup_frequency 0.3
+		}
+
+		# One key signs the publisher token the application uses, the subscriber token handed to
+		# the browser, and is what the hub verifies with. compose.yaml passes the value in from
+		# .env so there is a single source; an empty one is a startup error, not a silent 401.
+		publisher_jwt {$MERCURE_JWT_SECRET}
+		subscriber_jwt {$MERCURE_JWT_SECRET}
+	}
+
 	php_server {
 		worker  {
 		    file /var/www/musicall/public/index.php

--- a/.env
+++ b/.env
@@ -96,3 +96,21 @@ BAND_SPACE_FILE_QUOTA_BYTES=5368709120
 # network alias and does not resolve anywhere else, so every other environment has to set its own:
 # production through the deploy configuration, CI through the workflow.
 GOTENBERG_DSN=http://gotenberg.musicall:3000
+
+###> symfony/mercure-bundle ###
+# The hub lives inside the FrankenPHP process that serves the site, so publishing is a loopback.
+# compose.yaml gives php-web the extra site address `http://php-web:8080`: the scheme is written out
+# because that is what turns automatic HTTPS off, an explicit port only doing so when the port is 80,
+# and plain HTTP is what lets PHP reach the hub without trusting Caddy's own CA. The port is one
+# compose publishes nowhere, so the address exists only on the docker network. Production publishes
+# to its own public HTTPS URL instead.
+#
+# There is no MERCURE_PUBLIC_URL: the browser's URL is a literal in config/packages/mercure.yaml,
+# because it is the same in every environment and one variable a deploy cannot forget.
+MERCURE_URL=http://php-web:8080/.well-known/mercure
+# Signs the publisher token PHP uses and the subscriber token handed to the browser, and is the key
+# the hub itself verifies with. compose.yaml passes this same variable into php-web so that Caddy
+# reads the identical value, which is why it belongs here and not in .env.local: put it there and
+# the app and the hub sign with different keys, and every subscription is rejected.
+MERCURE_JWT_SECRET="!ChangeThisMercureHubJWTSecretKey!"
+###< symfony/mercure-bundle ###

--- a/.env.test
+++ b/.env.test
@@ -15,3 +15,7 @@ MAIL_NO_REPLY_EMAIL=no-reply@musicall.localhost
 MAIL_CONTACT_EMAIL=contact@musicall.localhost
 
 DEFAULT_URI=http://localhost
+# The suite never publishes, and this reserved TLD guarantees it: an accidental publish from a test
+# fails to resolve instead of quietly reaching the dev hub over the docker network. The subscriber
+# cookie needs no override, because MERCURE_PUBLIC_URL is a host-less path.
+MERCURE_URL=http://mercure.invalid/.well-known/mercure

--- a/assets/js/views/Legal/MentionsLegales.vue
+++ b/assets/js/views/Legal/MentionsLegales.vue
@@ -83,6 +83,7 @@
           <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2">
             <li><strong>jwt_hp</strong> et <strong>jwt_s</strong> : maintien de votre session de connexion (1 heure)</li>
             <li><strong>refresh_token</strong> : renouvellement de votre session sans nouvelle saisie de mot de passe (30 jours)</li>
+            <li><strong>mercureAuthorization</strong> : réception des notifications en temps réel (1 heure)</li>
             <li><strong>PHPSESSID</strong> : session technique du serveur (durée de votre navigation)</li>
             <li><strong>is_dark_mode</strong> : mémorisation du thème clair ou sombre que vous avez choisi (1 an)</li>
           </ul>

--- a/assets/js/views/Legal/Privacy.vue
+++ b/assets/js/views/Legal/Privacy.vue
@@ -159,6 +159,7 @@
           <ul class="list-none text-surface-600 dark:text-surface-300 space-y-2">
             <li><strong>jwt_hp</strong> et <strong>jwt_s</strong> : maintien de votre session de connexion (1 heure)</li>
             <li><strong>refresh_token</strong> : renouvellement de votre session sans nouvelle saisie de mot de passe (30 jours)</li>
+            <li><strong>mercureAuthorization</strong> : réception des notifications en temps réel (1 heure)</li>
             <li><strong>PHPSESSID</strong> : session technique du serveur (durée de votre navigation)</li>
             <li><strong>is_dark_mode</strong> : mémorisation du thème clair ou sombre que vous avez choisi (1 an)</li>
           </ul>

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,24 @@ services:
             - ./.docker/frankenphp/local/99-custom.ini:/usr/local/etc/php/conf.d/99-custom.ini
         environment:
             # we need localhost for google oauth...
-            SERVER_NAME: 'musicall.local, localhost'
+            #
+            # http://php-web:8080 is the address PHP publishes Mercure updates to. The scheme is
+            # written out because that is what turns automatic HTTPS off for this address alone: an
+            # explicit port only does that when the port is 80. Plain HTTP is the point, since the
+            # image is built with skip_install_trust and so nothing inside the container trusts the
+            # certificate Caddy issues itself.
+            #
+            # 8080 rather than 80 because 80 is published to the host, and there a request carrying
+            # `Host: php-web` would be served the whole application in the clear instead of the
+            # redirect to HTTPS every other host gets. 8080 is published nowhere, so this address
+            # exists only on the docker network, which is also the only place the name resolves.
+            SERVER_NAME: 'musicall.local, localhost, http://php-web:8080'
+            # Read out of .env by compose and handed to Caddy, which reads it back in the Caddyfile's
+            # mercure block. PHP inherits the same real environment variable and Symfony's Dotenv
+            # never overrides one, so the hub and the application cannot end up signing with
+            # different keys. An empty value makes Caddy refuse to start rather than silently reject
+            # every subscription.
+            MERCURE_JWT_SECRET: '${MERCURE_JWT_SECRET}'
         tty: true
         networks:
             musicall:
@@ -35,6 +52,12 @@ services:
         container_name: php-cli
         working_dir: /var/www/musicall
         command: /bin/true
+        environment:
+            # Same value, same source as php-web above, so app:mercure:ping signs with the key the
+            # hub verifies with. Without it this container would fall back to .env plus .env.local,
+            # and a secret put in .env.local (the natural place for one) would be a key Caddy has
+            # never seen.
+            MERCURE_JWT_SECRET: '${MERCURE_JWT_SECRET}'
         networks:
             - musicall
         volumes:

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "symfony/http-client": "8.1.*",
         "symfony/intl": "8.1.*",
         "symfony/mailer": "8.1.*",
+        "symfony/mercure-bundle": "^0.5.0",
         "symfony/mime": "8.1.*",
         "symfony/monolog-bundle": "^4.0",
         "symfony/process": "8.1.*",
@@ -142,7 +143,8 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "8.1.*"
+            "require": "8.1.*",
+            "docker": false
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67de4fec2e628426a739dd7984c12224",
+    "content-hash": "76256d84e98e83ccbcfdc190d1375174",
     "packages": [
         {
             "name": "api-platform/core",
@@ -8939,6 +8939,176 @@
                 }
             ],
             "time": "2026-08-21T17:47:34+00:00"
+        },
+        {
+            "name": "symfony/mercure",
+            "version": "v0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mercure.git",
+                "reference": "920f08c73793f37e94981e5d9fc1a84351ec8c6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mercure/zipball/920f08c73793f37e94981e5d9fc1a84351ec8c6c",
+                "reference": "920f08c73793f37e94981e5d9fc1a84351ec8c6c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.0|^3.0",
+                "symfony/http-client": "^6.4|^7.3|^8.0",
+                "symfony/http-foundation": "^6.4|^7.3|^8.0",
+                "symfony/web-link": "^6.4|^7.3|^8.0"
+            },
+            "require-dev": {
+                "lcobucci/jwt": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^6.4|^7.3|^8.0",
+                "symfony/http-kernel": "^6.4|^7.3|^8.0",
+                "symfony/phpunit-bridge": "^7.3.4|^8.0",
+                "symfony/stopwatch": "^6.4|^7.3|^8.0",
+                "twig/twig": "^2.0|^3.0|^4.0",
+                "web-token/jwt-library": "^4.1"
+            },
+            "suggest": {
+                "symfony/stopwatch": "Integration with the profiler performances",
+                "web-token/jwt-library": "To build Mercure protocol 1.0-compatible JSON Web Tokens with WebTokenFactory"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/dunglas/mercure",
+                    "name": "dunglas/mercure"
+                },
+                "branch-alias": {
+                    "dev-main": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mercure\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Mercure Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mercure",
+                "push",
+                "sse",
+                "updates"
+            ],
+            "support": {
+                "issues": "https://github.com/symfony/mercure/issues",
+                "source": "https://github.com/symfony/mercure/tree/v0.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dunglas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/mercure",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-11T07:23:36+00:00"
+        },
+        {
+            "name": "symfony/mercure-bundle",
+            "version": "v0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mercure-bundle.git",
+                "reference": "84143afcd5225bbc3cc5e05b9218a05f2ae4a566"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mercure-bundle/zipball/84143afcd5225bbc3cc5e05b9218a05f2ae4a566",
+                "reference": "84143afcd5225bbc3cc5e05b9218a05f2ae4a566",
+                "shasum": ""
+            },
+            "require": {
+                "lcobucci/jwt": "^3.4|^4.0|^5.0",
+                "php": ">=8.2",
+                "symfony/config": "^6.4|^7.3|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.3|^8.0",
+                "symfony/http-kernel": "^6.4|^7.3|^8.0",
+                "symfony/mercure": "^0.8",
+                "symfony/web-link": "^6.4|^7.3|^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^7.3.4|^8.0",
+                "symfony/stopwatch": "^6.4|^7.3|^8.0",
+                "symfony/ux-turbo": "*",
+                "symfony/var-dumper": "^6.4|^7.3|^8.0",
+                "web-token/jwt-library": "^4.1"
+            },
+            "suggest": {
+                "symfony/messenger": "To use the Messenger integration",
+                "web-token/jwt-library": "To build Mercure protocol 1.0-compatible JSON Web Tokens from a \"jwt.jwks_uri\" option"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\MercureBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony MercureBundle",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mercure",
+                "push",
+                "sse",
+                "updates"
+            ],
+            "support": {
+                "issues": "https://github.com/symfony/mercure-bundle/issues",
+                "source": "https://github.com/symfony/mercure-bundle/tree/v0.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dunglas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/mercure-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-11T11:25:49+00:00"
         },
         {
             "name": "symfony/mime",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -29,4 +29,5 @@ return [
     // Renders the setlist PDF export (#741). Needed in test too, where the client is swapped for a
     // recording double rather than the bundle being switched off.
     Sensiolabs\GotenbergBundle\SensiolabsGotenbergBundle::class => ['all' => true],
+    Symfony\Bundle\MercureBundle\MercureBundle::class => ['all' => true],
 ];

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -27,6 +27,14 @@ api_platform:
         cache_headers:
             vary: ['Content-Type', 'Authorization', 'Origin']
     use_symfony_listeners: false
+    # Installing MercureBundle flips this option from off-by-default to on-by-default, so it is
+    # written out rather than left to change underneath us. Broadcasting is per resource and nothing
+    # opts in, so switching it off changes no behaviour today; what it removes is the footgun. A
+    # `mercure: true` on a resource publishes the serialized entity on a topic derived from its IRI,
+    # and non-private, which the hub delivers to every subscriber that asks for that topic rather
+    # than only to those whose token names it. Realtime here carries a signal and the client refetches
+    # through the API it already calls, which keeps one serialization contract instead of two.
+    mercure: false
     exception_to_status:
         # Symfony
         Symfony\Component\RateLimiter\Exception\RateLimitExceededException: 429

--- a/config/packages/mercure.yaml
+++ b/config/packages/mercure.yaml
@@ -1,0 +1,40 @@
+parameters:
+    # Publishing is a loopback: the hub lives inside the very process that serves the site, so the
+    # site's own URL is the right endpoint and MERCURE_URL does not have to be set at all. Dev is the
+    # exception and sets it, because the image is built with skip_install_trust and so does not trust
+    # the certificate Caddy issues itself, which is why it publishes over plain HTTP on the docker
+    # network instead.
+    #
+    # A default rather than a bare '%env(MERCURE_URL)%' because the bundle registers a Twig extension
+    # that holds the hub, and Twig builds its extensions eagerly. Twig renders the page the whole SPA
+    # is served from, so an unresolvable variable here is not a broken notification, it is a blank
+    # site. Deployer shares .env rather than deploying it, so "not set yet" is the normal state of a
+    # first release and must stay survivable.
+    mercure.default_hub_url: '%env(DEFAULT_URI)%/.well-known/mercure'
+
+mercure:
+    hubs:
+        default:
+            # Where PHP publishes, which is not the browser's URL. See the parameter above.
+            url: '%env(default:mercure.default_hub_url:MERCURE_URL)%'
+            # Where the browser connects, and a literal rather than an environment variable because
+            # it is the same everywhere. The hub is served by the very Caddy that serves the
+            # application, so it is always same-origin, and a path carries no host for Authorization
+            # to scope the subscriber cookie against: it compares the host here with the host the
+            # request came in on and throws when they differ. So this one value is right on
+            # localhost, on musicall.local, on the suite's musicall.test and in production, there is
+            # nothing to keep in step, and it is one fewer variable that a deploy can forget.
+            public_url: /.well-known/mercure
+            jwt:
+                secret: '%env(MERCURE_JWT_SECRET)%'
+                # The topics the token PHP publishes with is allowed to reach. Without it the
+                # publish grant is an empty selector list, and the hub matches requested topics
+                # against that list, so every publish comes back 401.
+                publish: '*'
+    # The subscriber cookie is renewed by the same POST /api/token/refresh that renews the JWT, so
+    # it gets the same life. Left unset it falls back to session.cookie_lifetime, which nothing
+    # here controls: every firewall is stateless and a session is rarely started at all. Reading
+    # Lexik's parameter means the two cannot drift; it resolves because MercureBundle is registered
+    # after LexikJWTAuthenticationBundle in config/bundles.php, and reordering them would fail loudly
+    # at compile time rather than quietly.
+    default_cookie_lifetime: '%lexik_jwt_authentication.token_ttl%'

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -53,6 +53,12 @@ security:
                 delete_cookies:
                     jwt_hp: null
                     jwt_s: null
+                    # Scoped to the hub's own path, so clearing it needs that path spelled out: a
+                    # path-less clearing cookie would leave a logged-out browser able to keep
+                    # reading its previous account's Mercure topic until the token expired, which
+                    # matters on a shared machine. clear_site_data below would also do it, but
+                    # Safari does not implement it.
+                    mercureAuthorization: { path: /.well-known/mercure }
                 clear_site_data:
                     - cookies
                     - storage

--- a/config/reference.php
+++ b/config/reference.php
@@ -1950,7 +1950,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *     },
  *     mercure?: bool|array{
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *         hub_url?: scalar|Param|null, // The URL sent in the Link HTTP header. If not set, will default to the URL for MercureBundle's default hub. // Default: null
  *         include_type?: bool|Param, // Always include @type in updates (including delete ones). // Default: false
  *     },
@@ -3360,6 +3360,32 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *     },
  * }
+ * @psalm-type MercureConfig = array{
+ *     hubs?: array<string, array{ // Default: []
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
+ *         jwt?: Param|string|array{ // JSON Web Token configuration.
+ *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
+ *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.
+ *             factory?: scalar|Param|null, // The ID of a service to call to create the JSON Web Token.
+ *             publish?: list<scalar|Param|null>,
+ *             subscribe?: list<scalar|Param|null>,
+ *             secret?: scalar|Param|null, // The JWT Secret to use.
+ *             passphrase?: scalar|Param|null, // The JWT secret passphrase. // Default: ""
+ *             algorithm?: scalar|Param|null, // The algorithm to use to sign the JWT. With "secret", one of LcobucciFactory::SIGN_ALGORITHMS ("hmac.sha256", the default). With "jwks_uri", a JWA name from WebTokenFactory::SIGN_ALGORITHMS ("HS256", the default).
+ *             jwks_uri?: scalar|Param|null, // URL of a JSON Web Key Set (JWKS) to fetch the signing key from, instead of "secret". Requires "protocol_version: 1.0" and "web-token/jwt-library".
+ *             key_id?: scalar|Param|null, // The "kid" of the key to select from "jwks_uri", required when the key set holds more than one matching key.
+ *             claims?: array<string, mixed>,
+ *         },
+ *         jwt_provider?: scalar|Param|null, // Deprecated: The child node "jwt_provider" at path "mercure.hubs..jwt_provider" is deprecated, use "jwt.provider" instead. // The ID of a service to call to generate the JSON Web Token.
+ *         bus?: scalar|Param|null, // Name of the Messenger bus where the handler for this hub must be registered. Default to the default bus if Messenger is enabled.
+ *         protocol_version?: "0.x"|"1.0"|Param, // The Mercure protocol version spoken by this hub: "0.x" (default) or "1.0". Affects the default cookie name, the JWT claim shape built by "jwt.secret", and how the mercure() Twig function interprets matcher-typed topics. // Default: "0.x"
+ *         cookie_name?: scalar|Param|null, // Name of the subscriber authorization cookie. Defaults to a value computed from "protocol_version" ("mercureAuthorization" for "0.x", "__Secure-mercure_access_token" for "1.0") when not set. // Default: null
+ *     }>,
+ *     default_hub?: scalar|Param|null,
+ *     default_cookie_lifetime?: int|Param, // Default lifetime of the cookie containing the JWT, in seconds. Defaults to the value of "framework.session.cookie_lifetime". // Default: null
+ *     enable_profiler?: bool|Param, // Deprecated: The child node "enable_profiler" at path "mercure.enable_profiler" is deprecated. // Enable Symfony Web Profiler integration.
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -3382,6 +3408,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     elastically?: ElasticallyConfig,
  *     knpu_oauth2_client?: KnpuOauth2ClientConfig,
  *     sensiolabs_gotenberg?: SensiolabsGotenbergConfig,
+ *     mercure?: MercureConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -3408,6 +3435,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         elastically?: ElasticallyConfig,
  *         knpu_oauth2_client?: KnpuOauth2ClientConfig,
  *         sensiolabs_gotenberg?: SensiolabsGotenbergConfig,
+ *         mercure?: MercureConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -3432,6 +3460,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         elastically?: ElasticallyConfig,
  *         knpu_oauth2_client?: KnpuOauth2ClientConfig,
  *         sensiolabs_gotenberg?: SensiolabsGotenbergConfig,
+ *         mercure?: MercureConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -3458,6 +3487,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         elastically?: ElasticallyConfig,
  *         knpu_oauth2_client?: KnpuOauth2ClientConfig,
  *         sensiolabs_gotenberg?: SensiolabsGotenbergConfig,
+ *         mercure?: MercureConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/src/Command/Mercure/MercurePingCommand.php
+++ b/src/Command/Mercure/MercurePingCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\Mercure;
+
+use App\Mercure\MercureTopic;
+use App\Repository\UserRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+
+/**
+ * Publishes one update on a user's notification topic, and nothing else.
+ *
+ * A smoke test rather than a feature. The hub is a Caddy directive, and in production that Caddyfile
+ * lives on the server rather than in this repository, alongside environment variables that Deployer
+ * shares rather than deploys: a release can therefore go out with a perfectly green test suite and a
+ * hub that nothing can reach. Running this after a deploy, with the browser open on the site, is what
+ * says the whole chain works.
+ */
+#[AsCommand(
+    name: 'app:mercure:ping',
+    description: 'Publish a test update on a user\'s Mercure notification topic, to check the hub is reachable',
+)]
+class MercurePingCommand extends Command
+{
+    public function __construct(
+        private readonly HubInterface $hub,
+        private readonly UserRepository $userRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('username', InputArgument::REQUIRED, 'The username whose notification topic to publish on');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $username = $input->getArgument('username');
+        $user = $this->userRepository->findOneBy(['username' => $username]);
+
+        if ($user === null) {
+            $output->writeln(sprintf('<error>No user named "%s"</error>', $username));
+
+            return Command::FAILURE;
+        }
+
+        $topic = MercureTopic::userNotifications($user->id);
+
+        // Private, and that is the whole point: the hub only checks a subscriber's topic selectors
+        // for private updates, so a public one on this topic would reach anybody holding any valid
+        // subscriber token who thought to ask for it.
+        $this->hub->publish(new Update(
+            $topic,
+            (string) json_encode(['type' => 'ping', 'sent_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM)]),
+            private: true,
+        ));
+
+        $output->writeln(sprintf('Published on <info>%s</info>', $topic));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/OAuth/AbstractOAuthController.php
+++ b/src/Controller/OAuth/AbstractOAuthController.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Exception\OAuth\OAuthEmailExistsException;
 use App\Exception\OAuth\OAuthEmailNotVerifiedException;
 use App\Http\ReturnUrl;
+use App\Mercure\MercureSubscriberCookie;
 use App\Service\OAuth\OAuthUserData;
 use App\Service\OAuth\OAuthUserService;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
@@ -31,6 +32,7 @@ abstract class AbstractOAuthController extends AbstractController
         protected readonly RefreshTokenGeneratorInterface $refreshTokenGenerator,
         protected readonly RefreshTokenManagerInterface $refreshTokenManager,
         protected readonly LoggerInterface $logger,
+        protected readonly MercureSubscriberCookie $mercureSubscriberCookie,
         protected readonly string $frontendUrl,
         protected readonly int $refreshTokenTtl,
     ) {
@@ -154,6 +156,12 @@ abstract class AbstractOAuthController extends AbstractController
                 ->withHttpOnly(true)
                 ->withSameSite('lax')
         );
+
+        // This path mints its own cookies and never reaches Lexik's success handler, so the listener
+        // that renews the Mercure subscriber cookie on login and on refresh does not fire here.
+        // Without this call a Google sign-in would have no subscriber token until the first refresh,
+        // an hour later.
+        $this->mercureSubscriberCookie->attachTo($response, $user, $request);
 
         return $response;
     }

--- a/src/EventListener/MercureSubscriberCookieListener.php
+++ b/src/EventListener/MercureSubscriberCookieListener.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Entity\User;
+use App\Mercure\MercureSubscriberCookie;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Renews the Mercure subscriber cookie every time a JWT is issued.
+ *
+ * One listener covers both ways that happens through the firewall: gesdinet's refresh handler
+ * delegates to Lexik's, which is the only thing that dispatches this event, so `POST /api/login_check`
+ * and `POST /api/token/refresh` both land here and the subscriber token tracks the JWT it accompanies.
+ * The OAuth callback mints its cookies by hand and never reaches the handler, so
+ * AbstractOAuthController calls the same service itself.
+ *
+ * Kept separate from AuthenticationSuccessListener, which listens to the same event to stamp
+ * lastLoginDatetime: one reason to change each.
+ */
+#[AsEventListener(event: 'lexik_jwt_authentication.on_authentication_success')]
+final readonly class MercureSubscriberCookieListener
+{
+    public function __construct(
+        private MercureSubscriberCookie $subscriberCookie,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    public function __invoke(AuthenticationSuccessEvent $event): void
+    {
+        $user = $event->getUser();
+        // Authorization::createCookie() demands a Request in order to scope the cookie's domain
+        // against it. Under this configuration it never reads it, because a host-less public_url has
+        // no domain to derive, which MercureHubConfigurationTest pins. The main request rather than
+        // the current one anyway, so that stays true if a host is ever put back.
+        $request = $this->requestStack->getMainRequest();
+
+        // The cookie is scoped to a user id, so anything else authenticating has no topic to name.
+        if (!$user instanceof User || !$request instanceof Request) {
+            return;
+        }
+
+        $this->subscriberCookie->attachTo($event->getResponse(), $user, $request);
+    }
+}

--- a/src/Mercure/MercureSubscriberCookie.php
+++ b/src/Mercure/MercureSubscriberCookie.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mercure;
+
+use App\Entity\User;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mercure\Authorization;
+
+/**
+ * Hands the browser the token that lets it subscribe to its own Mercure topics.
+ *
+ * A subscription is an EventSource, which cannot set a header, so the token travels as a cookie on
+ * the hub's own path. It is minted wherever a JWT is (login, token refresh, the OAuth callback) and
+ * given the same life, so the refresh the frontend already performs renews both.
+ *
+ * The grant is a flat topic list, which the component normalises into a single subscribe grant: this
+ * token can read one user's notifications and cannot publish anything at all.
+ */
+readonly class MercureSubscriberCookie
+{
+    public function __construct(
+        private Authorization $authorization,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Never throws, deliberately, and `\Throwable` rather than `\Exception` because a misconfigured
+     * hub surfaces as a `TypeError` as readily as an exception.
+     *
+     * Everything that can fail here is a deployment mistake found on the first login after a
+     * release, `MERCURE_URL` or `MERCURE_JWT_SECRET` missing from the server's shared `.env` being
+     * the likely one, since Deployer shares those files rather than deploying them. None of it is a
+     * reason to stop somebody signing in. Letting it escape would be worse than it looks on the
+     * OAuth path, where the call sits inside AbstractOAuthController::callback()'s own `catch`, so a
+     * valid Google account would be bounced to /login?oauth_error=oauth_failed. Realtime silently
+     * degrading to the existing poll is the cheaper failure, and the log line reaches Sentry.
+     */
+    public function attachTo(Response $response, User $user, Request $request): void
+    {
+        try {
+            $response->headers->setCookie(
+                $this->authorization->createCookie($request, [MercureTopic::userNotifications($user->id)])
+            );
+        } catch (\Throwable $throwable) {
+            $this->logger->error('Could not issue a Mercure subscriber cookie, realtime will fall back to polling', [
+                'exception' => $throwable,
+                'user_id' => $user->id,
+            ]);
+        }
+    }
+
+    /**
+     * Takes the cookie back out of the browser, on the same name, path and domain the component
+     * derived when it put it there, rather than on three values retyped at the call site. Those are
+     * not constants: the name follows the hub's protocol version, and `__Secure-mercure_access_token`
+     * under 1.0 would not clear a `mercureAuthorization` written under 0.x.
+     *
+     * Nothing is revoked by this. There is no blocklist behind a subscriber token the way there is
+     * behind the JWT, so a copy taken beforehand keeps working until it expires, an hour at most.
+     * What it does is stop the *browser* holding one, which is the case that matters on a shared
+     * machine.
+     */
+    public function clearFrom(Response $response, Request $request): void
+    {
+        try {
+            $response->headers->setCookie($this->authorization->createClearCookie($request));
+        } catch (\Throwable $throwable) {
+            $this->logger->error('Could not clear the Mercure subscriber cookie', ['exception' => $throwable]);
+        }
+    }
+}

--- a/src/Mercure/MercureTopic.php
+++ b/src/Mercure/MercureTopic.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mercure;
+
+/**
+ * The Mercure topics the application publishes on and hands out subscriber tokens for.
+ *
+ * These strings are the security boundary, not a naming convention. Caddy's own handler terminates
+ * `/.well-known/mercure` and never forwards it to PHP, so no firewall, voter or checker in this
+ * application is on the path of a subscription: what a subscriber may read is decided entirely by
+ * the topic selectors inside the token they present. A publisher and a subscriber that disagree by
+ * one character silently deliver nothing, and one that is accidentally broadened delivers somebody
+ * else's mail, so the string is written once, here.
+ *
+ * Two things have to be true for a per-user topic to actually be private, and only one of them lives
+ * in this file. The token must name the topic (that is the cookie issued by MercureSubscriberCookie),
+ * and the update must be published with `private: true`: the hub only consults a subscriber's
+ * selectors for private updates, so a public update on a user's topic reaches anybody holding any
+ * valid token who asks for it.
+ */
+final class MercureTopic
+{
+    /**
+     * Everything addressed to one user: the notification bell first, and whatever else later wants
+     * to reach a signed-in person rather than a page they happen to have open.
+     */
+    public static function userNotifications(string $userId): string
+    {
+        return '/users/' . $userId . '/notifications';
+    }
+}

--- a/src/State/Processor/User/DeleteAccountProcessor.php
+++ b/src/State/Processor/User/DeleteAccountProcessor.php
@@ -8,10 +8,13 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\User\DeleteAccount;
 use App\Entity\User;
+use App\Mercure\MercureSubscriberCookie;
 use App\Service\Procedure\User\DeleteAccountProcedure;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @implements ProcessorInterface<DeleteAccount, Response>
@@ -21,6 +24,8 @@ readonly class DeleteAccountProcessor implements ProcessorInterface
     public function __construct(
         private Security $security,
         private DeleteAccountProcedure $deleteAccountProcedure,
+        private MercureSubscriberCookie $mercureSubscriberCookie,
+        private RequestStack $requestStack,
     ) {
     }
 
@@ -36,6 +41,10 @@ readonly class DeleteAccountProcessor implements ProcessorInterface
         $response = new Response(null, Response::HTTP_NO_CONTENT);
         $response->headers->setCookie(Cookie::create('jwt_hp', '', 1, '/', null, true, false, false, Cookie::SAMESITE_STRICT));
         $response->headers->setCookie(Cookie::create('jwt_s', '', 1, '/', null, true, true, false, Cookie::SAMESITE_STRICT));
+        // And the Mercure subscriber token, which lives on the hub's own path rather than on /.
+        if (($request = $this->requestStack->getMainRequest()) instanceof Request) {
+            $this->mercureSubscriberCookie->clearFrom($response, $request);
+        }
 
         return $response;
     }

--- a/symfony.lock
+++ b/symfony.lock
@@ -590,6 +590,18 @@
             "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
         }
     },
+    "symfony/mercure-bundle": {
+        "version": "0.5",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "0.4",
+            "ref": "b141b8c8f13bc8c31d718a5488039b712c0d3592"
+        },
+        "files": [
+            "config/packages/mercure.yaml"
+        ]
+    },
     "symfony/mime": {
         "version": "v4.3.0"
     },

--- a/tests/Api/Mercure/MercureSubscriberCookieRefreshTest.php
+++ b/tests/Api/Mercure/MercureSubscriberCookieRefreshTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Mercure;
+
+use App\Entity\RefreshToken;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\User\UserFactory;
+use App\Tests\JwtPayload;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\BrowserKit\Cookie as BrowserKitCookie;
+use Symfony\Component\HttpFoundation\Cookie;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * That `POST /api/token/refresh` renews the subscriber cookie is the load-bearing half of the claim
+ * that one listener covers both ways a JWT is issued, and it rests on a vendor detail: gesdinet's
+ * success handler delegates to Lexik's, which is the only thing that dispatches the event the
+ * listener is on. If a bundle upgrade ever stops delegating, the cookie simply expires after an hour
+ * and realtime dies with nothing in any log. Hence a test rather than a comment.
+ *
+ * `loginUser()` is no use here, since it authenticates one request and produces no refresh token, so
+ * the token is seeded and put in the jar directly. It is stored unhashed by this bundle, and the
+ * cookie has to be non-Secure or the test client will not replay it over plain HTTP.
+ */
+#[ResetDatabase]
+class MercureSubscriberCookieRefreshTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_refreshing_the_jwt_renews_the_subscriber_cookie_for_the_same_user(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->persist(RefreshToken::createForUserWithTtl('a-refresh-token', $user, 3600));
+        $entityManager->flush();
+
+        $this->client->getCookieJar()->set(new BrowserKitCookie('refresh_token', 'a-refresh-token', null, '/', self::HTTP_HOST));
+        $this->client->request('POST', '/api/token/refresh');
+        $this->assertResponseIsSuccessful();
+
+        $this->assertResponseHasCookie('mercureAuthorization', '/.well-known/mercure');
+
+        $cookie = null;
+        foreach ($this->client->getResponse()->headers->getCookies() as $responseCookie) {
+            if ($responseCookie->getName() === 'mercureAuthorization') {
+                $cookie = $responseCookie;
+            }
+        }
+        self::assertInstanceOf(Cookie::class, $cookie);
+
+        // The same user's topic, not merely "a" cookie: a refresh that renewed somebody else's token
+        // would be a far worse bug than one that renewed nothing.
+        $this->assertSame(
+            ['subscribe' => ['/users/' . $user->id . '/notifications']],
+            JwtPayload::of($cookie->getValue())['mercure']
+        );
+    }
+}

--- a/tests/Api/Mercure/MercureSubscriberCookieTest.php
+++ b/tests/Api/Mercure/MercureSubscriberCookieTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Mercure;
+
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\User\UserFactory;
+use App\Tests\JwtPayload;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class MercureSubscriberCookieTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    private const string COOKIE_NAME = 'mercureAuthorization';
+    private const string COOKIE_PATH = '/.well-known/mercure';
+
+    public function test_login_issues_a_subscriber_token_for_that_user_and_nothing_else(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->jsonRequest('POST', '/api/login_check', [
+            'username' => $user->username,
+            'password' => 'password',
+        ]);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertResponseHasCookie(self::COOKIE_NAME, self::COOKIE_PATH);
+
+        $cookie = $this->responseCookie(self::COOKIE_NAME);
+        $this->assertTrue($cookie->isHttpOnly(), 'A token the page never reads must not be scriptable.');
+        $this->assertTrue($cookie->isSecure());
+        $this->assertSame(Cookie::SAMESITE_STRICT, $cookie->getSameSite());
+
+        // The whole claim, not a subset: the hub decides what this browser may read from exactly
+        // this, and an extra key here is an extra permission. In particular there is no "publish".
+        $this->assertSame(
+            ['subscribe' => ['/users/' . $user->id . '/notifications']],
+            JwtPayload::of($cookie->getValue())['mercure']
+        );
+    }
+
+    public function test_the_subscriber_token_expires_with_the_jwt_it_came_with(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->jsonRequest('POST', '/api/login_check', [
+            'username' => $user->username,
+            'password' => 'password',
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        // Both live one hour, so the refresh the frontend already performs renews the pair. A
+        // subscriber token outliving its JWT would keep an open stream for a logged-out browser.
+        $this->assertEqualsWithDelta(
+            time() + 3600,
+            $this->responseCookie(self::COOKIE_NAME)->getExpiresTime(),
+            5
+        );
+    }
+
+    public function test_logout_clears_the_subscriber_token(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('POST', '/api/token/invalidate');
+
+        // A real browser reaches here with a refresh_token cookie and gets a 200. loginUser() cannot
+        // produce one, and the cookie a real login would set is Secure, which the test client never
+        // replays over plain HTTP. The 400 is gesdinet's answer to that, and it comes after the
+        // clearing this test is about: CookieClearingLogoutListener runs at priority -255 on all
+        // three of gesdinet's branches alike, so the 400 path exercises the identical mechanism.
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $this->assertJsonEquals([
+            'code' => 400,
+            'message' => 'No refresh_token found.',
+        ]);
+
+        // Cleared on its own path, or the browser keeps the old one and the next person on this
+        // machine can still read the previous account's topic until the token expires.
+        $cookie = $this->responseCookie(self::COOKIE_NAME);
+        $this->assertSame(self::COOKIE_PATH, $cookie->getPath());
+        $this->assertTrue($cookie->isCleared());
+    }
+
+    public function test_deleting_an_account_clears_the_subscriber_token(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('POST', '/api/users/delete_account', [
+            'password' => 'password',
+        ], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $cookie = $this->responseCookie(self::COOKIE_NAME);
+        $this->assertSame(self::COOKIE_PATH, $cookie->getPath());
+        $this->assertTrue($cookie->isCleared());
+    }
+
+    private function responseCookie(string $name): Cookie
+    {
+        foreach ($this->client->getResponse()->headers->getCookies() as $cookie) {
+            if ($cookie->getName() === $name) {
+                return $cookie;
+            }
+        }
+
+        self::fail(sprintf('The response set no "%s" cookie.', $name));
+    }
+}

--- a/tests/Double/RecordingHub.php
+++ b/tests/Double/RecordingHub.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Double;
+
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
+use Symfony\Component\Mercure\ProtocolVersion;
+use Symfony\Component\Mercure\Update;
+
+/**
+ * Stands in for the Mercure hub and keeps the Update it was handed, so a test can assert on the
+ * topic and the private flag rather than on a return value that says nothing.
+ *
+ * Hand written rather than a mock because the interesting assertion is about an object that was
+ * built, which reads better recorded than trapped inside an expectation callback. It also means no
+ * test needs any Mercure wiring, so the suite can never reach a real hub by accident.
+ */
+final class RecordingHub implements HubInterface
+{
+    public ?Update $published = null;
+
+    public function publish(Update $update): string
+    {
+        $this->published = $update;
+
+        return 'urn:uuid:00000000-0000-0000-0000-000000000000';
+    }
+
+    public function getPublicUrl(): string
+    {
+        return '/.well-known/mercure';
+    }
+
+    public function getFactory(): ?TokenFactoryInterface
+    {
+        return null;
+    }
+
+    public function getProtocolVersion(): ProtocolVersion
+    {
+        return ProtocolVersion::Legacy;
+    }
+
+    public function getCookieName(): string
+    {
+        return 'mercureAuthorization';
+    }
+}

--- a/tests/Integration/Mercure/MercureHubConfigurationTest.php
+++ b/tests/Integration/Mercure/MercureHubConfigurationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Mercure;
+
+use App\Tests\JwtPayload;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\RemoteHubInterface;
+
+/**
+ * Guards the two pieces of hub configuration that fail silently.
+ *
+ * Neither can be caught by anything else here: CI runs no hub, `bin/console about` compiles the
+ * container without ever instantiating one, and a wrong value produces a token that is perfectly
+ * well formed and simply not allowed to do anything. Both have to be read out of a real container.
+ */
+class MercureHubConfigurationTest extends KernelTestCase
+{
+    public function test_the_publisher_token_may_publish_on_any_topic(): void
+    {
+        self::bootKernel();
+        $hub = self::getContainer()->get(HubInterface::class);
+        self::assertInstanceOf(RemoteHubInterface::class, $hub);
+
+        // Drop "jwt.publish" from config/packages/mercure.yaml and this claim becomes an empty
+        // selector list, which matches no topic, so every publish comes back 401 while the app looks
+        // entirely healthy. It is the default when the option is simply left out.
+        $this->assertSame(['*'], JwtPayload::of($hub->getProvider()->getJwt())['mercure']['publish']);
+    }
+
+    public function test_the_public_url_carries_no_host(): void
+    {
+        self::bootKernel();
+        $hub = self::getContainer()->get(HubInterface::class);
+        self::assertInstanceOf(HubInterface::class, $hub);
+
+        // Authorization scopes the subscriber cookie's domain by comparing this host with the host
+        // the request came in on, and throws when they are on different second-level domains. The
+        // hub is served by the same Caddy as the application, so it is always same-origin and the
+        // host is noise: with one it would have to be restated for localhost, musicall.local, the
+        // test client's musicall.test and production, and any of them getting it wrong loses
+        // realtime for that environment only, quietly.
+        $this->assertNull(parse_url($hub->getPublicUrl(), PHP_URL_HOST));
+        $this->assertSame('/.well-known/mercure', parse_url($hub->getPublicUrl(), PHP_URL_PATH));
+    }
+}

--- a/tests/JwtPayload.php
+++ b/tests/JwtPayload.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+/**
+ * Reads the claims out of a JWT without verifying it.
+ *
+ * Only tests use this, and only to assert on what was minted. The part worth writing once is the
+ * alphabet: a JWT segment is base64url, so `-` and `_` stand where `+` and `/` would, and almost
+ * every real token contains at least one of them. Feed it to base64_decode() untranslated and strict
+ * mode returns false while lax mode quietly drops the offending characters, either way producing
+ * something that is not the payload. The missing padding needs no attention, base64_decode() handles
+ * an unpadded string at every length.
+ */
+final class JwtPayload
+{
+    /**
+     * @return array<string, mixed> the claims, or an empty array when the value is not a JWT, so a
+     *                              failure shows up as a missing claim in the assertion's diff
+     */
+    public static function of(string $jwt): array
+    {
+        $segments = explode('.', $jwt);
+        if (count($segments) !== 3) {
+            return [];
+        }
+
+        $claims = json_decode((string) base64_decode(strtr($segments[1], '-_', '+/'), true), true);
+
+        return is_array($claims) ? $claims : [];
+    }
+}

--- a/tests/Unit/Command/Mercure/MercurePingCommandTest.php
+++ b/tests/Unit/Command/Mercure/MercurePingCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command\Mercure;
+
+use App\Command\Mercure\MercurePingCommand;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Tests\Double\RecordingHub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+
+class MercurePingCommandTest extends TestCase
+{
+    public function test_it_publishes_privately_on_the_named_users_topic(): void
+    {
+        $user = new User();
+        $user->id = 'd1be73fc-b0c4-4530-a30a-d41f43e6ebea';
+        $user->username = 'user_base';
+
+        $hub = new RecordingHub();
+        $tester = new CommandTester($this->command($hub, $user));
+
+        $this->assertSame(Command::SUCCESS, $tester->execute(['username' => 'user_base']));
+
+        $update = $hub->published;
+        self::assertInstanceOf(Update::class, $update);
+        $this->assertSame(['/users/d1be73fc-b0c4-4530-a30a-d41f43e6ebea/notifications'], $update->getTopics());
+        // The flag is the isolation, not the token: the hub only checks a subscriber's selectors for
+        // private updates, so a public one here would reach every signed-in browser that asked.
+        $this->assertTrue($update->isPrivate());
+        $this->assertStringContainsString('/users/d1be73fc-b0c4-4530-a30a-d41f43e6ebea/notifications', $tester->getDisplay());
+    }
+
+    public function test_an_unknown_username_publishes_nothing(): void
+    {
+        $hub = new RecordingHub();
+        $tester = new CommandTester($this->command($hub, null));
+
+        $this->assertSame(Command::FAILURE, $tester->execute(['username' => 'nobody']));
+        $this->assertNull($hub->published);
+        $this->assertStringContainsString('No user named "nobody"', $tester->getDisplay());
+    }
+
+    private function command(HubInterface $hub, ?User $user): MercurePingCommand
+    {
+        $userRepository = $this->createStub(UserRepository::class);
+        $userRepository->method('findOneBy')->willReturn($user);
+
+        return new MercurePingCommand($hub, $userRepository);
+    }
+}

--- a/tests/Unit/Mercure/MercureSubscriberCookieTest.php
+++ b/tests/Unit/Mercure/MercureSubscriberCookieTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Mercure;
+
+use App\Entity\User;
+use App\Mercure\MercureSubscriberCookie;
+use App\Tests\Double\RecordingHub;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mercure\Authorization;
+use Symfony\Component\Mercure\HubRegistry;
+
+/**
+ * The swallowing is the whole design decision, so it gets a test of its own rather than resting on
+ * the docblock that argues for it.
+ *
+ * A hub with no token factory is what a misconfiguration actually looks like from here: it is the
+ * state `Authorization::createCookie()` refuses, and `RecordingHub` returns null from `getFactory()`
+ * already.
+ */
+class MercureSubscriberCookieTest extends TestCase
+{
+    public function test_a_hub_it_cannot_mint_against_leaves_the_response_alone_and_is_logged(): void
+    {
+        $logger = new class extends AbstractLogger {
+            /** @var list<array{string, string, array<string, mixed>}> */
+            public array $records = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = [(string) $level, (string) $message, $context];
+            }
+        };
+
+        $user = new User();
+        $user->id = 'd1be73fc-b0c4-4530-a30a-d41f43e6ebea';
+
+        $response = new Response();
+        (new MercureSubscriberCookie(new Authorization(new HubRegistry(new RecordingHub())), $logger))
+            ->attachTo($response, $user, Request::create('https://musicall.test/api/login_check'));
+
+        // Not a cookie, and not an exception either: a login must not fail over this.
+        $this->assertSame([], $response->headers->getCookies());
+
+        $this->assertCount(1, $logger->records);
+        [$level, , $context] = $logger->records[0];
+        $this->assertSame('error', $level);
+        $this->assertInstanceOf(\Throwable::class, $context['exception']);
+        // The user id is what makes the line actionable: it says whose realtime is silently off.
+        $this->assertSame('d1be73fc-b0c4-4530-a30a-d41f43e6ebea', $context['user_id']);
+    }
+}

--- a/tests/Unit/Mercure/MercureTopicTest.php
+++ b/tests/Unit/Mercure/MercureTopicTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Mercure;
+
+use App\Mercure\MercureTopic;
+use PHPUnit\Framework\TestCase;
+
+class MercureTopicTest extends TestCase
+{
+    /**
+     * Pinned rather than obvious. A publisher and a subscriber that disagree on this string deliver
+     * nothing, silently, and nothing else in the stack would notice: the hub has no idea the two are
+     * meant to be talking about the same thing.
+     */
+    public function test_a_user_notification_topic_is_scoped_to_that_user(): void
+    {
+        $this->assertSame(
+            '/users/d1be73fc-b0c4-4530-a30a-d41f43e6ebea/notifications',
+            MercureTopic::userNotifications('d1be73fc-b0c4-4530-a30a-d41f43e6ebea')
+        );
+    }
+}


### PR DESCRIPTION
Closes #949. Track A1 of #948, the first ticket of the realtime chapter.

Enables the Mercure hub that is already inside the FrankenPHP binary serving the site, and wires Symfony to it. **No consumer ships here.** #950 (live notification bell) is the first one, so nothing in the application publishes yet and the notification bell still polls.

## What is in it

- `symfony/mercure-bundle`, and a `mercure` block in the dev Caddyfile. No new container, systemd unit or deploy target: the hub is a Caddy handler in the binary we already run, so subscriber connections are held in Go rather than by PHP workers.
- A subscriber token handed to the browser as `mercureAuthorization`: Secure, HttpOnly, SameSite=Strict, path `/.well-known/mercure`, one hour. Minted on login, on token refresh and on the OAuth callback, so it is renewed by the refresh the frontend already performs. Cleared on logout and on account deletion.
- The token grants subscribe to exactly one topic, `/users/{id}/notifications`, and cannot publish anything at all.
- `app:mercure:ping <username>` publishes one private update on a user's topic. It is a smoke test rather than a feature: the production hub configuration lives on the server, outside version control, so this is the only way to check a hand edit actually worked.
- Both legal pages list the fourth cookie, since both say "uniquement les cookies suivants".

## The security model, in one paragraph

Caddy's handler terminates `/.well-known/mercure` and never forwards it to PHP, so no firewall, voter or checker in this application is on the path of a subscription. The topic selectors inside the token are the entire boundary. Two things have to be true for a per-user topic to be private: the token must name it, and the update must be published with `private: true`, because the hub consults a subscriber's selectors only for private updates. `Update`'s `$private` defaults to false, so that is written down in `MercureTopic`'s docblock and in the ping command, and it is the one thing #950 must not get wrong.

## Verified against the running hub, not just asserted

- A ping on a user's topic reaches a browser holding that user's cookie.
- The same browser, explicitly subscribed to a second user's topic, receives nothing.
- Port 80 answers `Host: php-web` with a 308 like every other host, the internal publish address on 8080 is published nowhere, and the app still serves over HTTPS.

Suite 2645 green, PHPStan level 8 clean, Biome clean, `npm run build` clean.

## Things worth a reviewer's attention

- **A missing `MERCURE_URL` would have taken the whole site down, not just realtime.** The bundle registers a Twig extension that holds the hub, Twig builds its extensions eagerly, and Twig renders the page the SPA is served from. Since Deployer shares `.env` rather than deploying it, that is the normal state of a first release. The publish URL now falls back to `DEFAULT_URI`, which is already on the server, so production publishes correctly without the variable being set at all.
- **`MERCURE_PUBLIC_URL` is a literal, not a variable.** It is a bare path on purpose: `Authorization` scopes the subscriber cookie's domain by comparing that host with the request host and throws when they differ, and this app is reached as `localhost`, `musicall.local`, `musicall.test` in the suite and its own domain in production. A path has no host to disagree about, so one committed value is right everywhere.
- **`api_platform.mercure` is pinned to `false`.** Installing the bundle silently flips it from off-by-default to on-by-default. Nothing broadcasts today, but a `mercure: true` on a resource would publish the serialized entity non-private, which is both a leak and the opposite of the "carry a signal, not data" decision in #948.
- **`composer.json` gained `extra.symfony.docker: false`.** Flex persisted the answer to its Docker prompt, which opts every future recipe out of Docker configuration. Right for this repository, since `compose.yaml` is hand maintained, but it is invisible in the diff.
- The Caddyfile's bolt history is bounded. Both `size` and `cleanup_frequency` are needed: the transport prunes nothing unless both are non-zero.

## Before deploying

`MERCURE_JWT_SECRET` in the shared `.env` **and** in the FrankenPHP systemd unit, because Caddy reads it from the process environment. Generate a fresh key rather than reusing the committed development default. The `mercure` block into the production Caddyfile, keeping its plain HTTP publish address on an unpublished port. Worth raising `LimitNOFILE` on the unit at some point too: the documented first bottleneck for a hub is file descriptors, not CPU or memory.
