### PR TITLE
Mercure: live notification bell, poll becomes a fallback

### DIFF
--- a/.docker/frankenphp/Caddyfile
+++ b/.docker/frankenphp/Caddyfile
@@ -44,9 +44,10 @@
 		# Bolt is the default transport and its default path is Caddy's own data directory,
 		# /data/caddy/mercure.db here: writable by the container user, inside the caddy_data
 		# volume, and on the server outside the release directory, so a deploy does not lose it.
-		# History is a bonus rather than a contract - the design publishes a signal and lets the
-		# client refetch - but it means a reconnect after the deploy restart can replay what it
-		# missed, which is the one moment every subscriber reconnects at once.
+		# History is a bonus rather than a contract, and as of #950 nothing claims it: the client
+		# builds a fresh EventSource on every retry, which sends no Last-Event-ID, so the hub
+		# replays nothing to it. The client refetches on reconnect instead. Kept because it costs
+		# almost nothing and a future consumer may want replay.
 		#
 		# Bounded because that is the only thing standing between a per-notification signal and a
 		# file that grows for the lifetime of the server. Both settings are needed: the transport

--- a/.env.test
+++ b/.env.test
@@ -15,7 +15,8 @@ MAIL_NO_REPLY_EMAIL=no-reply@musicall.localhost
 MAIL_CONTACT_EMAIL=contact@musicall.localhost
 
 DEFAULT_URI=http://localhost
-# The suite never publishes, and this reserved TLD guarantees it: an accidental publish from a test
-# fails to resolve instead of quietly reaching the dev hub over the docker network. The subscriber
-# cookie needs no override, because MERCURE_PUBLIC_URL is a host-less path.
+# A backstop. Since #950 the suite does publish, on every notification, but when@test points
+# HubInterface at a recording double so nothing reaches a hub. This reserved TLD is what catches a
+# publisher that slips past that double: it fails to resolve rather than quietly reaching the dev hub
+# over the docker network.
 MERCURE_URL=http://mercure.invalid/.well-known/mercure

--- a/assets/js/components/Notification/NotificationBell.vue
+++ b/assets/js/components/Notification/NotificationBell.vue
@@ -96,7 +96,10 @@ import { RouterLink } from 'vue-router'
 import { useUserNotificationStore } from '../../store/notification/userNotification.js'
 import NotificationItem from './NotificationItem.vue'
 
-const POLL_INTERVAL_MS = 60_000
+// A fallback, not the mechanism: the count arrives over Mercure now (#950). This only has to cover
+// a hub that is down or a stream that has not reconnected yet, so it is minutes rather than the
+// minute it used to be. The focus listener below still gives an immediate refresh on tab switch.
+const POLL_INTERVAL_MS = 5 * 60_000
 
 const emit = defineEmits(['navigate'])
 
@@ -138,10 +141,20 @@ let intervalId = null
 
 function refreshCount() {
   store.loadCount()
+  // The self-heal. The store connects as soon as the profile lands, but if that fetch failed there is
+  // nothing else that would ever try again, and the poll would mask it perfectly: a live-looking bell
+  // that is only ever five minutes fresh. connect() is idempotent, so this costs nothing when the
+  // stream is already up.
+  store.connect()
 }
 
 onMounted(() => {
   store.loadCount()
+  // The store has already tried by the time this runs: creating it above ran its immediate watch.
+  // This is here for the case where the profile had not landed then, alongside refreshCount() below.
+  // Deliberately never closed on unmount, because a layout switch unmounts this component and the
+  // stream should outlive that.
+  store.connect()
   intervalId = setInterval(refreshCount, POLL_INTERVAL_MS)
   window.addEventListener('focus', refreshCount)
 })

--- a/assets/js/store/notification/userNotification.js
+++ b/assets/js/store/notification/userNotification.js
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
-import { readonly, ref } from 'vue'
+import { readonly, ref, watch } from 'vue'
 import userNotificationApi from '../../api/notification/userNotification.js'
+import { createNotificationStream, notificationTopic } from '../../utils/notificationStream.js'
+import { useUserSecurityStore } from '../user/security.js'
 
 export const useUserNotificationStore = defineStore('userNotification', () => {
   // Bell dropdown feed (latest page only).
@@ -101,7 +103,44 @@ export const useUserNotificationStore = defineStore('userNotification', () => {
     pageTotalItems.value = 0
   }
 
+  // The live stream. It lives in the store rather than in NotificationBell.vue because the bell
+  // unmounts whenever the layout changes (AppBaseLayout to AppBandLayout and back), which would drop
+  // and reopen the connection on every entry into a Band Space. A store is a singleton for the page,
+  // so whoever mounts first connects and the rest is a no-op.
+  const stream = createNotificationStream({
+    // A list of one. See notificationStream.js for why it is a list at all.
+    getTopics: () => {
+      const userId = useUserSecurityStore().userProfile?.id
+
+      return userId ? [notificationTopic(userId)] : []
+    },
+    onSignal: () => loadCount(),
+    onAuthRefreshNeeded: () => useUserSecurityStore().checkAuthInfo()
+  })
+
+  // Authentication completes one HTTP round trip before the profile does: checkAuthInfo() sets
+  // isAuthenticated and then calls fetchUserProfile() without awaiting it. So a bell that mounts from
+  // a warm cache can call connect() while userProfile is still null, find no id, and never open the
+  // stream at all, leaving the user on the fallback poll for the whole session with nothing logged.
+  // Waiting for the id rather than for the mount is what makes that race unlosable.
+  watch(
+    () => useUserSecurityStore().userProfile?.id,
+    (userId, previousUserId) => {
+      // Reconnect rather than connect: connect() refuses to run while a stream is open, and the
+      // topics live in that stream's URL. Without the teardown, a session that changed user would
+      // keep listening on the old topic and a widened topic list would be silently ignored.
+      if (previousUserId) {
+        stream.disconnect()
+      }
+      if (userId) {
+        stream.connect()
+      }
+    },
+    { immediate: true }
+  )
+
   function clear() {
+    stream.disconnect()
     items.value = []
     unreadCount.value = 0
     clearPage()
@@ -120,6 +159,8 @@ export const useUserNotificationStore = defineStore('userNotification', () => {
     markRead,
     markAllRead,
     recordInvitationAction,
+    connect: stream.connect,
+    disconnect: stream.disconnect,
     clearPage,
     clear
   }

--- a/assets/js/utils/notificationStream.js
+++ b/assets/js/utils/notificationStream.js
@@ -1,0 +1,146 @@
+import { reconnectDelay } from './realtimeBackoff.js'
+
+/**
+ * The live notification stream: one `EventSource` on the signed-in user's own Mercure topic.
+ *
+ * Lives here rather than inside the Pinia store so that the lifecycle, which is the part with real
+ * failure modes, can be driven by a test with a fake `EventSource` and fake timers. The store keeps
+ * the state; this keeps the connection.
+ *
+ * The server publishes a tag, not a notification, so nothing here reads the event body: a message
+ * means "refetch", and the refetching is the store's job.
+ *
+ * Topics are a list because Mercure multiplexes: one connection carries as many `topic=` parameters
+ * as you give it, and opening a second EventSource per topic would cost a second hub subscriber and
+ * a second reconnect on every deploy for nothing. Today the list holds one entry, because the
+ * subscriber cookie authorizes exactly one topic and a topic the token does not name receives
+ * nothing at all. When the cookie widens to a member's band spaces, the caller passes a longer list
+ * and has to `disconnect()` first: the topics are fixed in the URL, so a longer list cannot take
+ * effect on a stream that is already open. Two things worth knowing at that point. The SSE frame
+ * carries only an id and data, never the topic that matched, so the payload's own `type` is what
+ * tells the client what changed. And a subscriber has to *ask* for a topic, not merely hold a token
+ * that authorizes it.
+ */
+
+/**
+ * Must match `App\Mercure\MercureTopic::userNotifications()`. The two are the same contract written
+ * in two languages, and a rename on either side delivers nothing while erroring nowhere.
+ */
+export function notificationTopic(userId) {
+  return `/users/${userId}/notifications`
+}
+
+/** Path of the hub, fixed by the Mercure protocol and by `public_url` in config/packages/mercure.yaml. */
+const HUB_PATH = '/.well-known/mercure'
+
+/** How many consecutive failures between attempts at renewing credentials. */
+const FAILURES_PER_AUTH_REFRESH = 3
+
+/**
+ * @param {object} deps
+ * @param {() => string[]} deps.getTopics the topics to subscribe to, read at connect time rather
+ *   than captured, because they depend on a profile that arrives after authentication does
+ * @param {() => void} deps.onSignal something changed, go and refetch
+ * @param {() => Promise<unknown>} deps.onAuthRefreshNeeded renew credentials, best effort
+ * @param {(url: string) => EventSource} [deps.openStream] injected for tests
+ * @param {{ set: Function, clear: Function }} [deps.timers] injected for tests
+ * @param {(attempt: number) => number} [deps.delayFor] injected for tests
+ */
+export function createNotificationStream({
+  getTopics,
+  onSignal,
+  onAuthRefreshNeeded,
+  openStream = (url) => new EventSource(url),
+  timers = { set: setTimeout, clear: clearTimeout },
+  delayFor = reconnectDelay
+}) {
+  let stream = null
+  let retryHandle = null
+  let failures = 0
+  // Bumped by every disconnect, so an error event still queued against a stream we have already
+  // closed cannot count as a failure or schedule a reconnect nobody asked for.
+  let generation = 0
+
+  function connect() {
+    if (stream !== null || retryHandle !== null) {
+      return
+    }
+
+    const topics = getTopics()
+    if (topics.length === 0) {
+      // Authentication lands one HTTP round trip before the profile does, so the first call from a
+      // mounting component can arrive with nothing to subscribe to. The caller watches the profile
+      // and calls back.
+      return
+    }
+
+    const currentGeneration = generation
+    const query = topics.map((topic) => `topic=${encodeURIComponent(topic)}`).join('&')
+    stream = openStream(`${HUB_PATH}?${query}`)
+
+    stream.onopen = () => {
+      // Anything published while the stream was down is simply gone. `Last-Event-ID` belongs to the
+      // EventSource object and every retry here builds a new one, so the hub replays nothing however
+      // much history the transport keeps. Refetching on recovery is what closes that gap, and a
+      // deploy restart is exactly when it opens, for every subscriber at once.
+      if (failures > 0) {
+        onSignal()
+      }
+      failures = 0
+    }
+
+    stream.onmessage = () => {
+      onSignal()
+    }
+
+    stream.onerror = () => {
+      if (currentGeneration !== generation) {
+        return
+      }
+
+      // Taking the retry over is not belt and braces, it is the only thing that recovers from the
+      // failure that actually happens. EventSource retries a dropped *connection* by itself, but a
+      // non-200 "fails the connection": one error event, readyState CLOSED, and per the specification
+      // no reconnect at all. An expired subscriber cookie is exactly that, a 401, because the hub
+      // runs without `anonymous`. Measured in Chrome to be sure. So a browser that slept past the
+      // token refresh would otherwise lose the stream for good, silently, bell still looking healthy.
+      disconnect()
+      failures += 1
+
+      // Every third failure, not *the* third: a renewal that fails, or that returns without minting
+      // a usable cookie, has to be retried or the stream reconnects into the same 401 forever. Every
+      // failure would be worse than the poll this protects, since renewing also refetches the profile.
+      if (failures % FAILURES_PER_AUTH_REFRESH === 0) {
+        // Fired, not awaited. Chaining the reconnect behind it meant a hung refresh request left no
+        // stream, no timer and nothing scheduled, which is the same silent death this handler exists
+        // to prevent. The reconnect keeps its own schedule and uses whatever cookie is current by then.
+        onAuthRefreshNeeded().catch(() => {})
+      }
+
+      const scheduledGeneration = generation
+      retryHandle = timers.set(
+        () => {
+          retryHandle = null
+          if (scheduledGeneration === generation) {
+            connect()
+          }
+        },
+        delayFor(failures - 1)
+      )
+    }
+  }
+
+  function disconnect() {
+    generation += 1
+    if (stream !== null) {
+      stream.close()
+      stream = null
+    }
+    if (retryHandle !== null) {
+      timers.clear(retryHandle)
+      retryHandle = null
+    }
+  }
+
+  return { connect, disconnect }
+}

--- a/assets/js/utils/notificationStream.test.js
+++ b/assets/js/utils/notificationStream.test.js
@@ -1,0 +1,328 @@
+import assert from 'node:assert/strict'
+import { beforeEach, describe, it } from 'node:test'
+import { createNotificationStream, notificationTopic } from './notificationStream.js'
+
+/**
+ * The connection lifecycle, which is the part of the live bell with real failure modes: a stream
+ * that never opens, two streams open at once, a reconnect that outlives a logout, or credentials
+ * renewed on every retry of an outage.
+ *
+ * Run with `npm test`.
+ */
+
+/** Stands in for the browser's EventSource, and lets a test fire its callbacks by hand. */
+class FakeEventSource {
+  static opened = []
+
+  constructor(url) {
+    this.url = url
+    this.closed = false
+    FakeEventSource.opened.push(this)
+  }
+
+  close() {
+    this.closed = true
+  }
+}
+
+/** Runs scheduled callbacks on demand instead of on a clock. */
+function fakeTimers() {
+  const scheduled = new Map()
+  let nextId = 1
+
+  return {
+    delays: [],
+    set(fn, delay) {
+      this.delays.push(delay)
+      const id = nextId++
+      scheduled.set(id, fn)
+      return id
+    },
+    clear(id) {
+      scheduled.delete(id)
+    },
+    runAll() {
+      const pending = [...scheduled.values()]
+      scheduled.clear()
+      return Promise.all(pending.map((fn) => fn()))
+    },
+    get pending() {
+      return scheduled.size
+    }
+  }
+}
+
+function build(overrides = {}) {
+  const timers = fakeTimers()
+  const calls = { signals: 0, authRefreshes: 0 }
+  const stream = createNotificationStream({
+    getTopics: () => ['/users/a-user-id/notifications'],
+    onSignal: () => {
+      calls.signals += 1
+    },
+    onAuthRefreshNeeded: () => {
+      calls.authRefreshes += 1
+      return Promise.resolve()
+    },
+    openStream: (url) => new FakeEventSource(url),
+    timers,
+    delayFor: () => 1000,
+    ...overrides
+  })
+
+  return { stream, timers, calls }
+}
+
+/** Lets queued promise callbacks run, since the reconnect is chained off a promise. */
+const settle = () => new Promise((resolve) => setImmediate(resolve))
+
+beforeEach(() => {
+  FakeEventSource.opened = []
+})
+
+describe('notificationTopic', () => {
+  it('matches the topic MercureTopic::userNotifications() builds', () => {
+    assert.equal(notificationTopic('d1be73fc'), '/users/d1be73fc/notifications')
+  })
+})
+
+describe('createNotificationStream', () => {
+  it('subscribes to the signed-in user topic, encoded', () => {
+    build().stream.connect()
+
+    assert.equal(FakeEventSource.opened.length, 1)
+    assert.equal(
+      FakeEventSource.opened[0].url,
+      '/.well-known/mercure?topic=%2Fusers%2Fa-user-id%2Fnotifications'
+    )
+  })
+
+  it('opens nothing when the profile has not arrived yet', () => {
+    // The race this whole design exists for: authentication lands before the profile does.
+    const { stream } = build({ getTopics: () => [] })
+    stream.connect()
+
+    assert.equal(FakeEventSource.opened.length, 0)
+  })
+
+  it('opens on a later call once the profile is there', () => {
+    let topics = []
+    const { stream } = build({ getTopics: () => topics })
+
+    stream.connect()
+    assert.equal(FakeEventSource.opened.length, 0)
+
+    topics = ['/users/a-user-id/notifications']
+    stream.connect()
+    assert.equal(FakeEventSource.opened.length, 1)
+  })
+
+  it('multiplexes several topics onto one connection', () => {
+    // Mercure carries as many topics as it is given on a single stream. Today the caller passes one,
+    // but a second EventSource per topic would be the expensive way to do this and is worth pinning
+    // against before the band space chat adds more.
+    const { stream } = build({
+      getTopics: () => ['/users/a/notifications', '/band-spaces/b/chat']
+    })
+    stream.connect()
+
+    assert.equal(FakeEventSource.opened.length, 1)
+    assert.equal(
+      FakeEventSource.opened[0].url,
+      '/.well-known/mercure?topic=%2Fusers%2Fa%2Fnotifications&topic=%2Fband-spaces%2Fb%2Fchat'
+    )
+  })
+
+  it('is idempotent, so two mounting components share one stream', () => {
+    const { stream } = build()
+
+    stream.connect()
+    stream.connect()
+    stream.connect()
+
+    assert.equal(FakeEventSource.opened.length, 1)
+  })
+
+  it('refetches on a message without reading the event', () => {
+    const { stream, calls } = build()
+    stream.connect()
+
+    FakeEventSource.opened[0].onmessage({ data: 'ignored' })
+
+    assert.equal(calls.signals, 1)
+  })
+
+  it('closes and reopens on an error rather than leaving it to EventSource', async () => {
+    const { stream, timers } = build()
+    stream.connect()
+
+    FakeEventSource.opened[0].onerror()
+    assert.equal(FakeEventSource.opened[0].closed, true)
+
+    await timers.runAll()
+    await settle()
+
+    assert.equal(FakeEventSource.opened.length, 2)
+  })
+
+  it('renews credentials every third failure, not on every retry', async () => {
+    const { stream, timers, calls } = build()
+    stream.connect()
+
+    // Every retry would be a heavier load than the poll this protects, since renewing also refetches
+    // the profile. Only at the third does the cookie become the likelier suspect than the network.
+    for (let i = 0; i < 2; i++) {
+      FakeEventSource.opened.at(-1).onerror()
+      await timers.runAll()
+      await settle()
+    }
+    assert.equal(calls.authRefreshes, 0)
+
+    FakeEventSource.opened.at(-1).onerror()
+    await timers.runAll()
+    await settle()
+    assert.equal(calls.authRefreshes, 1)
+  })
+
+  it('keeps retrying the renewal, because a renewal can fail too', async () => {
+    // Renewing exactly once per outage would strand the stream reconnecting into the same 401
+    // forever whenever the first attempt did not produce a usable cookie.
+    const { stream, timers, calls } = build({
+      onAuthRefreshNeeded: () => {
+        calls.authRefreshes += 1
+
+        return Promise.reject(new Error('refresh failed'))
+      }
+    })
+    stream.connect()
+
+    for (let i = 0; i < 9; i++) {
+      FakeEventSource.opened.at(-1).onerror()
+      await timers.runAll()
+      await settle()
+    }
+
+    assert.equal(calls.authRefreshes, 3)
+  })
+
+  it('a hung renewal does not strand the stream', async () => {
+    // The reconnect must not be chained behind the renewal: a refresh request that never settles
+    // would otherwise leave no stream, no timer and nothing scheduled.
+    const { stream, timers } = build({ onAuthRefreshNeeded: () => new Promise(() => {}) })
+    stream.connect()
+
+    for (let i = 0; i < 3; i++) {
+      FakeEventSource.opened.at(-1).onerror()
+      await timers.runAll()
+      await settle()
+    }
+
+    assert.equal(FakeEventSource.opened.length, 4)
+  })
+
+  it('starts the streak over after a connection that worked', async () => {
+    const { stream, timers, calls } = build()
+    stream.connect()
+
+    for (let i = 0; i < 3; i++) {
+      FakeEventSource.opened.at(-1).onerror()
+      await timers.runAll()
+      await settle()
+    }
+    assert.equal(calls.authRefreshes, 1)
+
+    FakeEventSource.opened.at(-1).onopen()
+    for (let i = 0; i < 3; i++) {
+      FakeEventSource.opened.at(-1).onerror()
+      await timers.runAll()
+      await settle()
+    }
+
+    assert.equal(calls.authRefreshes, 2)
+  })
+
+  it('refetches on recovery, because nothing replays what the gap swallowed', async () => {
+    const { stream, timers, calls } = build()
+    stream.connect()
+
+    // A first open is not a recovery: the store already loaded the count on mount.
+    FakeEventSource.opened[0].onopen()
+    assert.equal(calls.signals, 0)
+
+    FakeEventSource.opened[0].onerror()
+    await timers.runAll()
+    await settle()
+    FakeEventSource.opened.at(-1).onopen()
+
+    assert.equal(calls.signals, 1)
+  })
+
+  it('backs off further the longer an outage lasts', async () => {
+    const timers = fakeTimers()
+    const { stream } = build({ timers, delayFor: (attempt) => attempt })
+    stream.connect()
+
+    for (let i = 0; i < 3; i++) {
+      FakeEventSource.opened.at(-1).onerror()
+      await timers.runAll()
+      await settle()
+    }
+
+    assert.deepEqual(timers.delays, [0, 1, 2])
+  })
+
+  it('disconnecting closes the stream and cancels a pending retry', async () => {
+    const { stream, timers } = build()
+    stream.connect()
+
+    FakeEventSource.opened[0].onerror()
+    assert.equal(timers.pending, 1)
+
+    stream.disconnect()
+
+    assert.equal(timers.pending, 0)
+    await timers.runAll()
+    await settle()
+    assert.equal(FakeEventSource.opened.length, 1)
+  })
+
+  it('a stale error from a closed stream cannot resurrect it', async () => {
+    const { stream, timers } = build()
+    stream.connect()
+    const abandoned = FakeEventSource.opened[0]
+
+    stream.disconnect()
+    abandoned.onerror()
+
+    assert.equal(timers.pending, 0)
+    await settle()
+    assert.equal(FakeEventSource.opened.length, 1)
+  })
+
+  it('can be reopened after a clean disconnect', async () => {
+    // The generation counter is the one thing that could leave the stream permanently unopenable, so
+    // the reopen is worth pinning rather than inferring from the cancellation cases above.
+    const { stream } = build()
+
+    stream.connect()
+    stream.disconnect()
+    stream.connect()
+
+    assert.equal(FakeEventSource.opened.length, 2)
+    assert.equal(FakeEventSource.opened[0].closed, true)
+    assert.equal(FakeEventSource.opened[1].closed, false)
+  })
+
+  it('still reconnects normally after a reopen', async () => {
+    const { stream, timers } = build()
+    stream.connect()
+    stream.disconnect()
+    stream.connect()
+
+    FakeEventSource.opened.at(-1).onerror()
+    await timers.runAll()
+    await settle()
+
+    assert.equal(FakeEventSource.opened.length, 3)
+  })
+})

--- a/assets/js/utils/realtimeBackoff.js
+++ b/assets/js/utils/realtimeBackoff.js
@@ -1,0 +1,36 @@
+/**
+ * How long to wait before reopening a dropped realtime connection.
+ *
+ * `EventSource` reconnects on its own, which is fine for one browser and wrong for all of them at
+ * once: every deploy restarts FrankenPHP, every open stream drops in the same instant, and the
+ * built-in retry brings them all back together. The jitter is the point of this function, not the
+ * growth.
+ *
+ * Exponential from `BASE_DELAY_MS`, capped at `MAX_BASE_DELAY_MS`, then spread across a window
+ * either side of that value so two clients that failed together do not return together. The spread
+ * is applied after the cap, so the delay actually returned reaches 1.5 times it.
+ */
+
+const BASE_DELAY_MS = 1_000
+const MAX_BASE_DELAY_MS = 30_000
+/** Fraction of the delay the jitter may add or remove. */
+const JITTER_RATIO = 0.5
+
+/**
+ * @param {number} attempt zero for the first retry after a working connection
+ * @param {() => number} random injectable so the spread can be asserted rather than sampled
+ * @returns {number} milliseconds to wait
+ */
+export function reconnectDelay(attempt, random = Math.random) {
+  const safeAttempt = Number.isFinite(attempt) && attempt > 0 ? Math.floor(attempt) : 0
+  const exponential = Math.min(BASE_DELAY_MS * 2 ** safeAttempt, MAX_BASE_DELAY_MS)
+  const spread = exponential * JITTER_RATIO
+
+  return Math.round(exponential - spread + random() * spread * 2)
+}
+
+/** The ceiling before jitter. What the function returns goes half again as high. */
+export const RECONNECT_MAX_BASE_DELAY_MS = MAX_BASE_DELAY_MS
+
+/** What the function will actually never exceed. */
+export const RECONNECT_MAX_DELAY_MS = MAX_BASE_DELAY_MS * (1 + JITTER_RATIO)

--- a/assets/js/utils/realtimeBackoff.test.js
+++ b/assets/js/utils/realtimeBackoff.test.js
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  RECONNECT_MAX_BASE_DELAY_MS,
+  RECONNECT_MAX_DELAY_MS,
+  reconnectDelay
+} from './realtimeBackoff.js'
+
+/**
+ * The reconnect delay for the notification stream. `random` is injected so these assert the spread
+ * rather than sample it.
+ *
+ * Run with `npm test`.
+ */
+
+describe('reconnectDelay', () => {
+  it('waits about a second on the first retry', () => {
+    // Mid-jitter, so the raw exponential.
+    assert.equal(
+      reconnectDelay(0, () => 0.5),
+      1000
+    )
+  })
+
+  it('grows exponentially', () => {
+    assert.equal(
+      reconnectDelay(1, () => 0.5),
+      2000
+    )
+    assert.equal(
+      reconnectDelay(2, () => 0.5),
+      4000
+    )
+    assert.equal(
+      reconnectDelay(3, () => 0.5),
+      8000
+    )
+  })
+
+  it('stops growing at the cap', () => {
+    assert.equal(
+      reconnectDelay(20, () => 0.5),
+      RECONNECT_MAX_BASE_DELAY_MS
+    )
+    assert.equal(
+      reconnectDelay(9999, () => 0.5),
+      RECONNECT_MAX_BASE_DELAY_MS
+    )
+  })
+
+  it('never exceeds the advertised ceiling, jitter included', () => {
+    // The cap applies before the spread, so the exported maximum has to account for it. Asserting
+    // only the mid-jitter point would have proved the exponent stops growing and nothing more.
+    for (const roll of [0, 0.5, 0.999999]) {
+      for (const attempt of [0, 3, 20, 9999]) {
+        assert.ok(
+          reconnectDelay(attempt, () => roll) <= RECONNECT_MAX_DELAY_MS,
+          `attempt ${attempt} roll ${roll} exceeded ${RECONNECT_MAX_DELAY_MS}`
+        )
+      }
+    }
+  })
+
+  it('spreads clients either side of the delay, which is the whole point', () => {
+    // Two browsers dropped by the same deploy restart, at the same attempt, come back apart.
+    assert.equal(
+      reconnectDelay(2, () => 0),
+      2000
+    )
+    assert.equal(
+      reconnectDelay(2, () => 1),
+      6000
+    )
+  })
+
+  it('never returns a negative or fractional delay', () => {
+    for (const roll of [0, 0.25, 0.5, 0.75, 1]) {
+      for (const attempt of [0, 1, 5, 50]) {
+        const delay = reconnectDelay(attempt, () => roll)
+        assert.ok(delay >= 0, `attempt ${attempt} roll ${roll} gave ${delay}`)
+        assert.equal(delay, Math.round(delay))
+      }
+    }
+  })
+
+  it('treats a nonsense attempt as the first one', () => {
+    // setTimeout(fn, NaN) fires immediately, so a bad counter must not become a hot loop.
+    assert.equal(
+      reconnectDelay(Number.NaN, () => 0.5),
+      1000
+    )
+    assert.equal(
+      reconnectDelay(-3, () => 0.5),
+      1000
+    )
+  })
+})

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -89,6 +89,28 @@ when@test:
     services:
         App\Contracts\Google\Youtube\YoutubeRepositoryInterface: '@App\Service\Google\DummyYoutubeRepository'
 
+        # NotificationCreator publishes a Mercure signal on every notification and fifteen source
+        # files call it, so without this a large part of the suite would attempt an HTTP POST to a
+        # host that deliberately does not resolve. Replaced rather than decorated: there is no real
+        # hub behind it to pass through to, and nothing in the suite should ever reach one.
+        #
+        # Public so a test can fetch it and assert on what was published.
+        App\Tests\Double\RecordingHub:
+            public: true
+
+        # Only the interface, which is what publishers inject. Not mercure.hub.default itself: that
+        # one is also what Authorization reads the token factory and public URL from, so replacing it
+        # would stop the subscriber cookie being minted and take the #949 tests with it.
+        #
+        # All three forms of HubInterface, because MercureBundle registers named-argument aliases and
+        # those win over the bare interface. A publisher written as `HubInterface $defaultHub` would
+        # otherwise get the real hub here and POST to a host that does not resolve. The deprecated
+        # PublisherInterface aliases and HubRegistry still point at the real hub; nothing uses them to
+        # publish, and .env.test's unresolvable MERCURE_URL is the backstop if something ever does.
+        Symfony\Component\Mercure\HubInterface: '@App\Tests\Double\RecordingHub'
+        Symfony\Component\Mercure\HubInterface $default: '@App\Tests\Double\RecordingHub'
+        Symfony\Component\Mercure\HubInterface $defaultHub: '@App\Tests\Double\RecordingHub'
+
         # The suite renders PDFs without a Gotenberg container. Substituting the client rather than
         # the renderer keeps the real builder, the real Twig render and the real fit arithmetic under
         # test, and lets a test assert on what was actually sent.

--- a/src/Mercure/MercureTopic.php
+++ b/src/Mercure/MercureTopic.php
@@ -12,7 +12,8 @@ namespace App\Mercure;
  * application is on the path of a subscription: what a subscriber may read is decided entirely by
  * the topic selectors inside the token they present. A publisher and a subscriber that disagree by
  * one character silently deliver nothing, and one that is accidentally broadened delivers somebody
- * else's mail, so the string is written once, here.
+ * else's mail, so the string is written once, here. Once per language, strictly: the browser builds
+ * the same topic in `assets/js/utils/notificationStream.js`, and the two have to be changed together.
  *
  * Two things have to be true for a per-user topic to actually be private, and only one of them lives
  * in this file. The token must name the topic (that is the cookie issued by MercureSubscriberCookie),

--- a/src/Service/Notification/NotificationCreator.php
+++ b/src/Service/Notification/NotificationCreator.php
@@ -5,7 +5,11 @@ namespace App\Service\Notification;
 use App\Entity\Notification\Notification;
 use App\Entity\User;
 use App\Enum\Notification\NotificationType;
+use App\Mercure\MercureTopic;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
 
 /**
  * Persists notifications. Producers (event listeners) build the recipient
@@ -14,8 +18,18 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 readonly class NotificationCreator
 {
-    public function __construct(private EntityManagerInterface $entityManager)
-    {
+    /**
+     * A tag, not the notification. The browser calls the count endpoint it already calls, so there is
+     * no second payload shape to keep in step with the API, no ordering to guarantee, and nothing
+     * arriving over SSE that ends up rendered. See decision 4 of epic #948.
+     */
+    private const string SIGNAL = '{"type":"notification"}';
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private HubInterface $hub,
+        private LoggerInterface $logger,
+    ) {
     }
 
     /**
@@ -31,6 +45,8 @@ readonly class NotificationCreator
     {
         $this->entityManager->persist($this->build($recipient, $type, $payload));
         $this->entityManager->flush();
+
+        $this->signal([$recipient->id]);
     }
 
     /**
@@ -47,16 +63,59 @@ readonly class NotificationCreator
             if (!$recipient instanceof User) {
                 continue;
             }
-            $recipientId = (string) $recipient->id;
+            $recipientId = $recipient->id;
             if ($recipientId === '' || isset($seen[$recipientId])) {
                 continue;
             }
-            $seen[$recipientId] = true;
+            // Keyed to de-duplicate, valued so array_values() below returns a list<string> without
+            // anything having to assert that array keys are still strings.
+            $seen[$recipientId] = $recipientId;
             $this->entityManager->persist($this->build($recipient, $type, $payload));
         }
 
-        if ($seen !== []) {
-            $this->entityManager->flush();
+        if ($seen === []) {
+            return;
+        }
+
+        $this->entityManager->flush();
+
+        // The de-duplicated set, so a recipient named twice is still signalled once.
+        $this->signal(array_values($seen));
+    }
+
+    /**
+     * Tells the recipients that something changed, after their notifications are already persisted.
+     *
+     * **One update carrying every topic, not one publish per recipient.** A publish is a blocking
+     * HTTP round trip, so per-recipient fan-out would multiply any hub slowness by the size of the
+     * recipient list, and some lists are unbounded: a forum reply notifies every participant of the
+     * topic. The hub delivers a private update to a subscriber when one of its topics is both asked
+     * for and authorized by their token, so N topics reach N recipients and nobody else, and the
+     * frame carries only the id and the data, so a recipient never learns who else was on the list.
+     * Verified against the hub rather than assumed.
+     *
+     * **Private**, which is the whole of the authorization: the hub consults a subscriber's topic
+     * selectors only for private updates, so a public one here would hand every connected browser
+     * every user's signal.
+     *
+     * **Never throws.** The notifications exist and are flushed by the time this runs, so an
+     * unreachable hub costs the live update and nothing else; the browser's fallback poll picks it
+     * up within a few minutes, or on its next tab focus. Creation must not fail for a side channel,
+     * which is the same line the epic #689 listener contract holds.
+     *
+     * @param list<string> $recipientIds
+     */
+    private function signal(array $recipientIds): void
+    {
+        $topics = array_map(MercureTopic::userNotifications(...), $recipientIds);
+
+        try {
+            $this->hub->publish(new Update($topics, self::SIGNAL, private: true));
+        } catch (\Throwable $throwable) {
+            $this->logger->error('Could not publish a notification signal, the bell will fall back to polling', [
+                'exception' => $throwable,
+                'recipient_ids' => $recipientIds,
+            ]);
         }
     }
 

--- a/tests/Double/RecordingHub.php
+++ b/tests/Double/RecordingHub.php
@@ -8,22 +8,37 @@ use Symfony\Component\Mercure\ProtocolVersion;
 use Symfony\Component\Mercure\Update;
 
 /**
- * Stands in for the Mercure hub and keeps the Update it was handed, so a test can assert on the
- * topic and the private flag rather than on a return value that says nothing.
+ * Stands in for the Mercure hub and keeps every Update it was handed, so a test can assert on the
+ * topics and the private flag rather than on a return value that says nothing.
  *
- * Hand written rather than a mock because the interesting assertion is about an object that was
- * built, which reads better recorded than trapped inside an expectation callback. It also means no
- * test needs any Mercure wiring, so the suite can never reach a real hub by accident.
+ * Hand written rather than a mock because the interesting assertion is about objects that were
+ * built, which read better recorded than trapped inside an expectation callback.
+ *
+ * It is also registered for the whole suite in config/services.yaml under when@test, and that is not
+ * a convenience: NotificationCreator publishes on every notification, fifteen source files call it,
+ * and without this every one of them would try an HTTP POST to a host that does not resolve.
  */
 final class RecordingHub implements HubInterface
 {
-    public ?Update $published = null;
+    /** @var list<Update> */
+    public array $updates = [];
 
     public function publish(Update $update): string
     {
-        $this->published = $update;
+        $this->updates[] = $update;
 
         return 'urn:uuid:00000000-0000-0000-0000-000000000000';
+    }
+
+    /**
+     * Every topic published on, in order, flattened across updates. One entry per topic rather than
+     * per publish, since one update carries the whole recipient list.
+     *
+     * @return list<string>
+     */
+    public function publishedTopics(): array
+    {
+        return array_merge(...array_map(static fn (Update $update): array => $update->getTopics(), $this->updates));
     }
 
     public function getPublicUrl(): string

--- a/tests/Integration/Mercure/MercureHubConfigurationTest.php
+++ b/tests/Integration/Mercure/MercureHubConfigurationTest.php
@@ -21,7 +21,9 @@ class MercureHubConfigurationTest extends KernelTestCase
     public function test_the_publisher_token_may_publish_on_any_topic(): void
     {
         self::bootKernel();
-        $hub = self::getContainer()->get(HubInterface::class);
+        // The configured hub by its own id, not through HubInterface: when@test points that alias at
+        // a recording double so no test reaches a real hub, and this test is about the real config.
+        $hub = self::getContainer()->get('mercure.hub.default');
         self::assertInstanceOf(RemoteHubInterface::class, $hub);
 
         // Drop "jwt.publish" from config/packages/mercure.yaml and this claim becomes an empty
@@ -33,7 +35,7 @@ class MercureHubConfigurationTest extends KernelTestCase
     public function test_the_public_url_carries_no_host(): void
     {
         self::bootKernel();
-        $hub = self::getContainer()->get(HubInterface::class);
+        $hub = self::getContainer()->get('mercure.hub.default');
         self::assertInstanceOf(HubInterface::class, $hub);
 
         // Authorization scopes the subscriber cookie's domain by comparing this host with the host

--- a/tests/Integration/Notification/NotificationCreatorSignalTest.php
+++ b/tests/Integration/Notification/NotificationCreatorSignalTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Notification;
+
+use App\Enum\Notification\NotificationType;
+use App\Mercure\MercureTopic;
+use App\Repository\Notification\NotificationRepository;
+use App\Service\Notification\NotificationCreator;
+use App\Tests\Double\RecordingHub;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class NotificationCreatorSignalTest extends KernelTestCase
+{
+    public function test_creating_a_notification_signals_that_recipient_privately(): void
+    {
+        self::bootKernel();
+        $hub = self::getContainer()->get(RecordingHub::class);
+        $creator = self::getContainer()->get(NotificationCreator::class);
+
+        $recipient = UserFactory::new()->asBaseUser()->create();
+        $creator->create($recipient, NotificationType::ForumTopicReply, ['topic_slug' => 'a-topic']);
+
+        self::assertCount(1, $hub->updates);
+        $update = $hub->updates[0];
+        self::assertSame([MercureTopic::userNotifications($recipient->id)], $update->getTopics());
+
+        // Without this the hub stops consulting subscriber topic selectors and hands the signal to
+        // every connected browser, whatever their token says.
+        self::assertTrue($update->isPrivate());
+
+        // A tag, not the notification: the browser refetches through the API it already uses.
+        self::assertSame('{"type":"notification"}', $update->getData());
+    }
+
+    public function test_a_recipient_named_twice_is_signalled_once(): void
+    {
+        self::bootKernel();
+        $hub = self::getContainer()->get(RecordingHub::class);
+        $creator = self::getContainer()->get(NotificationCreator::class);
+
+        $first = UserFactory::new()->asBaseUser()->create();
+        $second = UserFactory::new()->create(['username' => 'second', 'email' => 'second@test.com']);
+
+        // The same de-duplication the persist side already does, and a null, which is skipped.
+        $creator->createForRecipients(
+            [$first, $second, $first, null],
+            NotificationType::ForumTopicReply,
+            ['topic_slug' => 'a-topic']
+        );
+
+        self::assertSame(
+            [MercureTopic::userNotifications($first->id), MercureTopic::userNotifications($second->id)],
+            $hub->publishedTopics()
+        );
+    }
+
+    public function test_no_recipient_means_no_signal(): void
+    {
+        self::bootKernel();
+        $hub = self::getContainer()->get(RecordingHub::class);
+
+        self::getContainer()->get(NotificationCreator::class)
+            ->createForRecipients([null], NotificationType::ForumTopicReply, []);
+
+        self::assertSame([], $hub->updates);
+    }
+
+    public function test_an_unreachable_hub_still_leaves_the_notification_created(): void
+    {
+        self::bootKernel();
+
+        // Built by hand rather than through the container, because the point is the one dependency
+        // the container deliberately never provides: a hub that fails.
+        $creator = new NotificationCreator(
+            self::getContainer()->get(EntityManagerInterface::class),
+            new ThrowingHub(),
+            new NullLogger(),
+        );
+
+        $recipient = UserFactory::new()->asBaseUser()->create();
+        $creator->create($recipient, NotificationType::ForumTopicReply, ['topic_slug' => 'a-topic']);
+
+        // The notification is the thing that matters. Losing the live update costs a minute of
+        // latency; losing the notification would lose it for good.
+        self::assertCount(
+            1,
+            self::getContainer()->get(NotificationRepository::class)->findBy(['recipient' => $recipient])
+        );
+    }
+}
+
+final class ThrowingHub implements HubInterface
+{
+    public function publish(Update $update): string
+    {
+        throw new \RuntimeException('the hub is down');
+    }
+
+    public function getPublicUrl(): string
+    {
+        return '/.well-known/mercure';
+    }
+
+    public function getFactory(): ?\Symfony\Component\Mercure\Jwt\TokenFactoryInterface
+    {
+        return null;
+    }
+
+    public function getProtocolVersion(): \Symfony\Component\Mercure\ProtocolVersion
+    {
+        return \Symfony\Component\Mercure\ProtocolVersion::Legacy;
+    }
+
+    public function getCookieName(): string
+    {
+        return 'mercureAuthorization';
+    }
+}

--- a/tests/Unit/Command/Mercure/MercurePingCommandTest.php
+++ b/tests/Unit/Command/Mercure/MercurePingCommandTest.php
@@ -27,8 +27,8 @@ class MercurePingCommandTest extends TestCase
 
         $this->assertSame(Command::SUCCESS, $tester->execute(['username' => 'user_base']));
 
-        $update = $hub->published;
-        self::assertInstanceOf(Update::class, $update);
+        self::assertCount(1, $hub->updates);
+        $update = $hub->updates[0];
         $this->assertSame(['/users/d1be73fc-b0c4-4530-a30a-d41f43e6ebea/notifications'], $update->getTopics());
         // The flag is the isolation, not the token: the hub only checks a subscriber's selectors for
         // private updates, so a public one here would reach every signed-in browser that asked.
@@ -42,7 +42,7 @@ class MercurePingCommandTest extends TestCase
         $tester = new CommandTester($this->command($hub, null));
 
         $this->assertSame(Command::FAILURE, $tester->execute(['username' => 'nobody']));
-        $this->assertNull($hub->published);
+        $this->assertSame([], $hub->updates);
         $this->assertStringContainsString('No user named "nobody"', $tester->getDisplay());
     }
 


### PR DESCRIPTION
Closes #950. Track A2 of #948, and the first consumer of the Mercure transport #949 put in production.

The bell was polling every 60 seconds. It is now live, and the poll drops to a five minute fallback: a dead hub costs latency, not function.

## Why the bell first

`NotificationCreator::create()` and `createForRecipients()` are the only two ways a notification is ever born, so one file lights up all 21 `NotificationType` cases with no per-feature work. Authorization is the easy case the transport was designed around, one private topic per user, and the creator already holds the recipient. Chat then inherits a transport proven in production rather than debuting one.

## What it publishes

A tag, `{"type":"notification"}`, not the notification. The browser calls the count endpoint it already calls. No serialization contract between SSE and REST, no ordering to guarantee, no second payload shape, and nothing arriving over the stream that ends up rendered. This is decision 4 of #948.

**One update carrying every topic, not one publish per recipient.** A publish is a blocking HTTP round trip and some recipient lists are unbounded: a forum reply notifies every participant of the topic. Verified against the running hub rather than assumed: a private update reaches a subscriber when one of its topics is both asked for and authorized by their token, and the SSE frame carries only `id` and `data`, so a recipient never learns who else was on the list.

## The client

The connection lives in the Pinia store, not in `NotificationBell.vue`, and the lifecycle is a separate injectable module so it can be tested with a fake `EventSource` and fake timers. Topics are a **list**, so the connection multiplexes the way Mercure intends rather than opening one stream per topic; today the list holds one entry, because the subscriber cookie authorizes one topic.

Three failure modes are handled explicitly, and each one is a case that would otherwise fail silently while the bell looked healthy:

- **An expired subscriber cookie.** `EventSource` retries a dropped *connection* by itself, but a non-200 "fails the connection": one error event, `readyState` CLOSED, no reconnect. An expired cookie is a 401, so the stream would die permanently. Measured in Chrome to be sure. So the retry is taken over here, with jittered backoff, and every third failure renews the token, which re-mints the cookie.
- **A gap.** `Last-Event-ID` belongs to the `EventSource` object and every retry builds a new one, so the hub replays nothing to us however much history the transport keeps. The client refetches on recovery instead. A deploy restart is exactly when that matters, for every subscriber at once.
- **A profile that never arrives.** `checkAuthInfo()` sets `isAuthenticated` and then calls `fetchUserProfile()` without awaiting it, so the profile lands one round trip later. The store waits for the id rather than for a component to mount, and the fallback poll also calls `connect()` so a failed profile fetch cannot leave the stream permanently unopened.

## Keeping the hub out of the suite

`when@test` points `HubInterface` at a recording double. Not `mercure.hub.default`: that service also feeds `Authorization`, which mints the subscriber cookie, so replacing it would have broken #949's tests. All three `HubInterface` alias forms are covered, because MercureBundle registers named-argument aliases and those win over the bare interface.

Without this, fifteen source files that create notifications would each attempt an HTTP POST to a host that does not resolve.

## Verified in a browser, not only in tests

- Exactly one `EventSource`, on `/users/<uuid>/notifications`.
- A real invitation sent by `user_admin` moved the badge live, with the poll at five minutes so it cannot have been the poll.
- A signal published on `user_admin`'s topic did not reach `user_base`'s browser.
- `docker compose restart php-web`, which is what a deploy does: the client reconnected on its own in three attempts rather than hot looping, and the next signal was delivered.

2649 PHP tests, 610 JS tests, PHPStan level 8, Biome and the Vite build all clean.

## Known limitation, deliberate

A publish to a hub that accepts the connection and then never answers blocks for `default_socket_timeout`, 60 seconds. Measured: connection refused fails in ~0.3s and an unresolvable host in ~4s, so only a wedged hub is slow, and the single multi-topic publish removed the per-recipient multiplication that made it dangerous. Bounding it properly needs a compiler pass to override the hub's HTTP client, since MercureBundle passes it positionally and exposes no option, and that would be this repository's first compiler pass. Judged disproportionate for a hub that runs inside the same process, and `catch (\Throwable)` means the cost is latency rather than a lost notification.

## No deployment steps

No new environment variables, no migrations. The hub has been configured in production since #949.
