### PR TITLE
Chat: unread count on the Band Space sidebar entry

### DIFF
--- a/assets/js/api/bandSpace/band-space-chat.js
+++ b/assets/js/api/bandSpace/band-space-chat.js
@@ -17,6 +17,13 @@ export default {
       .catch(handleApiError)
   },
 
+  markAsRead(bandSpaceId) {
+    return axios
+      .post(Routing.generate('api_band_space_chat_read', { bandSpaceId }))
+      .then((resp) => resp.data)
+      .catch(handleApiError)
+  },
+
   postMessage(bandSpaceId, content) {
     return axios
       .post(

--- a/assets/js/components/BandSpace/BandSidebar.vue
+++ b/assets/js/components/BandSpace/BandSidebar.vue
@@ -14,13 +14,22 @@
         <a
           :href="href"
           :aria-current="isExactActive ? 'page' : undefined"
-          :aria-label="item.label"
+          :aria-label="ariaLabelFor(item)"
           @click="(e) => handleClick(e, navigate)"
           :class="linkClasses(isExactActive)"
           v-tooltip.right="tooltipFor(item.label)"
         >
           <i :class="['pi', item.icon, 'text-base shrink-0']" aria-hidden="true"></i>
+          <!-- The badge is pulled into the row's right padding: « Discussion » is the longest label
+               that carries one, and at 11rem it needs those few pixels back to avoid ellipsising. -->
           <span v-if="!collapsed" class="font-medium truncate">{{ item.label }}</span>
+          <Badge
+            v-if="unreadFor(item) > 0"
+            :value="unreadLabel(unreadFor(item))"
+            severity="danger"
+            size="small"
+            :class="collapsed ? 'ml-0' : 'ml-auto shrink-0 -mr-1.5'"
+          />
         </a>
       </RouterLink>
 
@@ -85,10 +94,12 @@
 </template>
 
 <script setup>
+import Badge from 'primevue/badge'
 import { computed } from 'vue'
 import { useBandSpaceNavigation } from '../../composables/useBandSpaceNavigation.js'
 import { BAND_SPACE_ROUTES, NAVIGATION_ITEMS } from '../../constants/bandSpace.js'
 import { useFeedbackStore } from '../../store/feedback.js'
+import { useNotificationStore } from '../../store/notification/notification.js'
 import { useUserSecurityStore } from '../../store/user/security.js'
 
 const props = defineProps({
@@ -103,6 +114,29 @@ const emit = defineEmits(['navigate'])
 const { currentSpaceId } = useBandSpaceNavigation()
 const userSecurityStore = useUserSecurityStore()
 const feedbackStore = useFeedbackStore()
+const notificationStore = useNotificationStore()
+
+/**
+ * Only the chat carries a count today. The map is keyed by band space, so the number is this space's
+ * and never a sum across the bands a member belongs to.
+ */
+function unreadFor(item) {
+  return item.route === BAND_SPACE_ROUTES.CHAT
+    ? notificationStore.chatUnreadFor(currentSpaceId.value)
+    : 0
+}
+
+// Capped like the notification bell and the message inbox, so a long-ignored conversation cannot
+// stretch the rail.
+function unreadLabel(count) {
+  return count > 99 ? '99+' : String(count)
+}
+
+function ariaLabelFor(item) {
+  const unread = unreadFor(item)
+
+  return unread > 0 ? `${item.label} (${unread} non lus)` : item.label
+}
 
 function handleFeedbackClick() {
   // Closes the mobile drawer the same way a navigation does, otherwise the drawer sits on top of

--- a/assets/js/components/Notification/NotificationBell.vue
+++ b/assets/js/components/Notification/NotificationBell.vue
@@ -93,6 +93,7 @@ import OverlayBadge from 'primevue/overlaybadge'
 import Popover from 'primevue/popover'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
+import { useNotificationStore } from '../../store/notification/notification.js'
 import { useUserNotificationStore } from '../../store/notification/userNotification.js'
 import NotificationItem from './NotificationItem.vue'
 
@@ -104,6 +105,7 @@ const POLL_INTERVAL_MS = 5 * 60_000
 const emit = defineEmits(['navigate'])
 
 const store = useUserNotificationStore()
+const notificationStore = useNotificationStore()
 
 const popover = ref(null)
 const isPopoverOpen = ref(false)
@@ -141,6 +143,11 @@ let intervalId = null
 
 function refreshCount() {
   store.loadCount()
+  // The other header counters ride this timer rather than running one of their own: the direct
+  // message envelope, and the per Band Space chat badge the sidebar reads (#962). Both arrive over
+  // Mercure for direct messages, but a Band Space channel publishes nothing until #963, so without
+  // this the chat badge would only ever be as fresh as the last page load.
+  notificationStore.loadNotifications()
   // The self-heal. The store connects as soon as the profile lands, but if that fetch failed there is
   // nothing else that would ever try again, and the poll would mask it perfectly: a live-looking bell
   // that is only ever five minutes fresh. connect() is idempotent, so this costs nothing when the

--- a/assets/js/store/bandSpace/bandSpaceChat.js
+++ b/assets/js/store/bandSpace/bandSpaceChat.js
@@ -6,6 +6,7 @@ import {
   mergeMessages,
   nextOlderPageToLoad
 } from '../../utils/messagePagination.js'
+import { useNotificationStore } from '../notification/notification.js'
 
 /**
  * The band's conversation. Held oldest first, which is reading order, while the API answers newest
@@ -119,6 +120,20 @@ export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
     }
   }
 
+  /**
+   * Opening the tab is reading it. The badge lives on the notification payload rather than in this
+   * store, because the sidebar shows it from every other module too, so clearing it means refreshing
+   * that payload, the same shape the direct message store uses after marking a thread read.
+   */
+  async function markAsRead(bandSpaceId) {
+    try {
+      await bandSpaceChatApi.markAsRead(bandSpaceId)
+      await useNotificationStore().loadNotifications()
+    } catch (e) {
+      console.error('Failed to mark the chat as read:', e)
+    }
+  }
+
   function clear() {
     messages.value = []
     totalMessages.value = 0
@@ -141,6 +156,7 @@ export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
     loadMessages,
     loadOlderMessages,
     sendMessage,
+    markAsRead,
     clear
   }
 })

--- a/assets/js/store/notification/notification.js
+++ b/assets/js/store/notification/notification.js
@@ -7,6 +7,9 @@ export const useNotificationStore = defineStore('notification', () => {
   const pendingPublications = ref(0)
   const pendingGalleries = ref(0)
   const newFeedbacks = ref(0)
+  // Keyed by band space id, and a space with nothing unread is absent rather than zero, so read it
+  // through chatUnreadFor() rather than indexing the map.
+  const bandSpaceChatUnread = ref({})
 
   async function loadNotifications() {
     try {
@@ -15,13 +18,20 @@ export const useNotificationStore = defineStore('notification', () => {
       pendingPublications.value = data.pending_publications || 0
       pendingGalleries.value = data.pending_galleries || 0
       newFeedbacks.value = data.new_feedbacks || 0
+      bandSpaceChatUnread.value = data.band_space_chat_unread || {}
     } catch (e) {
       console.error('Failed to load notifications:', e)
     }
   }
 
+  function chatUnreadFor(bandSpaceId) {
+    return bandSpaceChatUnread.value[bandSpaceId] ?? 0
+  }
+
   return {
     unreadMessages: readonly(unreadMessages),
+    bandSpaceChatUnread: readonly(bandSpaceChatUnread),
+    chatUnreadFor,
     pendingPublications: readonly(pendingPublications),
     pendingGalleries: readonly(pendingGalleries),
     newFeedbacks: readonly(newFeedbacks),

--- a/assets/js/views/BandSpace/Chat.vue
+++ b/assets/js/views/BandSpace/Chat.vue
@@ -52,8 +52,13 @@ const messageList = useTemplateRef('messageList')
 // Synchronously, before the first render, so another band's conversation never flashes here.
 chatStore.clear()
 
-function load() {
-  chatStore.loadMessages(bandSpaceId)
+async function load() {
+  await chatStore.loadMessages(bandSpaceId)
+  // Arriving on the tab is reading it, like the direct message inbox does on selecting a thread.
+  // After the load rather than before, so a failed load does not claim the member read anything.
+  if (!chatStore.loadError) {
+    await chatStore.markAsRead(bandSpaceId)
+  }
 }
 
 onMounted(load)

--- a/src/ApiResource/BandSpace/Chat/ChatRead.php
+++ b/src/ApiResource/BandSpace/Chat/ChatRead.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\ApiResource\BandSpace\Chat;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation;
+use App\State\Processor\BandSpace\Chat\ChatReadProcessor;
+
+/**
+ * « I have read the band's conversation », which is what clears the sidebar badge (#962).
+ *
+ * A command with nothing to say and nothing to return, so no input and a 204, like the restore
+ * endpoint. The read position it moves is the member's own, not the space's content.
+ */
+#[ApiResource(
+    operations: [
+        new Post(
+            uriTemplate: '/band_spaces/{bandSpaceId}/chat/read',
+            uriVariables: [
+                'bandSpaceId' => new Link(fromClass: self::class, identifiers: ['bandSpaceId']),
+            ],
+            status: 204,
+            openapi: new Operation(tags: ['Band Space Chat']),
+            security: "is_granted('ROLE_USER')",
+            input: false,
+            output: false,
+            name: 'api_band_space_chat_read',
+            processor: ChatReadProcessor::class,
+        ),
+    ],
+)]
+class ChatRead
+{
+    #[ApiProperty(identifier: true)]
+    public string $bandSpaceId;
+}

--- a/src/ApiResource/Notification/Notification.php
+++ b/src/ApiResource/Notification/Notification.php
@@ -15,6 +15,15 @@ class Notification
 {
     public int $unreadMessages = 0;
 
+    /**
+     * Unread in each Band Space chat, keyed by band space id, for the sidebar badge (#962). Separate
+     * from unreadMessages on purpose: that one is direct messages, and its inbox cannot show or clear
+     * a band's conversation. A space with nothing unread is absent, so the client reads it with `?? 0`.
+     *
+     * @var array<string, int>
+     */
+    public array $bandSpaceChatUnread = [];
+
     public ?int $pendingGalleries = null;
 
     public ?int $pendingPublications = null;

--- a/src/EventSubscriber/BandSpaceInvitationAutoAcceptListener.php
+++ b/src/EventSubscriber/BandSpaceInvitationAutoAcceptListener.php
@@ -12,6 +12,7 @@ use App\Event\BandSpaceInvitationRespondedEvent;
 use App\Event\UserRegisteredEvent;
 use App\Repository\BandSpace\BandSpaceInvitationRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Repository\Message\MessageThreadMetaRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -23,6 +24,7 @@ readonly class BandSpaceInvitationAutoAcceptListener
     public function __construct(
         private BandSpaceInvitationRepository $invitationRepository,
         private BandSpaceMembershipRepository $membershipRepository,
+        private MessageThreadMetaRepository $messageThreadMetaRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private EntityManagerInterface $entityManager,
         private EventDispatcherInterface $eventDispatcher,
@@ -38,6 +40,7 @@ readonly class BandSpaceInvitationAutoAcceptListener
             return;
         }
 
+        $rejoinedSpaces = [];
         $acceptedInvitations = [];
         foreach ($pendingInvitations as $invitation) {
             if ($this->membershipRepository->isMember($invitation->bandSpace, $user)) {
@@ -57,6 +60,7 @@ readonly class BandSpaceInvitationAutoAcceptListener
                 $existingMembership->status = MembershipStatus::Active;
                 $existingMembership->leftDatetime = null;
                 $existingMembership->role = Role::User;
+                $rejoinedSpaces[] = $invitation->bandSpace;
             } else {
                 $existingMembership = new BandSpaceMembership();
                 $existingMembership->bandSpace = $invitation->bandSpace;
@@ -86,6 +90,14 @@ readonly class BandSpaceInvitationAutoAcceptListener
         }
 
         $this->entityManager->flush();
+
+        // Same rule as the accept endpoint, and after the flush for the same reason: a rejoining
+        // member reuses their old membership row and its old read position, which would present
+        // everything said while they were gone as unread (#962). One flush covers the whole loop, so
+        // resetting inside it would commit for invitations that never persisted.
+        foreach ($rejoinedSpaces as $bandSpace) {
+            $this->messageThreadMetaRepository->markChannelsReadForUser($bandSpace, $user);
+        }
 
         // Best-effort notifications dispatched after the commit (epic #689 contract): tell each inviter
         // their invitation was accepted, exactly as the explicit accept endpoint does.

--- a/src/Repository/Message/MessageRepository.php
+++ b/src/Repository/Message/MessageRepository.php
@@ -2,10 +2,12 @@
 
 namespace App\Repository\Message;
 
+use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\Message\Message;
 use App\Entity\Message\MessageThread;
 use App\Entity\Message\MessageThreadMeta;
 use App\Entity\User;
+use App\Enum\BandSpace\MembershipStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\Persistence\ManagerRegistry;
@@ -141,6 +143,63 @@ class MessageRepository extends ServiceEntityRepository
             ->setParameter('user', $user)
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    /**
+     * Unread in each Band Space chat the user is an active member of, keyed by band space id.
+     *
+     * This is the sidebar badge. It is a separate number from the envelope on purpose: the envelope
+     * sits above an inbox that lists direct messages only, and a member clicking it would find
+     * nothing to explain a band's conversation (#961).
+     *
+     * The membership join is doing two jobs. It filters to **active** members, which is what keeps a
+     * former member's surviving read-state row out of the count without deleting anything (#948
+     * concern 3). And its creationDatetime is the floor: a member's row is created lazily by the first
+     * message sent after they join, with no read position, so without the floor somebody who joined
+     * this morning would be told the whole history is unread. Flooring at the moment they joined needs
+     * no write at join time, which is what keeps this clear of the duplicate-key hazard
+     * MessageSenderProcedure::findOrCreateMetaFor() warns about.
+     *
+     * A space with nothing unread is absent rather than present with a zero, like the sibling method,
+     * so callers read it with `?? 0`.
+     *
+     * @return array<string, int>
+     */
+    public function countUnreadChannelsForUser(User $user): array
+    {
+        /** @var list<array{band_space_id: string, unread_count: int|string}> $rows */
+        $rows = $this->createQueryBuilder('message')
+            ->select('IDENTITY(thread.bandSpace) AS band_space_id, COUNT(message.id) AS unread_count')
+            ->join('message.thread', 'thread')
+            ->join(
+                MessageThreadMeta::class,
+                'meta',
+                Join::WITH,
+                'meta.thread = message.thread AND meta.user = :user'
+            )
+            ->join(
+                BandSpaceMembership::class,
+                'membership',
+                Join::WITH,
+                'membership.bandSpace = thread.bandSpace AND membership.user = :user AND membership.status = :active'
+            )
+            ->where('thread.bandSpace IS NOT NULL')
+            // Own messages never count: you have read what you wrote.
+            ->andWhere('message.author != :user')
+            ->andWhere('(meta.lastReadDatetime IS NULL OR message.creationDatetime > meta.lastReadDatetime)')
+            ->andWhere('message.creationDatetime > membership.creationDatetime')
+            ->groupBy('thread.bandSpace')
+            ->setParameter('user', $user)
+            ->setParameter('active', MembershipStatus::Active)
+            ->getQuery()
+            ->getResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(string) $row['band_space_id']] = (int) $row['unread_count'];
+        }
+
+        return $counts;
     }
 
     /**

--- a/src/Repository/Message/MessageThreadMetaRepository.php
+++ b/src/Repository/Message/MessageThreadMetaRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository\Message;
 
+use App\Entity\BandSpace\BandSpace;
 use App\Entity\Message\MessageThread;
 use App\Entity\Message\MessageThreadMeta;
 use App\Entity\User;
@@ -47,6 +48,43 @@ class MessageThreadMetaRepository extends ServiceEntityRepository
         }
 
         return $indexed;
+    }
+
+    /**
+     * Moves this member's read position in the space's channels to now, creating the row if they have
+     * none.
+     *
+     * Two callers, one rule: your read position starts when you join, and starts again when you
+     * rejoin. Opening the tab uses it to clear the badge, and the invitation paths use it because a
+     * rejoining member reuses their old membership row, and its creation date is their *first* join,
+     * which the unread count floors at.
+     *
+     * It has to insert, not just update, and that is the whole reason this is raw SQL: DQL has no
+     * INSERT, and a member whose first stint saw no messages at all never got a row, so an update
+     * would silently do nothing for exactly the person who needs it most. `ON DUPLICATE KEY UPDATE`
+     * against `UNIQUE (thread_id, user_id)` also makes this safe against a send creating the same row
+     * concurrently, which a bare insert outside the thread lock would not be.
+     *
+     * UUID() is MariaDB's version 1 where the application mints version 4. Nothing reads the version,
+     * and the same trade was already made for the channel backfill in #959.
+     */
+    public function markChannelsReadForUser(BandSpace $bandSpace, User $user): void
+    {
+        $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+                INSERT INTO message_thread_meta
+                    (id, thread_id, user_id, creation_datetime, is_deleted, pending_notification_sent, last_read_datetime)
+                SELECT UUID(), thread.id, :user, :now, 0, 0, :now
+                FROM message_thread thread
+                WHERE thread.band_space_id = :band_space
+                ON DUPLICATE KEY UPDATE last_read_datetime = :now
+                SQL,
+            [
+                'user' => (string) $user->id,
+                'band_space' => (string) $bandSpace->id,
+                'now' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            ],
+        );
     }
 
     /**

--- a/src/State/Processor/BandSpace/BandSpaceInvitationAcceptProcessor.php
+++ b/src/State/Processor/BandSpace/BandSpaceInvitationAcceptProcessor.php
@@ -15,6 +15,7 @@ use App\Enum\BandSpace\Role;
 use App\Event\BandSpaceInvitationRespondedEvent;
 use App\Repository\BandSpace\BandSpaceInvitationRepository;
 use App\Repository\BandSpace\BandSpaceMembershipRepository;
+use App\Repository\Message\MessageThreadMetaRepository;
 use App\Service\BandSpace\BandSpaceActivityRecorder;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,6 +34,7 @@ readonly class BandSpaceInvitationAcceptProcessor implements ProcessorInterface
         private EntityManagerInterface $entityManager,
         private BandSpaceInvitationRepository $bandSpaceInvitationRepository,
         private BandSpaceMembershipRepository $bandSpaceMembershipRepository,
+        private MessageThreadMetaRepository $messageThreadMetaRepository,
         private BandSpaceActivityRecorder $bandSpaceActivityRecorder,
         private Security $security,
         private EventDispatcherInterface $eventDispatcher,
@@ -69,7 +71,9 @@ readonly class BandSpaceInvitationAcceptProcessor implements ProcessorInterface
 
         $existingMembership = $this->bandSpaceMembershipRepository->findMembershipIncludingInactive($invitation->bandSpace, $user);
 
-        if ($existingMembership instanceof \App\Entity\BandSpace\BandSpaceMembership) {
+        $isRejoining = $existingMembership instanceof \App\Entity\BandSpace\BandSpaceMembership;
+
+        if ($isRejoining) {
             $existingMembership->status = MembershipStatus::Active;
             $existingMembership->leftDatetime = null;
             $existingMembership->role = Role::User;
@@ -88,6 +92,14 @@ readonly class BandSpaceInvitationAcceptProcessor implements ProcessorInterface
             $this->entityManager->flush();
         } catch (UniqueConstraintViolationException) {
             throw new ConflictHttpException('Vous êtes déjà membre de ce Band Space');
+        }
+
+        // After the flush, like the event dispatch below: rejoining reuses the same membership row and
+        // its old read position, which would present everything said while they were gone as unread
+        // (#962). This commits on its own, so doing it before would leave the reset standing even if
+        // the reactivation never persisted.
+        if ($isRejoining) {
+            $this->messageThreadMetaRepository->markChannelsReadForUser($invitation->bandSpace, $user);
         }
 
         $this->bandSpaceActivityRecorder->record(

--- a/src/State/Processor/BandSpace/Chat/ChatReadProcessor.php
+++ b/src/State/Processor/BandSpace/Chat/ChatReadProcessor.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\State\Processor\BandSpace\Chat;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\User;
+use App\Repository\Message\MessageThreadMetaRepository;
+use App\Security\BandSpace\BandSpaceMemberChecker;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * @implements ProcessorInterface<mixed, void>
+ */
+readonly class ChatReadProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private BandSpaceMemberChecker $memberChecker,
+        private MessageThreadMetaRepository $messageThreadMetaRepository,
+        private Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // checkMember(), not checkMemberForWrite(): see BandSpaceWriteGuardCoverageTest's allow list.
+        // A space in its grace period stays readable, so a member has to be able to stop being told
+        // there is something unread in a conversation they can still open.
+        [$bandSpace] = $this->memberChecker->checkMember((string) $uriVariables['bandSpaceId'], $user);
+
+        $this->messageThreadMetaRepository->markChannelsReadForUser($bandSpace, $user);
+    }
+}

--- a/src/State/Provider/Notification/NotificationProvider.php
+++ b/src/State/Provider/Notification/NotificationProvider.php
@@ -39,6 +39,7 @@ readonly class NotificationProvider implements ProviderInterface
         $unreadMessagesCount = $this->messageRepository->countUnreadForUser($user);
         $notification = new Notification();
         $notification->unreadMessages = $unreadMessagesCount;
+        $notification->bandSpaceChatUnread = $this->messageRepository->countUnreadChannelsForUser($user);
         if ($this->security->isGranted('ROLE_ADMIN')) {
             $notification->pendingGalleries = $this->galleryRepository->count(['status' => Gallery::STATUS_PENDING]);
             $notification->pendingPublications = $this->publicationRepository->count(['status' => Publication::STATUS_PENDING]);

--- a/tests/Api/BandSpace/Chat/ChatReadTest.php
+++ b/tests/Api/BandSpace/Chat/ChatReadTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\BandSpace\Chat;
+
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\Message\MessageThread;
+use App\Entity\User;
+use App\Repository\Message\MessageRepository;
+use App\Tests\ApiTestAssertionsTrait;
+use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
+use App\Tests\Factory\Message\MessageFactory;
+use App\Tests\Factory\Message\MessageThreadFactory;
+use App\Tests\Factory\Message\MessageThreadMetaFactory;
+use App\Tests\Factory\User\UserFactory;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+#[ResetDatabase]
+class ChatReadTest extends ApiTestCase
+{
+    use ApiTestAssertionsTrait;
+
+    public function test_not_logged(): void
+    {
+        $space = BandSpaceFactory::new()->create();
+
+        $this->client->request('POST', '/api/band_spaces/' . $space->id . '/chat/read');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertJsonEquals(['code' => 401, 'message' => 'JWT Token not found']);
+    }
+
+    public function test_reading_the_channel_clears_the_count(): void
+    {
+        [$member, $writer, $space] = $this->band();
+        $channel = $this->channelWithAnUnreadMessage($space, $member, $writer);
+
+        $messageRepository = self::getContainer()->get(MessageRepository::class);
+        $this->assertSame(
+            [(string) $space->id => 1],
+            $messageRepository->countUnreadChannelsForUser($member),
+            'The fixture is pointless unless it starts unread',
+        );
+
+        $this->client->loginUser($member);
+        $this->client->request('POST', '/api/band_spaces/' . $space->id . '/chat/read');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertSame([], $messageRepository->countUnreadChannelsForUser($member));
+        $this->assertNotNull($channel->id);
+    }
+
+    public function test_a_non_member_cannot_mark_the_channel_read(): void
+    {
+        [$member, $writer, $space] = $this->band();
+        $this->channelWithAnUnreadMessage($space, $member, $writer);
+        $stranger = UserFactory::new()->asBaseUser()->create(['username' => 'inconnu', 'email' => 'inconnu@test.com']);
+
+        $this->client->loginUser($stranger);
+        $this->client->request('POST', '/api/band_spaces/' . $space->id . '/chat/read');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/403',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Vous n\'êtes pas membre de ce Band Space',
+            'description' => 'Vous n\'êtes pas membre de ce Band Space',
+            'status' => 403,
+            'type' => '/errors/403',
+        ]);
+    }
+
+    public function test_a_band_space_that_does_not_exist_is_a_404(): void
+    {
+        $user = UserFactory::new()->asBaseUser()->create();
+
+        $this->client->loginUser($user);
+        $this->client->request('POST', '/api/band_spaces/3f2504e0-4f89-11d3-9a0c-0305e82c3301/chat/read');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Error',
+            '@id' => '/api/errors/404',
+            '@type' => 'Error',
+            'title' => 'An error occurred',
+            'detail' => 'Band Space introuvable',
+            'description' => 'Band Space introuvable',
+            'status' => 404,
+            'type' => '/errors/404',
+        ]);
+    }
+
+    public function test_a_space_pending_deletion_can_still_be_marked_read(): void
+    {
+        // The one place in the Band Space where a POST is deliberately not guarded against the
+        // deletion grace period, which is why ChatReadProcessor is on BandSpaceWriteGuardCoverageTest's
+        // allow list. Reads stay open for those 30 days, so being unable to stop the badge insisting
+        // there is something new would be the odd behaviour, not this.
+        [$member, $writer, $space] = $this->band(new \DateTimeImmutable('+30 days'));
+        $this->channelWithAnUnreadMessage($space, $member, $writer);
+
+        $this->client->loginUser($member);
+        $this->client->request('POST', '/api/band_spaces/' . $space->id . '/chat/read');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+        $this->assertSame(
+            [],
+            self::getContainer()->get(MessageRepository::class)->countUnreadChannelsForUser($member),
+        );
+    }
+
+    /**
+     * @return array{0: User, 1: User, 2: BandSpace}
+     */
+    private function band(?\DateTimeImmutable $deletionScheduledFor = null): array
+    {
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $writer = UserFactory::new()->asBaseUser()->create(['username' => 'bassiste', 'email' => 'bassiste@test.com']);
+
+        $space = BandSpaceFactory::new()->create(['deletionScheduledDatetime' => $deletionScheduledFor]);
+        foreach ([$member, $writer] as $user) {
+            BandSpaceMembershipFactory::new([
+                'bandSpace' => $space,
+                'user' => $user,
+                'creationDatetime' => new \DateTime('2026-09-01 09:00:00'),
+            ])->create();
+        }
+
+        return [$member, $writer, $space];
+    }
+
+    private function channelWithAnUnreadMessage(BandSpace $space, User $member, User $writer): MessageThread
+    {
+        $channel = MessageThreadFactory::new()->forBandSpace($space)->create();
+        MessageFactory::new([
+            'thread' => $channel,
+            'author' => $writer,
+            'creationDatetime' => new \DateTime('2026-09-02 10:00:00'),
+        ])->create();
+        MessageThreadMetaFactory::new(['thread' => $channel, 'user' => $member, 'lastReadDatetime' => null])->create();
+
+        return $channel;
+    }
+}

--- a/tests/Api/Notification/NotificationGetTest.php
+++ b/tests/Api/Notification/NotificationGetTest.php
@@ -2,10 +2,14 @@
 
 namespace App\Tests\Api\Notification;
 
+use App\Entity\BandSpace\BandSpace;
 use App\Entity\Gallery;
 use App\Entity\Publication;
+use App\Entity\User;
 use App\Tests\ApiTestAssertionsTrait;
 use App\Tests\ApiTestCase;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\Feedback\FeedbackFactory;
 use App\Tests\Factory\Message\MessageFactory;
 use App\Tests\Factory\Message\MessageThreadFactory;
@@ -70,8 +74,71 @@ class NotificationGetTest extends ApiTestCase
             '@context' => '/api/contexts/Notification',
             '@id' => '/api/notifications',
             '@type' => 'Notification',
-            'unread_messages' => 3
+            'unread_messages' => 3,
+            'band_space_chat_unread' => []
         ]);
+    }
+
+    public function test_the_chat_unread_is_keyed_by_band_space(): void
+    {
+        // The sidebar badge (#962). Keyed by space so a member of several bands sees each band's own
+        // number rather than a sum, and a space with nothing unread is absent rather than zero.
+        $member = UserFactory::new()->asBaseUser()->create(['username' => 'batteur', 'email' => 'batteur@test.com']);
+        $writer = UserFactory::new()->asBaseUser()->create(['username' => 'bassiste', 'email' => 'bassiste@test.com']);
+
+        $loud = $this->bandWithChannel($member, $writer, 2);
+        $quiet = $this->bandWithChannel($member, $writer, 0);
+        $chatty = $this->bandWithChannel($member, $writer, 1);
+
+        $this->client->loginUser($member);
+        $this->client->enableProfiler();
+        self::getContainer()->get('doctrine.debug_data_holder')->reset();
+        $this->client->request('GET', '/api/notifications');
+
+        $this->assertResponseIsSuccessful();
+
+        // One grouped query for every space the member belongs to, not one per space. This endpoint is
+        // on a five minute timer for every signed-in user, so a per-space query here would be the
+        // expensive kind of mistake.
+        $profile = $this->client->getProfile();
+        $this->assertNotFalse($profile, 'The profiler must be enabled to inspect the queries.');
+        $channelQueries = array_filter(
+            $profile->getCollector('db')->getQueries()['default'] ?? [],
+            static fn (array $query): bool => str_contains((string) $query['sql'], 'band_space_membership'),
+        );
+        $this->assertCount(1, $channelQueries);
+        $this->assertJsonEquals([
+            '@context' => '/api/contexts/Notification',
+            '@id' => '/api/notifications',
+            '@type' => 'Notification',
+            'unread_messages' => 0,
+            'band_space_chat_unread' => [(string) $loud->id => 2, (string) $chatty->id => 1],
+        ]);
+        $this->assertNotNull($quiet->id);
+    }
+
+    private function bandWithChannel(User $member, User $writer, int $unreadMessages): BandSpace
+    {
+        $space = BandSpaceFactory::new()->create();
+        foreach ([$member, $writer] as $user) {
+            BandSpaceMembershipFactory::new([
+                'bandSpace' => $space,
+                'user' => $user,
+                'creationDatetime' => new \DateTime('2026-09-01 09:00:00'),
+            ])->create();
+        }
+
+        $channel = MessageThreadFactory::new()->forBandSpace($space)->create();
+        for ($index = 1; $index <= $unreadMessages; ++$index) {
+            MessageFactory::new([
+                'thread' => $channel,
+                'author' => $writer,
+                'creationDatetime' => new \DateTime(sprintf('2026-09-02 10:%02d:00', $index)),
+            ])->create();
+        }
+        MessageThreadMetaFactory::new(['thread' => $channel, 'user' => $member, 'lastReadDatetime' => null])->create();
+
+        return $space;
     }
 
     public function test_get_notification_with_role_admin(): void
@@ -101,6 +168,7 @@ class NotificationGetTest extends ApiTestCase
             'pending_galleries'    => 1,
             'pending_publications' => 1,
             'new_feedbacks'        => 1,
+            'band_space_chat_unread' => [],
         ]);
     }
 
@@ -123,6 +191,7 @@ class NotificationGetTest extends ApiTestCase
             'pending_galleries'    => 0,
             'pending_publications' => 0,
             'new_feedbacks'        => 0,
+            'band_space_chat_unread' => [],
         ]);
     }
 }

--- a/tests/Integration/Message/UnreadMessageCountTest.php
+++ b/tests/Integration/Message/UnreadMessageCountTest.php
@@ -4,15 +4,21 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Message;
 
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\BandSpace\BandSpaceMembership;
 use App\Entity\Message\MessageThread;
 use App\Entity\Message\MessageThreadMeta;
 use App\Entity\User;
+use App\Enum\BandSpace\MembershipStatus;
 use App\Repository\Message\MessageRepository;
+use App\Repository\Message\MessageThreadMetaRepository;
 use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\Message\MessageFactory;
 use App\Tests\Factory\Message\MessageThreadFactory;
 use App\Tests\Factory\Message\MessageThreadMetaFactory;
 use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 
@@ -166,6 +172,148 @@ class UnreadMessageCountTest extends KernelTestCase
 
         self::assertSame(0, $this->messageRepository->countUnreadForUser($reader));
         self::assertSame(1, $this->messageRepository->countUnreadForUser($writer));
+    }
+
+    public function test_a_channel_counts_what_arrived_after_the_read_position(): void
+    {
+        [$reader, $writer] = $this->twoUsers();
+        [$space, $channel] = $this->bandWith($reader, $writer, '2026-09-01 09:00:00');
+
+        $this->messageAt($channel, $writer, '2026-09-02 10:00:00');
+        $this->messageAt($channel, $writer, '2026-09-02 10:05:00');
+        $this->messageAt($channel, $reader, '2026-09-02 10:10:00');
+        $this->metaFor($reader, $channel, new \DateTimeImmutable('2026-09-02 10:00:00'));
+
+        // The reader's own message never counts, and the one at the read position is already read.
+        self::assertSame(
+            [(string) $space->id => 1],
+            $this->messageRepository->countUnreadChannelsForUser($reader)
+        );
+    }
+
+    public function test_a_channel_that_is_fully_read_is_absent(): void
+    {
+        [$reader, $writer] = $this->twoUsers();
+        [, $channel] = $this->bandWith($reader, $writer, '2026-09-01 09:00:00');
+
+        $this->messageAt($channel, $writer, '2026-09-02 10:00:00');
+        $this->metaFor($reader, $channel, new \DateTimeImmutable('2026-09-02 10:00:01'));
+
+        // Absent rather than present with a zero, like the per-thread map, so callers read it with ?? 0.
+        self::assertSame([], $this->messageRepository->countUnreadChannelsForUser($reader));
+    }
+
+    public function test_a_member_does_not_inherit_the_history_from_before_they_joined(): void
+    {
+        // Their read-state row is created lazily by the first message after they join, with no read
+        // position, so without the membership floor the whole back catalogue would read as unread.
+        [$reader, $writer] = $this->twoUsers();
+        [$space, $channel] = $this->bandWith($reader, $writer, '2026-09-10 09:00:00');
+
+        $this->messageAt($channel, $writer, '2026-09-01 10:00:00');
+        $this->messageAt($channel, $writer, '2026-09-05 10:00:00');
+        $this->messageAt($channel, $writer, '2026-09-11 10:00:00');
+        $this->metaFor($reader, $channel, null);
+
+        self::assertSame(
+            [(string) $space->id => 1],
+            $this->messageRepository->countUnreadChannelsForUser($reader)
+        );
+    }
+
+    public function test_a_former_member_is_not_counted_even_though_their_row_survives(): void
+    {
+        // Leaving does not delete the read-state row (#948 concern 3). The membership join is what
+        // keeps it out of the count, so nothing has to be cleaned up when somebody goes.
+        [$reader, $writer] = $this->twoUsers();
+        [, $channel, $membership] = $this->bandWith($reader, $writer, '2026-09-01 09:00:00');
+
+        $this->messageAt($channel, $writer, '2026-09-02 10:00:00');
+        $this->metaFor($reader, $channel, null);
+
+        $membership->status = MembershipStatus::Kicked;
+        \Zenstruck\Foundry\Persistence\save($membership);
+
+        self::assertSame([], $this->messageRepository->countUnreadChannelsForUser($reader));
+    }
+
+    public function test_rejoining_starts_the_read_position_again(): void
+    {
+        // What the invitation paths call when they reactivate a membership: without it a rejoining
+        // member is handed everything said while they were gone.
+        [$reader, $writer] = $this->twoUsers();
+        [$space, $channel] = $this->bandWith($reader, $writer, '2026-09-01 09:00:00');
+
+        $this->messageAt($channel, $writer, '2026-09-02 10:00:00');
+        $this->messageAt($channel, $writer, '2026-09-03 10:00:00');
+        $this->metaFor($reader, $channel, new \DateTimeImmutable('2026-09-01 10:00:00'));
+
+        self::assertSame(
+            [(string) $space->id => 2],
+            $this->messageRepository->countUnreadChannelsForUser($reader)
+        );
+
+        self::getContainer()->get(MessageThreadMetaRepository::class)
+            ->markChannelsReadForUser($space, $reader);
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+
+        self::assertSame([], $this->messageRepository->countUnreadChannelsForUser($reader));
+    }
+
+    public function test_rejoining_after_a_first_stint_that_saw_nothing_starts_from_the_rejoin(): void
+    {
+        // The case an update-only reset silently missed. Somebody invited, then removed before anyone
+        // wrote, never got a read-state row at all, so there was nothing to update. Their row was then
+        // created by the first message after they came back, with no read position, and the floor is
+        // their *original* join, so everything said while they were gone counted. Measured at 3.
+        [$reader, $writer] = $this->twoUsers();
+        [$space, $channel, $membership] = $this->bandWith($reader, $writer, '2026-01-01 09:00:00');
+
+        $membership->status = MembershipStatus::Kicked;
+        \Zenstruck\Foundry\Persistence\save($membership);
+
+        $this->messageAt($channel, $writer, '2026-05-01 10:00:00');
+        $this->messageAt($channel, $writer, '2026-06-01 10:00:00');
+
+        $membership->status = MembershipStatus::Active;
+        \Zenstruck\Foundry\Persistence\save($membership);
+        self::getContainer()->get(MessageThreadMetaRepository::class)
+            ->markChannelsReadForUser($space, $reader);
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+
+        // Nothing from the months they were gone.
+        self::assertSame([], $this->messageRepository->countUnreadChannelsForUser($reader));
+
+        // And the conversation carries on from there.
+        $this->messageAt($channel, $writer, '+1 hour');
+
+        self::assertSame(
+            [(string) $space->id => 1],
+            $this->messageRepository->countUnreadChannelsForUser($reader)
+        );
+    }
+
+    /**
+     * A band both users are active members of, with its channel. The membership date is pinned
+     * because it is the floor the count uses, and the factory would otherwise pick a random one.
+     *
+     * @return array{0: BandSpace, 1: MessageThread, 2: BandSpaceMembership}
+     */
+    private function bandWith(User $reader, User $writer, string $joinedAt): array
+    {
+        $space = BandSpaceFactory::new()->create();
+        $membership = BandSpaceMembershipFactory::new([
+            'bandSpace' => $space,
+            'user' => $reader,
+            'creationDatetime' => new \DateTime($joinedAt),
+        ])->create();
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $space,
+            'user' => $writer,
+            'creationDatetime' => new \DateTime($joinedAt),
+        ])->create();
+
+        return [$space, MessageThreadFactory::new()->forBandSpace($space)->create(), $membership];
     }
 
     /**

--- a/tests/Unit/Security/BandSpace/BandSpaceWriteGuardCoverageTest.php
+++ b/tests/Unit/Security/BandSpace/BandSpaceWriteGuardCoverageTest.php
@@ -42,6 +42,7 @@ class BandSpaceWriteGuardCoverageTest extends TestCase
         'BandSpaceInvitationDeleteProcessor.php' => 'Revoking only ever takes an invitation away, and accepting one '
             . 'is refused for the whole grace period anyway, so blocking it bought nothing and left an admin unable '
             . 'to tidy up the pending invitations of a condemned space.',
+        'ChatReadProcessor.php' => 'Moves the member\'s own read position, not the space\'s content. Reads stay open for the whole grace period, so being unable to clear your own badge would be the odd behaviour.',
         'BandSpaceMemberUpdateRoleProcessor.php' => 'Leaving requires promoting a successor first, so guarding '
             . 'this would trap the sole admin of a condemned space. Letting them leave without a successor is '
             . 'not the alternative: it would strand the space with nobody able to restore it.',


### PR DESCRIPTION
Closes #962. Track D of #948, on top of #961.

## What changes

An unread count on the « Discussion » entry of the Band Space sidebar, the endpoint that clears it,
and the read-position rules #960 left open.

The badge is per space, so somebody in three bands sees each band's own number rather than a sum, and
it is a different number from the direct message envelope on purpose: that one sits above an inbox
which cannot show or clear a band's conversation, which is why #961 took channels out of it.

## The issue's premise had gone stale, and it changed the design

#962 says to feed the badge from "the existing 60 second poll and focus listener that
`NotificationBell.vue` already runs". Measured on master:

- the interval is **5 minutes**, not 60 seconds, stretched by #950 when Mercure took over,
- and it calls `loadCount()` on the bell store, never `loadNotifications()`, so `unreadMessages`, the
  direct message envelope, has not been on that timer since.

So there is a timer to ride, but it was not refreshing the counter family this badge belongs to. The
per-space counts go on `/api/notifications` beside `unreadMessages`, and `refreshCount()` now refreshes
both. No second polling loop, which is the constraint that mattered, and the envelope gets refreshed
along the way.

Without #963 the badge is right on load, on window focus, every five minutes, and immediately when the
member opens the tab. #963 makes it instant.

## One query, and what its joins are for

`MessageRepository::countUnreadChannelsForUser()` is a single grouped query keyed by band space. The
`BandSpaceMembership` join does two jobs:

- **active memberships only**, which is what keeps a former member's surviving read-state row out of
  everyone's count without deleting anything (#948 concern 3),
- and **`creationDatetime` as a floor**, so a member who joined yesterday is not told the whole back
  catalogue is unread. Flooring needs no write at join time, which keeps this clear of the duplicate
  key hazard `MessageSenderProcedure::findOrCreateMetaFor()` warns about for any writer that inserts a
  meta row without holding the thread lock.

A test pins that the endpoint issues exactly one `band_space_membership` query however many bands the
member belongs to. It is polled by every signed-in user, so a per-space query there would be the
expensive kind of mistake.

Worth recording for later, from the review: neither datetime comparison in this query can use an
index, because both compare against another joined table's column rather than a literal, and a range
scan needs a fixed bound. Nothing scans fully today, but the join order is currently driven from
`message_thread` rather than from the far more selective membership filter, and that is worth a look
once there are enough channels for the planner's choice to matter.

## Your read position starts when you join, and starts again when you rejoin

Both invitation paths reactivate the *same* membership row, so a rejoining member kept a read position
from before they left and everything since would have read as unread.
`MessageThreadMetaRepository::markChannelsReadForUser()` resets it, called after the flush in both
paths, for the same reason those files already dispatch their events after the commit.

**That method is an upsert, and the first version was wrong.** Update-only looked sufficient until the
review found the case it silently missed: somebody invited and then removed *before anyone ever wrote*
never got a read-state row at all, so there was nothing to update. Their row was then created by the
first message after they came back, with no read position, floored at their **original** join, and
everything said during their absence counted. Measured at 3 where it should be 1.

So it inserts as well, which is the one place the ORM to DQL to raw SQL ladder genuinely bottoms out:
DQL has no `INSERT`. `ON DUPLICATE KEY UPDATE` against the existing `UNIQUE (thread_id, user_id)` also
makes it safe against a send creating the same row concurrently, which a bare insert outside the
thread lock would not be. The test for it fails against the update-only version and passes against
this one.

## Clearing the badge

`POST /api/band_spaces/{bandSpaceId}/chat/read`, 204, no input, called when the tab finishes loading
and skipped when that load failed, so a broken request never claims the member read anything.

It uses `checkMember()` rather than `checkMemberForWrite()` and is therefore on
`BandSpaceWriteGuardCoverageTest`'s allow list: a read position is the member's own state rather than
the space's content, and reads stay open for the whole 30 day grace period, so being unable to stop a
badge insisting there is something new in a conversation you can still open would be the odd
behaviour. A test asserts 204 rather than 409 for a space pending deletion, so that decision is
visible rather than implied.

## Verification

- PHP suite 2711 green, PHPStan level 8 clean, `npm test` 650 green, Biome clean, build clean.
- In a real browser, two spaces, one with unread: the badge shows on the right space and not on the
  other, the accessibility tree reads `link "Discussion (3 non lus)"`, opening the tab clears it and
  the server then reports an empty map, and the collapsed 4rem rail renders the icon plus the count
  without overflowing.
- One bug found that way and not by any test: `currentSpaceId` from `useBandSpaceNavigation()` is a
  ref, auto unwrapped in a template but not in a script scope function, so the map was being keyed by
  a ref object and the badge never rendered while the API returned the right numbers.
- « Discussion » is the longest label carrying a badge and ellipsised at 11rem once the number was
  beside it: measured needing 81px in 75px, so the badge is pulled into the row's right padding.

## Out of scope

Live delivery (#963) is what makes this instant. A badge in the space **selector**, for unread in a
band the member is not currently looking at, is now possible for nothing because the payload is keyed
by space id, but it is not what this issue asks for.

## Deploy

Nothing. No migration, no new environment variable.
