### PR TITLE
Messages: replace the isRead boolean with a read position

### DIFF
--- a/assets/js/components/Message/ThreadList.vue
+++ b/assets/js/components/Message/ThreadList.vue
@@ -7,7 +7,7 @@
           :key="threadMeta.thread.id"
           class="p-4 border-b border-surface-200 dark:border-surface-700 cursor-pointer transition-colors"
           :class="{
-            'bg-primary-50 dark:bg-primary-900/20': !threadMeta.is_read,
+            'bg-primary-50 dark:bg-primary-900/20': threadMeta.unread_count > 0,
             'bg-surface-100 dark:bg-surface-800': messageStore.currentThreadId === threadMeta.thread.id,
             'hover:bg-surface-50 dark:hover:bg-surface-800/50': messageStore.currentThreadId !== threadMeta.thread.id
           }"
@@ -44,7 +44,13 @@
                 <span v-else class="font-semibold text-surface-500 truncate">
                   {{ getParticipantName(threadMeta) }}
                 </span>
-                <Tag v-if="!threadMeta.is_read" severity="info" value="new" class="text-xs" />
+                <Tag
+                  v-if="threadMeta.unread_count > 0"
+                  severity="info"
+                  :value="unreadLabel(threadMeta.unread_count)"
+                  :aria-label="`${threadMeta.unread_count} message(s) non lu(s)`"
+                  class="text-xs"
+                />
               </div>
 
               <div class="text-xs text-surface-600 dark:text-surface-400 mb-1">
@@ -83,5 +89,10 @@ function getParticipant(threadMeta) {
 function getParticipantName(threadMeta) {
   const participant = getParticipant(threadMeta)
   return participant ? displayName(participant) : 'Utilisateur inconnu'
+}
+
+// Capped like NotificationBell's badge, so a long-abandoned thread cannot stretch the row.
+function unreadLabel(count) {
+  return count > 99 ? '99+' : String(count)
 }
 </script>

--- a/assets/js/store/message/message.js
+++ b/assets/js/store/message/message.js
@@ -26,10 +26,6 @@ export const useMessageStore = defineStore('message', () => {
     return threads.value.find((t) => t.thread.id === currentThreadId.value)
   })
 
-  const unreadCount = computed(() => {
-    return threads.value.filter((t) => !t.is_read).length
-  })
-
   async function loadThreads() {
     isLoading.value = true
     try {
@@ -49,8 +45,9 @@ export const useMessageStore = defineStore('message', () => {
 
     await loadMessages(threadMeta.thread.id)
 
-    // Mark as read if unread
-    if (!threadMeta.is_read) {
+    // Mark as read if anything is unread. Still driven by arriving on the thread rather than by
+    // scrolling to the new message, which is what it did before the count replaced the boolean (#954).
+    if (threadMeta.unread_count > 0) {
       await markAsRead(threadMeta.id)
     }
   }
@@ -74,7 +71,7 @@ export const useMessageStore = defineStore('message', () => {
       await messageApi.markThreadAsRead({ threadMetaId })
       const thread = threads.value.find((t) => t.id === threadMetaId)
       if (thread) {
-        thread.is_read = true
+        thread.unread_count = 0
         // Refresh navbar notification count
         const notificationStore = useNotificationStore()
         notificationStore.loadNotifications()
@@ -148,7 +145,6 @@ export const useMessageStore = defineStore('message', () => {
     isAddingMessage: readonly(isAddingMessage),
     orderedThreads,
     currentThread,
-    unreadCount,
     loadThreads,
     selectThread,
     postMessage,

--- a/migrations/2026/09/Version20260908192030.php
+++ b/migrations/2026/09/Version20260908192030.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260908192030 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace message_thread_meta.is_read with a last_read_datetime read position';
+    }
+
+    /**
+     * The conversion is the interesting half, and it is deliberately not "read = now".
+     *
+     * A row already marked read becomes the thread's last message, because that is what they have
+     * read, and a read position in the future would hide the next message to arrive.
+     *
+     * A row marked unread becomes one second *before* that last message, so exactly one message
+     * counts as unread. Null would be the other defensible answer, but null means every message ever
+     * written in the thread is unread, so a badge showing "4 threads" today would show hundreds after
+     * the deploy. This preserves what people currently see and lets real counts build from here.
+     *
+     * A thread with no last message gets null either way: there is nothing there to have read.
+     */
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE message_thread_meta ADD last_read_datetime DATETIME DEFAULT NULL');
+
+        $this->addSql(<<<'SQL'
+            UPDATE message_thread_meta meta
+            INNER JOIN message_thread thread ON thread.id = meta.thread_id
+            INNER JOIN message last_message ON last_message.id = thread.last_message_id
+            SET meta.last_read_datetime = IF(
+                meta.is_read = 1,
+                last_message.creation_datetime,
+                DATE_SUB(last_message.creation_datetime, INTERVAL 1 SECOND)
+            )
+            SQL);
+
+        $this->addSql('ALTER TABLE message_thread_meta DROP is_read');
+    }
+
+    /**
+     * Back to a boolean: read means the position has reached the thread's last message. A row with no
+     * position, or one behind the last message, is unread. Threads with no last message come back as
+     * read, arbitrarily: going forward gave them a null position, which the new model reads as unread,
+     * so the distinction is already lost by then. No such row exists in practice, since a thread gets
+     * its last_message_id inside the transaction that creates it.
+     */
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE message_thread_meta ADD is_read TINYINT(1) DEFAULT 1 NOT NULL');
+
+        $this->addSql(<<<'SQL'
+            UPDATE message_thread_meta meta
+            INNER JOIN message_thread thread ON thread.id = meta.thread_id
+            INNER JOIN message last_message ON last_message.id = thread.last_message_id
+            SET meta.is_read = IF(
+                meta.last_read_datetime IS NOT NULL
+                    AND meta.last_read_datetime >= last_message.creation_datetime,
+                1,
+                0
+            )
+            SQL);
+
+        $this->addSql('ALTER TABLE message_thread_meta DROP last_read_datetime');
+        $this->addSql('ALTER TABLE message_thread_meta ALTER is_read DROP DEFAULT');
+    }
+}

--- a/src/ApiResource/Message/MessageThreadMetaResource.php
+++ b/src/ApiResource/Message/MessageThreadMetaResource.php
@@ -13,6 +13,7 @@ use App\State\Processor\Message\MessageThreadMetaPatchProcessor;
 use App\State\Provider\Message\MessageThreadMetaCollectionProvider;
 use App\State\Provider\Message\MessageThreadMetaItemProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     shortName: 'MessageThreadMeta',
@@ -45,8 +46,26 @@ class MessageThreadMetaResource
     #[Groups([MessageThreadMetaResource::LIST, MessageThreadMetaResource::ITEM])]
     public string $id;
 
-    #[Groups([MessageThreadMetaResource::LIST, MessageThreadMetaResource::PATCH])]
-    public bool $isRead;
+    /** How many messages in this thread the user has not read. Read only. */
+    #[Groups([MessageThreadMetaResource::LIST, MessageThreadMetaResource::ITEM])]
+    public int $unreadCount;
+
+    /**
+     * Write only, and a command rather than a state: true marks the thread read as of now, false puts
+     * the read position back to nothing. It is the boolean that used to be stored (#954), kept on the
+     * input side because "mark this read" is what a client actually wants to say, and because the
+     * alternative is making every caller compute a position the server already knows.
+     *
+     * Nullable with a NotNull rather than a bare `bool`, and that is load bearing. Nothing populates
+     * it on the read side any more, so a merge-patch body that omits the key would leave a typed
+     * property uninitialised, and reading it raises an `Error` rather than an exception: a 500 where
+     * this used to be a harmless no-op. The constraint turns the same request into a 422 naming the
+     * field, decided before the processor runs. A default of `false` would be worse than either,
+     * silently running the destructive half of the command.
+     */
+    #[Assert\NotNull(message: 'Veuillez indiquer si le fil est lu')]
+    #[Groups([MessageThreadMetaResource::PATCH])]
+    public ?bool $isRead = null;
 
     #[Groups([MessageThreadMetaResource::LIST])]
     public MessageThreadResource $thread;

--- a/src/Entity/Message/MessageThreadMeta.php
+++ b/src/Entity/Message/MessageThreadMeta.php
@@ -38,8 +38,26 @@ class MessageThreadMeta
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     public DateTimeInterface $creationDatetime;
 
-    #[ORM\Column(type: Types::BOOLEAN)]
-    public bool $isRead;
+    /**
+     * How far this user has read in the thread, or null when they have read nothing. An unread count
+     * is then the messages after it that somebody else wrote.
+     *
+     * A position rather than the boolean it replaced (#954), because a boolean can say "something is
+     * new" and cannot say how much or where. A datetime rather than a relation to the last read
+     * message, because Message ids are uuid4 and therefore carry no order: a relation would have had
+     * to fall back on this very column to compare two messages, so it would have bought a foreign key
+     * and no accuracy.
+     *
+     * The column is one-second precision, like message.creation_datetime. A message written in the
+     * same second as a mark-read, just after it, therefore reads as already read and stays hidden
+     * until the next one arrives. It has one knock-on worth knowing: the client only marks a thread
+     * read when the count is non-zero, and that reset is what clears pendingNotificationSent, so such
+     * a message also suppresses the *next* email. It heals on the following read, so the worst case
+     * is one late message and one missing email. Making it exact means microsecond precision on
+     * message.creation_datetime, not a different shape here.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    public ?\DateTimeImmutable $lastReadDatetime = null;
 
     #[ORM\Column(type: Types::BOOLEAN)]
     public bool $isDeleted;
@@ -56,5 +74,34 @@ class MessageThreadMeta
     public function __construct()
     {
         $this->creationDatetime = new DateTime();
+    }
+
+    /**
+     * Whether the thread has moved on since this user last read it.
+     *
+     * This is what the `isRead` boolean used to answer directly, and it is the same predicate the
+     * #954 migration uses in both directions. Compared against the thread's denormalised last message
+     * rather than counted, because the only caller is the email throttle, which wants a yes or no and
+     * not a number. That costs no query for its current caller, because the PATCH provider has already
+     * built the thread resource and warmed the association; reached cold it would be two lazy loads.
+     *
+     * A null position is unread even in a thread with no messages, which is exactly what a `false`
+     * boolean meant, and is the safe direction for the flag it guards.
+     *
+     * Unlike the unread *count*, this ignores who wrote the last message, so the two can disagree: a
+     * sender whose own message landed a second after their position stamp reads as having unread
+     * while their count is zero. Harmless where it is used, but do not read this as `count > 0`.
+     */
+    public function hasUnread(): bool
+    {
+        if ($this->lastReadDatetime === null) {
+            return true;
+        }
+
+        if ($this->thread->lastMessage === null) {
+            return false;
+        }
+
+        return $this->lastReadDatetime < $this->thread->lastMessage->creationDatetime;
     }
 }

--- a/src/Repository/Message/MessageRepository.php
+++ b/src/Repository/Message/MessageRepository.php
@@ -3,7 +3,10 @@
 namespace App\Repository\Message;
 
 use App\Entity\Message\Message;
+use App\Entity\Message\MessageThreadMeta;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -14,6 +17,94 @@ class MessageRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Message::class);
+    }
+
+    /**
+     * How many messages in each of this user's threads they have not read yet, keyed by thread id.
+     *
+     * One grouped query for the whole inbox rather than one per thread: the message list is already
+     * hydrated with five joins by MessageThreadMetaRepository::findByUserAndNotDeleted(), and adding
+     * a count per row on top of that is how an inbox starts costing dozens of queries.
+     *
+     * A thread the user has read entirely is absent from the result, not present with a zero, so
+     * callers read it with `?? 0`.
+     *
+     * @return array<string, int>
+     */
+    public function countUnreadByThreadForUser(User $user): array
+    {
+        /** @var list<array{thread_id: string, unread_count: int|string}> $rows */
+        $rows = $this->createQueryBuilder('message')
+            ->select('IDENTITY(message.thread) AS thread_id, COUNT(message.id) AS unread_count')
+            ->join(
+                MessageThreadMeta::class,
+                'meta',
+                Join::WITH,
+                'meta.thread = message.thread AND meta.user = :user'
+            )
+            // Own messages never count: you have read what you wrote.
+            ->where('message.author != :user')
+            ->andWhere('(meta.lastReadDatetime IS NULL OR message.creationDatetime > meta.lastReadDatetime)')
+            ->groupBy('message.thread')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(string) $row['thread_id']] = (int) $row['unread_count'];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Every message this user has not read, across every thread they have not deleted.
+     *
+     * This is the navbar badge. It used to count *threads* with an unread flag and to ignore
+     * isDeleted, which made it disagree with the inbox it sits above on both counts (#954).
+     */
+    public function countUnreadForUser(User $user): int
+    {
+        return (int) $this->createQueryBuilder('message')
+            ->select('COUNT(message.id)')
+            ->join(
+                MessageThreadMeta::class,
+                'meta',
+                Join::WITH,
+                'meta.thread = message.thread AND meta.user = :user'
+            )
+            ->where('message.author != :user')
+            ->andWhere('meta.isDeleted = false')
+            ->andWhere('(meta.lastReadDatetime IS NULL OR message.creationDatetime > meta.lastReadDatetime)')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * The same count as countUnreadByThreadForUser(), for one thread.
+     *
+     * Not that method with a filter: buildItem() is reached twice per "open a thread" click, once
+     * from the PATCH provider and once from its processor, and running a GROUP BY over every message
+     * the user has to learn a number that is about to be zero is the wrong shape for a click.
+     */
+    public function countUnreadForThread(MessageThreadMeta $meta): int
+    {
+        $queryBuilder = $this->createQueryBuilder('message')
+            ->select('COUNT(message.id)')
+            ->where('message.thread = :thread')
+            ->andWhere('message.author != :user')
+            ->setParameter('thread', $meta->thread)
+            ->setParameter('user', $meta->user);
+
+        // Nothing read means everything counts, so there is simply no bound to add.
+        if ($meta->lastReadDatetime !== null) {
+            $queryBuilder->andWhere('message.creationDatetime > :lastRead')
+                ->setParameter('lastRead', $meta->lastReadDatetime);
+        }
+
+        return (int) $queryBuilder->getQuery()->getSingleScalarResult();
     }
 
     /**

--- a/src/Service/Builder/Message/MessageThreadMetaBuilder.php
+++ b/src/Service/Builder/Message/MessageThreadMetaBuilder.php
@@ -6,32 +6,50 @@ namespace App\Service\Builder\Message;
 
 use App\ApiResource\Message\MessageThreadMetaResource;
 use App\Entity\Message\MessageThreadMeta;
+use App\Entity\User;
+use App\Repository\Message\MessageRepository;
 
 readonly class MessageThreadMetaBuilder
 {
     public function __construct(
         private MessageThreadBuilder $messageThreadBuilder,
+        private MessageRepository $messageRepository,
     ) {
     }
 
     /**
-     * @param MessageThreadMeta[] $entities
+     * @param MessageThreadMeta[] $entities every one of them belonging to $user
      *
      * @return MessageThreadMetaResource[]
      */
-    public function buildList(array $entities): array
+    public function buildList(array $entities, User $user): array
     {
+        if ($entities === []) {
+            return [];
+        }
+
+        // One grouped query for the whole list, not one per thread.
+        $unreadCounts = $this->messageRepository->countUnreadByThreadForUser($user);
+
         return array_map(
-            fn (MessageThreadMeta $entity): MessageThreadMetaResource => $this->buildItem($entity),
+            fn (MessageThreadMeta $entity): MessageThreadMetaResource => $this->build(
+                $entity,
+                $unreadCounts[(string) $entity->thread->id] ?? 0,
+            ),
             $entities,
         );
     }
 
     public function buildItem(MessageThreadMeta $entity): MessageThreadMetaResource
     {
+        return $this->build($entity, $this->messageRepository->countUnreadForThread($entity));
+    }
+
+    private function build(MessageThreadMeta $entity, int $unreadCount): MessageThreadMetaResource
+    {
         $dto = new MessageThreadMetaResource();
         $dto->id = (string) $entity->id;
-        $dto->isRead = $entity->isRead;
+        $dto->unreadCount = $unreadCount;
         $dto->thread = $this->messageThreadBuilder->buildItem($entity->thread);
 
         return $dto;

--- a/src/Service/Builder/Message/MessageThreadMetaDirector.php
+++ b/src/Service/Builder/Message/MessageThreadMetaDirector.php
@@ -8,12 +8,17 @@ use App\Entity\User;
 
 class MessageThreadMetaDirector
 {
-    public function create(MessageThread $thread, User $user, bool $isRead): MessageThreadMeta
+    /**
+     * @param \DateTimeImmutable|null $lastReadDatetime how far this user has already read, null when
+     *                                                 they have read nothing. The sender of the first
+     *                                                 message has read it; the recipient has not.
+     */
+    public function create(MessageThread $thread, User $user, ?\DateTimeImmutable $lastReadDatetime): MessageThreadMeta
     {
         $meta = new MessageThreadMeta();
         $meta->thread = $thread;
         $meta->isDeleted = false;
-        $meta->isRead = $isRead;
+        $meta->lastReadDatetime = $lastReadDatetime;
         $meta->user = $user;
 
         return $meta;

--- a/src/Service/Procedure/Message/MessageSenderProcedure.php
+++ b/src/Service/Procedure/Message/MessageSenderProcedure.php
@@ -52,8 +52,9 @@ class MessageSenderProcedure
 
             if (!$thread = $this->messageThreadRepository->findByParticipants($recipient, $sender)) {
                 $thread = $this->messageThreadDirector->create();
-                $threadMetaSender = $this->messageThreadMetaDirector->create($thread, $sender, true);
-                $threadMetaRecipient = $this->messageThreadMetaDirector->create($thread, $recipient, false);
+                // The sender has read their own opening message; the recipient has read nothing.
+                $threadMetaSender = $this->messageThreadMetaDirector->create($thread, $sender, new \DateTimeImmutable());
+                $threadMetaRecipient = $this->messageThreadMetaDirector->create($thread, $recipient, null);
                 $participantSender = $this->messageParticipantDirector->create($thread, $sender);
                 $participantRecipient = $this->messageParticipantDirector->create($thread, $recipient);
 
@@ -138,7 +139,11 @@ class MessageSenderProcedure
             if ($recipient->id !== $sender->id) {
                 $threadMetaRecipient = $this->messageThreadMetaRepository->findOneBy(['user' => $recipient, 'thread' => $thread]);
                 assert($threadMetaRecipient !== null);
-                $threadMetaRecipient->isRead = false;
+                // The recipient's read position is deliberately left alone: the message about to be
+                // written is newer than it, so it already counts as unread. Rewinding the position to
+                // null, which is what the boolean's `false` amounted to, would resurrect every
+                // message they had already read in this thread. This is the same shape the forum
+                // already uses, see ForumTopicParticipationService::recordPost().
                 if ($this->shouldNotify($recipient, $threadMetaRecipient)) {
                     $threadMetaRecipient->pendingNotificationSent = true;
                     $events[] = new MessageSentEvent($recipient, $sender, $thread);
@@ -146,9 +151,12 @@ class MessageSenderProcedure
             }
         }
 
+        // Writing a message is reading the thread, so the sender's position moves to now. Stamped
+        // before the message exists, which leaves the position at or just behind their own message;
+        // that never shows as unread because the count ignores messages you wrote yourself.
         $threadMetaSender = $this->messageThreadMetaRepository->findOneBy(['user' => $sender, 'thread' => $thread]);
         assert($threadMetaSender !== null);
-        $threadMetaSender->isRead = true;
+        $threadMetaSender->lastReadDatetime = new \DateTimeImmutable();
 
         return $events;
     }

--- a/src/State/Processor/Message/MessageThreadMetaPatchProcessor.php
+++ b/src/State/Processor/Message/MessageThreadMetaPatchProcessor.php
@@ -45,12 +45,15 @@ readonly class MessageThreadMetaPatchProcessor implements ProcessorInterface
 
         // When the recipient catches up on the thread, reset the
         // one-email-per-unread-streak flag so the next incoming message can
-        // trigger another notification (#533).
-        if (!$entity->isRead && $data->isRead) {
+        // trigger another notification (#533). The trigger is unchanged by #954,
+        // only how "was it unread" is asked: there is something unread when the
+        // count is not zero, which is what the boolean used to stand for.
+        if ($data->isRead === true && $entity->hasUnread()) {
             $entity->pendingNotificationSent = false;
         }
 
-        $entity->isRead = $data->isRead;
+        // A command, not a state: mark read as of now, or put the position back to nothing.
+        $entity->lastReadDatetime = $data->isRead === true ? new \DateTimeImmutable() : null;
         $this->entityManager->flush();
 
         return $this->messageThreadMetaBuilder->buildItem($entity);

--- a/src/State/Provider/Message/MessageThreadMetaCollectionProvider.php
+++ b/src/State/Provider/Message/MessageThreadMetaCollectionProvider.php
@@ -36,6 +36,6 @@ readonly class MessageThreadMetaCollectionProvider implements ProviderInterface
 
         $entities = $this->messageThreadMetaRepository->findByUserAndNotDeleted($user);
 
-        return $this->messageThreadMetaBuilder->buildList($entities);
+        return $this->messageThreadMetaBuilder->buildList($entities, $user);
     }
 }

--- a/src/State/Provider/Notification/NotificationProvider.php
+++ b/src/State/Provider/Notification/NotificationProvider.php
@@ -7,9 +7,10 @@ use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\Notification\Notification;
 use App\Entity\Gallery;
 use App\Entity\Publication;
+use App\Entity\User;
 use App\Repository\Feedback\FeedbackRepository;
 use App\Repository\GalleryRepository;
-use App\Repository\Message\MessageThreadMetaRepository;
+use App\Repository\Message\MessageRepository;
 use App\Repository\PublicationRepository;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -21,7 +22,7 @@ readonly class NotificationProvider implements ProviderInterface
 {
     public function __construct(
         private Security                    $security,
-        private MessageThreadMetaRepository $messageThreadMetaRepository,
+        private MessageRepository           $messageRepository,
         private GalleryRepository           $galleryRepository,
         private PublicationRepository       $publicationRepository,
         private FeedbackRepository          $feedbackRepository
@@ -33,8 +34,9 @@ readonly class NotificationProvider implements ProviderInterface
         if (!$this->security->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
             throw new AccessDeniedException('Vous n\'êtes pas connecté.');
         }
+        /** @var User $user */
         $user = $this->security->getUser();
-        $unreadMessagesCount = $this->messageThreadMetaRepository->count(['user' => $user, 'isRead' => 0]);
+        $unreadMessagesCount = $this->messageRepository->countUnreadForUser($user);
         $notification = new Notification();
         $notification->unreadMessages = $unreadMessagesCount;
         if ($this->security->isGranted('ROLE_ADMIN')) {

--- a/tests/Api/Message/MessageEmailThrottleTest.php
+++ b/tests/Api/Message/MessageEmailThrottleTest.php
@@ -31,7 +31,7 @@ class MessageEmailThrottleTest extends ApiTestCase
         $metaRepo = self::getContainer()->get(MessageThreadMetaRepository::class);
         $recipientMeta = $metaRepo->findOneBy(['user' => $recipient->id, 'thread' => $thread->id]);
         $this->assertTrue($recipientMeta->pendingNotificationSent);
-        $this->assertFalse($recipientMeta->isRead);
+        $this->assertNull($recipientMeta->lastReadDatetime, 'An incoming message must not move the recipient\'s read position');
     }
 
     public function test_first_message_in_brand_new_thread_sends_email(): void
@@ -63,7 +63,7 @@ class MessageEmailThrottleTest extends ApiTestCase
         $recipientMeta = $metaRepo->findOneBy(['user' => $recipient->id]);
         $this->assertNotNull($recipientMeta);
         $this->assertTrue($recipientMeta->pendingNotificationSent);
-        $this->assertFalse($recipientMeta->isRead);
+        $this->assertNull($recipientMeta->lastReadDatetime, 'An incoming message must not move the recipient\'s read position');
     }
 
     public function test_second_message_in_same_unread_streak_does_not_send_email(): void
@@ -94,7 +94,7 @@ class MessageEmailThrottleTest extends ApiTestCase
         $recipientMeta = $metaRepo->findOneBy(['user' => $recipient->id, 'thread' => $thread->id]);
         $recipientMetaId = $recipientMeta->id;
         $recipientMeta->pendingNotificationSent = true;
-        $recipientMeta->isRead = false;
+        $recipientMeta->lastReadDatetime = null;
         $em->flush();
 
         // Recipient reads the thread.
@@ -107,10 +107,40 @@ class MessageEmailThrottleTest extends ApiTestCase
 
         $em->clear();
         $reloaded = $metaRepo->find($recipientMetaId);
-        $this->assertTrue($reloaded->isRead);
+        $this->assertNotNull($reloaded->lastReadDatetime);
         $this->assertFalse(
             $reloaded->pendingNotificationSent,
-            'Flipping is_read true must reset pending_notification_sent so the next incoming message can email again',
+            'Marking the thread read must reset pending_notification_sent so the next incoming message can email again',
+        );
+    }
+
+    public function test_marking_an_already_read_thread_does_not_reset_the_streak(): void
+    {
+        // The other half of the guard, and the half that had no test. "None ever do again" is what
+        // happens if the reset fires too readily; this pins that it only fires on catching up. The
+        // old boolean expressed it as the unread-to-read transition.
+        [$sender, $recipient, $thread] = $this->createThreadWithMembers();
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $metaRepo = self::getContainer()->get(MessageThreadMetaRepository::class);
+        $recipientMeta = $metaRepo->findOneBy(['user' => $recipient->id, 'thread' => $thread->id]);
+        $recipientMetaId = $recipientMeta->id;
+        // An email is in flight, and they have already read to the end of the thread.
+        $recipientMeta->pendingNotificationSent = true;
+        $recipientMeta->lastReadDatetime = new \DateTimeImmutable('+1 hour');
+        $em->flush();
+
+        $this->client->loginUser($recipient);
+        $this->client->jsonRequest('PATCH', '/api/message_thread_metas/' . $recipientMetaId, [
+            'is_read' => true,
+        ], ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+
+        $em->clear();
+        $this->assertTrue(
+            $metaRepo->find($recipientMetaId)->pendingNotificationSent,
+            'Re-reading a thread with nothing new must leave the streak alone',
         );
     }
 
@@ -162,7 +192,7 @@ class MessageEmailThrottleTest extends ApiTestCase
         $metaRepo = self::getContainer()->get(MessageThreadMetaRepository::class);
         $recipientMeta = $metaRepo->findOneBy(['user' => $recipient->id, 'thread' => $thread->id]);
         $recipientMeta->pendingNotificationSent = false;
-        $recipientMeta->isRead = true;
+        $recipientMeta->lastReadDatetime = new \DateTimeImmutable();
         $em->flush();
 
         $this->client->loginUser($sender);
@@ -191,12 +221,12 @@ class MessageEmailThrottleTest extends ApiTestCase
         MessageThreadMetaFactory::new([
             'thread' => $thread,
             'user' => $sender,
-            'isRead' => true,
+            'lastReadDatetime' => new \DateTimeImmutable(),
         ])->create();
         MessageThreadMetaFactory::new([
             'thread' => $thread,
             'user' => $recipient,
-            'isRead' => false,
+            'lastReadDatetime' => null,
         ])->create();
 
         return [$sender, $recipient, $thread];

--- a/tests/Api/Message/MessageThreadMetaGetCollectionTest.php
+++ b/tests/Api/Message/MessageThreadMetaGetCollectionTest.php
@@ -40,6 +40,15 @@ class MessageThreadMetaGetCollectionTest extends ApiTestCase
         ])->create();
         $thread->lastMessage = $message;
         \Zenstruck\Foundry\Persistence\save($thread);
+        // An earlier message from the other participant, so the count under test is non-zero. Without
+        // it the only message is $user1's own, and a zero would pass against an implementation that
+        // always returned zero.
+        MessageFactory::new([
+            'author' => $user2,
+            'thread' => $thread,
+            'content' => 'something to read',
+            'creationDatetime' => new \DateTime('2026-08-01 09:00:00'),
+        ])->create();
         $meta = MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $thread])->create();
 
         // thread between user2 & user3 : shouldn't appear in the response
@@ -63,7 +72,7 @@ class MessageThreadMetaGetCollectionTest extends ApiTestCase
                     '@id' => '/api/message_thread_metas/' . $meta->id,
                     '@type' => 'MessageThreadMeta',
                     'id'      => $meta->id,
-                    'is_read' => false,
+                    'unread_count' => 1,
                     'thread'  => [
                         '@id' => '/api/message_threads/' . $thread->id,
                         '@type' => 'MessageThread',

--- a/tests/Api/Message/MessageThreadMetaPatchTest.php
+++ b/tests/Api/Message/MessageThreadMetaPatchTest.php
@@ -38,7 +38,7 @@ class MessageThreadMetaPatchTest extends ApiTestCase
 
         // pretest
         $result = $messageMetaRepository->find($meta->id);
-        $this->assertFalse($result->isRead);
+        $this->assertNull($result->lastReadDatetime);
         $this->assertFalse($result->isDeleted);
 
         $this->client->loginUser($user1);
@@ -51,11 +51,63 @@ class MessageThreadMetaPatchTest extends ApiTestCase
             '@context' => '/api/contexts/MessageThreadMeta',
             '@id' => '/api/message_thread_metas/' . $meta->id,
             '@type' => 'MessageThreadMeta',
-            'id' => $meta->id
+            'id' => $meta->id,
+            // The response carries the new count so the client does not have to guess it.
+            'unread_count' => 0,
         ]);
 
         $result = $messageMetaRepository->find($meta->id);
-        $this->assertTrue($result->isRead);
+        $this->assertNotNull($result->lastReadDatetime);
         $this->assertFalse($result->isDeleted);
+    }
+
+    public function test_patch_without_is_read_is_a_validation_error(): void
+    {
+        // Nothing populates isRead on the read side any more, so an omitted key leaves a typed
+        // property uninitialised. Reading that raises an Error, not an exception, which no handler
+        // turns into a 4xx: this used to be a 500. The constraint decides it before the processor.
+        $user1 = UserFactory::new()->asBaseUser()->create(['username' => 'base_user_1', 'email' => 'base_user1@email.com']);
+        $meta = MessageThreadMetaFactory::new(['user' => $user1])->create();
+
+        $this->client->loginUser($user1);
+        $this->client->jsonRequest('PATCH', '/api/message_thread_metas/' . $meta->id, [
+        ], ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/ad32d13f-c3d4-423b-909a-857b961eb720',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'is_read',
+                    'message' => 'Veuillez indiquer si le fil est lu',
+                    'code' => 'ad32d13f-c3d4-423b-909a-857b961eb720',
+                ],
+            ],
+            'detail' => 'is_read: Veuillez indiquer si le fil est lu',
+            'type' => '/validation_errors/ad32d13f-c3d4-423b-909a-857b961eb720',
+            'title' => 'An error occurred',
+            'description' => 'is_read: Veuillez indiquer si le fil est lu',
+        ]);
+    }
+
+    public function test_patch_is_read_false_puts_the_position_back_to_nothing(): void
+    {
+        $messageMetaRepository = static::getContainer()->get(MessageThreadMetaRepository::class);
+        $user1 = UserFactory::new()->asBaseUser()->create(['username' => 'base_user_1', 'email' => 'base_user1@email.com']);
+        $meta = MessageThreadMetaFactory::new([
+            'user' => $user1,
+            'lastReadDatetime' => new \DateTimeImmutable('2026-09-01 10:00:00'),
+        ])->create();
+
+        $this->client->loginUser($user1);
+        $this->client->jsonRequest('PATCH', '/api/message_thread_metas/' . $meta->id, [
+            'is_read' => false,
+        ], ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($messageMetaRepository->find($meta->id)->lastReadDatetime);
     }
 }

--- a/tests/Api/Notification/NotificationGetTest.php
+++ b/tests/Api/Notification/NotificationGetTest.php
@@ -7,6 +7,7 @@ use App\Entity\Publication;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\Feedback\FeedbackFactory;
+use App\Tests\Factory\Message\MessageFactory;
 use App\Tests\Factory\Message\MessageThreadFactory;
 use App\Tests\Factory\Message\MessageThreadMetaFactory;
 use App\Tests\Factory\Publication\GalleryFactory;
@@ -37,13 +38,30 @@ class NotificationGetTest extends ApiTestCase
         $user2 = UserFactory::new()->asBaseUser()->create(['username' => 'base_user_2', 'email' => 'base_user2@email.com']);
 
 
-        $thread = MessageThreadFactory::new()->create();
-        $thread2 = MessageThreadFactory::new()->create();
-        $thread3 = MessageThreadFactory::new()->create();
-        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $thread, 'isRead' => 0])->create();
-        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $thread2, 'isRead' => 0])->create();
-        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $thread3, 'isRead' => 1])->create();
-        MessageThreadMetaFactory::new(['user' => $user2, 'thread' => $thread, 'isRead' => 0])->create();
+        // Two unread messages in one thread, one in another, and a third thread read to the end.
+        // The answer is therefore 3 messages across 2 threads: under the boolean it was 2, because it
+        // counted threads and called them messages (#954).
+        $twoUnread = MessageThreadFactory::new()->create();
+        MessageFactory::new(['thread' => $twoUnread, 'author' => $user2, 'creationDatetime' => new \DateTime('2026-09-01 10:00:00')])->create();
+        MessageFactory::new(['thread' => $twoUnread, 'author' => $user2, 'creationDatetime' => new \DateTime('2026-09-01 10:01:00')])->create();
+        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $twoUnread, 'lastReadDatetime' => null])->create();
+
+        $oneUnread = MessageThreadFactory::new()->create();
+        MessageFactory::new(['thread' => $oneUnread, 'author' => $user2, 'creationDatetime' => new \DateTime('2026-09-02 10:00:00')])->create();
+        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $oneUnread, 'lastReadDatetime' => null])->create();
+
+        $caughtUp = MessageThreadFactory::new()->create();
+        MessageFactory::new(['thread' => $caughtUp, 'author' => $user2, 'creationDatetime' => new \DateTime('2026-09-03 10:00:00')])->create();
+        MessageThreadMetaFactory::new([
+            'user' => $user1,
+            'thread' => $caughtUp,
+            'lastReadDatetime' => new \DateTimeImmutable('2026-09-03 10:00:01'),
+        ])->create();
+
+        // Somebody else's unread message in a thread of their own, which must not leak into the count.
+        $otherPersons = MessageThreadFactory::new()->create();
+        MessageFactory::new(['thread' => $otherPersons, 'author' => $user1, 'creationDatetime' => new \DateTime('2026-09-04 10:00:00')])->create();
+        MessageThreadMetaFactory::new(['user' => $user2, 'thread' => $otherPersons, 'lastReadDatetime' => null])->create();
 
         $this->client->loginUser($user1);
         $this->client->request('GET', '/api/notifications');
@@ -52,7 +70,7 @@ class NotificationGetTest extends ApiTestCase
             '@context' => '/api/contexts/Notification',
             '@id' => '/api/notifications',
             '@type' => 'Notification',
-            'unread_messages' => 2
+            'unread_messages' => 3
         ]);
     }
 
@@ -61,7 +79,8 @@ class NotificationGetTest extends ApiTestCase
         $user1 = UserFactory::new()->asAdminUser()->create();
 
         $thread = MessageThreadFactory::new()->create();
-        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $thread, 'isRead' => 0])->create();
+        MessageFactory::new(['thread' => $thread, 'author' => UserFactory::new()->asBaseUser()])->create();
+        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $thread, 'lastReadDatetime' => null])->create();
         PublicationFactory::new(['status' => Publication::STATUS_PENDING,])->create();
         PublicationFactory::new(['status' => Publication::STATUS_ONLINE,])->create(); // not taken into count
         PublicationFactory::new(['status' => Publication::STATUS_DRAFT,])->create(); // not taken into count
@@ -90,7 +109,8 @@ class NotificationGetTest extends ApiTestCase
         $user1 = UserFactory::new()->asAdminUser()->create();
 
         $thread = MessageThreadFactory::new()->create();
-        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $thread, 'isRead' => 0])->create();
+        MessageFactory::new(['thread' => $thread, 'author' => UserFactory::new()->asBaseUser()])->create();
+        MessageThreadMetaFactory::new(['user' => $user1, 'thread' => $thread, 'lastReadDatetime' => null])->create();
 
         $this->client->loginUser($user1);
         $this->client->request('GET', '/api/notifications');

--- a/tests/Factory/Message/MessageThreadMetaFactory.php
+++ b/tests/Factory/Message/MessageThreadMetaFactory.php
@@ -15,7 +15,7 @@ final class MessageThreadMetaFactory extends PersistentObjectFactory
         return [
             'creationDatetime' => new \DateTime(),
             'isDeleted' => false,
-            'isRead' => false,
+            'lastReadDatetime' => null,
             'thread' => MessageThreadFactory::new(),
             'user' => UserFactory::new(),
         ];

--- a/tests/Integration/Message/UnreadMessageCountTest.php
+++ b/tests/Integration/Message/UnreadMessageCountTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Message;
+
+use App\Entity\Message\MessageThread;
+use App\Entity\Message\MessageThreadMeta;
+use App\Entity\User;
+use App\Repository\Message\MessageRepository;
+use App\Tests\Factory\Message\MessageFactory;
+use App\Tests\Factory\Message\MessageThreadFactory;
+use App\Tests\Factory\Message\MessageThreadMetaFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * What the read position bought over the boolean it replaced (#954): a number rather than a dot.
+ *
+ * These sit at the query rather than at the API, because that is where the semantics live and the
+ * cases are all about *what counts*. The contract that carries the number to the browser is asserted
+ * in full in tests/Api/Message/MessageThreadMetaGetCollectionTest.
+ */
+#[ResetDatabase]
+class UnreadMessageCountTest extends KernelTestCase
+{
+    private MessageRepository $messageRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->messageRepository = self::getContainer()->get(MessageRepository::class);
+    }
+
+    public function test_a_position_mid_thread_counts_only_what_came_after_it(): void
+    {
+        [$reader, $writer] = $this->twoUsers();
+        $thread = MessageThreadFactory::new()->create();
+
+        $this->messageAt($thread, $writer, '2026-09-01 10:00:00');
+        $this->messageAt($thread, $writer, '2026-09-01 10:05:00');
+        $this->messageAt($thread, $writer, '2026-09-01 10:10:00');
+
+        $meta = $this->metaFor($reader, $thread, new \DateTimeImmutable('2026-09-01 10:02:00'));
+
+        self::assertSame(2, $this->messageRepository->countUnreadForThread($meta));
+        self::assertSame(2, $this->messageRepository->countUnreadForUser($reader));
+        self::assertSame(
+            [(string) $thread->id => 2],
+            $this->messageRepository->countUnreadByThreadForUser($reader)
+        );
+    }
+
+    public function test_no_position_counts_the_whole_thread(): void
+    {
+        [$reader, $writer] = $this->twoUsers();
+        $thread = MessageThreadFactory::new()->create();
+
+        $this->messageAt($thread, $writer, '2026-09-01 10:00:00');
+        $this->messageAt($thread, $writer, '2026-09-01 10:05:00');
+
+        self::assertSame(2, $this->messageRepository->countUnreadForThread($this->metaFor($reader, $thread, null)));
+    }
+
+    public function test_your_own_messages_never_count(): void
+    {
+        [$reader, $writer] = $this->twoUsers();
+        $thread = MessageThreadFactory::new()->create();
+
+        // Everything after the position, but two of the three written by the reader.
+        $this->messageAt($thread, $reader, '2026-09-01 10:00:00');
+        $this->messageAt($thread, $reader, '2026-09-01 10:05:00');
+        $this->messageAt($thread, $writer, '2026-09-01 10:10:00');
+
+        self::assertSame(1, $this->messageRepository->countUnreadForThread($this->metaFor($reader, $thread, null)));
+    }
+
+    public function test_a_position_past_the_last_message_counts_nothing(): void
+    {
+        [$reader, $writer] = $this->twoUsers();
+        $thread = MessageThreadFactory::new()->create();
+
+        $this->messageAt($thread, $writer, '2026-09-01 10:00:00');
+        $meta = $this->metaFor($reader, $thread, new \DateTimeImmutable('2026-09-01 10:00:01'));
+
+        self::assertSame(0, $this->messageRepository->countUnreadForThread($meta));
+        // Absent from the grouped result rather than present as a zero, which is why its callers
+        // read it with `?? 0`.
+        self::assertSame([], $this->messageRepository->countUnreadByThreadForUser($reader));
+    }
+
+    public function test_a_message_in_the_same_second_as_the_position_reads_as_already_read(): void
+    {
+        // The documented cost of a one-second column. Pinned so it is a known limit rather than a
+        // surprise, and so anyone moving message.creation_datetime to microseconds sees this fail.
+        [$reader, $writer] = $this->twoUsers();
+        $thread = MessageThreadFactory::new()->create();
+
+        $this->messageAt($thread, $writer, '2026-09-01 10:00:00');
+        $meta = $this->metaFor($reader, $thread, new \DateTimeImmutable('2026-09-01 10:00:00'));
+
+        self::assertSame(0, $this->messageRepository->countUnreadForThread($meta));
+    }
+
+    public function test_the_total_ignores_a_thread_the_user_deleted(): void
+    {
+        // The navbar count used to ignore isDeleted while the inbox beside it did not, so the two
+        // disagreed. Nothing sets the flag today, which is the only reason it never showed.
+        [$reader, $writer] = $this->twoUsers();
+
+        $kept = MessageThreadFactory::new()->create();
+        $this->messageAt($kept, $writer, '2026-09-01 10:00:00');
+        $this->metaFor($reader, $kept, null);
+
+        $deleted = MessageThreadFactory::new()->create();
+        $this->messageAt($deleted, $writer, '2026-09-02 10:00:00');
+        $this->messageAt($deleted, $writer, '2026-09-02 10:05:00');
+        MessageThreadMetaFactory::new([
+            'user' => $reader,
+            'thread' => $deleted,
+            'lastReadDatetime' => null,
+            'isDeleted' => true,
+        ])->create();
+
+        self::assertSame(1, $this->messageRepository->countUnreadForUser($reader));
+    }
+
+    public function test_another_persons_unread_never_leaks_into_yours(): void
+    {
+        [$reader, $writer] = $this->twoUsers();
+        $thread = MessageThreadFactory::new()->create();
+
+        $this->messageAt($thread, $reader, '2026-09-01 10:00:00');
+        $this->metaFor($writer, $thread, null);
+
+        self::assertSame(0, $this->messageRepository->countUnreadForUser($reader));
+        self::assertSame(1, $this->messageRepository->countUnreadForUser($writer));
+    }
+
+    /**
+     * @return array{0: User, 1: User}
+     */
+    private function twoUsers(): array
+    {
+        return [
+            UserFactory::new()->asBaseUser()->create(['username' => 'reader', 'email' => 'reader@test.com']),
+            UserFactory::new()->asBaseUser()->create(['username' => 'writer', 'email' => 'writer@test.com']),
+        ];
+    }
+
+    private function metaFor(User $user, MessageThread $thread, ?\DateTimeImmutable $lastRead): MessageThreadMeta
+    {
+        return MessageThreadMetaFactory::new([
+            'user' => $user,
+            'thread' => $thread,
+            'lastReadDatetime' => $lastRead,
+        ])->create();
+    }
+
+    private function messageAt(MessageThread $thread, User $author, string $at): void
+    {
+        MessageFactory::new([
+            'thread' => $thread,
+            'author' => $author,
+            'creationDatetime' => new \DateTime($at),
+        ])->create();
+    }
+}


### PR DESCRIPTION
Closes #954. Track C1 of #948. Ships on its own and blocks the D track (#959, #960).

`MessageThreadMeta.isRead` was a boolean, so read state could answer "is there something new" and nothing else. The navbar badge computed `count(['isRead' => 0])`, which counted **threads and called them messages**, and ignored `isDeleted` while the inbox beside it did not. The thread list showed a "new" tag. All three are now a real number.

## Why a datetime, against the issue's own suggestion

The issue offered `lastReadDatetime` or a `lastReadMessage` relation, and said the relation would be "exact" while a datetime was merely "simpler". The relation would **not** be exact: `Message` ids are `Uuid::uuid4()`, so they carry no order, and a relation would still have had to compare through `creationDatetime` anyway. It would have bought a foreign key, a join and a deletion problem, for no accuracy.

So `?\DateTimeImmutable $lastReadDatetime`, null meaning nothing read. This also turns out to be the existing house pattern: `ForumTopicParticipation.readDatetime` works exactly this way, and `ForumTopicParticipationService::recordPost()` already documents why it does not rewind other participants.

The real limitation is one-second precision, inherited from `message.creation_datetime`. It is written into the entity docblock along with its one knock-on: a message landing in the same second as a mark-read keeps the count at zero, so the client does not mark read, so the *next* email is suppressed. It heals on the following read. Making it exact means `DATETIME(6)` on the message table, which is a follow-up.

## The migration converts rather than resets

Validated on the **migration** database with rows seeded in all the interesting states first, not against an empty table, then round-tripped `down()`/`up()`.

- `is_read = 1` becomes the thread's last message timestamp, not `NOW()`. A read position in the future would hide the next message to arrive.
- `is_read = 0` becomes one second **before** it, so exactly one message reads as unread. `NULL` was the other defensible answer, but it would make every message ever written in the thread unread, so a badge showing "4 threads" today would show hundreds after the deploy.
- A thread with no last message becomes `NULL` either way.

## What changed elsewhere

- Two counting queries in `MessageRepository`: one grouped query for the whole inbox (no N+1 on a list that already fetch-joins five relations), one for the navbar total, which is where the `isDeleted` divergence gets fixed.
- `handleReadMessage()` no longer rewinds the recipient's position. The boolean's `false` amounted to resurrecting every message they had already read.
- The email throttle from #533 keeps its exact trigger, expressed on the new model as `hasUnread()`: a query-free comparison against the thread's denormalised last message, and the same predicate the migration uses in both directions.
- API: `unread_count` read-only, `is_read` write-only as a command (true marks read as of now, false puts the position back to nothing).
- Frontend: the count replaces the "new" tag, with a French `aria-label` and a 99+ cap matching the notification bell. A dead duplicate unread computation in the store is gone.

## Verified

- 2659 PHP tests, PHPStan level 8, 610 JS tests, Biome and the Vite build clean.
- `NotificationGetTest` now asserts **3 messages across 2 threads** where the old code said 2. That number difference is the bug being fixed.
- End to end in the browser: three messages, a read, then two more gave `unread_count = 2`, exactly what came after the position. A second thread rendered `2` where the old UI said "new", the navbar envelope agreed, and the author of the messages saw 0.

## Two notes for review

**A regression the review caught and I fixed.** Making `isRead` write-only meant the builder stopped populating it, so a merge-patch body that omitted the key left a typed property uninitialised, and reading that raises an `Error` rather than an exception: a 500 where this used to be a harmless no-op. It is now `?bool` with `Assert\NotNull`, so the same request is a 422 naming the field, decided before the processor runs. A default of `false` would have been worse, silently running the destructive half of the command. Both branches are now tested.

**A question rather than a change.** Replying to a thread advances the sender's read position but does not reset their `pendingNotificationSent`. So after A emails B, B replying leaves B's flag set, and the next message from A emails nobody until B explicitly marks the thread read. That is pre-existing, and the new guard preserves it deliberately, because the issue is emphatic that changing email behaviour by accident is how #533 breaks. It looks wrong to me. Worth deciding separately.
