### PR TITLE
Messages: print the inbox preview as text instead of raw markup

### DIFF
--- a/assets/js/components/Message/ThreadList.vue
+++ b/assets/js/components/Message/ThreadList.vue
@@ -58,7 +58,7 @@
               </div>
 
               <p class="text-sm text-surface-600 dark:text-surface-300 truncate">
-                {{ threadMeta.thread.last_message?.content || 'Aucun message' }}
+                {{ threadMeta.thread.last_message?.content_preview || 'Aucun message' }}
               </p>
             </div>
           </div>

--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -9,6 +9,10 @@ framework:
                 allow_static_elements: false
                 allow_elements:
                     br: [ ]
+            app.plain_text_sanitizer:
+                allow_safe_elements: false
+                allow_static_elements: false
+                allow_elements: [ ]
             app.publication_sanitizer:
                 allow_elements:
                     div: ['class', 'data-youtube-video', 'data-type', 'data-cols']

--- a/src/ApiResource/Message/MessageResource.php
+++ b/src/ApiResource/Message/MessageResource.php
@@ -69,5 +69,8 @@ class MessageResource
     public MessageThreadResource $thread;
 
     #[Groups([MessageResource::LIST, MessageResource::ITEM, MessageThreadMetaResource::LIST])]
-    public string $content;
+    public string $content; // HTML, render with v-html
+
+    #[Groups([MessageResource::ITEM, MessageThreadMetaResource::LIST])]
+    public string $contentPreview; // plain text, never v-html
 }

--- a/src/Service/Builder/Message/MessageBuilder.php
+++ b/src/Service/Builder/Message/MessageBuilder.php
@@ -7,12 +7,14 @@ namespace App\Service\Builder\Message;
 use App\ApiResource\Message\MessageResource;
 use App\ApiResource\Message\MessageThreadResource;
 use App\Entity\Message\Message;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 readonly class MessageBuilder
 {
     public function __construct(
         private HtmlSanitizerInterface $appOnlybrSanitizer,
+        private HtmlSanitizerInterface $appPlainTextSanitizer,
     ) {
     }
 
@@ -37,11 +39,23 @@ readonly class MessageBuilder
         $dto->author = $entity->author;
         $dto->thread = $this->buildShallowThread($entity->thread->id);
         $dto->content = $this->appOnlybrSanitizer->sanitize(nl2br($entity->content));
+        $dto->contentPreview = $this->toPreview($entity->content);
 
         return $dto;
     }
 
-    private function buildShallowThread(\Ramsey\Uuid\UuidInterface|string|null $threadId): MessageThreadResource
+    private function toPreview(string $content): string
+    {
+        $text = html_entity_decode(
+            $this->appPlainTextSanitizer->sanitize($content),
+            ENT_QUOTES | ENT_HTML5,
+            'UTF-8',
+        );
+
+        return trim((string) preg_replace('/\s+/u', ' ', $text));
+    }
+
+    private function buildShallowThread(UuidInterface|string|null $threadId): MessageThreadResource
     {
         $dto = new MessageThreadResource();
         $dto->id = (string) $threadId;

--- a/tests/Api/Message/MessagePostInThreadTest.php
+++ b/tests/Api/Message/MessagePostInThreadTest.php
@@ -65,6 +65,7 @@ class MessagePostInThreadTest extends ApiTestCase
                 'id' => $thread->id,
             ],
             'content'           => 'new content from user1',
+            'content_preview'   => 'new content from user1',
         ]);
     }
 

--- a/tests/Api/Message/MessageThreadMetaGetCollectionTest.php
+++ b/tests/Api/Message/MessageThreadMetaGetCollectionTest.php
@@ -109,6 +109,95 @@ class MessageThreadMetaGetCollectionTest extends ApiTestCase
                                 'id'       => $user1->id,
                             ],
                             'content'           => 'basic_content with  in it',
+                            'content_preview'   => 'basic_content with in it',
+                        ],
+                    ],
+                ],
+            ],
+            'totalItems' => 1,
+        ]);
+    }
+
+    public function test_the_preview_of_the_last_message_carries_no_markup(): void
+    {
+        // The reported bug: the inbox printed the field the thread renders with v-html, so a message
+        // written across three lines read "Bonjour Amy,<br /> <br /> J&#039;ai vu ..." in the list.
+        // The content below carries all four shapes at once: newlines, an apostrophe, a tag the sender
+        // typed, and angle brackets in ordinary prose.
+        $reader = UserFactory::new()->asBaseUser()->create(['username' => 'reader', 'email' => 'reader@email.com']);
+        $writer = UserFactory::new()->asBaseUser()->create(['username' => 'writer', 'email' => 'writer@email.com']);
+
+        $thread = MessageThreadFactory::new()->create();
+        $mp1 = MessageParticipantFactory::new(['thread' => $thread, 'participant' => $reader])->create();
+        $mp2 = MessageParticipantFactory::new(['thread' => $thread, 'participant' => $writer])->create();
+        $message = MessageFactory::new([
+            'author' => $writer,
+            'thread' => $thread,
+            'content' => "Bonjour Harry,\n\nJ'ai vu <b>ton</b> retour, on commence < 20h",
+        ])->create();
+        $thread->lastMessage = $message;
+        \Zenstruck\Foundry\Persistence\save($thread);
+        $meta = MessageThreadMetaFactory::new([
+            'user' => $reader,
+            'thread' => $thread,
+            'lastReadDatetime' => null,
+        ])->create();
+
+        $this->client->loginUser($reader);
+        $this->client->request('GET', '/api/message_thread_metas');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/MessageThreadMeta',
+            '@id' => '/api/message_thread_metas',
+            '@type' => 'Collection',
+            'member' => [
+                [
+                    '@id' => '/api/message_thread_metas/' . $meta->id,
+                    '@type' => 'MessageThreadMeta',
+                    'id' => $meta->id,
+                    'unread_count' => 1,
+                    'thread' => [
+                        '@id' => '/api/message_threads/' . $thread->id,
+                        '@type' => 'MessageThread',
+                        'id' => $thread->id,
+                        'message_participants' => [
+                            [
+                                '@id' => '/api/message_participants/' . $mp1->id,
+                                '@type' => 'MessageParticipant',
+                                'participant' => [
+                                    '@id' => '/api/users/' . $reader->id,
+                                    '@type' => 'User',
+                                    'id' => $reader->id,
+                                    'username' => 'reader',
+                                ],
+                            ], [
+                                '@id' => '/api/message_participants/' . $mp2->id,
+                                '@type' => 'MessageParticipant',
+                                'participant' => [
+                                    '@id' => '/api/users/' . $writer->id,
+                                    '@type' => 'User',
+                                    'id' => $writer->id,
+                                    'username' => 'writer',
+                                ],
+                            ],
+                        ],
+                        'last_message' => [
+                            '@id' => '/api/messages/' . $message->id,
+                            '@type' => 'Message',
+                            'creation_datetime' => $message->creationDatetime->format('c'),
+                            'author' => [
+                                '@id' => '/api/users/' . $writer->id,
+                                '@type' => 'User',
+                                'id' => $writer->id,
+                                'username' => 'writer',
+                            ],
+                            // What the thread renders with v-html.
+                            'content' => "Bonjour Harry,<br />\n<br />\nJ&#039;ai vu  retour, on commence &lt; 20h",
+                            // What the inbox prints. One line, the apostrophe is an apostrophe, and the
+                            // tag the sender typed is gone rather than shown at them. The `<` of
+                            // "< 20h" stays, because that is a character in their sentence and it is
+                            // what the thread puts on screen too: this field is text, not inert HTML.
+                            'content_preview' => "Bonjour Harry, J'ai vu retour, on commence < 20h",
                         ],
                     ],
                 ],

--- a/tests/Api/Message/MessageUserPostTest.php
+++ b/tests/Api/Message/MessageUserPostTest.php
@@ -71,6 +71,7 @@ class MessageUserPostTest extends ApiTestCase
                 'id' => $resultUser1[0]->thread->id,
             ],
             'content'           => 'new content from user1',
+            'content_preview'   => 'new content from user1',
         ]);
     }
 
@@ -124,6 +125,7 @@ class MessageUserPostTest extends ApiTestCase
                 'id' => $resultUser1[0]->thread->id
             ],
             'content'           => 'new content from user1',
+            'content_preview'   => 'new content from user1',
         ]);
     }
 


### PR DESCRIPTION
Closes #987.

The inbox thread list printed raw markup in the last message line: `Bonjour Amy,<br /> <br /> J&#039;ai vu ton retour sur le ...`. Both symptoms, the `<br />` and the `&#039;`, are the one cause. Nothing was corrupted in the database, which holds the plain text the sender typed.

## The cause

`MessageBuilder::buildItem()` sets `MessageResource::$content` to `appOnlybrSanitizer->sanitize(nl2br($raw))`, so the field is an HTML fragment. `Thread.vue:65` renders it with `v-html`, which is what the field is for. `ThreadList.vue:61` printed the same field with `{{ }}`.

One property cannot be both: the thread needs HTML, the inbox needs text.

## The fix

`MessageResource::$contentPreview`, serialized as `content_preview`, built by sanitizing the raw column with a new `app.plain_text_sanitizer` that allows no element at all, then decoding the entities and collapsing whitespace to one line.

Sanitized rather than passed straight through, because a sender typing `<b>salut</b>` must not be shown their own tags in the list: the preview drops exactly what the thread drops. The sanitizer is deliberately separate from `onlybr_sanitizer` so that teaching that one a new tag can never put a tag in a preview.

## Groups

In `MessageResource::ITEM` and `MessageThreadMetaResource::LIST`, not in `MessageResource::LIST`.

`LIST` is the thread's own 50 message page, which renders `content`, and would otherwise carry every body twice. `ITEM` is required rather than incidental: `postMessageInThread` in `assets/js/store/message/message.js` assigns the POST response straight onto `thread.last_message` without refetching, so without it a reply would leave its own thread reading "Aucun message" until the next page load. The other send path, `postMessage`, calls `loadThreads()` and would not have needed it.

## The preview is text, so it can contain an angle bracket

Somebody writing "on commence < 20h", or typing the characters `&lt;b&gt;` by hand, gets those characters back in the preview, because that is exactly what the thread view puts on screen for the same message. Checked against the running app: a message reading `le concert commence < 20h et &lt;b&gt;gras&lt;/b&gt;` comes back as

```
content          le concert commence &lt; 20h et &lt;b&gt;gras&lt;/b&gt;
content_preview  le concert commence < 20h et <b>gras</b>
```

and the first of those renders through `v-html` as exactly the second. The guarantee is that no tag survives and no entity is left undecoded, not that the string is inert HTML. It is printed, never rendered, and anything that ever puts it into HTML escapes it first, the same as it would for a username.

## Deploy

**Run `cache:pool:clear`.** `content_preview` is a new property on an already shipped ApiResource, `api_platform.cache.metadata.property` lives in Valkey, and Deployer clears no pools. A stale pool does not merely filter the property out, it makes it invisible to the metadata entirely, so every thread in every inbox falls back to "Aucun message". Same hazard as #954, and this is the fifth time it has come up, so a permanent `cache:pool:clear` task in `deploy.php` is worth doing on its own.

## Verified

- Full suite 2664 green, PHPStan level 8 clean, Biome exit 0, 610 JS tests, build clean.
- `MessageThreadMetaGetCollectionTest` asserts the full inbox body, so `content` and `content_preview` are pinned side by side. The new case carries all four shapes at once: newlines, an apostrophe, a tag the sender typed and an angle bracket in ordinary prose. Confirmed it fails on revert.
- Checked end to end against the running app, on both the inbox response and the POST response that feeds it.

## Noticed, not in scope

The only-br sanitizer deletes a disallowed element together with its text, so typing `<b>salut</b>` in a message makes the word vanish from the thread entirely rather than just losing its bold. Pre-existing. The preview now matches that rather than contradicting it, but the behaviour itself deserves its own look.
