### PR TITLE
Messages: harden the multi participant send path

### DIFF
--- a/src/Repository/Message/MessageThreadMetaRepository.php
+++ b/src/Repository/Message/MessageThreadMetaRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository\Message;
 
+use App\Entity\Message\MessageThread;
 use App\Entity\Message\MessageThreadMeta;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -15,6 +16,37 @@ class MessageThreadMetaRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, MessageThreadMeta::class);
+    }
+
+    /**
+     * Every read-state row for one thread, keyed by the id of the user it belongs to.
+     *
+     * One query instead of the `findOneBy` per participant the send path used to run (#957). Invisible
+     * at two participants and linear in channel size, which is the point: a Band Space channel is the
+     * caller this exists for.
+     *
+     * Deliberately unfiltered on `isDeleted`, unlike findByUserAndNotDeleted() below. That flag is a
+     * user hiding the thread from their own inbox, not a row to be replaced: hiding it from the send
+     * path would mean finding no row, inserting a second one, and hitting `UNIQUE (thread_id, user_id)`.
+     * Reuse leaves the row hidden, which is the conservative answer rather than the obviously right
+     * one, and academic either way since nothing in the application sets the flag today.
+     *
+     * @return array<string, MessageThreadMeta>
+     */
+    public function findByThreadIndexedByUserId(MessageThread $thread): array
+    {
+        $metas = $this->createQueryBuilder('message_thread_meta')
+            ->where('message_thread_meta.thread = :thread')
+            ->setParameter('thread', $thread)
+            ->getQuery()
+            ->getResult();
+
+        $indexed = [];
+        foreach ($metas as $meta) {
+            $indexed[(string) $meta->user->id] = $meta;
+        }
+
+        return $indexed;
     }
 
     public function findByUserAndNotDeleted(User $user): mixed

--- a/src/Service/Procedure/Message/MessageSenderProcedure.php
+++ b/src/Service/Procedure/Message/MessageSenderProcedure.php
@@ -46,9 +46,9 @@ class MessageSenderProcedure
 
         $message = $this->entityManager->wrapInTransaction(function () use ($sender, $recipient, $content, &$eventsToDispatch): Message {
             // Serialize concurrent A↔B thread creation by acquiring write locks on the
-            // two user rows in deterministic id-sorted order (deadlock-free). The second
-            // request in a race blocks here, then sees the thread the first just created.
-            $this->lockUserPair($sender, $recipient);
+            // two user rows in deterministic id-sorted order. The second request in a race blocks
+            // here, then sees the thread the first just created.
+            $this->lockUsers([$sender, $recipient]);
 
             if (!$thread = $this->messageThreadRepository->findByParticipants($recipient, $sender)) {
                 $thread = $this->messageThreadDirector->create();
@@ -69,6 +69,12 @@ class MessageSenderProcedure
                     $eventsToDispatch[] = new MessageSentEvent($recipient, $sender, $thread);
                 }
             } else {
+                // The pair lock above serialises this path against itself, but not against
+                // processByThread(), so the thread lock is what makes "every send into a thread is
+                // serialised" an invariant of the procedure rather than a property of one entry point.
+                // No further user lock is needed: findByParticipants() only matches a thread whose
+                // participants are exactly this pair, so the two rows already locked are all of them.
+                $this->lockThread($thread);
                 $eventsToDispatch = array_merge(
                     $eventsToDispatch,
                     $this->handleReadMessage($thread, $sender),
@@ -96,12 +102,23 @@ class MessageSenderProcedure
 
     public function processByThread(MessageThread $thread, User $sender, string $content): Message
     {
-        $eventsToDispatch = $this->handleReadMessage($thread, $sender);
+        /** @var MessageSentEvent[] $eventsToDispatch */
+        $eventsToDispatch = [];
 
-        $message = $this->messageDirector->create($thread, $sender, $content);
-        $this->entityManager->persist($message);
-        $thread->lastMessage = $message;
-        $this->entityManager->flush();
+        $message = $this->entityManager->wrapInTransaction(function () use ($thread, $sender, $content, &$eventsToDispatch): Message {
+            // Users first, then the thread, in the same order process() uses. See lockThread().
+            $this->lockUsers($this->participantsOf($thread));
+            $this->lockThread($thread);
+
+            $eventsToDispatch = $this->handleReadMessage($thread, $sender);
+
+            $message = $this->messageDirector->create($thread, $sender, $content);
+            $this->entityManager->persist($message);
+            $thread->lastMessage = $message;
+            $this->entityManager->flush();
+
+            return $message;
+        });
 
         // Same rule as process(): only emit notifications once the message is
         // actually persisted, never before.
@@ -112,9 +129,64 @@ class MessageSenderProcedure
         return $message;
     }
 
-    private function lockUserPair(User $sender, User $recipient): void
+    /**
+     * Serialises one send into a thread against another.
+     *
+     * Three things here are unsafe concurrently and this settles all three. The throttle is a
+     * read-modify-write: two senders both see `pendingNotificationSent = false` for a third
+     * participant and both email them. `thread->lastMessage` is last-writer-wins, so an older message
+     * can end up as the thread's last and put the inbox out of order. And the find-or-create in
+     * handleReadMessage() could otherwise hit `UNIQUE (thread_id, user_id)` from two sides at once.
+     * Three participants is where *different* senders start colliding on a third party's row, which is
+     * what a Band Space channel is (#957, mandatory before #960), but a two-person conversation is not
+     * immune: one sender double submitting from two tabs races on the recipient's single flag just the
+     * same, and this covers both identically. It also removes a race that was already
+     * there: without an exclusive lock up front, two concurrent sends both take the foreign key shared
+     * lock on the thread row when inserting their message and then both need it exclusively to write
+     * `last_message_id`, which is an upgrade deadlock either way round.
+     *
+     * **Always after lockUsers(), never before.** The flush at the end of the transaction takes locks
+     * on `fos_user` rows, both the foreign key shared locks from inserting a message and a meta row,
+     * and, until User's identifier mapping is fixed, an exclusive lock from a spurious
+     * `UPDATE fos_user SET id = ?` that Doctrine emits for every hydrated user. So a transaction that
+     * locked the thread first would hold thread and want users while process() holds users and wants
+     * thread. That is a real deadlock, reproducible with an ordinary direct message: the profile
+     * page's "send a message" hits process() while the thread view hits processByThread(). Both paths
+     * therefore take users in id order first and the thread second.
+     *
+     * Taking every participant rather than just the sender does not widen the footprint: the flush
+     * locks all of them anyway through that spurious update, and handleReadMessage() hydrates every
+     * one of them regardless. What it does change is *duration*, since those rows are now held from
+     * the top of the transaction rather than from the flush, which is the price of the lock existing at
+     * all. It cannot be narrowed to the sender on principle either: findOrCreateMetaFor() inserts a
+     * row for whichever participant is missing one, and that insert takes a foreign key lock on an
+     * arbitrary participant's user row.
+     *
+     * **What it does not cover: send against mark-as-read.** A pessimistic lock only orders
+     * transactions that agree to take it, and MessageThreadMetaPatchProcessor writes the same
+     * `pending_notification_sent` column without touching the thread. That race is currently
+     * self-healing rather than safe: a send that reads the flag before the PATCH commits sees it still
+     * set and skips one email, then the PATCH's `false` stands, so the next message emails normally.
+     * The cost is one missed email in the window, never a duplicate and never a stuck flag. That is a
+     * property of these two particular writes, not a guarantee from this lock, so a third writer to
+     * that column has to be thought about again.
+     */
+    private function lockThread(MessageThread $thread): void
     {
-        $ids = [(string) $sender->id, (string) $recipient->id];
+        $this->entityManager->lock($thread, LockMode::PESSIMISTIC_WRITE);
+    }
+
+    /**
+     * Write-locks these users' rows in id order.
+     *
+     * Ascending id is the whole point: a fixed order is what stops two transactions that want the
+     * same two rows from taking them in opposite orders and deadlocking.
+     *
+     * @param User[] $users
+     */
+    private function lockUsers(array $users): void
+    {
+        $ids = array_map(static fn (User $user): string => (string) $user->id, $users);
         sort($ids, SORT_STRING);
 
         $this->entityManager->createQueryBuilder()
@@ -129,21 +201,35 @@ class MessageSenderProcedure
     }
 
     /**
+     * @return User[]
+     */
+    private function participantsOf(MessageThread $thread): array
+    {
+        $users = [];
+        foreach ($thread->messageParticipants as $participant) {
+            $users[] = $participant->participant;
+        }
+
+        return $users;
+    }
+
+    /**
      * @return MessageSentEvent[]
      */
     private function handleReadMessage(MessageThread $thread, User $sender): array
     {
+        // One query for the whole thread, rather than one per participant.
+        $metas = $this->messageThreadMetaRepository->findByThreadIndexedByUserId($thread);
+
         $events = [];
         foreach ($thread->messageParticipants as $participant) {
             $recipient = $participant->participant;
             if ($recipient->id !== $sender->id) {
-                $threadMetaRecipient = $this->messageThreadMetaRepository->findOneBy(['user' => $recipient, 'thread' => $thread]);
-                assert($threadMetaRecipient !== null);
+                $threadMetaRecipient = $this->findOrCreateMetaFor($thread, $recipient, $metas);
                 // The recipient's read position is deliberately left alone: the message about to be
                 // written is newer than it, so it already counts as unread. Rewinding the position to
                 // null, which is what the boolean's `false` amounted to, would resurrect every
-                // message they had already read in this thread. This is the same shape the forum
-                // already uses, see ForumTopicParticipationService::recordPost().
+                // message they had already read in this thread.
                 if ($this->shouldNotify($recipient, $threadMetaRecipient)) {
                     $threadMetaRecipient->pendingNotificationSent = true;
                     $events[] = new MessageSentEvent($recipient, $sender, $thread);
@@ -153,12 +239,53 @@ class MessageSenderProcedure
 
         // Writing a message is reading the thread, so the sender's position moves to now. Stamped
         // before the message exists, which leaves the position at or just behind their own message;
-        // that never shows as unread because the count ignores messages you wrote yourself.
-        $threadMetaSender = $this->messageThreadMetaRepository->findOneBy(['user' => $sender, 'thread' => $thread]);
-        assert($threadMetaSender !== null);
-        $threadMetaSender->lastReadDatetime = new \DateTimeImmutable();
+        // that never shows as unread because the count ignores messages you wrote yourself. Same shape
+        // the forum already uses, see ForumTopicParticipationService::recordPost(), which is likewise
+        // find-or-create plus your own position to now.
+        $senderMeta = $this->findOrCreateMetaFor($thread, $sender, $metas);
+        $senderMeta->lastReadDatetime = new \DateTimeImmutable();
 
         return $events;
+    }
+
+    /**
+     * This participant's read-state row, created if they do not have one yet.
+     *
+     * The two lookups this replaces were `findOneBy` plus `assert($meta !== null)`, and **assertions
+     * are disabled in production**: a participant without a row did not fail loudly, their
+     * notification was silently skipped, and the sender's own missing row would have been a TypeError
+     * on the line after. Nothing triggers it today, because `process()` writes both rows when it
+     * creates a thread. It becomes the *normal* case for a Band Space channel, where membership is
+     * derived from BandSpaceMembership rather than materialised, so a member who has never opened the
+     * channel has no row at all (#957, mandatory before #960).
+     *
+     * A new row starts with no read position, so everything already in the thread counts as unread,
+     * which is the honest answer for somebody who has never looked at it.
+     *
+     * Creating rather than skipping is safe here only because lockThread() serialises the transaction;
+     * see the note there about `UNIQUE (thread_id, user_id)`. A future writer that inserts a meta row
+     * without taking that lock, a member joining a channel that already has history for instance,
+     * brings the duplicate key back and would need catching. Who *deserves* a row is not decided here:
+     * this trusts `thread->messageParticipants`, so filtering out members who have left stays with
+     * whatever populates that list.
+     *
+     * Each participant appears once in `messageParticipants` (`UNIQUE (thread_id, participant_id)`)
+     * and the sender is handled separately, so nothing is looked up twice and the map needs no
+     * updating.
+     *
+     * @param array<string, MessageThreadMeta> $metas
+     */
+    private function findOrCreateMetaFor(MessageThread $thread, User $user, array $metas): MessageThreadMeta
+    {
+        $userId = (string) $user->id;
+        if (isset($metas[$userId])) {
+            return $metas[$userId];
+        }
+
+        $meta = $this->messageThreadMetaDirector->create($thread, $user, null);
+        $this->entityManager->persist($meta);
+
+        return $meta;
     }
 
     /**

--- a/src/Service/Procedure/Message/MessageSenderProcedure.php
+++ b/src/Service/Procedure/Message/MessageSenderProcedure.php
@@ -244,6 +244,12 @@ class MessageSenderProcedure
         // find-or-create plus your own position to now.
         $senderMeta = $this->findOrCreateMetaFor($thread, $sender, $metas);
         $senderMeta->lastReadDatetime = new \DateTimeImmutable();
+        // And it clears their own throttle flag, which used to be the one way of catching up that
+        // did not (problem 4 of #957). Without this, somebody who was emailed and then replied kept
+        // the flag set, so the *next* message to them sent no email, and the direct message UI has no
+        // polling either: they were reachable by neither route until they navigated away and back.
+        // You cannot be more caught up on a thread than by writing in it.
+        $senderMeta->pendingNotificationSent = false;
 
         return $events;
     }

--- a/tests/Api/Message/MessageEmailThrottleTest.php
+++ b/tests/Api/Message/MessageEmailThrottleTest.php
@@ -144,6 +144,33 @@ class MessageEmailThrottleTest extends ApiTestCase
         );
     }
 
+    public function test_replying_clears_your_own_streak_so_the_next_message_can_email_you(): void
+    {
+        // Problem 4 of #957. Before this, being emailed and then replying left the flag set, so the
+        // next message to you sent nothing, and with no polling in the message UI you were reachable
+        // by neither route until you navigated away and back.
+        [$sender, $recipient, $thread] = $this->createThreadWithMembers();
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $metaRepo = self::getContainer()->get(MessageThreadMetaRepository::class);
+        // The recipient has been emailed and has not marked the thread read.
+        $recipientMeta = $metaRepo->findOneBy(['user' => $recipient->id, 'thread' => $thread->id]);
+        $recipientMetaId = $recipientMeta->id;
+        $recipientMeta->pendingNotificationSent = true;
+        $em->flush();
+
+        // They reply instead of marking it read.
+        $this->client->loginUser($recipient);
+        $this->postMessage($thread, 'replying rather than opening the inbox');
+        $this->assertResponseIsSuccessful();
+
+        $em->clear();
+        $this->assertFalse(
+            $metaRepo->find($recipientMetaId)->pendingNotificationSent,
+            'Replying is the strongest evidence of catching up, so it must clear the streak',
+        );
+    }
+
     public function test_no_email_when_recipient_was_recently_active(): void
     {
         // #712: recipient was active <5 min ago -> skip the email entirely

--- a/tests/Api/Message/MessageSendPathTest.php
+++ b/tests/Api/Message/MessageSendPathTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Message;
+
+use App\Entity\Message\MessageThread;
+use App\Entity\User;
+use App\Repository\Message\MessageThreadMetaRepository;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\Message\MessageParticipantFactory;
+use App\Tests\Factory\Message\MessageThreadFactory;
+use App\Tests\Factory\Message\MessageThreadMetaFactory;
+use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * The hardening from #957, which is all about behaviour that is invisible in a two-person
+ * conversation and becomes the normal case once a thread has three participants.
+ *
+ * The concurrency itself is not testable here: DAMA wraps every test in a transaction, so a second
+ * connection taking the same lock would block until the test timed out rather than assert anything.
+ * What is testable, and what these pin, is that the lock statement is issued at all and that the
+ * per-participant lookup is one query.
+ */
+#[ResetDatabase]
+class MessageSendPathTest extends ApiTestCase
+{
+    public function test_sending_locks_the_thread_row(): void
+    {
+        [$sender, $recipient] = $this->twoUsers();
+        $thread = $this->threadWith($sender, $recipient);
+
+        $this->client->loginUser($sender);
+        $this->client->enableProfiler();
+        self::getContainer()->get('doctrine.debug_data_holder')->reset();
+        $this->postMessage($thread, 'hello');
+
+        $this->assertResponseIsSuccessful();
+
+        // Matched in full rather than by searching for `message_thread`, which is a prefix of
+        // `message_thread_meta` and so would have passed on the wrong table.
+        $this->assertNotSame(
+            [],
+            $this->queriesMatching('FROM message_thread t0 WHERE t0.id = ? FOR UPDATE'),
+            'The send path must take a write lock on the thread row',
+        );
+        // And the users, before the thread. The order is the whole point: the flush at the end takes
+        // locks on fos_user rows, so a transaction that took the thread first would deadlock against
+        // process(), which takes the users first. See MessageSenderProcedure::lockThread().
+        $locks = $this->queriesMatching('FOR UPDATE');
+        $userLock = $this->firstIndexMatching($locks, 'FROM fos_user');
+        $threadLock = $this->firstIndexMatching($locks, 'FROM message_thread t0');
+        $this->assertNotNull($userLock, 'The send path must take a write lock on the participants');
+        $this->assertLessThan(
+            $threadLock,
+            $userLock,
+            'The participants must be locked before the thread, or the two entry points deadlock',
+        );
+    }
+
+    public function test_the_read_state_lookup_is_one_query_whatever_the_participant_count(): void
+    {
+        // Four participants, so a per-participant findOneBy would show up as four selects.
+        $sender = UserFactory::new()->asBaseUser()->create(['username' => 'sender', 'email' => 'sender@test.com']);
+        $thread = MessageThreadFactory::new()->create();
+        MessageParticipantFactory::new(['thread' => $thread, 'participant' => $sender])->create();
+        MessageThreadMetaFactory::new(['thread' => $thread, 'user' => $sender, 'lastReadDatetime' => null])->create();
+
+        foreach (range(1, 3) as $index) {
+            $other = UserFactory::new()->asBaseUser()->create([
+                'username' => 'other_' . $index,
+                'email' => 'other' . $index . '@test.com',
+            ]);
+            MessageParticipantFactory::new(['thread' => $thread, 'participant' => $other])->create();
+            MessageThreadMetaFactory::new(['thread' => $thread, 'user' => $other, 'lastReadDatetime' => null])->create();
+        }
+
+        $this->client->loginUser($sender);
+        $this->client->enableProfiler();
+        // Deliberately no EntityManager::clear() here, unlike the read-side query-count tests: the
+        // request persists a Message whose author is the logged-in user, and detaching that user
+        // makes Doctrine treat it as a new entity. The count is accurate anyway, because the lookup
+        // under test is DQL and DQL always goes to the database.
+        self::getContainer()->get('doctrine.debug_data_holder')->reset();
+        $this->postMessage($thread, 'hello everyone');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertCount(
+            1,
+            $this->queriesMatching('FROM message_thread_meta'),
+            'The read-state rows must be fetched in one query, not one per participant',
+        );
+    }
+
+    public function test_a_participant_with_no_read_state_row_still_gets_notified(): void
+    {
+        // The case that is silent in production: the old code asserted the row existed, and
+        // assertions are disabled there, so the notification was skipped with nothing logged. It
+        // becomes the normal case for a channel, where a member who never opened it has no row.
+        [$sender, $recipient] = $this->twoUsers();
+        $thread = $this->threadWith($sender, $recipient);
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $metaRepository = self::getContainer()->get(MessageThreadMetaRepository::class);
+        $entityManager->remove($metaRepository->findOneBy(['user' => $recipient->id, 'thread' => $thread->id]));
+        $entityManager->flush();
+
+        $this->client->loginUser($sender);
+        $this->postMessage($thread, 'you have no meta row');
+
+        $this->assertResponseIsSuccessful();
+
+        $entityManager->clear();
+        $created = $metaRepository->findOneBy(['user' => $recipient->id, 'thread' => $thread->id]);
+        $this->assertNotNull($created, 'The missing row must be created rather than skipped');
+        $this->assertNull(
+            $created->lastReadDatetime,
+            'Somebody who has never opened the thread has read none of it',
+        );
+        $this->assertTrue($created->pendingNotificationSent);
+        $this->assertEmailCount(1, message: 'A missing read-state row must not swallow the notification');
+    }
+
+    /**
+     * @return array{0: User, 1: User}
+     */
+    private function twoUsers(): array
+    {
+        return [
+            UserFactory::new()->asBaseUser()->create(['username' => 'sender', 'email' => 'sender@test.com']),
+            UserFactory::new()->asBaseUser()->create(['username' => 'recipient', 'email' => 'recipient@test.com']),
+        ];
+    }
+
+    private function threadWith(User $sender, User $recipient): MessageThread
+    {
+        $thread = MessageThreadFactory::new()->create();
+        MessageParticipantFactory::new(['thread' => $thread, 'participant' => $sender])->create();
+        MessageParticipantFactory::new(['thread' => $thread, 'participant' => $recipient])->create();
+        MessageThreadMetaFactory::new([
+            'thread' => $thread,
+            'user' => $sender,
+            'lastReadDatetime' => new \DateTimeImmutable(),
+        ])->create();
+        MessageThreadMetaFactory::new([
+            'thread' => $thread,
+            'user' => $recipient,
+            'lastReadDatetime' => null,
+        ])->create();
+
+        return $thread;
+    }
+
+    private function postMessage(MessageThread $thread, string $content): void
+    {
+        $this->client->jsonRequest('POST', '/api/messages', [
+            'thread' => '/api/message_threads/' . $thread->id,
+            'content' => $content,
+        ], ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+    }
+
+    /**
+     * @param list<string> $queries
+     */
+    private function firstIndexMatching(array $queries, string $needle): ?int
+    {
+        foreach ($queries as $index => $sql) {
+            if (str_contains($sql, $needle)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function queriesMatching(string $needle): array
+    {
+        $profile = $this->client->getProfile();
+        $this->assertNotFalse($profile, 'The profiler must be enabled to inspect the queries.');
+
+        $matching = [];
+        foreach ($profile->getCollector('db')->getQueries()['default'] ?? [] as $query) {
+            $sql = (string) $query['sql'];
+            if (str_contains($sql, $needle)) {
+                $matching[] = $sql;
+            }
+        }
+
+        return $matching;
+    }
+}


### PR DESCRIPTION
Closes #957. Part of #948, mandatory before #960.

`MessageSenderProcedure` has two entry points and only one of them was hardened. `process()` (start a
conversation from a profile) wrapped everything in a transaction and write-locked the two user rows in
id order. `processByThread()` (post into an existing thread, and the one a Band Space channel will use)
had neither. Everything wrong here is invisible in a two-person conversation and becomes the normal
case once a thread has three participants.

## The lock, and why (the issue asks for this in the PR)

Yes, `processByThread()` needs one, and it is `PESSIMISTIC_WRITE` on the thread row inside the
transaction. One row lock settles three separate races:

- **The throttle is a read-modify-write.** Two senders both read `pendingNotificationSent = false` for
  a third participant and both email them. Three participants is where *different* senders start
  colliding, but a DM is not immune either: one sender double submitting from two tabs races on the
  recipient's single flag just the same.
- **`thread->lastMessage` is last-writer-wins**, so an older message can end up as the thread's last,
  putting the inbox out of order and showing the wrong preview.
- **The find-or-create below** could otherwise hit `UNIQUE (thread_id, user_id)` from two sides at once.

It also closes a race that was already there and that the issue did not notice: without an exclusive
lock up front, two concurrent sends each take the thread row's foreign key shared lock when inserting
their message, then each needs it exclusively to write `last_message_id`. That is a lock upgrade
deadlock whichever way round it happens.

## Lock order, which is the load bearing part

`lockUserPair()` is now `lockUsers(User[])`, and `processByThread()` takes the participants in id order
**before** the thread, so both entry points share one global order.

This is not theoretical tidiness. The flush at the end of the transaction takes locks on `fos_user`
rows: the foreign key shared locks from inserting a message and a meta row, and an exclusive lock from
a spurious `UPDATE fos_user SET id = ? WHERE id = ?` that Doctrine emits for every hydrated User. So a
transaction that locked the thread first would hold the thread and want the users, while `process()`
holds the users and wants the thread. Reachable with an ordinary direct message: the profile page's
send button hits `process()` while the thread view hits `processByThread()`. Ordering it costs nothing,
because the flush locks all those rows anyway, and it cannot be narrowed to just the sender, because
the meta insert takes a foreign key lock on whichever participant was missing a row.

The spurious update has its own cause and is filed as #985: it is an app-wide flush cost and a lock
nobody asked for, not a message concern.

## What it does not cover

`MessageThreadMetaPatchProcessor` writes the same `pending_notification_sent` column without touching
the thread, so a pessimistic lock cannot order the two. That race is self-healing rather than safe: a
send reading the flag before the PATCH commits skips one email, the PATCH's `false` stands, and the
next message emails normally. Written down in the docblock so a third writer to that column gets
thought about.

## The other three problems

- **The assert.** `handleReadMessage()` did `findOneBy` plus `assert($meta !== null)`, and assertions
  are disabled in production, so a participant with no read-state row had their notification **silently
  skipped** and the sender's own missing row would have been a `TypeError` on the next line. Both are
  now find-or-create, and a new row starts with no read position, so everything already in the thread
  counts as unread. Nothing triggers this today; it becomes the normal case for a channel, where
  membership comes from `BandSpaceMembership` rather than from materialised participant rows.
- **The N+1.** One query for the whole thread's read-state rows, keyed by user id, instead of one
  `findOneBy` per participant.
- **Replying counts as catching up** (second commit, so the email change is reviewable on its own).
  `pendingNotificationSent` had two asymmetric writers: set when we email you, cleared only by the mark
  as read PATCH. Someone with the thread already open who replied without re-selecting it kept the flag
  set, so the *next* message sent no email, and the message UI has no polling and no live updates: they
  were reachable by neither route until they navigated away and back.

## Verified

- 2663 PHP tests green, PHPStan level 8 clean, Biome exit 0.
- The seven throttle tests from #533 and #712 are untouched and green. They set the flag on recipients;
  this touches only the sender's own row.
- `tests/Api/Message/MessageSendPathTest.php` pins the three things no other test would notice: the
  `FOR UPDATE` statement itself, its **order** relative to the user lock, and that the read-state
  lookup is one query with four participants. The order assertion is load bearing: swapping the two
  lock lines fails it.
- The concurrency itself is not testable in the suite. DAMA wraps every test in a transaction, so a
  second connection taking the same lock would block until the test timed out rather than assert
  anything. Confirmed against the real database in dev instead, from the profiler's query collector:
  `FOR UPDATE on fos_user`, then `FOR UPDATE on message_thread`, then the flush.
- Sent messages between two accounts in the browser: the inbox, the unread counts from #954 and the
  thread order are unchanged.

## Out of scope

A send still runs one `SELECT FROM fos_user` per participant, from `NotDeletedThreadRecipientValidator`
calling `isDeleted()` on each one. That is a different N+1 from the one the issue names (problem 3 is
about `handleReadMessage()`), the fix belongs on the thread load path shared with
`GET /api/message_threads/{id}`, and the User eager-load tax from #730 caps the win. Filed as #986.

Deriving channel membership and filtering out members who have left (#959, #960): this creates a row
for whoever `thread->messageParticipants` yields, so that filtering stays with whatever populates the
list. No migration, no new configuration, nothing to do at deploy.
