### PR TITLE
Messages: live delivery over Mercure for the existing inbox

### DIFF
--- a/assets/js/components/Message/Thread.vue
+++ b/assets/js/components/Message/Thread.vue
@@ -49,7 +49,7 @@
       <template v-else>
         <div
           v-for="message in messageStore.messages"
-          :key="message.id"
+          :key="message['@id']"
           class="flex"
           :class="{ 'justify-end': isSender(message) }"
         >
@@ -190,11 +190,30 @@ function scrollToBottom() {
   })
 }
 
-// Scroll to bottom when messages change
+/** Within a screenful of the end, which is close enough to count as following the conversation. */
+const FOLLOWING_THRESHOLD_PX = 120
+
+function isFollowingTheConversation() {
+  const container = messagesContainer.value
+  if (!container) {
+    return true
+  }
+
+  return (
+    container.scrollHeight - container.scrollTop - container.clientHeight < FOLLOWING_THRESHOLD_PX
+  )
+}
+
+// Scroll to bottom when messages change, unless the reader has gone back up. Messages now arrive on
+// their own (#989), so yanking the view to the bottom would interrupt somebody rereading history
+// rather than follow along with them. Read before the DOM updates, which is what a pre-flush watcher
+// gives us, so this is where the reader was rather than where the new content puts them.
 watch(
   () => messageStore.messages,
   () => {
-    scrollToBottom()
+    if (isFollowingTheConversation()) {
+      scrollToBottom()
+    }
   },
   { deep: true }
 )

--- a/assets/js/store/message/message.js
+++ b/assets/js/store/message/message.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, readonly, ref } from 'vue'
 import messageApi from '../../api/message/message.js'
 import { handleApiError } from '../../api/utils/handleApiError.js'
+import { isMessageAlreadyListed, messageSignalPlan } from '../../utils/messageSignal.js'
 import { useNotificationStore } from '../notification/notification.js'
 import { useUserSecurityStore } from '../user/security.js'
 
@@ -11,6 +12,16 @@ export const useMessageStore = defineStore('message', () => {
   const currentThreadId = ref(null)
   const currentThreadMetaId = ref(null)
   const isLoading = ref(false)
+  // Distinct from `threads.length`, which cannot tell "never opened the inbox" from "opened it and
+  // has no conversations yet". The second one still has to light up on a first ever message.
+  const hasLoadedThreads = ref(false)
+
+  // Both lists are replaced wholesale by their loader, so an older response landing after a newer one
+  // would put the stale version on screen and drop the message that just arrived. Signals arrive in
+  // bursts during an ordinary fast exchange, which is exactly when that happens. Same guard the band
+  // space stores use.
+  let threadsRequestId = 0
+  let messagesRequestId = 0
   const isLoadingMessages = ref(false)
   const isAddingMessage = ref(false)
 
@@ -26,16 +37,33 @@ export const useMessageStore = defineStore('message', () => {
     return threads.value.find((t) => t.thread.id === currentThreadId.value)
   })
 
-  async function loadThreads() {
-    isLoading.value = true
+  /**
+   * `silent` is for a refresh the user did not ask for (#989).
+   *
+   * The spinner replaces the whole list rather than sitting beside it, so toggling it on a live
+   * update makes the inbox disappear and come back every time somebody types. A background refresh
+   * also leaves the old data alone when it fails: blanking a list that is on screen because one
+   * request timed out is worse than showing something a few seconds stale.
+   */
+  async function loadThreads({ silent = false } = {}) {
+    const currentRequestId = ++threadsRequestId
+    if (!silent) {
+      isLoading.value = true
+    }
     try {
       const response = await messageApi.getThreads()
+      if (currentRequestId !== threadsRequestId) return
       threads.value = response.member || []
+      hasLoadedThreads.value = true
     } catch (e) {
       console.error('Failed to load threads:', e)
-      threads.value = []
+      if (!silent && currentRequestId === threadsRequestId) {
+        threads.value = []
+      }
     } finally {
-      isLoading.value = false
+      if (!silent && currentRequestId === threadsRequestId) {
+        isLoading.value = false
+      }
     }
   }
 
@@ -52,17 +80,26 @@ export const useMessageStore = defineStore('message', () => {
     }
   }
 
-  async function loadMessages(threadId) {
-    isLoadingMessages.value = true
+  /** Same rule as loadThreads(): a refresh nobody asked for neither blanks the pane nor wipes it. */
+  async function loadMessages(threadId, { silent = false } = {}) {
+    const currentRequestId = ++messagesRequestId
+    if (!silent) {
+      isLoadingMessages.value = true
+    }
     try {
       const response = await messageApi.getMessages({ threadId })
+      if (currentRequestId !== messagesRequestId) return
       // Reverse to show oldest first
       messages.value = (response.member || []).reverse()
     } catch (e) {
       console.error('Failed to load messages:', e)
-      messages.value = []
+      if (!silent && currentRequestId === messagesRequestId) {
+        messages.value = []
+      }
     } finally {
-      isLoadingMessages.value = false
+      if (!silent && currentRequestId === messagesRequestId) {
+        isLoadingMessages.value = false
+      }
     }
   }
 
@@ -100,7 +137,12 @@ export const useMessageStore = defineStore('message', () => {
     isAddingMessage.value = true
     try {
       const newMessage = await messageApi.postMessageInThread({ threadId, content })
-      messages.value.push(newMessage)
+      // The signal for this very message can arrive before this promise resolves, because the server
+      // publishes inside the send and answers afterwards. That refetch has already put the message in
+      // the list, so pushing it again would show it twice.
+      if (!isMessageAlreadyListed(messages.value, newMessage)) {
+        messages.value.push(newMessage)
+      }
 
       // Update last message in thread
       const thread = threads.value.find((t) => t.thread.id === threadId)
@@ -122,6 +164,40 @@ export const useMessageStore = defineStore('message', () => {
     return other?.participant || null
   }
 
+  /**
+   * A message landed somewhere in this user's threads (#989).
+   *
+   * The signal carries a thread id and nothing else, so what is on screen is refetched from the API
+   * rather than patched from the payload: no message content travels over the hub.
+   */
+  async function handleIncomingMessage(threadId) {
+    const openThreadId = currentThreadId.value
+    const plan = messageSignalPlan({
+      inboxLoaded: hasLoadedThreads.value,
+      signalThreadId: threadId,
+      openThreadId,
+      tabVisible: globalThis.document?.visibilityState === 'visible'
+    })
+
+    if (!plan.refreshInbox) {
+      return
+    }
+    // Silent: the user did not ask for this refresh and the panes should not blink.
+    await loadThreads({ silent: true })
+
+    if (!plan.refreshOpenThread) {
+      return
+    }
+    await loadMessages(openThreadId, { silent: true })
+
+    const threadMeta = plan.markRead
+      ? threads.value.find((t) => t.thread.id === openThreadId)
+      : null
+    if (threadMeta && threadMeta.unread_count > 0) {
+      await markAsRead(threadMeta.id)
+    }
+  }
+
   function clearCurrentThread() {
     currentThreadId.value = null
     currentThreadMetaId.value = null
@@ -141,6 +217,7 @@ export const useMessageStore = defineStore('message', () => {
     currentThreadId: readonly(currentThreadId),
     currentThreadMetaId: readonly(currentThreadMetaId),
     isLoading: readonly(isLoading),
+    hasLoadedThreads: readonly(hasLoadedThreads),
     isLoadingMessages: readonly(isLoadingMessages),
     isAddingMessage: readonly(isAddingMessage),
     orderedThreads,
@@ -149,6 +226,7 @@ export const useMessageStore = defineStore('message', () => {
     selectThread,
     postMessage,
     postMessageInThread,
+    handleIncomingMessage,
     getOtherParticipant,
     clearCurrentThread,
     reset

--- a/assets/js/store/notification/userNotification.js
+++ b/assets/js/store/notification/userNotification.js
@@ -2,7 +2,9 @@ import { defineStore } from 'pinia'
 import { readonly, ref, watch } from 'vue'
 import userNotificationApi from '../../api/notification/userNotification.js'
 import { createNotificationStream, notificationTopic } from '../../utils/notificationStream.js'
+import { useMessageStore } from '../message/message.js'
 import { useUserSecurityStore } from '../user/security.js'
+import { useNotificationStore } from './notification.js'
 
 export const useUserNotificationStore = defineStore('userNotification', () => {
   // Bell dropdown feed (latest page only).
@@ -114,7 +116,20 @@ export const useUserNotificationStore = defineStore('userNotification', () => {
 
       return userId ? [notificationTopic(userId)] : []
     },
-    onSignal: () => loadCount(),
+    onSignal: (payload) => {
+      // One topic, two kinds of update, so the payload's own type says which. A null payload is a
+      // reconnect, where anything published while we were down is gone for good: refresh both.
+      const type = payload?.type ?? null
+      if (type === null || type === 'notification') {
+        loadCount()
+      }
+      if (type === null || type === 'message') {
+        // The navbar count, which is live even for somebody who never opens the inbox, and then the
+        // inbox itself, which no-ops when it was never opened.
+        useNotificationStore().loadNotifications()
+        useMessageStore().handleIncomingMessage(payload?.thread_id ?? null)
+      }
+    },
     onAuthRefreshNeeded: () => useUserSecurityStore().checkAuthInfo()
   })
 

--- a/assets/js/utils/messageSignal.js
+++ b/assets/js/utils/messageSignal.js
@@ -1,0 +1,46 @@
+/**
+ * What a live message signal should make the inbox do (#989).
+ *
+ * Separated from the store so the policy can be tested without a Pinia harness and an API double.
+ * The store does the fetching; this decides what is worth fetching.
+ */
+export function messageSignalPlan({ inboxLoaded, signalThreadId, openThreadId, tabVisible }) {
+  // Never opened, so there is nothing on screen to refresh. Without this a signal would fetch the
+  // thread list for somebody who is reading the forum.
+  if (!inboxLoaded) {
+    return { refreshInbox: false, refreshOpenThread: false, markRead: false }
+  }
+
+  // A null id is a reconnect, or a body we could not read: we know something was missed but not
+  // what, so anything on screen is stale until proven otherwise. Naming a different thread is the
+  // only case where the open conversation is known not to have changed.
+  const isTheThreadOnScreen =
+    Boolean(openThreadId) && (!signalThreadId || signalThreadId === openThreadId)
+
+  return {
+    refreshInbox: true,
+    refreshOpenThread: isTheThreadOnScreen,
+    // Only when the tab is in front. A message arriving on a thread left open in a background tab
+    // has not been seen by anybody, and marking it read would make the unread count lie.
+    markRead: isTheThreadOnScreen && tabVisible
+  }
+}
+
+/**
+ * Is this message already on screen?
+ *
+ * The sender's own signal can beat their own POST response back, because the server publishes inside
+ * the send and answers afterwards, so the refetch it triggers can already have added the message.
+ *
+ * Matched on `@id`, which API Platform emits whatever the serialization groups say, unlike `id`,
+ * which the message collection does not carry. A message without one is treated as new: pushing a
+ * duplicate is recoverable on the next refetch, silently swallowing somebody's message is not.
+ */
+export function isMessageAlreadyListed(messages, message) {
+  const iri = message?.['@id']
+  if (!iri) {
+    return false
+  }
+
+  return messages.some((listed) => listed['@id'] === iri)
+}

--- a/assets/js/utils/messageSignal.test.js
+++ b/assets/js/utils/messageSignal.test.js
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { isMessageAlreadyListed, messageSignalPlan } from './messageSignal.js'
+
+describe('messageSignalPlan', () => {
+  it('does nothing when the inbox was never opened', () => {
+    assert.deepEqual(
+      messageSignalPlan({
+        inboxLoaded: false,
+        signalThreadId: 'a-thread',
+        openThreadId: 'a-thread',
+        tabVisible: true
+      }),
+      { refreshInbox: false, refreshOpenThread: false, markRead: false }
+    )
+  })
+
+  it('refreshes the list but not the messages when the signal is for another thread', () => {
+    assert.deepEqual(
+      messageSignalPlan({
+        inboxLoaded: true,
+        signalThreadId: 'another-thread',
+        openThreadId: 'the-open-one',
+        tabVisible: true
+      }),
+      { refreshInbox: true, refreshOpenThread: false, markRead: false }
+    )
+  })
+
+  it('refreshes the messages when the signal is for the thread on screen', () => {
+    assert.deepEqual(
+      messageSignalPlan({
+        inboxLoaded: true,
+        signalThreadId: 'the-open-one',
+        openThreadId: 'the-open-one',
+        tabVisible: true
+      }),
+      { refreshInbox: true, refreshOpenThread: true, markRead: true }
+    )
+  })
+
+  it('leaves a message unread when the tab is in the background', () => {
+    // The thread is open, but nobody is looking at it. Marking it read here is the difference
+    // between an unread count that means something and one that does not.
+    assert.deepEqual(
+      messageSignalPlan({
+        inboxLoaded: true,
+        signalThreadId: 'the-open-one',
+        openThreadId: 'the-open-one',
+        tabVisible: false
+      }),
+      { refreshInbox: true, refreshOpenThread: true, markRead: false }
+    )
+  })
+
+  it('refreshes the open thread too when a reconnect leaves us without a thread id', () => {
+    // A recovered connection carries no payload, so we know something was missed but not what.
+    // Refreshing the list and leaving the conversation on screen stale is the worst of both.
+    assert.deepEqual(
+      messageSignalPlan({
+        inboxLoaded: true,
+        signalThreadId: null,
+        openThreadId: 'the-open-one',
+        tabVisible: true
+      }),
+      { refreshInbox: true, refreshOpenThread: true, markRead: true }
+    )
+  })
+
+  it('refreshes only the list on a reconnect when no conversation is open', () => {
+    assert.deepEqual(
+      messageSignalPlan({
+        inboxLoaded: true,
+        signalThreadId: null,
+        openThreadId: null,
+        tabVisible: true
+      }),
+      { refreshInbox: true, refreshOpenThread: false, markRead: false }
+    )
+  })
+
+  it('lights up a first ever conversation, where the list loaded and was empty', () => {
+    // `threads.length > 0` would have read this as "never opened" and done nothing, so somebody's
+    // very first message would not have appeared.
+    assert.deepEqual(
+      messageSignalPlan({
+        inboxLoaded: true,
+        signalThreadId: 'a-brand-new-thread',
+        openThreadId: null,
+        tabVisible: true
+      }),
+      { refreshInbox: true, refreshOpenThread: false, markRead: false }
+    )
+  })
+})
+
+describe('isMessageAlreadyListed', () => {
+  const listed = [{ '@id': '/api/messages/one' }, { '@id': '/api/messages/two' }]
+
+  it('recognises a message the refetch already added', () => {
+    assert.equal(isMessageAlreadyListed(listed, { '@id': '/api/messages/two' }), true)
+  })
+
+  it('does not recognise one that is genuinely new', () => {
+    assert.equal(isMessageAlreadyListed(listed, { '@id': '/api/messages/three' }), false)
+  })
+
+  it('treats an empty conversation as having nothing in it', () => {
+    assert.equal(isMessageAlreadyListed([], { '@id': '/api/messages/one' }), false)
+  })
+
+  it('treats a message with no identifier as new rather than as a duplicate', () => {
+    // Matching on two undefined identifiers would swallow every message after the first. Showing one
+    // twice is recoverable on the next refetch; dropping somebody's message is not.
+    assert.equal(isMessageAlreadyListed([{}], {}), false)
+  })
+})

--- a/assets/js/utils/notificationStream.js
+++ b/assets/js/utils/notificationStream.js
@@ -7,8 +7,8 @@ import { reconnectDelay } from './realtimeBackoff.js'
  * failure modes, can be driven by a test with a fake `EventSource` and fake timers. The store keeps
  * the state; this keeps the connection.
  *
- * The server publishes a tag, not a notification, so nothing here reads the event body: a message
- * means "refetch", and the refetching is the store's job.
+ * The server publishes a tag, not the thing that changed, so the body is only ever a discriminator:
+ * this parses it and hands it over, and the refetching is the store's job.
  *
  * Topics are a list because Mercure multiplexes: one connection carries as many `topic=` parameters
  * as you give it, and opening a second EventSource per topic would cost a second hub subscriber and
@@ -30,6 +30,20 @@ export function notificationTopic(userId) {
   return `/users/${userId}/notifications`
 }
 
+/**
+ * A body we cannot read becomes null, which callers treat as "refetch everything". Refetching too
+ * much is the safe failure here, and throwing out of onmessage would take the handler with it.
+ */
+function parsePayload(data) {
+  try {
+    const parsed = JSON.parse(data)
+
+    return parsed !== null && typeof parsed === 'object' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
 /** Path of the hub, fixed by the Mercure protocol and by `public_url` in config/packages/mercure.yaml. */
 const HUB_PATH = '/.well-known/mercure'
 
@@ -40,7 +54,9 @@ const FAILURES_PER_AUTH_REFRESH = 3
  * @param {object} deps
  * @param {() => string[]} deps.getTopics the topics to subscribe to, read at connect time rather
  *   than captured, because they depend on a profile that arrives after authentication does
- * @param {() => void} deps.onSignal something changed, go and refetch
+ * @param {(payload: object | null) => void} deps.onSignal something changed, go and refetch. The
+ *   payload is the update's own body, or null when we cannot know what changed: on reconnect, and on
+ *   a body that does not parse. Null means refetch everything.
  * @param {() => Promise<unknown>} deps.onAuthRefreshNeeded renew credentials, best effort
  * @param {(url: string) => EventSource} [deps.openStream] injected for tests
  * @param {{ set: Function, clear: Function }} [deps.timers] injected for tests
@@ -84,13 +100,13 @@ export function createNotificationStream({
       // much history the transport keeps. Refetching on recovery is what closes that gap, and a
       // deploy restart is exactly when it opens, for every subscriber at once.
       if (failures > 0) {
-        onSignal()
+        onSignal(null)
       }
       failures = 0
     }
 
-    stream.onmessage = () => {
-      onSignal()
+    stream.onmessage = (event) => {
+      onSignal(parsePayload(event.data))
     }
 
     stream.onerror = () => {

--- a/assets/js/utils/notificationStream.test.js
+++ b/assets/js/utils/notificationStream.test.js
@@ -54,11 +54,12 @@ function fakeTimers() {
 
 function build(overrides = {}) {
   const timers = fakeTimers()
-  const calls = { signals: 0, authRefreshes: 0 }
+  const calls = { signals: 0, authRefreshes: 0, payloads: [] }
   const stream = createNotificationStream({
     getTopics: () => ['/users/a-user-id/notifications'],
-    onSignal: () => {
+    onSignal: (payload) => {
       calls.signals += 1
+      calls.payloads.push(payload)
     },
     onAuthRefreshNeeded: () => {
       calls.authRefreshes += 1
@@ -143,7 +144,7 @@ describe('createNotificationStream', () => {
     assert.equal(FakeEventSource.opened.length, 1)
   })
 
-  it('refetches on a message without reading the event', () => {
+  it('refetches on every message the hub sends', () => {
     const { stream, calls } = build()
     stream.connect()
 
@@ -324,5 +325,38 @@ describe('createNotificationStream', () => {
     await settle()
 
     assert.equal(FakeEventSource.opened.length, 3)
+  })
+})
+
+describe('the payload handed to onSignal', () => {
+  it('is the parsed body, because one topic now carries more than one kind of update', () => {
+    const { stream, calls } = build()
+    stream.connect()
+
+    FakeEventSource.opened[0].onmessage({ data: '{"type":"message","thread_id":"a-thread-id"}' })
+
+    assert.deepEqual(calls.payloads, [{ type: 'message', thread_id: 'a-thread-id' }])
+  })
+
+  it('is null when the body does not parse, so the caller refetches everything', () => {
+    // Refetching too much is the safe failure. Throwing out of onmessage would take the handler with
+    // it and the stream would look healthy while delivering nothing.
+    const { stream, calls } = build()
+    stream.connect()
+
+    FakeEventSource.opened[0].onmessage({ data: 'not json' })
+    FakeEventSource.opened[0].onmessage({ data: '"a string, not an object"' })
+
+    assert.deepEqual(calls.payloads, [null, null])
+  })
+
+  it('is null on a recovered connection, where we cannot know what was missed', () => {
+    const { stream, timers, calls } = build()
+    stream.connect()
+    FakeEventSource.opened[0].onerror()
+    timers.runAll()
+    FakeEventSource.opened.at(-1).onopen()
+
+    assert.deepEqual(calls.payloads, [null])
   })
 })

--- a/src/Event/MessagePostedEvent.php
+++ b/src/Event/MessagePostedEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event;
+
+use App\Entity\Message\Message;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * A message exists. Dispatched once per message, always, unlike MessageSentEvent, which is dispatched
+ * per recipient and only when the email throttle says somebody should be emailed.
+ *
+ * Listeners swallow their own failures. This is dispatched before the email events so a dead mailer
+ * cannot take the live update with it, and a listener that throws here would invert that.
+ */
+class MessagePostedEvent extends Event
+{
+    public function __construct(
+        public readonly Message $message,
+    ) {
+    }
+}

--- a/src/EventSubscriber/MessagePostedListener.php
+++ b/src/EventSubscriber/MessagePostedListener.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\Message\Message;
+use App\Event\MessagePostedEvent;
+use App\Mercure\MercureTopic;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+
+/**
+ * Tells every participant's browser that the thread changed.
+ */
+#[AsEventListener]
+readonly class MessagePostedListener
+{
+    public function __construct(
+        private HubInterface $hub,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(MessagePostedEvent $event): void
+    {
+        $message = $event->message;
+        $topics = [];
+        foreach ($message->thread->messageParticipants as $participant) {
+            // The sender included, so a send from their laptop still updates their phone. Their own
+            // tab pays one idempotent refetch for that.
+            $topics[] = MercureTopic::userNotifications((string) $participant->participant->id);
+        }
+
+        if ($topics === []) {
+            return;
+        }
+
+        try {
+            // A tag, not the message. The browser refetches through the API it already uses, so no
+            // message content ever travels this way and nothing here becomes a second place that
+            // renders it. `private` is the whole of the authorization: the hub consults subscriber
+            // topic selectors only for private updates.
+            $this->hub->publish(new Update($topics, self::tagFor($message), private: true));
+        } catch (\Throwable $throwable) {
+            $this->logger->error('Could not publish a message signal, the inbox will update on its next load', [
+                'exception' => $throwable,
+                'thread_id' => (string) $message->thread->id,
+            ]);
+        }
+    }
+
+    /**
+     * The thread id is here so a browser can tell the conversation it is looking at from any other and
+     * skip refetching messages it is not showing.
+     */
+    private static function tagFor(Message $message): string
+    {
+        return json_encode(
+            ['type' => 'message', 'thread_id' => (string) $message->thread->id],
+            JSON_THROW_ON_ERROR,
+        );
+    }
+}

--- a/src/Service/Builder/Message/MessageParticipantDirector.php
+++ b/src/Service/Builder/Message/MessageParticipantDirector.php
@@ -11,8 +11,11 @@ class MessageParticipantDirector
     public function create(MessageThread $thread, User $participant): MessageParticipant
     {
         $messageParticipant = new MessageParticipant();
-        $messageParticipant->thread = $thread;
         $messageParticipant->participant = $participant;
+        // Through the thread, so the in-memory collection matches what was persisted. Setting only
+        // `$messageParticipant->thread` is enough for Doctrine, and leaves anything that reads
+        // `$thread->messageParticipants` later in the same request seeing an empty thread.
+        $thread->addMessageParticipant($messageParticipant);
 
         return $messageParticipant;
     }

--- a/src/Service/Procedure/Message/MessageSenderProcedure.php
+++ b/src/Service/Procedure/Message/MessageSenderProcedure.php
@@ -6,6 +6,7 @@ use App\Entity\Message\Message;
 use App\Entity\Message\MessageThread;
 use App\Entity\Message\MessageThreadMeta;
 use App\Entity\User;
+use App\Event\MessagePostedEvent;
 use App\Event\MessageSentEvent;
 use App\Repository\Message\MessageThreadMetaRepository;
 use App\Repository\Message\MessageThreadRepository;
@@ -93,9 +94,7 @@ class MessageSenderProcedure
         // for a message that failed to persist. The throttle decision +
         // pending-flag flip already happened inside the transaction above,
         // so the listener is now a pure email sender.
-        foreach ($eventsToDispatch as $event) {
-            $this->eventDispatcher->dispatch($event);
-        }
+        $this->signalAndNotify($message, $eventsToDispatch);
 
         return $message;
     }
@@ -122,11 +121,33 @@ class MessageSenderProcedure
 
         // Same rule as process(): only emit notifications once the message is
         // actually persisted, never before.
-        foreach ($eventsToDispatch as $event) {
-            $this->eventDispatcher->dispatch($event);
-        }
+        $this->signalAndNotify($message, $eventsToDispatch);
 
         return $message;
+    }
+
+    /**
+     * The live signal first, then the emails, and the order is not cosmetic.
+     *
+     * Everybody in the thread is signalled whatever the email throttle decided: it is unconditional
+     * where MessageSentEvent is not, and its "recently active in the last five minutes" rule excludes
+     * exactly the person sitting in the conversation.
+     *
+     * Going second would also make the signal hostage to the email. An email listener that throws
+     * propagates out of here, and dispatching the emails first meant one failing provider took the
+     * live update with it: measured against a provider that was genuinely refusing us, the send was a
+     * 500 and no subscriber received anything. The signal is local, cheap and swallows its own
+     * failures, so it goes first and the slow remote thing goes after.
+     *
+     * @param MessageSentEvent[] $emailEvents
+     */
+    private function signalAndNotify(Message $message, array $emailEvents): void
+    {
+        $this->eventDispatcher->dispatch(new MessagePostedEvent($message));
+
+        foreach ($emailEvents as $event) {
+            $this->eventDispatcher->dispatch($event);
+        }
     }
 
     /**

--- a/tests/Integration/Message/MessagePostedSignalTest.php
+++ b/tests/Integration/Message/MessagePostedSignalTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Message;
+
+use App\Event\MessageSentEvent;
+use App\Mercure\MercureTopic;
+use App\Repository\Message\MessageRepository;
+use App\Service\Procedure\Message\MessageSenderProcedure;
+use App\Tests\Double\RecordingHub;
+use App\Tests\Factory\Message\MessageParticipantFactory;
+use App\Tests\Factory\Message\MessageThreadFactory;
+use App\Tests\Factory\Message\MessageThreadMetaFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class MessagePostedSignalTest extends KernelTestCase
+{
+    public function test_sending_signals_every_participant_including_the_sender(): void
+    {
+        self::bootKernel();
+        $hub = self::getContainer()->get(RecordingHub::class);
+
+        $sender = UserFactory::new()->asBaseUser()->create(['username' => 'sender', 'email' => 'sender@test.com']);
+        $first = UserFactory::new()->asBaseUser()->create(['username' => 'first', 'email' => 'first@test.com']);
+        $second = UserFactory::new()->asBaseUser()->create(['username' => 'second', 'email' => 'second@test.com']);
+        $thread = $this->threadWith($sender, $first, $second);
+
+        self::getContainer()->get(MessageSenderProcedure::class)->processByThread($thread, $sender, 'hello');
+
+        // The sender too: a send from the laptop has to update the same person's phone.
+        self::assertSame(
+            [
+                MercureTopic::userNotifications((string) $sender->id),
+                MercureTopic::userNotifications((string) $first->id),
+                MercureTopic::userNotifications((string) $second->id),
+            ],
+            $hub->publishedTopics()
+        );
+
+        $update = $hub->updates[0];
+        // Without this the hub stops consulting subscriber topic selectors and hands the signal to
+        // every connected browser, whatever their token says.
+        self::assertTrue($update->isPrivate());
+        // A tag, not the message: no content travels over the hub, so nothing here renders it.
+        self::assertSame(
+            '{"type":"message","thread_id":"' . $thread->id . '"}',
+            $update->getData()
+        );
+    }
+
+    public function test_the_signal_does_not_depend_on_the_email_throttle(): void
+    {
+        // MessageSentEvent is dispatched only when shouldNotify() agrees, and one of its rules skips
+        // anybody active in the last five minutes. That is exactly the person looking at the thread,
+        // so reusing it would have starved the live update of the case it exists for.
+        self::bootKernel();
+        $hub = self::getContainer()->get(RecordingHub::class);
+
+        $sender = UserFactory::new()->asBaseUser()->create(['username' => 'sender', 'email' => 'sender@test.com']);
+        $recipient = UserFactory::new()->asBaseUser()->create([
+            'username' => 'recipient',
+            'email' => 'recipient@test.com',
+            'lastActivityDatetime' => new \DateTimeImmutable(),
+        ]);
+        $thread = $this->threadWith($sender, $recipient);
+
+        self::getContainer()->get(MessageSenderProcedure::class)->processByThread($thread, $sender, 'hello');
+
+        self::assertCount(1, $hub->updates);
+        self::assertContains(
+            MercureTopic::userNotifications((string) $recipient->id),
+            $hub->publishedTopics()
+        );
+    }
+
+    public function test_starting_a_conversation_signals_the_recipient_too(): void
+    {
+        // The other entry point, and the one that matters most for the inbox: the thread is brand new,
+        // so the recipient has no row to update and has to pick up a whole new one.
+        self::bootKernel();
+        $hub = self::getContainer()->get(RecordingHub::class);
+
+        $sender = UserFactory::new()->asBaseUser()->create(['username' => 'sender', 'email' => 'sender@test.com']);
+        $recipient = UserFactory::new()->asBaseUser()->create(['username' => 'recipient', 'email' => 'recipient@test.com']);
+
+        self::getContainer()->get(MessageSenderProcedure::class)->process($sender, $recipient, 'hello');
+
+        self::assertContains(
+            MercureTopic::userNotifications((string) $recipient->id),
+            $hub->publishedTopics()
+        );
+    }
+
+    public function test_an_unreachable_hub_still_leaves_the_message_sent(): void
+    {
+        // The message is the thing that matters. Losing the live update costs a refresh; losing the
+        // message would lose it for good, and a hub is a side channel that must never fail a send.
+        self::bootKernel();
+        $container = self::getContainer();
+        $container->set(RecordingHub::class, new ThrowingHub());
+
+        $sender = UserFactory::new()->asBaseUser()->create(['username' => 'sender', 'email' => 'sender@test.com']);
+        $recipient = UserFactory::new()->asBaseUser()->create(['username' => 'recipient', 'email' => 'recipient@test.com']);
+        $thread = $this->threadWith($sender, $recipient);
+
+        $message = $container->get(MessageSenderProcedure::class)->processByThread($thread, $sender, 'hello');
+
+        self::assertNotNull(
+            $container->get(MessageRepository::class)->find($message->id),
+            'A hub that is down must not take the message with it'
+        );
+    }
+
+    public function test_an_email_that_fails_does_not_take_the_live_signal_with_it(): void
+    {
+        // Found in dev against a provider that was genuinely refusing us: with the emails dispatched
+        // first, one failing send meant a 500 and not a single subscriber heard anything. The signal
+        // is local and swallows its own failures, so it goes first.
+        self::bootKernel();
+        $container = self::getContainer();
+        $hub = $container->get(RecordingHub::class);
+        $container->get(EventDispatcherInterface::class)->addListener(
+            MessageSentEvent::class,
+            static fn () => throw new \RuntimeException('the email provider is down'),
+        );
+
+        $sender = UserFactory::new()->asBaseUser()->create(['username' => 'sender', 'email' => 'sender@test.com']);
+        $recipient = UserFactory::new()->asBaseUser()->create(['username' => 'recipient', 'email' => 'recipient@test.com']);
+        $thread = $this->threadWith($sender, $recipient);
+
+        try {
+            $container->get(MessageSenderProcedure::class)->processByThread($thread, $sender, 'hello');
+            self::fail('the email listener was supposed to throw');
+        } catch (\RuntimeException) {
+            // The email failure still surfaces, which is pre-existing behaviour and not what this pins.
+        }
+
+        self::assertContains(
+            MercureTopic::userNotifications((string) $recipient->id),
+            $hub->publishedTopics(),
+            'The live signal must be published before anything that can fail'
+        );
+    }
+
+    private function threadWith(\App\Entity\User ...$participants): \App\Entity\Message\MessageThread
+    {
+        $thread = MessageThreadFactory::new()->create();
+        foreach ($participants as $participant) {
+            MessageParticipantFactory::new(['thread' => $thread, 'participant' => $participant])->create();
+            MessageThreadMetaFactory::new([
+                'thread' => $thread,
+                'user' => $participant,
+                'lastReadDatetime' => null,
+            ])->create();
+        }
+
+        return $thread;
+    }
+}
+
+final class ThrowingHub implements \Symfony\Component\Mercure\HubInterface
+{
+    public function publish(\Symfony\Component\Mercure\Update $update): string
+    {
+        throw new \RuntimeException('the hub is down');
+    }
+
+    public function getPublicUrl(): string
+    {
+        return '/.well-known/mercure';
+    }
+
+    public function getFactory(): ?\Symfony\Component\Mercure\Jwt\TokenFactoryInterface
+    {
+        return null;
+    }
+
+    public function getProtocolVersion(): \Symfony\Component\Mercure\ProtocolVersion
+    {
+        return \Symfony\Component\Mercure\ProtocolVersion::Legacy;
+    }
+
+    public function getCookieName(): string
+    {
+        return 'mercureAuthorization';
+    }
+}


### PR DESCRIPTION
Closes #989. Part of #948.

The direct message feature had no live updates **and no polling either**: no `setInterval` and no `EventSource` anywhere under `assets/js/store/message`, `assets/js/views/Message` or `assets/js/components/Message`. Somebody sitting in a conversation received nothing until they navigated away and came back, which is behind where the notification bell was before #950.

It was never planned. #963 is scoped to the Band Space channel and depends on D3, and the existing inbox appears only in track C, which is schema prep. It needs none of the channel's authorization work: the per user topic already exists and is already authorized by the subscriber cookie.

## Publishing

A new `MessagePostedEvent`, dispatched unconditionally after the transaction commits, from **both** entry points. `process()` matters as much as `processByThread()`: a first message creates a thread the recipient has never seen, so their inbox has to pick up a new row rather than update one.

It deliberately does not reuse `MessageSentEvent`. Both of that event's dispatch sites sit inside `if ($this->shouldNotify(...))`, so it is gated by the one email per unread streak throttle and by a rule that skips anybody active in the last five minutes, which is exactly the person with the thread open. A test is built to fail under the naive "just reuse it" approach.

`MessagePostedListener` publishes one update to every participant's existing per user topic, **the sender included** so a send from the laptop updates the same person's phone, with `private: true` and a tag rather than content: `{"type":"message","thread_id":"..."}`. No message body travels over the hub, so nothing here becomes a second place that renders user content. A hub that is down never fails a send, and that is tested by removing the try/catch and watching the test fail.

**The signal is published before the emails, and that order is load bearing.** An email listener that throws propagates out of the procedure, so with the emails first, one failing provider took the live update with it. Measured in dev against a provider that genuinely refuses this machine: the send was a 500 and not one subscriber heard anything. The signal is local, cheap, and swallows its own failures, so it goes first and the slow remote thing goes after. Pinned by a test that registers a throwing listener on `MessageSentEvent`.

## Subscribing

`notificationStream.js` now parses the update body and hands it to `onSignal`, because one topic carries two kinds of update. Its own docblock had already named the mechanism. A body that does not parse, and a reconnect, both yield `null`, which means "refetch everything": refetching too much is the safe failure, and throwing out of `onmessage` would take the handler with it.

Three surfaces, one ping:

| surface | on `type === 'message'` |
|---|---|
| navbar count | `loadNotifications()` |
| inbox list | `loadThreads()`, which fixes the preview, the unread badge and the ordering together |
| open conversation | `loadMessages()`, only when the signal names the thread on screen |

The decision lives in `assets/js/utils/messageSignal.js`, a pure function with seven tests, because this project tests utils rather than stores and the visibility rule deserved to be provable rather than merely written down. **Marking read happens only when `document.visibilityState === 'visible'`**: a message arriving on a thread left open in a background tab has not been seen by anybody, and marking it read would make the unread count lie.

## Refreshing without blinking

The `ProgressSpinner` in `Index.vue` and `Thread.vue` **replaces** its whole pane rather than sitting beside it, so a live refresh was blanking the inbox or the conversation every time somebody typed. `loadThreads()` and `loadMessages()` now take a `silent` option that skips the loading flag, and that also leaves the data on screen alone when the request fails: blanking a list because one background request timed out is worse than showing something a few seconds stale.

The scroll watcher now only follows the conversation when the reader is already within a screenful of the end. Messages arrive on their own now, so the old unconditional `scrollToBottom()` would have interrupted somebody rereading history.

Both loaders also carry a request sequence guard, the same one the band space stores use. They replace their list wholesale, and signals arrive in bursts during an ordinary fast exchange, so without it an older response landing after a newer one would put the stale version on screen and drop the message that had just arrived.

## Two pre-existing bugs this work depends on

- **`MessageParticipantDirector::create()` set only the owning side**, so `$thread->messageParticipants` stayed empty in memory for the rest of the request that created the thread. Nothing had ever read it there, so nothing had noticed; the listener was the first, and `process()` therefore signalled nobody until a test caught it. It now goes through the entity's own `addMessageParticipant()` helper, which was already there and unused.
- **`Thread.vue` keyed its list on `message.id`**, but `MessageResource::$id` is only in the `ITEM` group, so the messages collection carries no `id` and every row was keyed `undefined`. Broken diffing, which is exactly what makes a repeated full array replace flash. Changed to `message['@id']`, which API Platform emits regardless of serialization groups, rather than widening the `LIST` group and taking on another metadata cache deploy hazard.

## Verified

- 2676 PHP tests, PHPStan level 8 clean, Biome exit 0, 620 JS tests, build clean.
- End to end against the real hub: subscribed as one user with curl, sent as the other, and the frame arrived. Repeated with the mailer failing, to prove the reordering.

## Not in scope, and #963 should not inherit it

Every message pings every participant and the handler refetches the whole thread list. That is fine for two people and will not be for a channel, which also derives membership from `BandSpaceMembership` rather than from `MessageParticipant` rows, so the listener's topic derivation has to change there anyway.
