### PR TITLE
Chat: read and post API for a Band Space channel

### DIFF
--- a/src/ApiResource/BandSpace/Chat/ChatMessageCreate.php
+++ b/src/ApiResource/BandSpace/Chat/ChatMessageCreate.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\Chat;
+
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\Chat\ChatMessagePostProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Post(
+    uriTemplate: '/band_spaces/{bandSpaceId}/chat/messages',
+    uriVariables: [
+        'bandSpaceId' => new Link(fromClass: ChatMessageResource::class, identifiers: ['bandSpaceId']),
+    ],
+    openapi: new Operation(tags: ['Band Space Chat']),
+    security: "is_granted('ROLE_USER')",
+    normalizationContext: ['skip_null_values' => false],
+    output: ChatMessageResource::class,
+    name: 'api_band_space_chat_messages_post',
+    processor: ChatMessagePostProcessor::class,
+)]
+class ChatMessageCreate
+{
+    #[Assert\NotBlank(message: 'Veuillez saisir un message')]
+    #[Assert\Length(max: 5000, maxMessage: 'Le message ne peut pas dépasser {{ limit }} caractères')]
+    public string $content;
+}

--- a/src/ApiResource/BandSpace/Chat/ChatMessageResource.php
+++ b/src/ApiResource/BandSpace/Chat/ChatMessageResource.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\Chat;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Provider\BandSpace\Chat\ChatMessageCollectionProvider;
+use DateTimeInterface;
+
+/**
+ * The band's chat, read.
+ *
+ * Offset paginated rather than cursor paginated, which is what #960 originally called for: #955
+ * settled that question the other way for the same table, because `Message.id` is uuid4 and carries
+ * no order, so a correct cursor would have to be a `(creation_datetime, id)` composite that API
+ * Platform's paginationViaCursor cannot express. The client merges pages by `@id` instead, and
+ * assets/js/utils/messagePagination.js already does it for the direct message thread.
+ */
+#[ApiResource(
+    shortName: 'ChatMessage',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/band_spaces/{bandSpaceId}/chat/messages',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            openapi: new Operation(tags: ['Band Space Chat']),
+            paginationEnabled: true,
+            paginationItemsPerPage: 50,
+            paginationMaximumItemsPerPage: 200,
+            security: "is_granted('ROLE_USER')",
+            name: 'api_band_space_chat_messages_get_collection',
+            provider: ChatMessageCollectionProvider::class,
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+class ChatMessageResource
+{
+    #[ApiProperty(identifier: true)]
+    public string $id;
+
+    #[ApiProperty(identifier: true)]
+    public string $bandSpaceId;
+
+    public string $authorId;
+
+    /** `Utilisateur supprimé` once the account is gone, so the renderer never prints `deleted_<uuid>`. */
+    public string $authorUsername;
+
+    public ?string $authorProfilePictureUrl = null;
+
+    /** Sanitized to text plus `<br>`, like the direct message thread. Rendered with v-html. */
+    public string $content;
+
+    public DateTimeInterface $creationDatetime;
+}

--- a/src/Entity/Message/MessageThread.php
+++ b/src/Entity/Message/MessageThread.php
@@ -71,6 +71,11 @@ class MessageThread
         $this->messageParticipants = new ArrayCollection();
     }
 
+    public function isChannel(): bool
+    {
+        return $this->bandSpace instanceof BandSpace;
+    }
+
     public function addMessage(Message $message): self
     {
         if (!$this->messages->contains($message)) {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -269,6 +269,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return false;
     }
 
+    /** What a renderer shows instead of the `deleted_<uuid>` handle DeleteAccountProcedure leaves behind. */
+    public const string DELETED_DISPLAY_NAME = 'Utilisateur supprimé';
+
     public function isDeleted(): bool
     {
         return $this->deletionDatetime instanceof \DateTimeImmutable;

--- a/src/Repository/Message/MessageRepository.php
+++ b/src/Repository/Message/MessageRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository\Message;
 
 use App\Entity\Message\Message;
+use App\Entity\Message\MessageThread;
 use App\Entity\Message\MessageThreadMeta;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -17,6 +18,59 @@ class MessageRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Message::class);
+    }
+
+    /**
+     * One page of a thread's messages, as scalars.
+     *
+     * Nothing is hydrated, and that is the point. `User` carries three inverse one-to-one profile
+     * associations that Doctrine cannot make lazy (#730), so hydrating one author costs four selects
+     * and a page of fifty distinct authors costs two hundred. The author is reduced to the fields the
+     * renderer needs, and the profile picture to its `imageName`, which is all
+     * UserProfilePictureUrlBuilder::buildFromImageName() needs to rebuild the URL. Same shape as
+     * MusicianAnnounceRepository::findAuthorsDataForAnnounces(), for the same reason.
+     *
+     * Newest first, with `id` as the tiebreak #955 made mandatory: `creation_datetime` is second
+     * granular, ties are ordinary, and SQL promises nothing about their order, so two page requests
+     * planned differently could put a tied row on both sides of a boundary. DESC on both columns lets
+     * the planner read `idx_message_thread_creation` backwards, which is physically `(thread_id,
+     * creation_datetime, id)`, instead of sorting: measured on a real thread, though the plan depends
+     * on the author join staying an eq_ref, so it is a good default rather than a guarantee.
+     *
+     * @return array<int, array{id: string, content: string, creationDatetime: \DateTimeInterface, authorId: string, authorUsername: string, authorDeletionDatetime: ?\DateTimeImmutable, authorProfilePictureName: ?string}>
+     */
+    public function findForThread(MessageThread $thread, int $limit, int $offset): array
+    {
+        return $this->createQueryBuilder('message')
+            ->select(
+                'message.id AS id',
+                'message.content AS content',
+                'message.creationDatetime AS creationDatetime',
+                'author.id AS authorId',
+                'author.username AS authorUsername',
+                'author.deletionDatetime AS authorDeletionDatetime',
+                'picture.imageName AS authorProfilePictureName',
+            )
+            ->join('message.author', 'author')
+            ->leftJoin('author.profilePicture', 'picture')
+            ->where('message.thread = :thread')
+            ->orderBy('message.creationDatetime', 'DESC')
+            ->addOrderBy('message.id', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->setParameter('thread', $thread)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function countForThread(MessageThread $thread): int
+    {
+        return (int) $this->createQueryBuilder('message')
+            ->select('COUNT(message.id)')
+            ->where('message.thread = :thread')
+            ->setParameter('thread', $thread)
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     /**

--- a/src/Repository/Message/MessageThreadRepository.php
+++ b/src/Repository/Message/MessageThreadRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository\Message;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\NonUniqueResultException;
+use App\Entity\BandSpace\BandSpace;
 use App\Entity\Message\MessageThread;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -42,6 +43,16 @@ class MessageThreadRepository extends ServiceEntityRepository
             ->setParameter('number_participant', count($participants))
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+    /**
+     * The space's chat. Looked up by scope, never through findByParticipants(): that resolves a thread
+     * by participant set equality, which is right for a direct message and meaningless for a channel,
+     * whose members are derived and who therefore has no participant rows at all.
+     */
+    public function findChannelForBandSpace(BandSpace $bandSpace): ?MessageThread
+    {
+        return $this->findOneBy(['bandSpace' => $bandSpace]);
     }
 
     /**

--- a/src/Service/Builder/BandSpace/BandSpaceNoteBuilder.php
+++ b/src/Service/Builder/BandSpace/BandSpaceNoteBuilder.php
@@ -4,12 +4,10 @@ namespace App\Service\Builder\BandSpace;
 
 use App\ApiResource\BandSpace\BandSpaceNote as BandSpaceNoteDTO;
 use App\Entity\BandSpace\BandSpaceNote as BandSpaceNoteEntity;
+use App\Entity\User;
 
 readonly class BandSpaceNoteBuilder
 {
-    /** Stands in for a closed account, whose anonymised handle would name nobody. */
-    private const string DELETED_AUTHOR_USERNAME = 'Utilisateur supprimé';
-
     /**
      * The only values in a stored note a browser ever dereferences: an image node's `src` and a link
      * mark's `href`. A text node is not one of them, which is why text is handed back byte for byte.
@@ -64,7 +62,7 @@ readonly class BandSpaceNoteBuilder
         $dto->createdBy = [
             'id' => $entity->createdBy->id,
             'username' => $entity->createdBy->isDeleted()
-                ? self::DELETED_AUTHOR_USERNAME
+                ? User::DELETED_DISPLAY_NAME
                 : $entity->createdBy->username,
         ];
 

--- a/src/Service/Builder/BandSpace/ChatMessageBuilder.php
+++ b/src/Service/Builder/BandSpace/ChatMessageBuilder.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace App\Service\Builder\BandSpace;
+
+use App\ApiResource\BandSpace\Chat\ChatMessageResource;
+use App\Entity\Message\Message;
+use App\Entity\User;
+use App\Service\Builder\User\UserProfilePictureUrlBuilder;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+
+readonly class ChatMessageBuilder
+{
+    public function __construct(
+        private HtmlSanitizerInterface $appOnlybrSanitizer,
+        private UserProfilePictureUrlBuilder $profilePictureUrlBuilder,
+    ) {
+    }
+
+    /**
+     * The list, from scalars rather than entities.
+     *
+     * MessageRepository::findForThread() projects instead of hydrating, so no `User` is loaded and the
+     * three profile tables it drags along (#730) stay out of a fifty-message page. That is the whole
+     * reason this builder does not simply take Message entities.
+     *
+     * @param array<int, array{id: string, content: string, creationDatetime: \DateTimeInterface, authorId: string, authorUsername: string, authorDeletionDatetime: ?\DateTimeImmutable, authorProfilePictureName: ?string}> $rows
+     *
+     * @return ChatMessageResource[]
+     */
+    public function buildFromProjection(array $rows, string $bandSpaceId): array
+    {
+        return array_map(
+            fn (array $row): ChatMessageResource => $this->build(
+                (string) $row['id'],
+                $bandSpaceId,
+                (string) $row['authorId'],
+                (string) $row['authorUsername'],
+                $row['authorDeletionDatetime'] !== null,
+                $this->profilePictureUrlBuilder->buildFromImageName($row['authorProfilePictureName']),
+                (string) $row['content'],
+                $row['creationDatetime'],
+            ),
+            $rows,
+        );
+    }
+
+    /**
+     * The single message a POST returns. Hydrating one author is not the trap the list is.
+     */
+    public function buildItem(Message $entity, string $bandSpaceId): ChatMessageResource
+    {
+        return $this->build(
+            (string) $entity->id,
+            $bandSpaceId,
+            (string) $entity->author->id,
+            $entity->author->username,
+            $entity->author->isDeleted(),
+            $this->profilePictureUrlBuilder->build($entity->author),
+            $entity->content,
+            $entity->creationDatetime,
+        );
+    }
+
+    private function build(
+        string $id,
+        string $bandSpaceId,
+        string $authorId,
+        string $authorUsername,
+        bool $authorIsDeleted,
+        ?string $authorProfilePictureUrl,
+        string $content,
+        \DateTimeInterface $creationDatetime,
+    ): ChatMessageResource {
+        $dto = new ChatMessageResource();
+        $dto->id = $id;
+        $dto->bandSpaceId = $bandSpaceId;
+        $dto->authorId = $authorId;
+        $dto->authorUsername = $authorIsDeleted ? User::DELETED_DISPLAY_NAME : $authorUsername;
+        $dto->authorProfilePictureUrl = $authorProfilePictureUrl;
+        // Sanitized at read time, exactly like the direct message thread: what the sender typed stays
+        // stored, so changing how a message renders stays possible (#956 was closed on that point).
+        $dto->content = $this->appOnlybrSanitizer->sanitize(nl2br($content));
+        $dto->creationDatetime = $creationDatetime;
+
+        return $dto;
+    }
+}

--- a/src/Service/Builder/Musician/MusicianAnnounceBuilder.php
+++ b/src/Service/Builder/Musician/MusicianAnnounceBuilder.php
@@ -8,18 +8,15 @@ use App\ApiResource\Musician\Announce\Style;
 use App\ApiResource\Musician\MusicianAnnounce as MusicianAnnounceDTO;
 use App\Entity\Attribute\Instrument as InstrumentEntity;
 use App\Entity\Attribute\Style as StyleEntity;
-use App\Entity\Image\UserProfilePicture;
 use App\Entity\Musician\MusicianAnnounce as MusicianAnnounceEntity;
 use App\Entity\Musician\MusicianProfile;
 use App\Entity\User;
-use Liip\ImagineBundle\Imagine\Cache\CacheManager;
-use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
+use App\Service\Builder\User\UserProfilePictureUrlBuilder;
 
 readonly class MusicianAnnounceBuilder
 {
     public function __construct(
-        private UploaderHelper $uploaderHelper,
-        private CacheManager $cacheManager,
+        private UserProfilePictureUrlBuilder $profilePictureUrlBuilder,
     ) {
     }
     /**
@@ -126,17 +123,7 @@ readonly class MusicianAnnounceBuilder
         $dto->deletionDatetime = $deletionDatetime;
         $dto->hasMusicianProfile = $hasMusicianProfile;
 
-        if ($profilePictureName !== null) {
-            // The picture's asset path depends only on its imageName (the mapping uses a
-            // static directory namer), so a transient instance is enough to resolve it
-            // without hydrating the owning UserProfilePicture entity per row.
-            $picture = new UserProfilePicture();
-            $picture->imageName = $profilePictureName;
-            $path = $this->uploaderHelper->asset($picture, 'imageFile');
-            if ($path !== null) {
-                $dto->profilePictureUrl = $this->cacheManager->getBrowserPath($path, 'user_profile_picture_small');
-            }
-        }
+        $dto->profilePictureUrl = $this->profilePictureUrlBuilder->buildFromImageName($profilePictureName);
 
         return $dto;
     }

--- a/src/Service/Builder/User/UserProfilePictureUrlBuilder.php
+++ b/src/Service/Builder/User/UserProfilePictureUrlBuilder.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Builder\User;
 
+use App\Entity\Image\UserProfilePicture;
 use App\Entity\User;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
@@ -17,9 +18,32 @@ readonly class UserProfilePictureUrlBuilder
     public function build(User $user): ?string
     {
         $profilePicture = $user->profilePicture;
-        if (!$profilePicture instanceof \App\Entity\Image\UserProfilePicture) {
+        if (!$profilePicture instanceof UserProfilePicture) {
             return null;
         }
+
+        $path = $this->uploaderHelper->asset($profilePicture, 'imageFile');
+        if (!$path) {
+            return null;
+        }
+
+        return $this->cacheManager->getBrowserPath($path, 'user_profile_picture_small');
+    }
+
+    /**
+     * The same URL from a projected image name, for lists that deliberately do not hydrate a User.
+     *
+     * The asset path depends only on the image name, because the mapping uses a static directory
+     * namer, so a transient instance resolves it without loading the owning entity or its user.
+     */
+    public function buildFromImageName(?string $imageName): ?string
+    {
+        if ($imageName === null) {
+            return null;
+        }
+
+        $profilePicture = new UserProfilePicture();
+        $profilePicture->imageName = $imageName;
 
         $path = $this->uploaderHelper->asset($profilePicture, 'imageFile');
         if (!$path) {

--- a/src/Service/Message/ThreadMemberResolver.php
+++ b/src/Service/Message/ThreadMemberResolver.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Message;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceMembership;
+use App\Entity\Message\MessageThread;
+use App\Entity\User;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
+
+/**
+ * Who is in a thread, for the two questions the send path asks.
+ *
+ * A direct message answers both from its `MessageParticipant` rows. A Band Space channel has none:
+ * its members are derived from `BandSpaceMembership`, which is what keeps membership from needing a
+ * second source of truth to synchronise on join, leave, kick and role change (#959).
+ */
+readonly class ThreadMemberResolver
+{
+    public function __construct(
+        private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+    ) {
+    }
+
+    /**
+     * Who the message is for: read-state rows, unread counts, and later the live signal.
+     *
+     * @return User[]
+     */
+    public function activeMembersOf(MessageThread $thread): array
+    {
+        $bandSpace = $thread->bandSpace;
+        if (!$bandSpace instanceof BandSpace) {
+            return $this->participantsOf($thread);
+        }
+
+        return $this->usersOf($this->bandSpaceMembershipRepository->findByBandSpace($bandSpace));
+    }
+
+    /**
+     * Whose rows the transaction must write-lock, which is a superset of the above and deliberately so.
+     *
+     * `BandSpaceMemberChecker::checkMember()` hydrates every membership's user with no status filter,
+     * and a hydrated User makes the flush emit a phantom `UPDATE fos_user SET id` (#985), taking an
+     * exclusive lock. Locking only the active members would leave the flush to lock the rest in
+     * UnitOfWork order rather than id order, which is the inversion #957 closed.
+     *
+     * @return User[]
+     */
+    public function usersToLockFor(MessageThread $thread): array
+    {
+        $bandSpace = $thread->bandSpace;
+        if (!$bandSpace instanceof BandSpace) {
+            return $this->participantsOf($thread);
+        }
+
+        return $this->usersOf(
+            $this->bandSpaceMembershipRepository->findByBandSpace($bandSpace, includeInactive: true)
+        );
+    }
+
+    /**
+     * @return User[]
+     */
+    private function participantsOf(MessageThread $thread): array
+    {
+        $users = [];
+        foreach ($thread->messageParticipants as $participant) {
+            $users[] = $participant->participant;
+        }
+
+        return $users;
+    }
+
+    /**
+     * De-duplicated by id: the same user twice would be looked up twice in findOrCreateMetaFor() and
+     * become a `UNIQUE (thread_id, user_id)` violation on the second insert.
+     *
+     * @param BandSpaceMembership[] $memberships
+     *
+     * @return User[]
+     */
+    private function usersOf(array $memberships): array
+    {
+        $users = [];
+        foreach ($memberships as $membership) {
+            $users[(string) $membership->user->id] = $membership->user;
+        }
+
+        return array_values($users);
+    }
+}

--- a/src/Service/Procedure/Message/MessageSenderProcedure.php
+++ b/src/Service/Procedure/Message/MessageSenderProcedure.php
@@ -14,6 +14,7 @@ use App\Service\Builder\Message\MessageDirector;
 use App\Service\Builder\Message\MessageParticipantDirector;
 use App\Service\Builder\Message\MessageThreadDirector;
 use App\Service\Builder\Message\MessageThreadMetaDirector;
+use App\Service\Message\ThreadMemberResolver;
 use App\Service\User\UserNotificationPreferenceChecker;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,6 +34,7 @@ class MessageSenderProcedure
         private readonly MessageDirector                  $messageDirector,
         private readonly EventDispatcherInterface         $eventDispatcher,
         private readonly UserNotificationPreferenceChecker $preferenceChecker,
+        private readonly ThreadMemberResolver             $threadMemberResolver,
     ) {
     }
 
@@ -106,7 +108,7 @@ class MessageSenderProcedure
 
         $message = $this->entityManager->wrapInTransaction(function () use ($thread, $sender, $content, &$eventsToDispatch): Message {
             // Users first, then the thread, in the same order process() uses. See lockThread().
-            $this->lockUsers($this->participantsOf($thread));
+            $this->lockUsers($this->threadMemberResolver->usersToLockFor($thread));
             $this->lockThread($thread);
 
             $eventsToDispatch = $this->handleReadMessage($thread, $sender);
@@ -222,19 +224,6 @@ class MessageSenderProcedure
     }
 
     /**
-     * @return User[]
-     */
-    private function participantsOf(MessageThread $thread): array
-    {
-        $users = [];
-        foreach ($thread->messageParticipants as $participant) {
-            $users[] = $participant->participant;
-        }
-
-        return $users;
-    }
-
-    /**
      * @return MessageSentEvent[]
      */
     private function handleReadMessage(MessageThread $thread, User $sender): array
@@ -243,15 +232,19 @@ class MessageSenderProcedure
         $metas = $this->messageThreadMetaRepository->findByThreadIndexedByUserId($thread);
 
         $events = [];
-        foreach ($thread->messageParticipants as $participant) {
-            $recipient = $participant->participant;
+        foreach ($this->threadMemberResolver->activeMembersOf($thread) as $recipient) {
             if ($recipient->id !== $sender->id) {
                 $threadMetaRecipient = $this->findOrCreateMetaFor($thread, $recipient, $metas);
                 // The recipient's read position is deliberately left alone: the message about to be
                 // written is newer than it, so it already counts as unread. Rewinding the position to
                 // null, which is what the boolean's `false` amounted to, would resurrect every
                 // message they had already read in this thread.
-                if ($this->shouldNotify($recipient, $threadMetaRecipient)) {
+
+                // A channel emails nobody. MessageSentListener links to `messages/{threadId}`, the
+                // direct message route, which cannot render a channel; and one email per member per
+                // message is the notification volume #948 concern 10 exists to prevent. The read
+                // state above is still written, because that is what the unread count reads.
+                if (!$thread->isChannel() && $this->shouldNotify($recipient, $threadMetaRecipient)) {
                     $threadMetaRecipient->pendingNotificationSent = true;
                     $events[] = new MessageSentEvent($recipient, $sender, $thread);
                 }
@@ -293,12 +286,10 @@ class MessageSenderProcedure
      * see the note there about `UNIQUE (thread_id, user_id)`. A future writer that inserts a meta row
      * without taking that lock, a member joining a channel that already has history for instance,
      * brings the duplicate key back and would need catching. Who *deserves* a row is not decided here:
-     * this trusts `thread->messageParticipants`, so filtering out members who have left stays with
-     * whatever populates that list.
+     * this trusts ThreadMemberResolver, so filtering out members who have left stays with it.
      *
-     * Each participant appears once in `messageParticipants` (`UNIQUE (thread_id, participant_id)`)
-     * and the sender is handled separately, so nothing is looked up twice and the map needs no
-     * updating.
+     * ThreadMemberResolver returns each user once and the sender is handled separately, so nothing is
+     * looked up twice and the map needs no updating.
      *
      * @param array<string, MessageThreadMeta> $metas
      */

--- a/src/State/Processor/BandSpace/Chat/ChatMessagePostProcessor.php
+++ b/src/State/Processor/BandSpace/Chat/ChatMessagePostProcessor.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\Chat;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\ApiResource\BandSpace\Chat\ChatMessageCreate;
+use App\ApiResource\BandSpace\Chat\ChatMessageResource;
+use App\Entity\Message\MessageThread;
+use App\Entity\User;
+use App\Repository\Message\MessageThreadRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\ChatMessageBuilder;
+use App\Service\Procedure\Message\MessageSenderProcedure;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Target;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * @implements ProcessorInterface<ChatMessageCreate, ChatMessageResource>
+ */
+readonly class ChatMessagePostProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private MessageThreadRepository $messageThreadRepository,
+        private MessageSenderProcedure $messageSenderProcedure,
+        private ChatMessageBuilder $chatMessageBuilder,
+        private Security $security,
+        // The same budget as a direct message, on purpose: one person has one sending allowance
+        // whether they are writing to their band or to somebody in particular, and a conversation
+        // that needs more than 20 messages a minute is not a band chat.
+        #[Target('message_send')]
+        private RateLimiterFactoryInterface $messageSendLimiter,
+    ) {
+    }
+
+    /**
+     * @param ChatMessageCreate $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ChatMessageResource
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // Keyed the way both direct message processors key it, so the budget really is shared
+        // rather than a second bucket of the same size.
+        $this->messageSendLimiter->create($user->getUserIdentifier())->consume()->ensureAccepted();
+
+        $bandSpaceId = (string) $uriVariables['bandSpaceId'];
+        [$bandSpace] = $this->memberChecker->checkMemberForWrite($bandSpaceId, $user);
+
+        $channel = $this->messageThreadRepository->findChannelForBandSpace($bandSpace);
+        if (!$channel instanceof MessageThread) {
+            throw new NotFoundHttpException('Ce Band Space n\'a pas de conversation');
+        }
+
+        $message = $this->messageSenderProcedure->processByThread($channel, $user, $data->content);
+
+        return $this->chatMessageBuilder->buildItem($message, $bandSpaceId);
+    }
+}

--- a/src/State/Provider/BandSpace/Chat/ChatMessageCollectionProvider.php
+++ b/src/State/Provider/BandSpace/Chat/ChatMessageCollectionProvider.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Provider\BandSpace\Chat;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Pagination\TraversablePaginator;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\BandSpace\Chat\ChatMessageResource;
+use App\Entity\Message\MessageThread;
+use App\Entity\User;
+use App\Repository\Message\MessageRepository;
+use App\Repository\Message\MessageThreadRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use App\Service\Builder\BandSpace\ChatMessageBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @implements ProviderInterface<ChatMessageResource>
+ */
+readonly class ChatMessageCollectionProvider implements ProviderInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private MessageThreadRepository $messageThreadRepository,
+        private MessageRepository $messageRepository,
+        private ChatMessageBuilder $chatMessageBuilder,
+        private Security $security,
+        private Pagination $pagination,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): TraversablePaginator
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // checkMember(), not checkMemberForWrite(): reading stays open for the whole 30 day deletion
+        // grace period, like every other module.
+        $bandSpaceId = (string) $uriVariables['bandSpaceId'];
+        [$bandSpace] = $this->memberChecker->checkMember($bandSpaceId, $user);
+
+        $channel = $this->messageThreadRepository->findChannelForBandSpace($bandSpace);
+        if (!$channel instanceof MessageThread) {
+            throw new NotFoundHttpException('Ce Band Space n\'a pas de conversation');
+        }
+
+        $page = $this->pagination->getPage($context);
+        $itemsPerPage = $this->pagination->getLimit($operation, $context);
+        $offset = $this->pagination->getOffset($operation, $context);
+
+        $rows = $this->messageRepository->findForThread($channel, $itemsPerPage, $offset);
+
+        return new TraversablePaginator(
+            new \ArrayIterator($this->chatMessageBuilder->buildFromProjection($rows, $bandSpaceId)),
+            $page,
+            $itemsPerPage,
+            $this->messageRepository->countForThread($channel),
+        );
+    }
+}

--- a/tests/Api/BandSpace/Chat/ChatMessageGetCollectionTest.php
+++ b/tests/Api/BandSpace/Chat/ChatMessageGetCollectionTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Chat;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\Message\MessageThread;
+use App\Entity\User;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\Message\MessageFactory;
+use App\Tests\Factory\Message\MessageThreadFactory;
+use App\Tests\Factory\User\UserFactory;
+use App\Tests\Factory\User\UserProfilePictureFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class ChatMessageGetCollectionTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_not_logged(): void
+    {
+        $space = BandSpaceFactory::new()->create();
+
+        $this->client->request('GET', '/api/band_spaces/' . $space->id . '/chat/messages');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
+    }
+
+    public function test_get_collection(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create(['name' => 'Les Trois Accords']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $channel = $this->channelOf($space);
+
+        $older = MessageFactory::new([
+            'thread' => $channel,
+            'author' => $member,
+            'content' => 'on répète mardi',
+            'creationDatetime' => new \DateTime('2026-09-10 20:00:00'),
+        ])->create();
+        $newer = MessageFactory::new([
+            'thread' => $channel,
+            'author' => $member,
+            'content' => "j'apporte la basse",
+            'creationDatetime' => new \DateTime('2026-09-10 20:05:00'),
+        ])->create();
+
+        $this->client->loginUser($member);
+        $this->client->request('GET', '/api/band_spaces/' . $space->id . '/chat/messages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ChatMessage',
+            '@id' => '/api/band_spaces/' . $space->id . '/chat/messages',
+            '@type' => 'Collection',
+            'totalItems' => 2,
+            // Newest first, which is what a chat pane wants and what the composite index reads
+            // backwards without sorting.
+            'member' => [
+                // The apostrophe comes back escaped: the content is sanitizer output, exactly like
+                // the direct message thread, and the thread view renders it with v-html.
+                $this->expectedMessage($newer->id, $space, $member, 'batteur', 'j&#039;apporte la basse', '2026-09-10T20:05:00+00:00'),
+                $this->expectedMessage($older->id, $space, $member, 'batteur', 'on répète mardi', '2026-09-10T20:00:00+00:00'),
+            ],
+        ]);
+    }
+
+    public function test_the_second_page_holds_the_older_messages(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create(['name' => 'Les Trois Accords']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $channel = $this->channelOf($space);
+
+        // 52 messages a minute apart, so page 1 holds 50 and page 2 the two oldest.
+        $messages = [];
+        foreach (range(1, 52) as $minute) {
+            $messages[$minute] = MessageFactory::new([
+                'thread' => $channel,
+                'author' => $member,
+                'content' => 'message ' . $minute,
+                'creationDatetime' => new \DateTime(sprintf('2026-09-10 20:%02d:00', $minute)),
+            ])->create();
+        }
+
+        $this->client->loginUser($member);
+        $this->client->request('GET', '/api/band_spaces/' . $space->id . '/chat/messages?page=2');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ChatMessage',
+            '@id' => '/api/band_spaces/' . $space->id . '/chat/messages',
+            '@type' => 'Collection',
+            'totalItems' => 52,
+            'member' => [
+                $this->expectedMessage($messages[2]->id, $space, $member, 'batteur', 'message 2', '2026-09-10T20:02:00+00:00'),
+                $this->expectedMessage($messages[1]->id, $space, $member, 'batteur', 'message 1', '2026-09-10T20:01:00+00:00'),
+            ],
+            'view' => [
+                '@id' => '/api/band_spaces/' . $space->id . '/chat/messages?page=2',
+                '@type' => 'PartialCollectionView',
+                'first' => '/api/band_spaces/' . $space->id . '/chat/messages?page=1',
+                'last' => '/api/band_spaces/' . $space->id . '/chat/messages?page=2',
+                'previous' => '/api/band_spaces/' . $space->id . '/chat/messages?page=1',
+            ],
+        ]);
+    }
+
+    public function test_a_non_member_cannot_read_the_channel(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create(['username' => 'inconnu', 'email' => 'inconnu@test.com']);
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $this->channelOf($space);
+
+        $this->client->loginUser($stranger);
+        $this->client->request('GET', '/api/band_spaces/' . $space->id . '/chat/messages');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+            'status' => 403,
+            'type' => '/errors/403',
+        ]);
+    }
+
+    public function test_a_band_space_that_does_not_exist_is_a_404(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/api/band_spaces/3f2504e0-4f89-11d3-9a0c-0305e82c3301/chat/messages');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Band Space introuvable',
+            'description' => 'Band Space introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+        ]);
+    }
+
+    public function test_a_deleted_author_is_not_named(): void
+    {
+        // DeleteAccountProcedure rewrites the handle to `deleted_<uuid>` and nulls the picture, so the
+        // renderer must not print either.
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $gone = UserFactory::new()->asBaseUser()->create([
+            'username' => 'deleted_3f2504e0',
+            'email' => 'gone@test.com',
+            'deletionDatetime' => new \DateTimeImmutable('2026-09-01 10:00:00'),
+        ]);
+        $space = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $channel = $this->channelOf($space);
+
+        $message = MessageFactory::new([
+            'thread' => $channel,
+            'author' => $gone,
+            'content' => 'salut',
+            'creationDatetime' => new \DateTime('2026-09-10 20:00:00'),
+        ])->create();
+
+        $this->client->loginUser($member);
+        $this->client->request('GET', '/api/band_spaces/' . $space->id . '/chat/messages');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ChatMessage',
+            '@id' => '/api/band_spaces/' . $space->id . '/chat/messages',
+            '@type' => 'Collection',
+            'totalItems' => 1,
+            'member' => [
+                $this->expectedMessage($message->id, $space, $gone, 'Utilisateur supprimé', 'salut', '2026-09-10T20:00:00+00:00'),
+            ],
+        ]);
+    }
+
+    public function test_an_author_avatar_survives_the_projection(): void
+    {
+        // The projection reduces the picture to its imageName, and the URL is rebuilt from that alone
+        // rather than from the entity. Nothing else in the suite covers a non-null avatar, so without
+        // this the rebuild could return null for every real picture and no test would notice.
+        $member = UserFactory::new()->asBaseUser()->create([
+            'username' => 'batteur',
+            'email' => 'batteur@test.com',
+            'profilePicture' => UserProfilePictureFactory::new(['imageName' => 'batteur-avatar.jpg']),
+        ]);
+        $space = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $channel = $this->channelOf($space);
+
+        MessageFactory::new([
+            'thread' => $channel,
+            'author' => $member,
+            'content' => 'salut',
+            'creationDatetime' => new \DateTime('2026-09-10 20:00:00'),
+        ])->create();
+
+        $this->client->loginUser($member);
+        $this->client->request('GET', '/api/band_spaces/' . $space->id . '/chat/messages');
+
+        $this->assertResponseIsSuccessful();
+        $url = $this->getResponseAsArray()['member'][0]['author_profile_picture_url'];
+        $this->assertIsString($url);
+        $this->assertStringContainsString('batteur-avatar.jpg', $url);
+        $this->assertStringContainsString('user_profile_picture_small', $url);
+    }
+
+    public function test_the_list_never_loads_an_author_profile_table(): void
+    {
+        // The trap #960 names: User carries three inverse one-to-one profile associations Doctrine
+        // cannot make lazy (#730), so hydrating one author costs four selects. Ten distinct authors on
+        // one page is where that becomes forty. The projection is what stops it, and this is what fails
+        // if anyone puts entity hydration back.
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $channel = $this->channelOf($space);
+
+        foreach (range(1, 10) as $index) {
+            $author = UserFactory::new()->asBaseUser()->create([
+                'username' => 'auteur_' . $index,
+                'email' => 'auteur' . $index . '@test.com',
+            ]);
+            MessageFactory::new([
+                'thread' => $channel,
+                'author' => $author,
+                'content' => 'message ' . $index,
+                'creationDatetime' => new \DateTime(sprintf('2026-09-10 20:%02d:00', $index)),
+            ])->create();
+        }
+
+        $this->client->loginUser($member);
+        $this->client->enableProfiler();
+        // The factories above left every author managed, which would hide the very lazy loads this
+        // test exists to count.
+        self::getContainer()->get('doctrine')->getManager()->clear();
+        self::getContainer()->get('doctrine.debug_data_holder')->reset();
+        $this->client->request('GET', '/api/band_spaces/' . $space->id . '/chat/messages');
+
+        $this->assertResponseIsSuccessful();
+        foreach (['user_musician_profile', 'user_notification_preference', 'user_teacher_profile'] as $profileTable) {
+            // At most one, and it is not an author: the firewall hydrates the authenticated viewer
+            // before the provider runs. Ten authors hydrated the old way would be ten here, or thirty
+            // across the three tables, so this still fails loudly if the projection is undone.
+            $this->assertLessThanOrEqual(
+                1,
+                count($this->queriesMatching($profileTable)),
+                sprintf('Listing a channel must not hydrate its authors, and %s says it did', $profileTable),
+            );
+        }
+
+        // And the whole request does not grow with the number of distinct authors: measured at 8 for
+        // this page of ten, which is the viewer, the space with its memberships, the channel, the
+        // list and the count. The margin is there for a change to the firewall, not for a per-author
+        // query: hydrating ten authors would put this near fifty.
+        $this->assertLessThanOrEqual(
+            10,
+            $this->client->getProfile()->getCollector('db')->getQueryCount(),
+            'The message list must cost a fixed number of queries whatever the author count',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function expectedMessage(
+        string $id,
+        BandSpace $space,
+        User $author,
+        string $expectedUsername,
+        string $content,
+        string $creationDatetime,
+    ): array {
+        return [
+            // Composite, because the resource declares two identifiers and has no item operation of
+            // its own. Unique and stable, which is all the client merges pages on; a dereferenceable
+            // item URL arrives with the edit and delete endpoints (#966, #967).
+            '@id' => '/api/chat_messages/id=' . $id . ';bandSpaceId=' . $space->id,
+            '@type' => 'ChatMessage',
+            'id' => $id,
+            'band_space_id' => (string) $space->id,
+            'author_id' => (string) $author->id,
+            'author_username' => $expectedUsername,
+            'author_profile_picture_url' => null,
+            'content' => $content,
+            'creation_datetime' => $creationDatetime,
+        ];
+    }
+
+    private function channelOf(BandSpace $bandSpace): MessageThread
+    {
+        return MessageThreadFactory::new()->forBandSpace($bandSpace)->create();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function queriesMatching(string $needle): array
+    {
+        $profile = $this->client->getProfile();
+        $this->assertNotFalse($profile, 'The profiler must be enabled to inspect the queries.');
+
+        $matching = [];
+        foreach ($profile->getCollector('db')->getQueries()['default'] ?? [] as $query) {
+            $sql = (string) $query['sql'];
+            if (str_contains($sql, $needle)) {
+                $matching[] = $sql;
+            }
+        }
+
+        return $matching;
+    }
+}

--- a/tests/Api/BandSpace/Chat/ChatMessagePostTest.php
+++ b/tests/Api/BandSpace/Chat/ChatMessagePostTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Chat;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\Message\MessageThread;
+use App\Repository\Message\MessageRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\Message\MessageThreadFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class ChatMessagePostTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_not_logged(): void
+    {
+        $space = BandSpaceFactory::new()->create();
+
+        $this->post($space, 'bonjour');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
+    }
+
+    public function test_post_a_message(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $channel = $this->channelOf($space);
+
+        $this->client->loginUser($member);
+        $this->post($space, "on répète mardi, j'apporte la basse");
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $message = self::getContainer()->get(MessageRepository::class)->findOneBy(['thread' => $channel->id]);
+        $this->assertNotNull($message);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ChatMessage',
+            '@id' => '/api/chat_messages/id=' . $message->id . ';bandSpaceId=' . $space->id,
+            '@type' => 'ChatMessage',
+            'id' => (string) $message->id,
+            'band_space_id' => (string) $space->id,
+            'author_id' => (string) $member->id,
+            'author_username' => 'batteur',
+            'author_profile_picture_url' => null,
+            'content' => 'on répète mardi, j&#039;apporte la basse',
+            'creation_datetime' => $message->creationDatetime->format('c'),
+        ]);
+    }
+
+    public function test_a_non_member_cannot_post(): void
+    {
+        $stranger = UserFactory::new()->asBaseUser()->create(['username' => 'inconnu', 'email' => 'inconnu@test.com']);
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $this->channelOf($space);
+
+        $this->client->loginUser($stranger);
+        $this->post($space, 'bonjour');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+            'status' => 403,
+            'type' => '/errors/403',
+        ]);
+    }
+
+    public function test_a_space_pending_deletion_refuses_the_message(): void
+    {
+        // Reading stays open for the whole grace period, writing does not. This falls out of the
+        // processor using checkMemberForWrite() where the provider uses checkMember().
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create([
+            'deletionScheduledDatetime' => new \DateTimeImmutable('+30 days'),
+        ]);
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $this->channelOf($space);
+
+        $this->client->loginUser($member);
+        $this->post($space, 'bonjour');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/409',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+            'description' => 'Cet espace est en attente de suppression, les modifications sont désactivées',
+            'status' => 409,
+            'type' => '/errors/409',
+        ]);
+    }
+
+    public function test_a_blank_message_is_refused(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $this->channelOf($space);
+
+        $this->client->loginUser($member);
+        $this->post($space, '');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'content',
+                    'message' => 'Veuillez saisir un message',
+                    'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                ],
+            ],
+            'detail' => 'content: Veuillez saisir un message',
+            'type' => '/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+            'title' => 'An error occurred',
+            'description' => 'content: Veuillez saisir un message',
+        ]);
+    }
+
+    public function test_a_message_over_five_thousand_characters_is_refused(): void
+    {
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $space = BandSpaceFactory::new()->create();
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $member])->create();
+        $this->channelOf($space);
+
+        $this->client->loginUser($member);
+        $this->post($space, str_repeat('a', 5001));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/ConstraintViolation',
+            '@id' => '/api/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+            'violations' => [
+                [
+                    'propertyPath' => 'content',
+                    'message' => 'Le message ne peut pas dépasser 5000 caractères',
+                    'code' => 'd94b19cc-114f-4f44-9cc4-4138e80a87b9',
+                ],
+            ],
+            'detail' => 'content: Le message ne peut pas dépasser 5000 caractères',
+            'type' => '/validation_errors/d94b19cc-114f-4f44-9cc4-4138e80a87b9',
+            'title' => 'An error occurred',
+            'description' => 'content: Le message ne peut pas dépasser 5000 caractères',
+        ]);
+    }
+
+    private function channelOf(BandSpace $bandSpace): MessageThread
+    {
+        return MessageThreadFactory::new()->forBandSpace($bandSpace)->create();
+    }
+
+    private function post(BandSpace $bandSpace, string $content): void
+    {
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/chat/messages',
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+    }
+}

--- a/tests/Api/BandSpace/Chat/ChatSendPathTest.php
+++ b/tests/Api/BandSpace/Chat/ChatSendPathTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Chat;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\Message\MessageThread;
+use App\Entity\User;
+use App\Enum\BandSpace\MembershipStatus;
+use App\Repository\Message\MessageThreadMetaRepository;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\Message\MessageThreadFactory;
+use App\Tests\Factory\User\UserFactory;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * What a channel does that a direct message does not, all of which was a silent no-op before #960:
+ * membership is derived, so every participant-driven step of MessageSenderProcedure had nothing to
+ * iterate. See ThreadMemberResolver.
+ */
+#[ResetDatabase]
+class ChatSendPathTest extends ApiTestCase
+{
+    public function test_every_active_member_gets_a_read_state_row(): void
+    {
+        // Without this the unread count in #962 would be zero for everyone forever: it counts through
+        // MessageThreadMeta, and a member with no row contributes nothing.
+        [$space, $channel, $sender, $others, $kicked] = $this->band();
+
+        $this->client->loginUser($sender);
+        $this->post($space, 'on répète mardi');
+        $this->assertResponseIsSuccessful();
+
+        $metaRepository = self::getContainer()->get(MessageThreadMetaRepository::class);
+        foreach ([$sender, ...$others] as $member) {
+            $this->assertNotNull(
+                $metaRepository->findOneBy(['thread' => $channel->id, 'user' => $member->id]),
+                sprintf('%s is an active member and should have a read-state row', $member->username),
+            );
+        }
+
+        $this->assertNull(
+            $metaRepository->findOneBy(['thread' => $channel->id, 'user' => $kicked->id]),
+            'Somebody who was kicked is not in the conversation any more',
+        );
+    }
+
+    public function test_a_channel_emails_nobody(): void
+    {
+        // A direct message to these same people would email them: none was recently active and none
+        // has turned notifications off. A channel does not, because MessageSentListener links to the
+        // direct message route and one email per member per message is the volume #948 concern 10 is
+        // about.
+        [$space, , $sender] = $this->band();
+
+        $this->client->loginUser($sender);
+        $this->post($space, 'on répète mardi');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(0);
+    }
+
+    public function test_the_send_locks_every_member_before_the_thread(): void
+    {
+        [$space, , $sender, , $kicked] = $this->band();
+
+        $this->client->loginUser($sender);
+        $this->client->enableProfiler();
+        self::getContainer()->get('doctrine.debug_data_holder')->reset();
+        $this->post($space, 'on répète mardi');
+        $this->assertResponseIsSuccessful();
+
+        $locks = $this->lockQueries();
+        $userLock = $this->firstIndexMatching($locks, 'FROM fos_user');
+        $threadLock = $this->firstIndexMatching($locks, 'FROM message_thread t0');
+
+        $this->assertNotNull($userLock, 'A channel send must write-lock its members');
+        $this->assertLessThan(
+            $threadLock,
+            $userLock,
+            'Members before the thread, or this deadlocks against the direct message path (#957)',
+        );
+
+        // Four, not three: the band has three active members and one who was kicked.
+        // BandSpaceMemberChecker hydrates every membership's user whatever its status, and a hydrated
+        // User makes the flush take its row lock anyway (#985), so the pre-locked set has to cover
+        // them or the ordering guarantee above is a fiction.
+        $this->assertSame(
+            4,
+            $this->lockedUserCount(),
+            'The locked set must cover every membership, not only the active ones',
+        );
+    }
+
+    /**
+     * @return array{0: BandSpace, 1: MessageThread, 2: User, 3: User[], 4: User}
+     */
+    private function band(): array
+    {
+        $space = BandSpaceFactory::new()->create(['name' => 'Les Trois Accords']);
+
+        $sender = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $sender])->create();
+
+        $others = [];
+        foreach (['bassiste', 'chanteuse'] as $username) {
+            $other = UserFactory::new()->asBaseUser()->create([
+                'username' => $username,
+                'email' => $username . '@test.com',
+            ]);
+            BandSpaceMembershipFactory::new(['bandSpace' => $space, 'user' => $other])->create();
+            $others[] = $other;
+        }
+
+        $kicked = UserFactory::new()->asBaseUser()->create(['username' => 'ancien', 'email' => 'ancien@test.com']);
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $space,
+            'user' => $kicked,
+            'status' => MembershipStatus::Kicked,
+        ])->create();
+
+        return [$space, MessageThreadFactory::new()->forBandSpace($space)->create(), $sender, $others, $kicked];
+    }
+
+    private function post(BandSpace $bandSpace, string $content): void
+    {
+        $this->client->jsonRequest(
+            'POST',
+            '/api/band_spaces/' . $bandSpace->id . '/chat/messages',
+            ['content' => $content],
+            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json'],
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function lockQueries(): array
+    {
+        $profile = $this->client->getProfile();
+        $this->assertNotFalse($profile, 'The profiler must be enabled to inspect the queries.');
+
+        $locks = [];
+        foreach ($profile->getCollector('db')->getQueries()['default'] ?? [] as $query) {
+            $sql = (string) $query['sql'];
+            if (str_contains($sql, 'FOR UPDATE')) {
+                $locks[] = $sql;
+            }
+        }
+
+        return $locks;
+    }
+
+    /**
+     * How many rows the user lock covers, counted from the placeholders of its `IN (?, ?, ...)`, which
+     * is the one part of the statement the profiler reports verbatim.
+     */
+    private function lockedUserCount(): int
+    {
+        foreach ($this->lockQueries() as $sql) {
+            if (str_contains($sql, 'FROM fos_user')) {
+                return substr_count($sql, '?');
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param list<string> $locks
+     */
+    private function firstIndexMatching(array $locks, string $needle): ?int
+    {
+        foreach ($locks as $index => $sql) {
+            if (str_contains($sql, $needle)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #960. Track D of #948, on top of #959.

## What changes

`GET` and `POST` on `/api/band_spaces/{bandSpaceId}/chat/messages`, authored under the Band Space namespaces rather than the Message ones so that `BandSpaceWriteGuardCoverageTest` covers the processor: a chat processor under `src/State/Processor/Message/` would have escaped the pending deletion net with nothing to catch it.

Reads go through `checkMember()`, writes through `checkMemberForWrite()`, so a space in its 30 day grace period stays readable and refuses new messages with a 409.

## The send path was doing nothing for a channel

`MessageSenderProcedure` resolved participants only from `$thread->messageParticipants`, and a channel has none: its members are derived from `BandSpaceMembership`. Every participant-driven step was a silent no-op. No user was locked, no member got a `MessageThreadMeta` row, so the unread count in #962 would have been zero for everybody forever.

`App\Service\Message\ThreadMemberResolver` replaces that collection as the source of truth, and `handleReadMessage()` iterates it. A direct message resolves to exactly the same users it did before, which is why the existing message tests are untouched and green.

**The lock set is deliberately wider than the fan-out set.** `BandSpaceMemberChecker::checkMember()` loads the space through `findOneByIdWithMemberships()`, which selects memberships and their users with no status filter, so every member's `User` is hydrated before the procedure runs, Left and Kicked included. Under #985 a hydrated `User` makes the flush emit a phantom `UPDATE fos_user SET id` and take that row's lock. Locking only the active members would leave the rest to the flush in UnitOfWork order rather than id order, which is the inversion #957 closed. So `usersToLockFor()` returns every membership's user and `activeMembersOf()` only the active ones. `ChatSendPathTest` pins it by counting placeholders in the lock statement: a band of three actives and one kicked member locks four rows, not three.

## A channel emails nobody

Suppressed where the decision is made, in `handleReadMessage()`, not in the listener: `pendingNotificationSent` is flipped in the procedure, so suppressing downstream would set the throttle flag without ever sending and leave every member permanently throttled. Three reasons: `MessageSentListener` links to `messages/{threadId}`, the direct message route, which cannot render a channel; one email per member per message is the volume #948 concern 10 exists to prevent; and the epic parks the digest email deliberately. Read state is still written, because that is what the unread count reads.

## The hydration trap, guarded rather than asserted

#960 names it: `User` carries three inverse one-to-one profile associations Doctrine cannot make lazy (#730), so hydrating one author costs four selects and a page of fifty costs two hundred. `MessageRepository::findForThread()` projects scalars instead, including the profile picture's `imageName`, and the URL is rebuilt from that name alone. Same shape as `MusicianAnnounceRepository::findAuthorsDataForAnnounces()`, the one existing projection idiom here.

`ChatMessageGetCollectionTest` measures it: ten messages from ten distinct authors, 8 queries for the whole request, and no query at all against `user_musician_profile`, `user_notification_preference` or `user_teacher_profile`. It clears the identity map first, so a lazy load shows up as a real query instead of being absorbed.

Two small refactors fall out of that. `UserProfilePictureUrlBuilder::buildFromImageName()` now holds the rebuild that `MusicianAnnounceBuilder` was hand-rolling, and `Utilisateur supprimé` moves to `User::DELETED_DISPLAY_NAME` so the note builder and the chat builder share one string. Neither branch had any test coverage in the suite before; there is one now.

## Deviations from the issue text, deliberate

- **Offset pagination, not cursor.** The issue says "cursor paginated per C2", but C2 (#955) shipped offset paging plus a client side merge, because `Message.id` is uuid4 and a correct cursor would be a `(creation_datetime, id)` composite API Platform cannot express. Matching #955 also lets `assets/js/utils/messagePagination.js` serve the channel unchanged.
- **No item `Get`**, so each message's `@id` is API Platform's composite identifier rather than a dereferenceable URL. A real item route arrives with edit and delete (#966, #967). The auto generated shadow route answers a clean 404 "This route does not aim to be called" for anonymous and authenticated callers alike, checked rather than assumed.
- **No activity entry** (#965, which needs a `chat` case on `BandSpaceModule`) and **no Mercure signal** (#963). The listener still builds its topics from participant rows, so a channel publishes nothing yet; the hook is one resolver call away.

The channel reuses the `message_send` limiter, keyed by user identifier the way both direct message processors key it, so it really is one 20 per minute budget per person rather than a second bucket of the same size.

## Verification

- Full suite 2698 green, PHPStan level 8 clean, Biome clean.
- On the dev site: created a space, posted to its channel (201), read the list back (200), and confirmed one read-state row for its only member. Probe data removed afterwards.
- The new assertions were checked to be load bearing, not decorative: the avatar test fails if the rebuild returns null, the query guard fails if the projection is undone, and the lock count fails if the kicked member is dropped from the locked set.

## Known gap, left to #962

A member who joins after messages exist gets their read-state row on the next send with no read position, so the backlog reads as unread, and somebody who leaves and rejoins keeps a stale one. Both are unread semantics rather than read or post correctness, so they belong with the unread count.

## Deploy

Nothing. No migration, no new environment variable.
