### PR TITLE
Messages: index the thread listing and make history reachable

### DIFF
--- a/assets/js/api/message/message.js
+++ b/assets/js/api/message/message.js
@@ -49,12 +49,15 @@ export default {
   },
 
   /**
-   * Get messages for a specific thread
+   * Get a page of messages for a thread, newest first. Page 1 is the newest, so paging up is paging
+   * backwards through the conversation.
    */
-  getMessages({ threadId }) {
+  getMessages({ threadId, page = 1 }) {
     return axios
       .get(Routing.generate('api_message_get_collection', { threadId }), {
-        params: { 'order[creation_datetime]': 'desc' }
+        // `order[id]` is the tiebreak, not a preference: the timestamp is second granular, and a tied
+        // row with no total order can land on both sides of a page boundary or on neither.
+        params: { 'order[creation_datetime]': 'desc', 'order[id]': 'desc', page }
       })
       .then((resp) => resp.data)
   },

--- a/assets/js/components/Message/Thread.vue
+++ b/assets/js/components/Message/Thread.vue
@@ -48,6 +48,27 @@
 
       <template v-else>
         <div
+          v-if="messageStore.hasOlderMessages"
+          class="flex justify-center"
+        >
+          <Button
+            label="Charger les messages plus anciens"
+            severity="secondary"
+            outlined
+            size="small"
+            :loading="messageStore.isLoadingOlderMessages"
+            @click="handleLoadOlder"
+          />
+        </div>
+        <Message
+          v-if="messageStore.loadOlderError"
+          severity="error"
+          :closable="false"
+        >
+          {{ messageStore.loadOlderError }}
+        </Message>
+
+        <div
           v-for="message in messageStore.messages"
           :key="message['@id']"
           class="flex"
@@ -204,14 +225,54 @@ function isFollowingTheConversation() {
   )
 }
 
+/**
+ * Loading history keeps the reader where they were.
+ *
+ * Prepending grows the list upwards, so without compensating, the message being read slides down by
+ * however tall the new page is. Measured either side of the DOM update and the difference added back
+ * to the offset, which is the whole trick.
+ */
+async function handleLoadOlder() {
+  const container = messagesContainer.value
+  const previousScrollHeight = container?.scrollHeight ?? 0
+  const previousScrollTop = container?.scrollTop ?? 0
+
+  await messageStore.loadOlderMessages()
+  await nextTick()
+
+  if (container) {
+    container.scrollTop = previousScrollTop + (container.scrollHeight - previousScrollHeight)
+  }
+}
+
 // Scroll to bottom when messages change, unless the reader has gone back up. Messages now arrive on
 // their own (#989), so yanking the view to the bottom would interrupt somebody rereading history
 // rather than follow along with them. Read before the DOM updates, which is what a pre-flush watcher
 // gives us, so this is where the reader was rather than where the new content puts them.
+//
+// Only when the list grew at its *end*. A conversation shorter than its pane has nothing to scroll,
+// so isFollowingTheConversation() is trivially true there, and loading history into it would jump to
+// the bottom having just been asked for the top. The last message's identity says which end moved.
+//
+// Reset per thread, because this component is not remounted when you switch conversation: the
+// messages route renders through AppBaseLayout's router-view, which carries no `:key`, unlike the
+// band space layout. Without this, arriving back at a thread whose last message has not changed since
+// you left would read as "nothing grew" and suppress the scroll to the bottom.
+let lastTailIri = null
+watch(
+  () => messageStore.currentThreadId,
+  () => {
+    lastTailIri = null
+  }
+)
 watch(
   () => messageStore.messages,
-  () => {
-    if (isFollowingTheConversation()) {
+  (currentMessages) => {
+    const tailIri = currentMessages.at(-1)?.['@id'] ?? null
+    const grewAtTheEnd = tailIri !== lastTailIri
+    lastTailIri = tailIri
+
+    if (grewAtTheEnd && isFollowingTheConversation()) {
       scrollToBottom()
     }
   },

--- a/assets/js/store/message/message.js
+++ b/assets/js/store/message/message.js
@@ -2,6 +2,11 @@ import { defineStore } from 'pinia'
 import { computed, readonly, ref } from 'vue'
 import messageApi from '../../api/message/message.js'
 import { handleApiError } from '../../api/utils/handleApiError.js'
+import {
+  hasOlderToLoad,
+  mergeMessages,
+  nextOlderPageToLoad
+} from '../../utils/messagePagination.js'
 import { isMessageAlreadyListed, messageSignalPlan } from '../../utils/messageSignal.js'
 import { useNotificationStore } from '../notification/notification.js'
 import { useUserSecurityStore } from '../user/security.js'
@@ -23,6 +28,12 @@ export const useMessageStore = defineStore('message', () => {
   let threadsRequestId = 0
   let messagesRequestId = 0
   const isLoadingMessages = ref(false)
+  // Its own flag, not isLoadingMessages: that one drives a v-if that takes the whole conversation out
+  // of the DOM, which is the opposite of what loading older messages should look like.
+  const isLoadingOlderMessages = ref(false)
+  // And its own error, so a page that fails to load leaves the conversation on screen (#955).
+  const loadOlderError = ref(null)
+  const totalMessages = ref(0)
   const isAddingMessage = ref(false)
 
   const orderedThreads = computed(() => {
@@ -32,6 +43,10 @@ export const useMessageStore = defineStore('message', () => {
       return dateB - dateA
     })
   })
+
+  const hasOlderMessages = computed(() =>
+    hasOlderToLoad(messages.value.length, totalMessages.value)
+  )
 
   const currentThread = computed(() => {
     return threads.value.find((t) => t.thread.id === currentThreadId.value)
@@ -90,16 +105,57 @@ export const useMessageStore = defineStore('message', () => {
       const response = await messageApi.getMessages({ threadId })
       if (currentRequestId !== messagesRequestId) return
       // Reverse to show oldest first
-      messages.value = (response.member || []).reverse()
+      const newest = (response.member || []).reverse()
+      // A silent reload is a live signal refetching the newest page, and the reader may have loaded
+      // history behind it. Replacing would throw that away mid-read, so merge instead (#989).
+      messages.value = silent ? mergeMessages(messages.value, newest) : newest
+      totalMessages.value = response.totalItems ?? newest.length
+      loadOlderError.value = null
     } catch (e) {
       console.error('Failed to load messages:', e)
       if (!silent && currentRequestId === messagesRequestId) {
         messages.value = []
+        totalMessages.value = 0
       }
     } finally {
       if (!silent && currentRequestId === messagesRequestId) {
         isLoadingMessages.value = false
       }
+    }
+  }
+
+  /**
+   * One page further back through the conversation (#955).
+   *
+   * The page is derived from what is loaded rather than counted up, so live messages arriving at the
+   * head cannot make it drift, and the result is merged rather than appended, so the rows the window
+   * repeats are dropped instead of shown twice. See messagePagination.js.
+   */
+  async function loadOlderMessages() {
+    const threadId = currentThreadId.value
+    if (!threadId || isLoadingOlderMessages.value || !hasOlderMessages.value) {
+      return
+    }
+
+    // Joins the same generation the other loaders use. Checking the thread id alone is not enough:
+    // leave this thread and come back while the page is in flight and the id matches again, but
+    // `messages` now holds whatever the thread in between loaded, and this would merge into that.
+    const currentRequestId = ++messagesRequestId
+    isLoadingOlderMessages.value = true
+    loadOlderError.value = null
+    try {
+      const response = await messageApi.getMessages({
+        threadId,
+        page: nextOlderPageToLoad(messages.value.length)
+      })
+      if (currentRequestId !== messagesRequestId || threadId !== currentThreadId.value) return
+      messages.value = mergeMessages(messages.value, (response.member || []).reverse())
+      totalMessages.value = response.totalItems ?? totalMessages.value
+    } catch (e) {
+      console.error('Failed to load older messages:', e)
+      loadOlderError.value = 'Impossible de charger les messages plus anciens.'
+    } finally {
+      isLoadingOlderMessages.value = false
     }
   }
 
@@ -202,6 +258,8 @@ export const useMessageStore = defineStore('message', () => {
     currentThreadId.value = null
     currentThreadMetaId.value = null
     messages.value = []
+    totalMessages.value = 0
+    loadOlderError.value = null
   }
 
   function reset() {
@@ -219,6 +277,10 @@ export const useMessageStore = defineStore('message', () => {
     isLoading: readonly(isLoading),
     hasLoadedThreads: readonly(hasLoadedThreads),
     isLoadingMessages: readonly(isLoadingMessages),
+    isLoadingOlderMessages: readonly(isLoadingOlderMessages),
+    loadOlderError: readonly(loadOlderError),
+    totalMessages: readonly(totalMessages),
+    hasOlderMessages,
     isAddingMessage: readonly(isAddingMessage),
     orderedThreads,
     currentThread,
@@ -226,6 +288,7 @@ export const useMessageStore = defineStore('message', () => {
     selectThread,
     postMessage,
     postMessageInThread,
+    loadOlderMessages,
     handleIncomingMessage,
     getOtherParticipant,
     clearCurrentThread,

--- a/assets/js/utils/messagePagination.js
+++ b/assets/js/utils/messagePagination.js
@@ -1,0 +1,117 @@
+/**
+ * Page bookkeeping for one conversation (#955).
+ *
+ * The collection is offset paginated newest first and the list grows at the head while later pages
+ * are on screen, because messages arrive on their own now (#989). Offset paging normally repeats rows
+ * when that happens: hold the newest 50, let three arrive, and the rows already held have slid to
+ * offsets 3 to 52, so the next window starts three rows inside what is already on screen.
+ *
+ * Two things make that harmless. The next page is derived from how many rows are actually loaded
+ * rather than from a counter, so the window follows the list instead of drifting away from it, and
+ * pages are merged rather than concatenated, so a repeated row is dropped instead of shown twice.
+ *
+ * Repeats are the only failure mode here, not holes: nothing deletes a message yet, so the list only
+ * ever grows at the head and no row can slide out of a window before it was read. Deleting a message
+ * is #967, and that is the point to revisit this for a keyset cursor, which would need
+ * `(creation_datetime, id)` because the id is a uuid4 and carries no order of its own.
+ */
+
+/** Rows per request, matching `paginationItemsPerPage` on the operation. Capped server side at 200. */
+export const MESSAGES_PAGE_SIZE = 50
+
+/**
+ * The page to request next, derived from the rows already held rather than from a counter.
+ *
+ * @param {number} loadedCount messages currently in the conversation
+ * @param {number} pageSize
+ * @returns {number} 1 based page number
+ */
+export function nextOlderPageToLoad(loadedCount, pageSize = MESSAGES_PAGE_SIZE) {
+  if (pageSize <= 0) {
+    return 1
+  }
+
+  return Math.floor(Math.max(0, loadedCount) / pageSize) + 1
+}
+
+/**
+ * Whether the thread holds messages the conversation has not loaded yet.
+ *
+ * @param {number} loadedCount
+ * @param {number} total totalItems reported by the collection
+ * @returns {boolean}
+ */
+export function hasOlderToLoad(loadedCount, total) {
+  return loadedCount < total
+}
+
+/**
+ * Merge a fetched page into the messages already held, oldest first, without duplicates.
+ *
+ * A two pointer merge rather than a concatenation, because the page can be older than everything
+ * held (loading history) or overlap its newest end (a live signal refetching the first page), and one
+ * function should not have to be told which. Both inputs are already oldest first, so comparing
+ * timestamps and keeping the input order on a tie is enough: the second granular column produces ties
+ * constantly, and a stable merge simply does not care.
+ *
+ * Matched on `@id` because the `message:list` group carries no `id`, the same reason
+ * `isMessageAlreadyListed` in messageSignal.js matches on it. A message with no `@id` is kept rather
+ * than dropped: showing one twice is recoverable, losing one is not.
+ *
+ * A known id keeps its position and takes the fetched copy, so a message the server has changed
+ * refreshes in place. Nothing changes a message today, and editing one is #966.
+ *
+ * @param {object[]} held oldest first
+ * @param {object[]} incoming oldest first
+ * @returns {object[]} a new array, never mutating either input
+ */
+export function mergeMessages(held, incoming) {
+  const fetched = new Map()
+  for (const message of incoming) {
+    const id = message?.['@id']
+    if (id) {
+      fetched.set(id, message)
+    }
+  }
+
+  const merged = []
+  const taken = new Set()
+  const push = (message) => {
+    const id = message?.['@id']
+    if (id) {
+      if (taken.has(id)) {
+        return
+      }
+      taken.add(id)
+      merged.push(fetched.get(id) ?? message)
+
+      return
+    }
+    merged.push(message)
+  }
+
+  let left = 0
+  let right = 0
+  while (left < held.length && right < incoming.length) {
+    if (writtenAt(held[left]) <= writtenAt(incoming[right])) {
+      push(held[left++])
+    } else {
+      push(incoming[right++])
+    }
+  }
+  while (left < held.length) {
+    push(held[left++])
+  }
+  while (right < incoming.length) {
+    push(incoming[right++])
+  }
+
+  return merged
+}
+
+/** Unparseable or missing sorts oldest, so a malformed row cannot jump to the end of a conversation. */
+function writtenAt(message) {
+  const parsed = Date.parse(message?.creation_datetime ?? '')
+
+  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed
+}

--- a/assets/js/utils/messagePagination.test.js
+++ b/assets/js/utils/messagePagination.test.js
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { hasOlderToLoad, mergeMessages, nextOlderPageToLoad } from './messagePagination.js'
+
+const at = (iri, time) => ({ '@id': iri, creation_datetime: time })
+
+describe('nextOlderPageToLoad', () => {
+  it('asks for the second page once a full first page is held', () => {
+    assert.equal(nextOlderPageToLoad(50), 2)
+  })
+
+  it('still asks for the second page after live messages grew the list past 50', () => {
+    // The three that arrived sit at the head, so the rows already held have slid to offsets 3 to 52
+    // and page 2 starts three rows inside them. Repeats, which the merge drops; never a hole.
+    assert.equal(nextOlderPageToLoad(53), 2)
+  })
+
+  it('moves on once the second page has been merged', () => {
+    assert.equal(nextOlderPageToLoad(100), 3)
+  })
+
+  it('asks for the first page when nothing is held', () => {
+    assert.equal(nextOlderPageToLoad(0), 1)
+  })
+
+  it('does not divide by a page size of zero', () => {
+    assert.equal(nextOlderPageToLoad(50, 0), 1)
+  })
+})
+
+describe('hasOlderToLoad', () => {
+  it('is true while the server reports more than is held', () => {
+    assert.equal(hasOlderToLoad(50, 120), true)
+  })
+
+  it('is false once everything is held', () => {
+    assert.equal(hasOlderToLoad(120, 120), false)
+  })
+
+  it('is false when the list somehow holds more than reported', () => {
+    // A live message arriving between the count and the render, which must not offer a button that
+    // would fetch a page the server does not have.
+    assert.equal(hasOlderToLoad(121, 120), false)
+  })
+})
+
+describe('mergeMessages', () => {
+  it('puts an older page in front of what is held', () => {
+    const held = [at('/api/messages/c', '2026-09-11T10:00:02+00:00')]
+    const older = [
+      at('/api/messages/a', '2026-09-11T10:00:00+00:00'),
+      at('/api/messages/b', '2026-09-11T10:00:01+00:00')
+    ]
+
+    assert.deepEqual(
+      mergeMessages(held, older).map((m) => m['@id']),
+      ['/api/messages/a', '/api/messages/b', '/api/messages/c']
+    )
+  })
+
+  it('drops a row the page repeats', () => {
+    // The whole reason pages are merged rather than concatenated.
+    const held = [
+      at('/api/messages/b', '2026-09-11T10:00:01+00:00'),
+      at('/api/messages/c', '2026-09-11T10:00:02+00:00')
+    ]
+    const page = [
+      at('/api/messages/a', '2026-09-11T10:00:00+00:00'),
+      at('/api/messages/b', '2026-09-11T10:00:01+00:00')
+    ]
+
+    assert.deepEqual(
+      mergeMessages(held, page).map((m) => m['@id']),
+      ['/api/messages/a', '/api/messages/b', '/api/messages/c']
+    )
+  })
+
+  it('appends what a live refetch of the first page brings', () => {
+    const held = [
+      at('/api/messages/a', '2026-09-11T10:00:00+00:00'),
+      at('/api/messages/b', '2026-09-11T10:00:01+00:00')
+    ]
+    const firstPageAgain = [
+      at('/api/messages/b', '2026-09-11T10:00:01+00:00'),
+      at('/api/messages/c', '2026-09-11T10:00:03+00:00')
+    ]
+
+    assert.deepEqual(
+      mergeMessages(held, firstPageAgain).map((m) => m['@id']),
+      ['/api/messages/a', '/api/messages/b', '/api/messages/c']
+    )
+  })
+
+  it('keeps both messages written in the same second', () => {
+    // The column is second granular, so ties are ordinary rather than rare. A merge that deduplicated
+    // on the timestamp would silently eat one of them.
+    const held = [at('/api/messages/b', '2026-09-11T10:00:00+00:00')]
+    const page = [at('/api/messages/a', '2026-09-11T10:00:00+00:00')]
+
+    assert.deepEqual(
+      mergeMessages(held, page).map((m) => m['@id']),
+      ['/api/messages/b', '/api/messages/a']
+    )
+  })
+
+  it('takes the fetched copy of a message it already held', () => {
+    const held = [
+      { '@id': '/api/messages/a', creation_datetime: '2026-09-11T10:00:00+00:00', content: 'old' }
+    ]
+    const page = [
+      { '@id': '/api/messages/a', creation_datetime: '2026-09-11T10:00:00+00:00', content: 'new' }
+    ]
+
+    assert.deepEqual(mergeMessages(held, page), [
+      { '@id': '/api/messages/a', creation_datetime: '2026-09-11T10:00:00+00:00', content: 'new' }
+    ])
+  })
+
+  it('keeps a message with no identifier rather than dropping it', () => {
+    const page = [{ creation_datetime: '2026-09-11T10:00:00+00:00' }]
+
+    assert.equal(mergeMessages([], page).length, 1)
+  })
+
+  it('sorts a message with no usable timestamp oldest rather than losing track of it', () => {
+    // Nothing should produce one, and if something does it must not jump to the end of a conversation
+    // it does not belong at. Oldest is the position that cannot be mistaken for the newest message.
+    const held = [at('/api/messages/b', '2026-09-11T10:00:01+00:00')]
+    const broken = [{ '@id': '/api/messages/a', creation_datetime: 'not a date' }]
+
+    assert.deepEqual(
+      mergeMessages(held, broken).map((m) => m['@id']),
+      ['/api/messages/a', '/api/messages/b']
+    )
+  })
+
+  it('keeps every message when neither input is actually sorted', () => {
+    // The order may be wrong, which is a display problem; losing one would not be.
+    const held = [
+      at('/api/messages/c', '2026-09-11T10:00:02+00:00'),
+      at('/api/messages/a', '2026-09-11T10:00:00+00:00')
+    ]
+    const incoming = [
+      at('/api/messages/d', '2026-09-11T10:00:03+00:00'),
+      at('/api/messages/b', '2026-09-11T10:00:01+00:00')
+    ]
+
+    assert.deepEqual(
+      mergeMessages(held, incoming)
+        .map((m) => m['@id'])
+        .sort(),
+      ['/api/messages/a', '/api/messages/b', '/api/messages/c', '/api/messages/d']
+    )
+  })
+
+  it('never mutates either input', () => {
+    const held = [at('/api/messages/b', '2026-09-11T10:00:01+00:00')]
+    const page = [at('/api/messages/a', '2026-09-11T10:00:00+00:00')]
+    mergeMessages(held, page)
+
+    assert.equal(held.length, 1)
+    assert.equal(page.length, 1)
+  })
+})

--- a/migrations/2026/09/Version20260911170000.php
+++ b/migrations/2026/09/Version20260911170000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260911170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add a composite index on message (thread_id, creation_datetime)';
+    }
+
+    /**
+     * The sort every thread read runs, unindexed since the table was created in 2023.
+     *
+     * `message` has carried only the two single column foreign key indexes Doctrine generated,
+     * `thread_id` and `author_id`, so reading a thread newest first meant filtering on one of them and
+     * then sorting the result. Invisible at the sizes we have and linear in thread length, which is
+     * what #955 is about now that history is reachable at all.
+     *
+     * No column is named for the tie break because InnoDB appends the primary key to every secondary
+     * index: this is physically `(thread_id, creation_datetime, id)`, so two messages written in the
+     * same second still come back in a stable order. That matters more than it sounds, since
+     * `creation_datetime` is second granular and same second pairs are ordinary rather than rare.
+     */
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_message_thread_creation ON message (thread_id, creation_datetime)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_message_thread_creation ON message');
+    }
+}

--- a/src/ApiResource/Message/MessageResource.php
+++ b/src/ApiResource/Message/MessageResource.php
@@ -34,6 +34,9 @@ use Symfony\Component\Serializer\Attribute\Groups;
             paginationEnabled: true,
             paginationItemsPerPage: 50,
             paginationClientItemsPerPage: true,
+            // The client may choose a page size, so it needs a ceiling: without one a thread can be
+            // asked for in a single unbounded page. Same cap as BandSpaceActivityResource.
+            paginationMaximumItemsPerPage: 200,
             normalizationContext: ['groups' => [MessageResource::LIST]],
             name: 'api_message_get_collection',
             provider: MessageCollectionProvider::class,
@@ -49,7 +52,20 @@ use Symfony\Component\Serializer\Attribute\Groups;
         ),
     ],
 )]
-#[ApiFilter(OrderFilter::class, properties: ['creationDatetime' => OrderFilterInterface::DIRECTION_DESC])]
+/**
+ * `id` is in the sort for a tiebreak, not because anybody wants to order by a uuid4.
+ *
+ * `creation_datetime` is second granular and same second pairs are ordinary rather than rare, and SQL
+ * promises nothing about the order of tied rows. Two page requests that happened to be planned
+ * differently could then put a tied row on both sides of a page boundary, or on neither, and the
+ * second of those loses a message. Naming `id` makes the total order explicit instead of borrowing it
+ * from whichever index the planner picked, which is what the composite index from #955 happens to
+ * give today. The client has to ask for it: OrderFilter only orders by what the request names.
+ */
+#[ApiFilter(OrderFilter::class, properties: [
+    'creationDatetime' => OrderFilterInterface::DIRECTION_DESC,
+    'id' => OrderFilterInterface::DIRECTION_DESC,
+])]
 class MessageResource
 {
     public const string LIST = 'message:list';

--- a/src/Entity/Message/Message.php
+++ b/src/Entity/Message/Message.php
@@ -14,6 +14,7 @@ use Ramsey\Uuid\Doctrine\UuidGenerator;
 use Ramsey\Uuid\UuidInterface;
 
 #[ORM\Entity(repositoryClass: MessageRepository::class)]
+#[ORM\Index(name: 'idx_message_thread_creation', columns: ['thread_id', 'creation_datetime'])]
 class Message
 {
     #[ORM\Id]

--- a/tests/Api/Message/MessageGetCollectionTest.php
+++ b/tests/Api/Message/MessageGetCollectionTest.php
@@ -128,13 +128,19 @@ class MessageGetCollectionTest extends ApiTestCase
             ],
             'search'     => [
                 '@type'                        => 'IriTemplate',
-                'template'               => '/api/messages/' . $thread->id . '{?order[creation_datetime]}',
+                'template'               => '/api/messages/' . $thread->id . '{?order[creation_datetime],order[id]}',
                 'variableRepresentation' => 'BasicRepresentation',
                 'mapping'                => [
                     [
                         '@type'    => 'IriTemplateMapping',
                         'variable' => 'order[creation_datetime]',
                         'property' => 'creation_datetime',
+                        'required' => false,
+                    ],
+                    [
+                        '@type' => 'IriTemplateMapping',
+                        'variable' => 'order[id]',
+                        'property' => 'id',
                         'required' => false,
                     ],
                 ],
@@ -182,13 +188,19 @@ class MessageGetCollectionTest extends ApiTestCase
             'totalItems' => 1,
             'search' => [
                 '@type' => 'IriTemplate',
-                'template' => '/api/messages/' . $thread->id . '{?order[creation_datetime]}',
+                'template' => '/api/messages/' . $thread->id . '{?order[creation_datetime],order[id]}',
                 'variableRepresentation' => 'BasicRepresentation',
                 'mapping' => [
                     [
                         '@type' => 'IriTemplateMapping',
                         'variable' => 'order[creation_datetime]',
                         'property' => 'creation_datetime',
+                        'required' => false,
+                    ],
+                    [
+                        '@type' => 'IriTemplateMapping',
+                        'variable' => 'order[id]',
+                        'property' => 'id',
                         'required' => false,
                     ],
                 ],
@@ -242,6 +254,90 @@ class MessageGetCollectionTest extends ApiTestCase
             'status' => 403,
             'type' => '/errors/403',
             '@context' => '/api/contexts/Error',
+        ]);
+    }
+
+    public function test_history_past_the_first_page_is_reachable(): void
+    {
+        // The defect #955 is about: the operation has always paginated, the client never asked for a
+        // page, so a conversation longer than 50 messages had simply lost its older half.
+        $reader = UserFactory::new()->asBaseUser()->create(['username' => 'reader', 'email' => 'reader@email.com']);
+        $writer = UserFactory::new()->asBaseUser()->create(['username' => 'writer', 'email' => 'writer@email.com']);
+
+        $thread = MessageThreadFactory::new()->create();
+        MessageParticipantFactory::new(['thread' => $thread, 'participant' => $reader])->create();
+        MessageParticipantFactory::new(['thread' => $thread, 'participant' => $writer])->create();
+
+        // 52 messages a minute apart, so page 1 holds 50 and page 2 holds the two oldest.
+        $messages = [];
+        foreach (range(1, 52) as $minute) {
+            $messages[$minute] = MessageFactory::new([
+                'author' => $writer,
+                'thread' => $thread,
+                'content' => 'message ' . $minute,
+                'creationDatetime' => new \DateTime(sprintf('2026-09-11 10:%02d:00', $minute)),
+            ])->create();
+        }
+
+        $this->client->loginUser($reader);
+        $this->client->request('GET', '/api/messages/' . $thread->id . '?order[creation_datetime]=desc&order[id]=desc&page=2');
+        $this->assertResponseIsSuccessful();
+
+        $writerJson = [
+            '@id' => '/api/users/' . $writer->id,
+            '@type' => 'User',
+            'id' => $writer->id,
+            'username' => 'writer',
+        ];
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Message',
+            '@id' => '/api/messages/' . $thread->id,
+            '@type' => 'Collection',
+            // Newest first, so the second page is the two oldest.
+            'member' => [
+                [
+                    '@id' => '/api/messages/' . $messages[2]->id,
+                    '@type' => 'Message',
+                    'creation_datetime' => '2026-09-11T10:02:00+00:00',
+                    'author' => $writerJson,
+                    'content' => 'message 2',
+                ],
+                [
+                    '@id' => '/api/messages/' . $messages[1]->id,
+                    '@type' => 'Message',
+                    'creation_datetime' => '2026-09-11T10:01:00+00:00',
+                    'author' => $writerJson,
+                    'content' => 'message 1',
+                ],
+            ],
+            'totalItems' => 52,
+            // The links that say there is more behind this page, which is what the client now reads.
+            'view' => [
+                '@id' => '/api/messages/' . $thread->id . '?order%5Bcreation_datetime%5D=desc&order%5Bid%5D=desc&page=2',
+                '@type' => 'PartialCollectionView',
+                'first' => '/api/messages/' . $thread->id . '?order%5Bcreation_datetime%5D=desc&order%5Bid%5D=desc&page=1',
+                'last' => '/api/messages/' . $thread->id . '?order%5Bcreation_datetime%5D=desc&order%5Bid%5D=desc&page=2',
+                'previous' => '/api/messages/' . $thread->id . '?order%5Bcreation_datetime%5D=desc&order%5Bid%5D=desc&page=1',
+            ],
+            'search' => [
+                '@type' => 'IriTemplate',
+                'template' => '/api/messages/' . $thread->id . '{?order[creation_datetime],order[id]}',
+                'variableRepresentation' => 'BasicRepresentation',
+                'mapping' => [
+                    [
+                        '@type' => 'IriTemplateMapping',
+                        'variable' => 'order[creation_datetime]',
+                        'property' => 'creation_datetime',
+                        'required' => false,
+                    ],
+                    [
+                        '@type' => 'IriTemplateMapping',
+                        'variable' => 'order[id]',
+                        'property' => 'id',
+                        'required' => false,
+                    ],
+                ],
+            ],
         ]);
     }
 }


### PR DESCRIPTION
Closes #955. Part of #948.

Two defects that only mattered together, and #989 had just made them matter more.

**Everything past the newest 50 messages was unreachable.** The operation has always declared `paginationEnabled: true, paginationItemsPerPage: 50`, but the client never sent a `page`, and the store read `member` while throwing `view` and `totalItems` away. There was no "load older" control of any kind, so a conversation longer than 50 messages had simply lost its older half from the interface.

**The sort was unindexed.** `message` has carried only its two generated foreign key indexes since 2023 and no migration had ever altered it, so reading a thread newest first meant filtering on `thread_id` and then sorting the result.

## The index

```
without   key: IDX_B6BD307FE2904019        Extra: Using index condition; Using filesort
with      key: idx_message_thread_creation Extra: Using where; Using index
```

A covering index and no sort. No column is named for the tie break because InnoDB appends the primary key to every secondary index, so it is physically `(thread_id, creation_datetime, id)`.

Validated on the **migration database** with `DATABASE_URL` overridden on the command rather than by editing `.env.local`: applied, `migrate prev`, applied again, with the index present, absent and present. `doctrine:schema:update --dump-sql` against dev then emitted exactly one statement, identical to the migration, so the mapping and the SQL agree and nothing else had drifted.

## Offset paging rather than a cursor, deliberately

The issue asks for cursor pagination because offset paging "skips and duplicates rows". Half of that is right, and the half that is wrong is the half that matters.

Walking backwards through append only data **duplicates but cannot skip**. Page 1 is offsets 0 to 49; if three messages arrive before page 2 is asked for, the rows already held have slid to offsets 3 to 52, so page 2 returns three of them again and then continues. A skip needs a **deletion**, and deleting a message is #967, not built.

The ticket's suggested cursor key is also unusable as written: "keyed on the message id" cannot work, because the id is a uuid4 and carries no order at all. A correct cursor would need `(creation_datetime, id)` as a composite predicate, which API Platform's `paginationViaCursor` cannot express, in a codebase with no keyset precedent to build on.

So duplication is the only failure mode to answer, and it is answered twice over:

- **The page is derived from the rows held**, `floor(loaded / 50) + 1`, not counted up. The window follows the list instead of drifting away from it when messages arrive mid read.
- **Pages are merged by `@id`, never concatenated.** A two pointer merge rather than a concat, because the incoming page can be entirely older than what is held, or overlap its newest end when a live signal refetches the first page, and one function should not need telling which. `@id` rather than `id` because the `message:list` group carries no `id`.

Revisit keyset at #967, when deletion makes skips real. The code says so where it matters.

## The tie break, which the first version of this reasoning missed

That argument quietly assumes tied rows come back in a **stable** order across two separate page requests, and `OrderFilter` was emitting only `ORDER BY creationDatetime DESC`. SQL promises nothing about tied rows, so two pages planned differently could put a row tied on the boundary second into both pages or into neither, and the second of those loses a message. `creation_datetime` is second granular and same second pairs are ordinary: there are five such collisions in seventy rows of dev data.

`id` is now named in the sort, so the total order is explicit instead of borrowed from whichever index the planner picked. It costs nothing, because the index already ends in the primary key: `EXPLAIN` still reports `Using where; Using index`.

## The interaction with #989, which is the sharpest edge here

`handleIncomingMessage()` called `loadMessages()`, and that **replaces**. So with history loaded, one incoming message collapsed the list back to 50 mid read. It merges now.

`loadOlderMessages()` also joins the `messagesRequestId` generation the other loaders use. Checking the thread id alone was not enough: leave a thread and come back while a page is in flight and the id matches again, but `messages` holds whatever the thread in between loaded, and the page would merge into that.

## Frontend

A "Charger les messages plus anciens" button, matching the `severity="secondary" outlined` idiom already used by the activity feed and the file list, with its own loading flag and its own error so a page that fails to load never blanks the conversation on screen.

Scroll is preserved across the prepend, which nothing in the codebase did before. The auto scroll also now only fires when the list grew at its **end**, tracked by the last message's `@id`: `isFollowingTheConversation()` is trivially true in a conversation shorter than its pane, so loading history into a short thread would have jumped to the bottom having just been asked for the top. That marker is reset per thread, because this component is not remounted when you switch conversation; the messages route renders through a `router-view` with no `:key`, unlike the band space layout.

## Verified

- 2677 PHP tests, PHPStan level 8 clean, Biome exit 0, 641 JS tests, build clean.
- In a real browser on a 72 message thread: 50 rendered, the button shown, and after loading, `contentAddedAboveTheAnchor` and `scrollTopMovedBy` both 2093, so the reader's viewport drifted by **0px**. Then a message sent from the other account left the loaded history in place rather than collapsing it, and did not yank the scrolled up reader to the bottom.
- The new API test seeds 52 messages and asserts the full page 2 body including `view.first`, `view.last` and `view.previous`. The two pre-existing full body assertions were updated for the sort property the `IriTemplate` now advertises.

## Deploy

Run `doctrine:migrations:migrate`. The Deployer recipe does not run migrations on its own, and without the index the thread read falls back to the filesort this change exists to remove.

No pool clearing, contrary to what I wrote on the last few of these. Every API Platform metadata pool is declared `->parent('cache.system')`, `cache.system` parents `cache.adapter.system`, which `AbstractAdapter::createSystemCache` builds at `%kernel.cache_dir%/pools/system`, and `config/packages/cache.yaml` points only `app` at Redis, never `system`. Deployer shares `var/log` and nothing else, so `var/cache` is per release and a new release cannot inherit a stale metadata pool. The stale pool problem is real in **dev**, where that directory persists and the FrankenPHP worker holds the booted kernel, and I had generalised it to production where it does not apply.
