### PR TITLE
Chat: the Band Space tab, behind the tester flag

### DIFF
--- a/assets/js/api/bandSpace/band-space-chat.js
+++ b/assets/js/api/bandSpace/band-space-chat.js
@@ -1,0 +1,30 @@
+/** global: Routing */
+
+import axios from 'axios'
+import { handleApiError } from '../utils/handleApiError.js'
+
+export default {
+  /**
+   * The whole Hydra body, not just `member`: the store needs `totalItems` to know whether there is
+   * older history left to load.
+   */
+  getMessages(bandSpaceId, { page } = {}) {
+    return axios
+      .get(Routing.generate('api_band_space_chat_messages_get_collection', { bandSpaceId }), {
+        params: { page }
+      })
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
+  postMessage(bandSpaceId, content) {
+    return axios
+      .post(
+        Routing.generate('api_band_space_chat_messages_post', { bandSpaceId }),
+        { content },
+        { headers: { 'Content-Type': 'application/ld+json', Accept: 'application/ld+json' } }
+      )
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  }
+}

--- a/assets/js/components/BandSpace/Chat/ChatComposer.vue
+++ b/assets/js/components/BandSpace/Chat/ChatComposer.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="border-t border-surface-200 dark:border-surface-700 p-4">
+    <Message v-if="sendError" severity="error" :closable="false" class="mb-2">
+      {{ sendError }}
+    </Message>
+
+    <div class="flex gap-2 items-end">
+      <Textarea
+        ref="messageInput"
+        v-model="content"
+        rows="2"
+        class="flex-1 resize-none"
+        placeholder="Votre message..."
+        aria-label="Votre message"
+        :disabled="chatStore.isSending"
+        @keydown.enter.exact.prevent="send"
+      />
+      <Button
+        icon="pi pi-send"
+        aria-label="Envoyer le message"
+        :loading="chatStore.isSending"
+        :disabled="!content.trim() || chatStore.isSending"
+        @click="send"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import Textarea from 'primevue/textarea'
+import { nextTick, ref } from 'vue'
+import { useBandSpaceChatStore } from '../../../store/bandSpace/bandSpaceChat.js'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true }
+})
+
+const emit = defineEmits(['sent'])
+
+const chatStore = useBandSpaceChatStore()
+const content = ref('')
+const sendError = ref('')
+const messageInput = ref(null)
+
+async function send() {
+  if (!content.value.trim() || chatStore.isSending) {
+    return
+  }
+
+  sendError.value = ''
+
+  try {
+    await chatStore.sendMessage(props.bandSpaceId, content.value)
+    content.value = ''
+    emit('sent')
+    nextTick(() => messageInput.value?.$el?.focus())
+  } catch (e) {
+    sendError.value = errorMessageFor(e)
+  }
+}
+
+/**
+ * handleApiError already carries the server's own French sentence, so a message too long or a space
+ * in its deletion grace period explains itself. Only the rate limiter needs wording of our own, since
+ * its 429 body says nothing a member could act on.
+ */
+function errorMessageFor(error) {
+  if (error.status === 429) {
+    return 'Trop de messages envoyés. Veuillez patienter un instant.'
+  }
+
+  console.error('Failed to send the message:', error)
+
+  return error.message || "Le message n'a pas pu être envoyé."
+}
+</script>

--- a/assets/js/components/BandSpace/Chat/ChatMessageList.vue
+++ b/assets/js/components/BandSpace/Chat/ChatMessageList.vue
@@ -1,0 +1,151 @@
+<template>
+  <div
+    ref="messagesContainer"
+    class="flex-1 overflow-y-auto p-4 space-y-4"
+    role="log"
+    aria-label="Messages de la discussion"
+  >
+    <div v-if="chatStore.hasOlderMessages" class="flex justify-center">
+      <Button
+        label="Charger les messages plus anciens"
+        severity="secondary"
+        outlined
+        size="small"
+        :loading="chatStore.isLoadingOlder"
+        @click="handleLoadOlder"
+      />
+    </div>
+
+    <Message v-if="chatStore.loadOlderError" severity="error" :closable="false">
+      {{ chatStore.loadOlderError }}
+    </Message>
+
+    <div
+      v-for="message in chatStore.messages"
+      :key="message['@id']"
+      class="flex gap-3"
+      :class="{ 'flex-row-reverse': isMine(message) }"
+    >
+      <Avatar
+        :username="message.author_username"
+        :picture-url="message.author_profile_picture_url"
+        size="md"
+        class="mt-1 shrink-0"
+      />
+
+      <div class="min-w-0 max-w-[75%]" :class="{ 'text-right': isMine(message) }">
+        <div
+          class="flex items-baseline gap-2 mb-1 text-xs text-surface-500 dark:text-surface-400"
+          :class="{ 'flex-row-reverse': isMine(message) }"
+        >
+          <span class="font-semibold text-surface-700 dark:text-surface-200 truncate">
+            {{ message.author_username }}
+          </span>
+          <span>{{ relativeDate(message.creation_datetime) }}</span>
+        </div>
+
+        <div
+          class="inline-block rounded-2xl px-4 py-2 text-sm break-words text-left"
+          :class="
+            isMine(message)
+              ? 'bg-primary-700 text-white [&_a]:text-white [&_a]:underline'
+              : 'bg-surface-100 dark:bg-surface-700 text-surface-900 dark:text-surface-0 [&_a]:text-primary-500 [&_a]:underline'
+          "
+          v-html="autoLink(message.content)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import { nextTick, onMounted, ref, watch } from 'vue'
+import relativeDate from '../../../helper/date/relative-date.js'
+import { useBandSpaceChatStore } from '../../../store/bandSpace/bandSpaceChat.js'
+import { useUserSecurityStore } from '../../../store/user/security.js'
+import { autoLink } from '../../../utils/autoLink.js'
+import Avatar from '../../User/Avatar.vue'
+
+const props = defineProps({
+  bandSpaceId: { type: String, required: true }
+})
+
+const chatStore = useBandSpaceChatStore()
+const userSecurityStore = useUserSecurityStore()
+const messagesContainer = ref(null)
+
+function isMine(message) {
+  return message.author_username === userSecurityStore.user?.username
+}
+
+function scrollToBottom() {
+  nextTick(() => {
+    if (messagesContainer.value) {
+      messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight
+    }
+  })
+}
+
+/** Within a screenful of the end, which is close enough to count as following the conversation. */
+const FOLLOWING_THRESHOLD_PX = 120
+
+function isFollowingTheConversation() {
+  const container = messagesContainer.value
+  if (!container) {
+    return true
+  }
+
+  return (
+    container.scrollHeight - container.scrollTop - container.clientHeight < FOLLOWING_THRESHOLD_PX
+  )
+}
+
+/**
+ * Keeps the reader where they were while the page grows above them: the message under the cursor has
+ * to stay under the cursor, so the scroll position moves by exactly how much taller the list got.
+ */
+async function handleLoadOlder() {
+  const container = messagesContainer.value
+  const previousScrollHeight = container?.scrollHeight ?? 0
+  const previousScrollTop = container?.scrollTop ?? 0
+
+  await chatStore.loadOlderMessages(props.bandSpaceId)
+  await nextTick()
+
+  if (container) {
+    container.scrollTop = previousScrollTop + (container.scrollHeight - previousScrollHeight)
+  }
+}
+
+/**
+ * Deliberately not `flush: 'post'`: the scroll position is read before the DOM updates, so it tells
+ * us where the reader was rather than where the browser has already put them.
+ *
+ * Comparing the last `@id` is what separates a new message at the end from a page prepended at the
+ * top. Height alone cannot: a conversation shorter than its pane is always "at the bottom", so a
+ * prepend would scroll the reader away from the history they just asked for.
+ */
+let lastTailIri = null
+
+watch(
+  () => chatStore.messages,
+  (currentMessages) => {
+    const tailIri = currentMessages.at(-1)?.['@id'] ?? null
+    const grewAtTheEnd = tailIri !== lastTailIri
+    lastTailIri = tailIri
+
+    if (grewAtTheEnd && isFollowingTheConversation()) {
+      scrollToBottom()
+    }
+  },
+  { deep: true }
+)
+
+onMounted(scrollToBottom)
+
+// Sending is the one case where the reader is moved without being asked: they wrote it, so they mean
+// to see it, even if they were up in the history a moment ago.
+defineExpose({ scrollToBottom })
+</script>

--- a/assets/js/components/Message/Thread.vue
+++ b/assets/js/components/Message/Thread.vue
@@ -147,6 +147,7 @@ import relativeDate from '../../helper/date/relative-date.js'
 import { displayName } from '../../helper/user/displayName.js'
 import { useMessageStore } from '../../store/message/message.js'
 import { useUserSecurityStore } from '../../store/user/security.js'
+import { autoLink } from '../../utils/autoLink.js'
 import { getAvatarStyle } from '../../utils/avatar.js'
 
 const emit = defineEmits(['back'])
@@ -172,13 +173,6 @@ const isRecipientDeleted = computed(() => !!otherParticipant.value?.deletion_dat
 
 function isSender(message) {
   return message.author?.username === securityStore.user?.username
-}
-
-function autoLink(str) {
-  if (!str) return ''
-  // Simple URL linkification
-  const urlPattern = /(https?:\/\/[^\s<]+)/g
-  return str.replace(urlPattern, '<a href="$1" target="_blank" rel="noopener">$1</a>')
 }
 
 async function send() {

--- a/assets/js/constants/bandSpace.js
+++ b/assets/js/constants/bandSpace.js
@@ -5,6 +5,7 @@ export const BAND_SPACE_ROUTES = {
   INDEX: 'app_band_index',
   DASHBOARD: 'app_band_dashboard',
   AGENDA: 'app_band_agenda',
+  CHAT: 'app_band_chat',
   NOTES: 'app_band_notes',
   FILES: 'app_band_files',
   TASKS: 'app_band_tasks',
@@ -30,6 +31,16 @@ export const LAST_TECH_RIDER_KEY = 'lastTechRiderId'
  * a tester (#942).
  */
 export const RIDER_TESTER_ONLY = true
+
+/**
+ * Same curtain as the tech riders above, for the same reason and with the same single flip. The chat
+ * is piloted with one real band first: the epic's risk is half a band switching and the other half
+ * staying on their old group conversation, and the only way to find that out is to ask one band.
+ *
+ * The route name says chat, matching the API it calls, while the tab reads « Discussion » because the
+ * main navigation already spends the word « Messages » on direct messages.
+ */
+export const CHAT_TESTER_ONLY = true
 
 /**
  * The modules a Band Space is described by, shared between the public presentation page and the
@@ -84,6 +95,7 @@ export const BAND_SPACE_MODULES = Object.freeze([
 export const SECTION_NAMES = {
   [BAND_SPACE_ROUTES.DASHBOARD]: 'Dashboard',
   [BAND_SPACE_ROUTES.AGENDA]: 'Agenda',
+  [BAND_SPACE_ROUTES.CHAT]: 'Discussion',
   [BAND_SPACE_ROUTES.NOTES]: 'Notes',
   [BAND_SPACE_ROUTES.FILES]: 'Fichiers',
   [BAND_SPACE_ROUTES.TASKS]: 'Tâches',
@@ -138,6 +150,12 @@ export function resolveSettingsSection(requestedKey, isAdmin) {
 export const NAVIGATION_ITEMS = Object.freeze([
   { label: 'Dashboard', route: BAND_SPACE_ROUTES.DASHBOARD, icon: 'pi-th-large' },
   { label: 'Agenda', route: BAND_SPACE_ROUTES.AGENDA, icon: 'pi-calendar' },
+  {
+    label: 'Discussion',
+    route: BAND_SPACE_ROUTES.CHAT,
+    icon: 'pi-comments',
+    testerOnly: CHAT_TESTER_ONLY
+  },
   { label: 'Notes', route: BAND_SPACE_ROUTES.NOTES, icon: 'pi-file-edit' },
   { label: 'Fichiers', route: BAND_SPACE_ROUTES.FILES, icon: 'pi-folder' },
   { label: 'Setlists', route: BAND_SPACE_ROUTES.SETLIST, icon: 'pi-list' },

--- a/assets/js/constants/bandSpace.test.js
+++ b/assets/js/constants/bandSpace.test.js
@@ -3,10 +3,12 @@ import { describe, it } from 'node:test'
 import {
   BAND_SPACE_ROUTES,
   BAND_SPACE_SETTINGS_SECTIONS,
+  CHAT_TESTER_ONLY,
   filterSectionsByRole,
   NAVIGATION_ITEMS,
   RIDER_TESTER_ONLY,
   resolveSettingsSection,
+  SECTION_NAMES,
   visibleSettingsSections
 } from './bandSpace.js'
 
@@ -41,13 +43,33 @@ describe('the Tech Riders curtain', () => {
     assert.equal(rider.testerOnly, RIDER_TESTER_ONLY)
   })
 
-  it('gates nothing else, so the flip cannot take another module with it', () => {
+  it('gates nothing beyond the two curtained modules, so a flip takes only its own', () => {
     const gated = NAVIGATION_ITEMS.filter((item) => item.testerOnly !== undefined)
 
     assert.deepEqual(
       gated.map((item) => item.route),
-      [BAND_SPACE_ROUTES.RIDER]
+      [BAND_SPACE_ROUTES.CHAT, BAND_SPACE_ROUTES.RIDER]
     )
+  })
+})
+
+describe('the Discussion curtain', () => {
+  // Same promise as the tech riders above, and the same trap: the sidebar entry and the route guard
+  // have to read one flag or releasing the chat stops being a single flip.
+  it('gates the sidebar entry on the shared flag', () => {
+    const chat = NAVIGATION_ITEMS.find((item) => item.route === BAND_SPACE_ROUTES.CHAT)
+
+    assert.ok(chat)
+    assert.equal(chat.testerOnly, CHAT_TESTER_ONLY)
+  })
+
+  it('is named for the members rather than for the API it calls', () => {
+    // « Messages » in the main navigation is direct messages. Two different things under one word,
+    // one click apart, is the confusion this label exists to avoid.
+    const chat = NAVIGATION_ITEMS.find((item) => item.route === BAND_SPACE_ROUTES.CHAT)
+
+    assert.equal(chat.label, 'Discussion')
+    assert.equal(SECTION_NAMES[BAND_SPACE_ROUTES.CHAT], 'Discussion')
   })
 })
 

--- a/assets/js/constants/feedback.js
+++ b/assets/js/constants/feedback.js
@@ -28,6 +28,7 @@ export const FEEDBACK_MODULE_GROUPS = Object.freeze([
     items: [
       { value: FEEDBACK_MODULES.DASHBOARD, label: 'Dashboard du Band Space' },
       { value: FEEDBACK_MODULES.AGENDA, label: 'Agenda' },
+      { value: FEEDBACK_MODULES.CHAT, label: 'Discussion' },
       { value: FEEDBACK_MODULES.NOTES, label: 'Notes' },
       { value: FEEDBACK_MODULES.FILE, label: 'Fichiers' },
       { value: FEEDBACK_MODULES.SETLIST, label: 'Setlists' },

--- a/assets/js/router/index.js
+++ b/assets/js/router/index.js
@@ -1,5 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import { RIDER_TESTER_ONLY } from '../constants/bandSpace.js'
+import { CHAT_TESTER_ONLY, RIDER_TESTER_ONLY } from '../constants/bandSpace.js'
 import admin from './admin.js'
 import course from './course.js'
 import forum from './forum.js'
@@ -68,6 +68,14 @@ const routes = [
         path: ':id/agenda',
         name: 'app_band_agenda',
         component: () => import('../views/BandSpace/Agenda.vue')
+      },
+      {
+        // The URL is French because that is what a member reads; the route name says chat, matching
+        // the API it calls. Gated like the rider module, so releasing is one flip in constants.
+        path: ':id/discussion',
+        name: 'app_band_chat',
+        component: () => import('../views/BandSpace/Chat.vue'),
+        meta: { testerOnly: CHAT_TESTER_ONLY }
       },
       {
         path: ':id/notes',

--- a/assets/js/store/bandSpace/bandSpaceChat.js
+++ b/assets/js/store/bandSpace/bandSpaceChat.js
@@ -1,0 +1,146 @@
+import { defineStore } from 'pinia'
+import { computed, readonly, ref } from 'vue'
+import bandSpaceChatApi from '../../api/bandSpace/band-space-chat.js'
+import {
+  hasOlderToLoad,
+  mergeMessages,
+  nextOlderPageToLoad
+} from '../../utils/messagePagination.js'
+
+/**
+ * The band's conversation. Held oldest first, which is reading order, while the API answers newest
+ * first so that page 1 is the newest page: every page is reversed on arrival.
+ *
+ * The pagination helpers are the ones the direct message thread already uses (#955). They key on
+ * `@id` and `creation_datetime`, both of which a chat message carries, so nothing there needed
+ * widening.
+ */
+export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
+  const messages = ref([])
+  const totalMessages = ref(0)
+  const isLoading = ref(false)
+  const loadError = ref(null)
+  const isLoadingOlder = ref(false)
+  const loadOlderError = ref(null)
+  const isSending = ref(false)
+
+  const hasOlderMessages = computed(() =>
+    hasOlderToLoad(messages.value.length, totalMessages.value)
+  )
+
+  /**
+   * The total can only go up, because nothing deletes a message yet. A response that was issued
+   * before a send lands with a total that predates it, and taking it at face value would hide the
+   * « charger les messages plus anciens » button while history is still unread. Revisit at #967,
+   * which is when a message can start disappearing.
+   */
+  function knownTotal(reported) {
+    return Math.max(reported ?? 0, totalMessages.value, messages.value.length)
+  }
+
+  // Compared after every await: switching space remounts the view, and a slow first page must not
+  // land on top of the space the member has already moved to.
+  let loadToken = 0
+
+  async function loadMessages(bandSpaceId) {
+    const token = ++loadToken
+    isLoading.value = true
+    loadError.value = null
+    loadOlderError.value = null
+
+    try {
+      const response = await bandSpaceChatApi.getMessages(bandSpaceId)
+      if (token !== loadToken) {
+        return
+      }
+      // Merged, not replaced: the composer is usable while this is in flight, and a message sent
+      // meanwhile would otherwise be wiped from the pane by a response that predates it. The store
+      // is cleared when the view mounts, so on a normal load there is nothing to merge with.
+      messages.value = mergeMessages(messages.value, (response.member || []).reverse())
+      totalMessages.value = knownTotal(response.totalItems)
+    } catch (e) {
+      console.error('Failed to load the chat:', e)
+      if (token === loadToken) {
+        messages.value = []
+        totalMessages.value = 0
+        loadError.value = 'Impossible de charger la discussion'
+      }
+    } finally {
+      if (token === loadToken) {
+        isLoading.value = false
+      }
+    }
+  }
+
+  /**
+   * Prepends the next page of history. The page to ask for is derived from how many messages are
+   * held rather than from a counter, so it cannot drift.
+   */
+  async function loadOlderMessages(bandSpaceId) {
+    if (isLoadingOlder.value || !hasOlderMessages.value) {
+      return
+    }
+
+    const token = loadToken
+    isLoadingOlder.value = true
+    loadOlderError.value = null
+
+    try {
+      const response = await bandSpaceChatApi.getMessages(bandSpaceId, {
+        page: nextOlderPageToLoad(messages.value.length)
+      })
+      if (token !== loadToken) {
+        return
+      }
+      messages.value = mergeMessages(messages.value, (response.member || []).reverse())
+      totalMessages.value = knownTotal(response.totalItems)
+    } catch (e) {
+      console.error('Failed to load older chat messages:', e)
+      loadOlderError.value = 'Impossible de charger les messages plus anciens.'
+    } finally {
+      isLoadingOlder.value = false
+    }
+  }
+
+  /**
+   * Appends through the merge rather than pushing, so the message is de-duplicated by `@id` the day
+   * #963 makes the same message arrive over Mercure as well.
+   */
+  async function sendMessage(bandSpaceId, content) {
+    isSending.value = true
+
+    try {
+      const message = await bandSpaceChatApi.postMessage(bandSpaceId, content)
+      const heldBefore = messages.value.length
+      messages.value = mergeMessages(messages.value, [message])
+      totalMessages.value += messages.value.length - heldBefore
+    } finally {
+      isSending.value = false
+    }
+  }
+
+  function clear() {
+    messages.value = []
+    totalMessages.value = 0
+    isLoading.value = false
+    loadError.value = null
+    isLoadingOlder.value = false
+    loadOlderError.value = null
+    isSending.value = false
+  }
+
+  return {
+    messages: readonly(messages),
+    totalMessages: readonly(totalMessages),
+    isLoading: readonly(isLoading),
+    loadError: readonly(loadError),
+    isLoadingOlder: readonly(isLoadingOlder),
+    loadOlderError: readonly(loadOlderError),
+    isSending: readonly(isSending),
+    hasOlderMessages,
+    loadMessages,
+    loadOlderMessages,
+    sendMessage,
+    clear
+  }
+})

--- a/assets/js/utils/autoLink.js
+++ b/assets/js/utils/autoLink.js
@@ -1,0 +1,21 @@
+/**
+ * Wraps bare URLs in anchors, for message bodies rendered with `v-html`.
+ *
+ * The input is always sanitizer output from the API, never raw user input: the server strips every
+ * tag but `<br>` and escapes the rest, which is what makes this safe to inject. `"` and `=` come back
+ * as entities, so a URL cannot break out of the `href` this builds, and the pattern only matches
+ * `http` and `https`, so no `javascript:` scheme can reach it either. See #956, closed on the point
+ * that sanitizing at read time is what keeps that guarantee.
+ *
+ * `[^\s<]` stops the match at a tag boundary, so a URL at the end of a line is not swallowed into the
+ * `<br>` that follows it.
+ */
+const URL_PATTERN = /(https?:\/\/[^\s<]+)/g
+
+export function autoLink(text) {
+  if (!text) {
+    return ''
+  }
+
+  return text.replace(URL_PATTERN, '<a href="$1" target="_blank" rel="noopener">$1</a>')
+}

--- a/assets/js/utils/autoLink.test.js
+++ b/assets/js/utils/autoLink.test.js
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { autoLink } from './autoLink.js'
+
+describe('autoLink', () => {
+  it('wraps a bare URL in an anchor that opens safely', () => {
+    assert.equal(
+      autoLink('voir https://musicall.com/publications'),
+      'voir <a href="https://musicall.com/publications" target="_blank" rel="noopener">https://musicall.com/publications</a>'
+    )
+  })
+
+  it('leaves text without a URL untouched', () => {
+    assert.equal(autoLink('on répète mardi'), 'on répète mardi')
+  })
+
+  it('returns an empty string for nothing at all', () => {
+    assert.equal(autoLink(''), '')
+    assert.equal(autoLink(null), '')
+    assert.equal(autoLink(undefined), '')
+  })
+
+  it('stops at a tag boundary rather than swallowing the line break after it', () => {
+    // The server turns newlines into `<br />` before this runs, so a URL ending a line sits right
+    // against a tag. `[^\s<]` is what keeps the tag out of the href.
+    assert.equal(
+      autoLink('https://musicall.com<br />suite'),
+      '<a href="https://musicall.com" target="_blank" rel="noopener">https://musicall.com</a><br />suite'
+    )
+  })
+
+  it('links every URL in the message, not only the first', () => {
+    const linked = autoLink('https://a.test et https://b.test')
+
+    assert.equal(linked.match(/<a /g)?.length, 2)
+  })
+
+  it('does not touch a scheme it cannot vouch for', () => {
+    assert.equal(autoLink('javascript:alert(1)'), 'javascript:alert(1)')
+    assert.equal(autoLink('ftp://files.test/x'), 'ftp://files.test/x')
+  })
+})

--- a/assets/js/utils/feedbackModule.js
+++ b/assets/js/utils/feedbackModule.js
@@ -6,6 +6,7 @@ import { BAND_SPACE_ROUTES } from '../constants/bandSpace.js'
  */
 export const FEEDBACK_MODULES = Object.freeze({
   AGENDA: 'agenda',
+  CHAT: 'chat',
   NOTES: 'notes',
   FILE: 'file',
   TASK: 'task',
@@ -34,6 +35,7 @@ export const FEEDBACK_MODULES = Object.freeze({
  */
 const ROUTE_TO_MODULE = Object.freeze({
   [BAND_SPACE_ROUTES.AGENDA]: FEEDBACK_MODULES.AGENDA,
+  [BAND_SPACE_ROUTES.CHAT]: FEEDBACK_MODULES.CHAT,
   [BAND_SPACE_ROUTES.NOTES]: FEEDBACK_MODULES.NOTES,
   [BAND_SPACE_ROUTES.FILES]: FEEDBACK_MODULES.FILE,
   [BAND_SPACE_ROUTES.TASKS]: FEEDBACK_MODULES.TASK,

--- a/assets/js/utils/feedbackModule.test.js
+++ b/assets/js/utils/feedbackModule.test.js
@@ -6,6 +6,7 @@ import { FEEDBACK_MODULES, resolveFeedbackModule } from './feedbackModule.js'
 describe('resolveFeedbackModule', () => {
   it('maps every Band Space route to its own module', () => {
     assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.AGENDA), FEEDBACK_MODULES.AGENDA)
+    assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.CHAT), FEEDBACK_MODULES.CHAT)
     assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.NOTES), FEEDBACK_MODULES.NOTES)
     assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.FILES), FEEDBACK_MODULES.FILE)
     assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.TASKS), FEEDBACK_MODULES.TASK)
@@ -14,6 +15,19 @@ describe('resolveFeedbackModule', () => {
     assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.RIDER), FEEDBACK_MODULES.RIDER)
     assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.PARAMETERS), FEEDBACK_MODULES.SETTINGS)
     assert.equal(resolveFeedbackModule(BAND_SPACE_ROUTES.DASHBOARD), FEEDBACK_MODULES.DASHBOARD)
+  })
+
+  // The list above names what each route maps to; this one catches a route that was never mapped at
+  // all. A new tab that skips feedbackModule.js files its feedback as OTHER and nothing else notices,
+  // which is how the chat tab nearly shipped (#961).
+  it('leaves no Band Space route falling through to OTHER', () => {
+    for (const routeName of Object.values(BAND_SPACE_ROUTES)) {
+      assert.notEqual(
+        resolveFeedbackModule(routeName),
+        FEEDBACK_MODULES.OTHER,
+        `Route ${routeName} has no entry in ROUTE_TO_MODULE, so its feedback files as « Autre »`
+      )
+    }
   })
 
   // The live view sits outside both layouts, so it is the one Band Space route that cannot be

--- a/assets/js/views/BandSpace/Chat.vue
+++ b/assets/js/views/BandSpace/Chat.vue
@@ -1,0 +1,61 @@
+<template>
+  <div
+    class="bg-surface-0 dark:bg-surface-900 rounded-2xl overflow-hidden flex flex-col h-[calc(100vh-16rem)] min-h-[400px]"
+  >
+    <div
+      v-if="chatStore.loadError"
+      class="flex flex-col items-center justify-center flex-1 p-8 gap-4"
+    >
+      <Message severity="error" :closable="false">{{ chatStore.loadError }}</Message>
+      <Button label="Réessayer" icon="pi pi-refresh" severity="secondary" @click="load" />
+    </div>
+
+    <div v-else-if="chatStore.isLoading" class="flex-1 flex items-center justify-center p-8">
+      <ProgressSpinner style="width: 2.5rem; height: 2.5rem" />
+    </div>
+
+    <div
+      v-else-if="chatStore.messages.length === 0"
+      class="flex flex-col items-center justify-center flex-1 text-center p-8"
+    >
+      <i class="pi pi-comments text-4xl text-surface-400 dark:text-surface-500" aria-hidden="true" />
+      <p class="mt-3 font-medium">Aucun message</p>
+      <p class="mt-1 text-surface-600 dark:text-surface-300">
+        Écrivez le premier message du groupe, il restera ici pour tout le monde.
+      </p>
+    </div>
+
+    <ChatMessageList v-else ref="messageList" :band-space-id="bandSpaceId" />
+
+    <ChatComposer :band-space-id="bandSpaceId" @sent="messageList?.scrollToBottom()" />
+  </div>
+</template>
+
+<script setup>
+import Button from 'primevue/button'
+import Message from 'primevue/message'
+import ProgressSpinner from 'primevue/progressspinner'
+import { onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { useRoute } from 'vue-router'
+import ChatComposer from '../../components/BandSpace/Chat/ChatComposer.vue'
+import ChatMessageList from '../../components/BandSpace/Chat/ChatMessageList.vue'
+import { useBandSpaceChatStore } from '../../store/bandSpace/bandSpaceChat.js'
+
+const route = useRoute()
+// Read once: AppBandLayout keys <router-view> on the space id, so this view is remounted rather than
+// reused when the member switches band.
+const bandSpaceId = route.params.id
+
+const chatStore = useBandSpaceChatStore()
+const messageList = useTemplateRef('messageList')
+
+// Synchronously, before the first render, so another band's conversation never flashes here.
+chatStore.clear()
+
+function load() {
+  chatStore.loadMessages(bandSpaceId)
+}
+
+onMounted(load)
+onUnmounted(() => chatStore.clear())
+</script>

--- a/src/Enum/Feedback/FeedbackModule.php
+++ b/src/Enum/Feedback/FeedbackModule.php
@@ -19,6 +19,7 @@ enum FeedbackModule: string
 {
     // Band Space, mirroring BandSpaceModule's values.
     case Agenda = 'agenda';
+    case Chat = 'chat';
     case Notes = 'notes';
     case File = 'file';
     case Task = 'task';
@@ -49,6 +50,7 @@ enum FeedbackModule: string
     {
         return match ($this) {
             self::Agenda => 'Agenda',
+            self::Chat => 'Discussion',
             self::Notes => 'Notes',
             self::File => 'Fichiers',
             self::Task => 'Tâches',

--- a/src/Repository/Message/MessageRepository.php
+++ b/src/Repository/Message/MessageRepository.php
@@ -113,15 +113,21 @@ class MessageRepository extends ServiceEntityRepository
     }
 
     /**
-     * Every message this user has not read, across every thread they have not deleted.
+     * Every message this user has not read, across every direct message thread they have not deleted.
      *
      * This is the navbar badge. It used to count *threads* with an unread flag and to ignore
      * isDeleted, which made it disagree with the inbox it sits above on both counts (#954).
+     *
+     * Band Space channels are excluded for the same reason: their members get read-state rows like
+     * anybody else (#960), but the inbox this badge sits above filters channels out, so counting them
+     * here would show a number that clicking through can neither explain nor clear. A channel's
+     * unread belongs on its own sidebar entry, which is #962.
      */
     public function countUnreadForUser(User $user): int
     {
         return (int) $this->createQueryBuilder('message')
             ->select('COUNT(message.id)')
+            ->join('message.thread', 'thread')
             ->join(
                 MessageThreadMeta::class,
                 'meta',
@@ -130,6 +136,7 @@ class MessageRepository extends ServiceEntityRepository
             )
             ->where('message.author != :user')
             ->andWhere('meta.isDeleted = false')
+            ->andWhere('thread.bandSpace IS NULL')
             ->andWhere('(meta.lastReadDatetime IS NULL OR message.creationDatetime > meta.lastReadDatetime)')
             ->setParameter('user', $user)
             ->getQuery()

--- a/tests/Integration/Message/UnreadMessageCountTest.php
+++ b/tests/Integration/Message/UnreadMessageCountTest.php
@@ -8,6 +8,7 @@ use App\Entity\Message\MessageThread;
 use App\Entity\Message\MessageThreadMeta;
 use App\Entity\User;
 use App\Repository\Message\MessageRepository;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
 use App\Tests\Factory\Message\MessageFactory;
 use App\Tests\Factory\Message\MessageThreadFactory;
 use App\Tests\Factory\Message\MessageThreadMetaFactory;
@@ -124,6 +125,35 @@ class UnreadMessageCountTest extends KernelTestCase
         ])->create();
 
         self::assertSame(1, $this->messageRepository->countUnreadForUser($reader));
+    }
+
+    public function test_a_band_space_channel_stays_out_of_the_navbar_badge(): void
+    {
+        // A channel gives its members read-state rows exactly like a direct message does (#960), so
+        // without an explicit filter its unread lands on the envelope in the main navigation. The
+        // inbox under that envelope excludes channels, so the number would be one a member cannot
+        // explain, reach or clear. Their sidebar entry is where it belongs, which is #962.
+        [$reader, $writer] = $this->twoUsers();
+
+        $directThread = MessageThreadFactory::new()->create();
+        $this->messageAt($directThread, $writer, '2026-09-01 10:00:00');
+        $this->metaFor($reader, $directThread, null);
+
+        $bandSpace = BandSpaceFactory::new()->create();
+        $channel = MessageThreadFactory::new()->forBandSpace($bandSpace)->create();
+        $this->messageAt($channel, $writer, '2026-09-02 10:00:00');
+        $this->messageAt($channel, $writer, '2026-09-02 10:05:00');
+        $this->metaFor($reader, $channel, null);
+
+        self::assertSame(1, $this->messageRepository->countUnreadForUser($reader));
+
+        // The per-thread map is keyed by thread and only ever read for threads the inbox already
+        // listed, so it counts the channel and that is harmless. Asserted key by key because the
+        // order of a GROUP BY result is not something to depend on.
+        $byThread = $this->messageRepository->countUnreadByThreadForUser($reader);
+        self::assertCount(2, $byThread);
+        self::assertSame(1, $byThread[(string) $directThread->id]);
+        self::assertSame(2, $byThread[(string) $channel->id]);
     }
 
     public function test_another_persons_unread_never_leaks_into_yours(): void


### PR DESCRIPTION
Closes #961. Track D of #948, on top of #960. The first time the chat is on screen.

## What changes

A « Discussion » entry in the Band Space sidebar, between Agenda and Notes, gated behind
`CHAT_TESTER_ONLY` exactly like the tech riders: one constant flip releases both the entry and the
route guard, and the API has been open all along, so this is a curtain rather than a permission.

The pane is one column: the newest 50 messages, scrolled to the bottom, a « Charger les messages plus
anciens » button above them, a composer underneath. Every bubble carries its author, unlike the direct
message thread where alignment is enough, because a channel has many.

## Two naming decisions

**« Discussion », not « Messages ».** The main navigation already spends « Messages » on direct
messages, and two different things under one word, one click apart, is the confusion worth avoiding.
The route name stays `app_band_chat` and the API stays `api_band_space_chat_*`, so the internal word
matches the backend and the French word is the one members read. The rider module already has that
split (`Rider` internally, « Tech riders » on screen). URL is `/band/:id/discussion`.

**The composer stays enabled while a space is pending deletion.** No Band Space module reads
`deletion_scheduled_datetime` in its own inputs: the amber banner warns and the 409 enforces.
Disabling here would make the chat the first module carrying a client side copy of that rule, for one
tab. The 409's own French sentence is what the composer shows.

## The touch points, and the one the issue did not list

Adding a Band Space tab has an exact set: the route constant, the navigation entry, the section name,
the child route, and the feedback module in both languages. There is a sixth:
**`FEEDBACK_MODULE_GROUPS`**, the picker behind « Un retour ? ». Without it the route prefills a module
the member cannot select. An existing test caught it, because that one derives its expectation from
`FEEDBACK_MODULES` rather than hardcoding a list.

Its neighbour `feedbackModule.test.js` does hardcode a list, and so it stayed silent. That is fixed
both ways here: the chat assertion it was missing, and a derived test that fails if **any**
`BAND_SPACE_ROUTES` value resolves to `OTHER`, so the next tab cannot repeat this.

## A badge that could not be cleared, found while reviewing this

Not strictly this ticket, but shipping the tab is what would have made it visible, so it is fixed here.

#960 gives channel members `MessageThreadMeta` rows, the same read-state rows a direct message uses.
`MessageThreadMetaRepository::findByUserAndNotDeleted()` already excluded channels from the inbox
(#959), but `MessageRepository::countUnreadForUser()`, which feeds the envelope badge in the main
navigation, did not. Measured: two unread channel messages, badge reports 2.

So a band message would bump the direct messages badge, the member would click it, the inbox would
show nothing unread because channels are filtered out of it, and nothing there could clear it. One
`andWhere('thread.bandSpace IS NULL')`, matching the filter the inbox already has, plus a test pinned
at 1 that fails with `3 is identical to 1` when the filter is removed. A channel's unread belongs on
its own sidebar entry, which is #962.

`countUnreadByThreadForUser()` is deliberately left counting channels: it is keyed by thread and only
ever read for threads the inbox has already listed.

## Reused rather than rewritten

`assets/js/utils/messagePagination.js` is untouched: `nextOlderPageToLoad`, `hasOlderToLoad` and
`mergeMessages` key on `@id` and `creation_datetime`, which a chat message carries, so #955's work
serves the channel as it stands. The scroll handling is `Thread.vue`'s, including the tail `@id`
comparison that tells a new message at the end from a page prepended at the top.

`autoLink` moves out of `Thread.vue` into `assets/js/utils/autoLink.js` with six unit tests, and both
components import it, rather than a second copy of a regex that builds anchors for `v-html`.

## Verification

- `npm test` 650 green, Biome clean, `npm run build` clean, PHP suite 2699 green, PHPStan level 8 clean.
- In a real browser against the dev site, with a seeded channel of 55 messages:
  - the list loads the newest 50 and opens at the bottom,
  - « Charger les messages plus anciens » brings it to 55 with a **measured viewport drift of 0px**,
    anchored on element identity rather than on text, since matching by text is what fooled a
    measurement back in #955,
  - posting works and auto-links a URL,
  - sending while scrolled up in the history carries the reader to their own message: 3122px from the
    bottom before, 0 after. That gap was found in the browser, not in review: `Thread.vue` scrolls
    explicitly in its send handler and a separate composer component had no way to.
- As a non-tester, with the JWT reissued so the guard actually saw the role change, the sidebar entry
  is absent and `/band/:id/discussion` redirects to the dashboard.
- Probe data and the temporary role change were reverted.

## Out of scope

Unread on the sidebar entry (#962), live delivery over Mercure (#963), mentions (#964), the activity
feed entry (#965), message actions (#966, #967). The pane loads on mount and after a send, nothing
more, and the store is shaped so #963 adds a signal handler without reshaping it.

## Deploy

Nothing. The tab is invisible to anyone without `ROLE_TESTER`.
