### PR TITLE
Messages: check ownership in the thread meta provider

### DIFF
--- a/src/ApiResource/Message/MessageThreadMetaResource.php
+++ b/src/ApiResource/Message/MessageThreadMetaResource.php
@@ -12,11 +12,13 @@ use ApiPlatform\OpenApi\Model\Operation;
 use App\State\Processor\Message\MessageThreadMetaPatchProcessor;
 use App\State\Provider\Message\MessageThreadMetaCollectionProvider;
 use App\State\Provider\Message\MessageThreadMetaItemProvider;
+use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     shortName: 'MessageThreadMeta',
+    requirements: ['id' => Requirement::UUID],
     operations: [
         new GetCollection(
             uriTemplate: '/message_thread_metas',
@@ -30,6 +32,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             openapi: new Operation(tags: ['Message']),
             normalizationContext: ['groups' => [MessageThreadMetaResource::ITEM]],
             denormalizationContext: ['groups' => [MessageThreadMetaResource::PATCH]],
+            security: 'is_granted("IS_AUTHENTICATED_REMEMBERED")',
             name: 'api_message_thread_meta_patch',
             provider: MessageThreadMetaItemProvider::class,
             processor: MessageThreadMetaPatchProcessor::class,

--- a/src/ApiResource/Message/MessageThreadResource.php
+++ b/src/ApiResource/Message/MessageThreadResource.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\OpenApi\Model\Operation;
 use App\State\Provider\Message\MessageThreadItemProvider;
+use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Serializer\Attribute\Groups;
 
 /**
@@ -21,6 +22,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
  */
 #[ApiResource(
     shortName: 'MessageThread',
+    requirements: ['id' => Requirement::UUID],
     operations: [
         new Get(
             uriTemplate: '/message_threads/{id}',

--- a/src/Repository/Message/MessageThreadMetaRepository.php
+++ b/src/Repository/Message/MessageThreadMetaRepository.php
@@ -49,6 +49,14 @@ class MessageThreadMetaRepository extends ServiceEntityRepository
         return $indexed;
     }
 
+    /**
+     * Scoped to the owner, so there is no way to load somebody else's row through this method.
+     */
+    public function findOneByIdAndUser(string $id, User $user): ?MessageThreadMeta
+    {
+        return $this->findOneBy(['id' => $id, 'user' => $user]);
+    }
+
     public function findByUserAndNotDeleted(User $user): mixed
     {
         return $this->createQueryBuilder('message_thread_meta')

--- a/src/State/Processor/Message/MessageThreadMetaPatchProcessor.php
+++ b/src/State/Processor/Message/MessageThreadMetaPatchProcessor.php
@@ -39,6 +39,8 @@ readonly class MessageThreadMetaPatchProcessor implements ProcessorInterface
         if (!$entity instanceof MessageThreadMeta) {
             throw new NotFoundHttpException('Message thread meta introuvable');
         }
+        // Unreachable while MessageThreadMetaItemProvider guards the same operation, and kept anyway:
+        // this lookup is its own, so a future operation wired to a different provider still lands here.
         if ($entity->user->id !== $user->id) {
             throw new AccessDeniedException('Vous ne pouvez pas modifier ceci.');
         }

--- a/src/State/Provider/Message/MessageThreadMetaItemProvider.php
+++ b/src/State/Provider/Message/MessageThreadMetaItemProvider.php
@@ -8,9 +8,12 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\ApiResource\Message\MessageThreadMetaResource;
 use App\Entity\Message\MessageThreadMeta;
+use App\Entity\User;
 use App\Repository\Message\MessageThreadMetaRepository;
 use App\Service\Builder\Message\MessageThreadMetaBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * @implements ProviderInterface<MessageThreadMetaResource>
@@ -20,12 +23,19 @@ readonly class MessageThreadMetaItemProvider implements ProviderInterface
     public function __construct(
         private MessageThreadMetaRepository $messageThreadMetaRepository,
         private MessageThreadMetaBuilder    $messageThreadMetaBuilder,
+        private Security                    $security,
     ) {
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): MessageThreadMetaResource
     {
-        $entity = $this->messageThreadMetaRepository->find($uriVariables['id']);
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedException('Vous n\'êtes pas connecté.');
+        }
+
+        // The id is a uuid by route requirement, so nothing unconvertible reaches Doctrine here.
+        $entity = $this->messageThreadMetaRepository->findOneByIdAndUser((string) $uriVariables['id'], $user);
         if (!$entity instanceof MessageThreadMeta) {
             throw new NotFoundHttpException('Message thread meta introuvable');
         }

--- a/tests/Api/Message/MessageThreadGetTest.php
+++ b/tests/Api/Message/MessageThreadGetTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Message;
+
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class MessageThreadGetTest extends ApiTestCase
+{
+    public function test_an_id_that_is_not_a_uuid_is_not_a_server_error(): void
+    {
+        // The id reached Doctrine, which cannot convert it to a uuid and throws where nothing catches
+        // it: a 500 on a route any signed in person can reach. Requirement::UUID on the operation stops
+        // the route matching at all, and unlike the sibling PATCH there is no other route on this path
+        // to fall through to, so this one is a plain 404.
+        $user = UserFactory::new()->asBaseUser()->create(['username' => 'base_user_1', 'email' => 'base_user1@email.com']);
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/message_threads/not-a-uuid', [], [], ['HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+}

--- a/tests/Api/Message/MessageThreadMetaPatchTest.php
+++ b/tests/Api/Message/MessageThreadMetaPatchTest.php
@@ -8,6 +8,7 @@ use App\Tests\ApiTestCase;
 use App\Tests\Factory\Message\MessageThreadFactory;
 use App\Tests\Factory\Message\MessageThreadMetaFactory;
 use App\Tests\Factory\User\UserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -27,6 +28,8 @@ class MessageThreadMetaPatchTest extends ApiTestCase
             'is_deleted' => true, // shouldn't change anything
         ], ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']);
         $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        // Asserted in full so it stays byte for byte the same answer as the nonexistent id below.
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
     }
 
     public function test_patch_message_thread_meta(): void
@@ -109,5 +112,105 @@ class MessageThreadMetaPatchTest extends ApiTestCase
 
         $this->assertResponseIsSuccessful();
         $this->assertNull($messageMetaRepository->find($meta->id)->lastReadDatetime);
+    }
+
+    public function test_you_cannot_patch_somebody_elses_thread_meta(): void
+    {
+        $owner = UserFactory::new()->asBaseUser()->create(['username' => 'owner', 'email' => 'owner@email.com']);
+        $other = UserFactory::new()->asBaseUser()->create(['username' => 'other', 'email' => 'other@email.com']);
+        $meta = MessageThreadMetaFactory::new(['user' => $owner])->create();
+
+        $this->client->loginUser($other);
+        $this->client->jsonRequest('PATCH', '/api/message_thread_metas/' . $meta->id, [
+            'is_read' => true,
+        ], ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        // 404 rather than 403, matching MessageThreadItemProvider: a 403 confirms the row exists.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'description' => 'Message thread meta introuvable',
+            'detail' => 'Message thread meta introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+        ]);
+    }
+
+    public function test_somebody_elses_thread_meta_is_indistinguishable_from_one_that_does_not_exist(): void
+    {
+        // The ownership check has to run before validation, not after. It used to live in the
+        // processor, which runs last, so a body that failed validation against somebody else's row
+        // came back 422 while a row that did not exist came back 404: an existence oracle for any id.
+        $owner = UserFactory::new()->asBaseUser()->create(['username' => 'owner', 'email' => 'owner@email.com']);
+        $other = UserFactory::new()->asBaseUser()->create(['username' => 'other', 'email' => 'other@email.com']);
+        $meta = MessageThreadMetaFactory::new(['user' => $owner])->create();
+
+        $this->client->loginUser($other);
+        $this->client->jsonRequest('PATCH', '/api/message_thread_metas/' . $meta->id, [
+        ], ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'description' => 'Message thread meta introuvable',
+            'detail' => 'Message thread meta introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function idsThatAreNotUuids(): iterable
+    {
+        yield 'not a uuid at all' => ['not-a-uuid'];
+        // Thirty six characters of hex with no hyphens. It is the shape a looser
+        // `[0-9a-fA-F\-]{36}` requirement would wave through, and Ramsey rejects it, so Doctrine
+        // would throw converting it. Requirement::UUID pins the hyphens, the version and the variant.
+        yield 'hex of the right length but not a uuid' => [str_repeat('a', 36)];
+        yield 'the nil uuid' => ['00000000-0000-0000-0000-000000000000'];
+    }
+
+    #[DataProvider('idsThatAreNotUuids')]
+    public function test_an_id_that_is_not_a_uuid_is_not_a_server_error(string $id): void
+    {
+        // The column is a uuid, so an unconvertible value reached Doctrine and threw where nothing
+        // catches it: a 500 on a route any signed in person can reach. The route requirement now
+        // refuses to match, so the request never reaches the provider at all.
+        $user = UserFactory::new()->asBaseUser()->create(['username' => 'base_user_1', 'email' => 'base_user1@email.com']);
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest('PATCH', '/api/message_thread_metas/' . $id, [
+            'is_read' => true,
+        ], ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        // The requirement is declared on the resource rather than on the operation, and that is what
+        // makes this a 404. API Platform also generates an item GET route here so it can build `@id`
+        // IRIs; declared per operation, that shadow route kept no requirement, still matched, and the
+        // router answered 405 with a misleading `Allow: GET`. Declared on the resource, neither route
+        // matches and the answer is the same 404 as every other rejection on this endpoint.
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function test_anonymous_cannot_tell_an_id_that_exists_from_one_that_does_not(): void
+    {
+        // The other half of the oracle, and the half that needed no account at all: before the
+        // operation declared its own gate, an id that existed reached the processor and came back 401
+        // while one that did not stopped at the provider and came back 404.
+        UserFactory::new()->asBaseUser()->create(['username' => 'base_user_1', 'email' => 'base_user1@email.com']);
+
+        $this->client->jsonRequest('PATCH', '/api/message_thread_metas/11111111-2222-4333-8444-555555555555', [
+            'is_read' => true,
+        ], ['CONTENT_TYPE' => 'application/merge-patch+json', 'HTTP_ACCEPT' => 'application/ld+json']);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
     }
 }


### PR DESCRIPTION
Closes #958. Part of #948.

`MessageThreadMetaItemProvider` loaded a row by id and returned it, with no ownership check. The only check lived in `MessageThreadMetaPatchProcessor`, the one consumer, which runs last.

## What that actually cost, measured on master against the running app

| caller | id exists | id absent |
|---|---|---|
| anonymous | **401** | 404 |
| authenticated non owner, valid body | **403** | 404 |
| authenticated non owner, body that fails validation | **422** | 404 |
| malformed id, not a uuid | **500** | |
| owner | 200 | |

No row was ever readable or writable by somebody else: the processor's check did hold. What leaked is existence. The provider runs first and the validator runs second, so both answer before the check, and the differing statuses tell any caller whether a given `MessageThreadMeta` id exists. The ticket describes it as a loaded gun with the safety held by another class; the sharper problem is that the class holding it runs too late. Uuid4 ids make it hard to use, and it needed no account at all.

The 500 on a malformed id is separate and was on the same route.

## The fix, outermost layer first

1. `security: 'is_granted("IS_AUTHENTICATED_REMEMBERED")'` on the Patch operation. This is the only one of the two mechanisms that closes the anonymous asymmetry, because it runs before any id lookup at all.
2. `MessageThreadMetaRepository::findOneByIdAndUser()`, so ownership and existence are the same `WHERE id = ? AND user = ?` and there is no way to load somebody else's row through the method.
3. 404 for "not yours" and "does not exist" alike, matching the reasoning already written into `MessageThreadItemProvider`: a 403 confirms the row is there.
4. `requirements: ['id' => Requirement::UUID]` rather than a hand written guard, matching what `UserNotification` already does here. Symfony's constant pins the hyphens, the version and the variant, and it is a strict subset of what `Uuid::isValid()` accepts while `ramsey/uuid-doctrine` throws exactly when that is false, so a value that clears the route provably cannot fail Doctrine's conversion. That also makes the processor's own unguarded `find()` safe by construction rather than by luck.

   Declared on the **resource** rather than on the operation, and that placement is load bearing. API Platform also registers an item GET route on `/message_thread_metas/{id}` so the IRI converter has something to resolve `@id` against. Per operation, that shadow route kept no requirement, still matched the path, and the router answered a malformed id with 405 and an `Allow: GET` pointing at a route that answers 404 to everybody including the owner. On the resource, the requirement reaches the shadow route too, neither matches, and the answer is the same 404 as every other rejection on the endpoint.
5. The processor's ownership check kept as defence in depth. Its lookup is independent of the provider's, so a future operation wired to a different provider still lands on it.

The same one line requirement fixes the identical 500 on `GET /api/message_threads/{id}`, which is the sibling this fix borrows its 404 reasoning from. It was a loose end rather than scope creep, but say the word and I will split it.

## After, measured the same way

| caller | id exists | id absent |
|---|---|---|
| anonymous | 401 | 401 |
| authenticated non owner, any body | 404 | 404 |
| malformed id, Patch | 404 | |
| malformed id, `GET /message_threads/{id}` | 404 | |
| owner | 200 | 200 |

## Tests

- Two ownership tests. The one that matters sends a body that fails validation, because that is the case the old ordering got wrong: the check now runs before the validator.
- The anonymous pair, both asserted in full, so they are pinned as byte for byte identical rather than merely both 401.
- Malformed ids through a data provider, including thirty six characters of hex with no hyphens (the shape a looser `[0-9a-fA-F\-]{36}` requirement waves through and Ramsey rejects) and the nil uuid.
- Confirmed the two ownership tests fail when the scoped lookup is reverted.

2671 tests green, PHPStan level 8 clean.

## Noticed, not in scope

`GET /api/messages/{threadId}` has the identical shape one level up, on `MessageThread` existence rather than on `MessageThreadMeta`. Measured: an authenticated non participant on a thread that exists gets **403**, one that does not exist gets **404**, so the pair tells a caller whether a given thread id is real. One line to fix, and the answer is already written down next door in `MessageThreadItemProvider`.

`POST /api/messages` looked like it had the same problem and does not: the `thread` IRI resolves through `MessageThreadItemProvider`, which already answers 404 for a non participant, so both cases come back 404 before the processor runs.
