### PR TITLE
Chat: scope a message thread to a Band Space

### DIFF
--- a/migrations/2026/09/Version20260912120000.php
+++ b/migrations/2026/09/Version20260912120000.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * A thread with no band_space_id is a direct message and keeps its participant rows. A thread with one
+ * is a Band Space channel, whose members are derived from band_space_membership, so it has no
+ * participant rows at all.
+ *
+ * The backfill mints ids with UUID(), which is version 1 where the application mints version 4. Nothing
+ * reads the version, the route requirement accepts any, and #955 established that these ids carry no
+ * ordering, so the difference is invisible. It is the only option MariaDB 10.11 offers: UUID_v4() does
+ * not exist before 11.7.
+ */
+final class Version20260912120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Scope a message thread to a Band Space and give every space its channel';
+    }
+
+    /**
+     * Both indexes are created before the constraint so that InnoDB finds one to satisfy the foreign key
+     * rather than adding a third of its own. The unique index is what forbids two channels with the same
+     * name in one space; it says nothing about direct messages, where both columns are null and a unique
+     * index reads every null as distinct.
+     */
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE message_thread ADD name VARCHAR(100) DEFAULT NULL, ADD band_space_id CHAR(36) DEFAULT NULL');
+        $this->addSql('CREATE INDEX IDX_607D18CE31C124A ON message_thread (band_space_id)');
+        $this->addSql('CREATE UNIQUE INDEX message_thread_band_space_name_unique ON message_thread (band_space_id, name)');
+        $this->addSql('ALTER TABLE message_thread ADD CONSTRAINT FK_607D18CE31C124A FOREIGN KEY (band_space_id) REFERENCES band_space (id) ON DELETE CASCADE');
+
+        // The channel is as old as the band, so it inherits the space's own creation datetime rather
+        // than the moment this migration happened to run.
+        $this->addSql(<<<'SQL'
+            INSERT INTO message_thread (id, name, band_space_id, creation_datetime)
+            SELECT UUID(), 'Général', id, creation_datetime
+            FROM band_space
+            SQL);
+    }
+
+    /**
+     * The rows have to go before the column, because band_space_id is the only thing that identifies a
+     * channel: dropping it first would leave threads with no participants sitting in the inbox query as
+     * broken direct messages.
+     *
+     * Deleting them takes the cycle in order, last_message_id first, for the same reason
+     * MessageThreadRepository::deleteByBandSpace() does: every foreign key here is RESTRICT and
+     * message_thread.last_message_id points back into message. This is lossy once a channel carries
+     * messages, which is the price of reversing a schema change that created the container for them.
+     */
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE message_thread SET last_message_id = NULL WHERE band_space_id IS NOT NULL');
+        $this->addSql('DELETE FROM message_thread_meta WHERE thread_id IN (SELECT id FROM message_thread WHERE band_space_id IS NOT NULL)');
+        $this->addSql('DELETE FROM message WHERE thread_id IN (SELECT id FROM message_thread WHERE band_space_id IS NOT NULL)');
+        $this->addSql('DELETE FROM message_participant WHERE thread_id IN (SELECT id FROM message_thread WHERE band_space_id IS NOT NULL)');
+        $this->addSql('DELETE FROM message_thread WHERE band_space_id IS NOT NULL');
+
+        $this->addSql('ALTER TABLE message_thread DROP FOREIGN KEY FK_607D18CE31C124A');
+        $this->addSql('DROP INDEX IDX_607D18CE31C124A ON message_thread');
+        $this->addSql('DROP INDEX message_thread_band_space_name_unique ON message_thread');
+        $this->addSql('ALTER TABLE message_thread DROP name, DROP band_space_id');
+    }
+}

--- a/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
+++ b/src/Command/BandSpace/PurgeBandSpaceStorageCommand.php
@@ -8,8 +8,10 @@ use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceFile;
 use App\Repository\BandSpace\BandSpaceFileRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\Message\MessageThreadRepository;
 use App\Service\BandSpace\File\BandSpaceFilePurger;
 use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -53,6 +55,8 @@ class PurgeBandSpaceStorageCommand extends Command
         private readonly BandSpaceRepository $bandSpaceRepository,
         private readonly BandSpaceFileRepository $bandSpaceFileRepository,
         private readonly BandSpaceFilePurger $filePurger,
+        private readonly MessageThreadRepository $messageThreadRepository,
+        private readonly EntityManagerInterface $entityManager,
         private readonly FilesystemOperator $musicallFilesystem,
         private readonly LoggerInterface $logger,
         #[Autowire('%band_space.file_retention_days%')]
@@ -197,8 +201,12 @@ class PurgeBandSpaceStorageCommand extends Command
     }
 
     /**
-     * Objects first, then the rows: deleteById() drops every child row by FK cascade, and a cascade at
+     * Objects first, then the rows: deleteById() drops most child rows by FK cascade, and a cascade at
      * database level never reaches VichUploader, so the storage prefix has to go on its own.
+     *
+     * The chat is the exception to that cascade and has to be deleted first, because the message tables
+     * reference each other in a cycle that ON DELETE CASCADE cannot walk. The two row deletions share a
+     * transaction so a failure between them cannot leave a space standing with its chat already gone.
      */
     private function purgeBandSpace(BandSpace $bandSpace): void
     {
@@ -206,6 +214,9 @@ class PurgeBandSpaceStorageCommand extends Command
 
         $this->musicallFilesystem->deleteDirectory(self::STORAGE_PREFIX . '/' . $bandSpaceId);
 
-        $this->bandSpaceRepository->deleteById($bandSpaceId);
+        $this->entityManager->wrapInTransaction(function () use ($bandSpaceId): void {
+            $this->messageThreadRepository->deleteByBandSpace($bandSpaceId);
+            $this->bandSpaceRepository->deleteById($bandSpaceId);
+        });
     }
 }

--- a/src/Entity/Message/MessageThread.php
+++ b/src/Entity/Message/MessageThread.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity\Message;
 
+use App\Entity\BandSpace\BandSpace;
 use App\Repository\Message\MessageThreadRepository;
 use DateTime;
 use DateTimeInterface;
@@ -15,8 +16,12 @@ use Ramsey\Uuid\Doctrine\UuidGenerator;
 use Ramsey\Uuid\UuidInterface;
 
 #[ORM\Entity(repositoryClass: MessageThreadRepository::class)]
+#[ORM\Table(name: 'message_thread')]
+#[ORM\UniqueConstraint(name: 'message_thread_band_space_name_unique', columns: ['band_space_id', 'name'])]
 class MessageThread
 {
+    public const string DEFAULT_CHANNEL_NAME = 'Général';
+
     #[ORM\Id]
     #[ORM\Column(type: "uuid", unique: true)]
     #[ORM\GeneratedValue(strategy: "CUSTOM")]
@@ -45,6 +50,19 @@ class MessageThread
     #[ORM\ManyToOne(targetEntity: Message::class)]
     #[ORM\JoinColumn(nullable: true)]
     public ?Message $lastMessage = null;
+
+    /**
+     * Null is a direct message, whose participants are the rows above. Set is a Band Space channel,
+     * whose members are derived from BandSpaceMembership so that nothing has to be synchronised on
+     * join, leave, kick or role change.
+     */
+    #[ORM\ManyToOne(targetEntity: BandSpace::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    public ?BandSpace $bandSpace = null;
+
+    /** Channels only, and never null for one: two nulls read as distinct, so the unique index cannot say it. */
+    #[ORM\Column(type: Types::STRING, length: 100, nullable: true)]
+    public ?string $name = null;
 
     public function __construct()
     {

--- a/src/Repository/BandSpace/BandSpaceRepository.php
+++ b/src/Repository/BandSpace/BandSpaceRepository.php
@@ -57,7 +57,12 @@ class BandSpaceRepository extends ServiceEntityRepository
     /**
      * Hard-deletes a space in one statement, for app:band-space:purge. Deliberately a bulk DQL delete
      * rather than an ORM remove(): hydrating a whole space and its children just to delete them would be
-     * pointless work, and every child table cascades from band_space at database level anyway.
+     * pointless work, and almost every child table cascades from band_space at database level anyway.
+     *
+     * Almost: message_thread is the exception. Its cascade cannot walk the cycle the message tables
+     * form, so a space's channels have to be deleted first, through
+     * MessageThreadRepository::deleteByBandSpace(). app:band-space:purge does that in the same
+     * transaction as this call.
      *
      * Two consequences the caller has to know about. A bulk delete never fires lifecycle events, so
      * VichUploader does not run and the stored objects must be removed separately - which is exactly why

--- a/src/Repository/Message/MessageThreadMetaRepository.php
+++ b/src/Repository/Message/MessageThreadMetaRepository.php
@@ -68,6 +68,10 @@ class MessageThreadMetaRepository extends ServiceEntityRepository
             ->join('last_message.author', 'author')
             ->where('message_thread_meta.user = :user')
             ->andWhere('message_thread_meta.isDeleted = 0')
+            // Direct messages only. A channel is kept out today by the inner join on participants,
+            // which it has none of, but #960 gives its members read-state rows and #994 is where
+            // showing them in this inbox becomes a decision rather than an accident.
+            ->andWhere('thread.bandSpace IS NULL')
             ->orderBy('last_message.creationDatetime', 'DESC')
             ->addOrderBy('participant.username', 'ASC')
             ->setParameter('user', $user)

--- a/src/Repository/Message/MessageThreadRepository.php
+++ b/src/Repository/Message/MessageThreadRepository.php
@@ -43,4 +43,38 @@ class MessageThreadRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    /**
+     * Deletes a Band Space's channels and everything in them, for app:band-space:purge.
+     *
+     * The order is the whole method. Every foreign key in the message domain is RESTRICT, and
+     * message_thread.last_message_id -> message.id -> message.thread_id -> message_thread.id is a
+     * cycle, so the pointer has to be nulled before the messages can go and the messages before the
+     * thread. Without this, the ON DELETE CASCADE from band_space cannot delete a channel that holds
+     * a single message, and the purge fails on the whole space.
+     *
+     * A bulk delete, so no lifecycle event fires: anything a message ever gains that lives outside
+     * the database, an attachment for instance, has to be removed by the caller. isDeleted on the
+     * read-state rows is ignored on purpose, since this is a hard purge and not somebody tidying
+     * their own inbox.
+     */
+    public function deleteByBandSpace(string $bandSpaceId): void
+    {
+        $entityManager = $this->getEntityManager();
+
+        $statements = [
+            'UPDATE App\Entity\Message\MessageThread thread SET thread.lastMessage = NULL WHERE thread.bandSpace = :band_space',
+            'DELETE FROM App\Entity\Message\MessageThreadMeta meta WHERE meta.thread IN (SELECT owned.id FROM App\Entity\Message\MessageThread owned WHERE owned.bandSpace = :band_space)',
+            'DELETE FROM App\Entity\Message\Message message WHERE message.thread IN (SELECT owned.id FROM App\Entity\Message\MessageThread owned WHERE owned.bandSpace = :band_space)',
+            'DELETE FROM App\Entity\Message\MessageParticipant participant WHERE participant.thread IN (SELECT owned.id FROM App\Entity\Message\MessageThread owned WHERE owned.bandSpace = :band_space)',
+            // The threads themselves go last, and by bandSpace rather than by a subquery over their own
+            // table: a DQL DELETE on a table with no inheritance is emitted verbatim, so that subquery
+            // would reach MariaDB as error 1093.
+            'DELETE FROM App\Entity\Message\MessageThread thread WHERE thread.bandSpace = :band_space',
+        ];
+
+        foreach ($statements as $dql) {
+            $entityManager->createQuery($dql)->setParameter('band_space', $bandSpaceId)->execute();
+        }
+    }
 }

--- a/src/Service/Builder/Message/MessageThreadDirector.php
+++ b/src/Service/Builder/Message/MessageThreadDirector.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Builder\Message;
 
+use App\Entity\BandSpace\BandSpace;
 use App\Entity\Message\MessageThread;
 
 class MessageThreadDirector
@@ -9,5 +10,18 @@ class MessageThreadDirector
     public function create(): MessageThread
     {
         return new MessageThread();
+    }
+
+    /**
+     * No participant rows: a channel's members are derived from BandSpaceMembership. The name is
+     * required here because the unique index on (band_space_id, name) cannot enforce it.
+     */
+    public function createForBandSpace(BandSpace $bandSpace, string $name = MessageThread::DEFAULT_CHANNEL_NAME): MessageThread
+    {
+        $thread = new MessageThread();
+        $thread->bandSpace = $bandSpace;
+        $thread->name = $name;
+
+        return $thread;
     }
 }

--- a/src/State/Processor/BandSpace/BandSpaceCreateProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceCreateProcessor.php
@@ -15,6 +15,7 @@ use App\Enum\BandSpace\Role;
 use App\Repository\BandSpace\BandSpaceRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use App\Service\Builder\BandSpace\BandSpaceBuilder;
+use App\Service\Builder\Message\MessageThreadDirector;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -33,6 +34,7 @@ readonly class BandSpaceCreateProcessor implements ProcessorInterface
         private BandSpaceBuilder $bandSpaceBuilder,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private BandSpaceRepository $bandSpaceRepository,
+        private MessageThreadDirector $messageThreadDirector,
         private Security $security,
         #[Target('band_space_creation')]
         private RateLimiterFactoryInterface $creationLimiter,
@@ -67,8 +69,13 @@ readonly class BandSpaceCreateProcessor implements ProcessorInterface
         // Add membership to band space (bidirectional relationship)
         $bandSpace->memberships->add($creatorMembership);
 
+        // The band's chat. Created here rather than on first use so that every space has one, including
+        // the ones nobody opens the chat on, which is what lets #960 read a channel without a fallback.
+        $channel = $this->messageThreadDirector->createForBandSpace($bandSpace);
+
         $this->entityManager->persist($bandSpace);
         $this->entityManager->persist($creatorMembership);
+        $this->entityManager->persist($channel);
 
         // BandSpace::id is assigned at persist time (CUSTOM UUID generator),
         // so we can safely read it before flush. record() only persists the

--- a/tests/Api/BandSpace/BandSpaceCreateTest.php
+++ b/tests/Api/BandSpace/BandSpaceCreateTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Api\BandSpace;
 use App\Enum\BandSpace\BandSpaceModule;
 use App\Repository\BandSpace\BandSpaceActivityRepository;
 use App\Repository\BandSpace\BandSpaceRepository;
+use App\Repository\Message\MessageThreadRepository;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
@@ -66,6 +67,30 @@ class BandSpaceCreateTest extends ApiTestCase
         $this->assertSame('band_created', $activities[0]->type);
         $this->assertSame(['name' => 'The Rockers'], $activities[0]->payload);
         $this->assertSame($user->id, $activities[0]->actor?->id);
+    }
+
+    public function test_creating_a_band_space_creates_its_channel(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces',
+            ['name' => 'The Rockers'],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json']
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $bandSpace = self::getContainer()->get(BandSpaceRepository::class)->findByUser($user)[0];
+        $channels = self::getContainer()->get(MessageThreadRepository::class)->findBy(['bandSpace' => $bandSpace]);
+
+        $this->assertCount(1, $channels);
+        $this->assertSame('Général', $channels[0]->name);
+        // A channel's members are derived from the space's memberships, so it writes no participant
+        // rows. Writing them is the escape hatch a private channel would use, and nothing does.
+        $this->assertCount(0, $channels[0]->messageParticipants);
     }
 
     public function test_a_padded_name_is_stored_trimmed(): void

--- a/tests/Api/Message/MessageThreadMetaGetCollectionTest.php
+++ b/tests/Api/Message/MessageThreadMetaGetCollectionTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Api\Message;
 
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\Message\MessageFactory;
 use App\Tests\Factory\Message\MessageParticipantFactory;
 use App\Tests\Factory\Message\MessageThreadFactory;
@@ -115,6 +116,34 @@ class MessageThreadMetaGetCollectionTest extends ApiTestCase
                 ],
             ],
             'totalItems' => 1,
+        ]);
+    }
+
+    public function test_a_band_space_channel_is_not_a_direct_message(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create(['username' => 'base_user_1', 'email' => 'base_user1@email.com']);
+        $bandSpace = BandSpaceFactory::new()->create();
+
+        $channel = MessageThreadFactory::new()->forBandSpace($bandSpace)->create();
+        // A real channel has no participant row, since its members are derived from the space. This one
+        // gets one so that the listing's join on participants cannot be what excludes it, leaving the
+        // scope filter as the only thing that can. #994 is where showing channels here becomes a choice.
+        MessageParticipantFactory::new(['thread' => $channel, 'participant' => $user])->create();
+        $message = MessageFactory::new(['author' => $user, 'thread' => $channel, 'content' => 'dans le groupe'])->create();
+        $channel->lastMessage = $message;
+        \Zenstruck\Foundry\Persistence\save($channel);
+        MessageThreadMetaFactory::new(['user' => $user, 'thread' => $channel])->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/message_thread_metas');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context'   => '/api/contexts/MessageThreadMeta',
+            '@id'        => '/api/message_thread_metas',
+            '@type'      => 'Collection',
+            'member'     => [],
+            'totalItems' => 0,
         ]);
     }
 

--- a/tests/Factory/Message/MessageThreadFactory.php
+++ b/tests/Factory/Message/MessageThreadFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Factory\Message;
 
+use App\Entity\BandSpace\BandSpace;
 use App\Entity\Message\MessageThread;
 use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
 
@@ -14,6 +15,12 @@ final class MessageThreadFactory extends PersistentObjectFactory
         return [
             'creationDatetime' => self::faker()->dateTime(),
         ];
+    }
+
+    /** A Band Space channel: no participant rows, because its members are derived from the space. */
+    public function forBandSpace(BandSpace $bandSpace, string $name = MessageThread::DEFAULT_CHANNEL_NAME): static
+    {
+        return $this->with(['bandSpace' => $bandSpace, 'name' => $name]);
     }
 
     public static function class(): string

--- a/tests/Integration/Command/BandSpace/PurgeBandSpaceStorageCommandTest.php
+++ b/tests/Integration/Command/BandSpace/PurgeBandSpaceStorageCommandTest.php
@@ -7,9 +7,15 @@ namespace App\Tests\Integration\Command\BandSpace;
 use App\Entity\BandSpace\BandSpace;
 use App\Entity\BandSpace\BandSpaceFile;
 use App\Repository\BandSpace\BandSpaceFileRepository;
+use App\Repository\BandSpace\BandSpaceRepository;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFileFactory;
 use App\Tests\Factory\BandSpace\File\BandSpaceFileVersionFactory;
+use App\Tests\Factory\Message\MessageFactory;
+use App\Tests\Factory\Message\MessageParticipantFactory;
+use App\Tests\Factory\Message\MessageThreadFactory;
+use App\Tests\Factory\Message\MessageThreadMetaFactory;
+use App\Tests\Factory\User\UserFactory;
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -131,6 +137,79 @@ class PurgeBandSpaceStorageCommandTest extends KernelTestCase
 
         $this->assertSame(1, $this->countBandSpaceRows($keptSpaceId));
         $this->assertTrue($this->filesystem()->fileExists($keptPath));
+    }
+
+    public function test_it_deletes_a_band_space_channel_and_everything_in_it(): void
+    {
+        // The one child table the band_space cascade cannot reach on its own. Every foreign key in the
+        // message domain is RESTRICT and message_thread.last_message_id points back into message, so a
+        // channel holding a single message used to make the whole purge fail.
+        $dueSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('-1 day'),
+        ]);
+        $member = UserFactory::new()->asBaseUser()->create();
+
+        $channel = MessageThreadFactory::new()->forBandSpace($dueSpace)->create();
+        $message = MessageFactory::new(['thread' => $channel, 'author' => $member])->create();
+        MessageThreadMetaFactory::new(['thread' => $channel, 'user' => $member])->create();
+        // Not what a channel looks like, but what the private channel escape hatch would write, so the
+        // purge is proven to sweep participant rows too.
+        MessageParticipantFactory::new(['thread' => $channel, 'participant' => $member])->create();
+
+        $channel->lastMessage = $message;
+        \Zenstruck\Foundry\Persistence\save($channel);
+
+        // A direct message that has nothing to do with the space, to prove the sweep is scoped.
+        $directThread = MessageThreadFactory::new()->create();
+        $directMessage = MessageFactory::new(['thread' => $directThread, 'author' => $member])->create();
+
+        $dueSpaceId = (string) $dueSpace->id;
+        $channelId = (string) $channel->id;
+        $directThreadId = (string) $directThread->id;
+        $directMessageId = (string) $directMessage->id;
+
+        $this->commandTester()->execute([]);
+        $this->commandTester()->assertCommandIsSuccessful();
+
+        $this->assertSame(0, $this->countBandSpaceRows($dueSpaceId));
+        $this->assertSame(0, $this->countRows('message_thread', 'band_space_id', $dueSpaceId));
+        $this->assertSame(0, $this->countRows('message', 'thread_id', $channelId));
+        $this->assertSame(0, $this->countRows('message_thread_meta', 'thread_id', $channelId));
+        $this->assertSame(0, $this->countRows('message_participant', 'thread_id', $channelId));
+
+        $this->assertSame(1, $this->countRows('message_thread', 'id', $directThreadId));
+        $this->assertSame(1, $this->countRows('message', 'id', $directMessageId));
+    }
+
+    public function test_a_failure_after_the_chat_is_deleted_puts_the_chat_back(): void
+    {
+        // The chat is deleted before the space row, in two statements the database cannot merge, so the
+        // pair is wrapped in a transaction. Without it, a failure here would leave a live space whose
+        // conversation had already been destroyed, and the next run would retry against the wreckage.
+        $dueSpace = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new DateTimeImmutable('-1 day'),
+        ]);
+        $member = UserFactory::new()->asBaseUser()->create();
+
+        $channel = MessageThreadFactory::new()->forBandSpace($dueSpace)->create();
+        $message = MessageFactory::new(['thread' => $channel, 'author' => $member])->create();
+        $channel->lastMessage = $message;
+        \Zenstruck\Foundry\Persistence\save($channel);
+
+        $dueSpaceId = (string) $dueSpace->id;
+        $channelId = (string) $channel->id;
+
+        // Swapped in before the command resolves it, like the storage failure test above. The space is
+        // handed back unchanged so the purge reaches the point where the chat is already gone.
+        $failingRepository = $this->createStub(BandSpaceRepository::class);
+        $failingRepository->method('findScheduledForDeletion')->willReturn([$dueSpace]);
+        $failingRepository->method('deleteById')->willThrowException(new \RuntimeException('row deletion failed'));
+        self::getContainer()->set(BandSpaceRepository::class, $failingRepository);
+
+        $this->assertSame(1, $this->commandTester()->execute([]));
+
+        $this->assertSame(1, $this->countRows('message_thread', 'band_space_id', $dueSpaceId));
+        $this->assertSame(1, $this->countRows('message', 'thread_id', $channelId));
     }
 
     public function test_dry_run_changes_nothing(): void


### PR DESCRIPTION
Closes #959. First ticket of Track D in #948, and the last schema change the chat needs.

## What changes

`MessageThread` gains a nullable `bandSpace` and a nullable `name`, so one table serves both kinds of conversation:

- `bandSpace = null` is a direct message, with its materialised `MessageParticipant` rows. Behaviour unchanged.
- `bandSpace != null` is a Band Space channel, whose members are derived from `BandSpaceMembership` and which writes no participant rows at all. Deriving avoids a second source of truth to synchronise on invite accept, leave, kick, role change and account deletion.

Every space gets one channel: created in `BandSpaceCreateProcessor` alongside the creator's membership, inside the single `flush()` that was already there, and backfilled for existing spaces by the migration. Nothing reads it yet, #960 is the read and post API.

## The part that is not a column

`band_space_id` is `ON DELETE CASCADE`, the convention every Band Space owned table follows. That cascade cannot delete a channel, because every foreign key in the message domain is RESTRICT and `message_thread.last_message_id -> message.id -> message.thread_id -> message_thread.id` is a cycle. Measured by hand on the migrated database:

```
ERROR 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails
(`message`, CONSTRAINT `FK_B6BD307FE2904019` FOREIGN KEY (`thread_id`) REFERENCES `message_thread` (`id`))
```

It passes today only because a backfilled channel is empty, so it would have broken the first time #960 put a message in one, on the purge of a real band's space.

So `MessageThreadRepository::deleteByBandSpace()` breaks the cycle explicitly, in order, and `app:band-space:purge` calls it before `deleteById()`, both in one transaction. The alternative, converting the four message foreign keys to CASCADE and SET NULL, was rejected: it arms a silent "delete a thread, lose its messages" on the direct message path this ticket does not otherwise touch, and builds a cyclic cascade the database vendors advise against.

`BandSpaceRepository::deleteById()`'s docblock said "every child table cascades from band_space at database level anyway". That stops being true here, so it is corrected in the same commit.

## Decisions recorded, as #959 asks

- **`name` is nullable.** A direct message has no name, and a non-nullable column would break every existing factory call site.
- **The default channel is `Général`, not `#général`.** The `#` is a channel affordance for the UI to render in #961, not part of the name: a band renaming their channel would not type it. A deliberate deviation from the wording in #959.
- **The private channel escape hatch**, designed and not built: on a channel, absent `MessageParticipant` rows mean every active member, present rows would mean restricted to those. Nothing implements it, and `UNIQUE (band_space_id, name)` leaves room for more than one channel per space if it ever happens.
- **A rejoining member sees the full history**, automatically, because membership is derived rather than stored. #948 concern 2, stated rather than left emergent.
- The unique index cannot enforce "a channel always has a name", because a unique index reads two nulls as distinct. `MessageThreadDirector::createForBandSpace()` is what guarantees it. A database CHECK would not work either: CI builds the test schema from metadata and DBAL emits no CHECK, so no test could reach it.

One line also lands in `MessageThreadMetaRepository::findByUserAndNotDeleted()`: channels are excluded from the direct message inbox explicitly. They were excluded only by an incidental inner join on participants, and #960 gives channel members read-state rows. #994 is where showing them there becomes a decision.

## Verification

- Full suite 2680 green, PHPStan level 8 clean, Biome clean.
- Migration applied, exercised and round tripped on the migration database with two seeded spaces and a direct message thread: one `Général` per space inheriting the space's own `creation_datetime`, the direct message untouched, and `down()` removing the channels with their messages, participants and read-state rows before dropping the column.
- `app:band-space:purge` run against that database with a non-empty channel: succeeds.
- A Band Space created through the dev site: its channel exists, with zero participants.
- Both new tests were checked to be load bearing rather than decorative. Removing the `deleteByBandSpace()` call makes the purge test fail with "Command failed"; removing `wrapInTransaction()` makes the rollback test fail with `0 is identical to 1`; removing the inbox scope filter makes its test report `totalItems: 1`.

## Deploy

Nothing manual. The migration runs from the Deployer pipeline before the symlink flips.
