### PR TITLE
feat(M-963): live message delivery over Mercure for a Band Space channel

### DIFF
--- a/assets/js/components/Notification/NotificationBell.vue
+++ b/assets/js/components/Notification/NotificationBell.vue
@@ -144,9 +144,9 @@ let intervalId = null
 function refreshCount() {
   store.loadCount()
   // The other header counters ride this timer rather than running one of their own: the direct
-  // message envelope, and the per Band Space chat badge the sidebar reads (#962). Both arrive over
-  // Mercure for direct messages, but a Band Space channel publishes nothing until #963, so without
-  // this the chat badge would only ever be as fresh as the last page load.
+  // message envelope, and the per Band Space chat badge the sidebar reads (#962). Both are live over
+  // Mercure now, direct messages since #989 and a Band Space channel since #963, so this is the same
+  // fallback as the count above: a hub that is down, or a stream that has not reconnected yet.
   notificationStore.loadNotifications()
   // The self-heal. The store connects as soon as the profile lands, but if that fetch failed there is
   // nothing else that would ever try again, and the poll would mask it perfectly: a live-looking bell

--- a/assets/js/store/bandSpace/bandSpaceChat.js
+++ b/assets/js/store/bandSpace/bandSpaceChat.js
@@ -6,6 +6,7 @@ import {
   mergeMessages,
   nextOlderPageToLoad
 } from '../../utils/messagePagination.js'
+import { isForTheOpenConversation } from '../../utils/messageSignal.js'
 import { useNotificationStore } from '../notification/notification.js'
 
 /**
@@ -17,6 +18,10 @@ import { useNotificationStore } from '../notification/notification.js'
  * widening.
  */
 export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
+  // Which space's conversation is held, which is how a live signal knows whether any of this is on
+  // screen. Chat.vue clears the store when it unmounts and AppBandLayout keys <router-view> on the
+  // space id, so leaving the tab or switching band empties it.
+  const openBandSpaceId = ref(null)
   const messages = ref([])
   const totalMessages = ref(0)
   const isLoading = ref(false)
@@ -43,11 +48,24 @@ export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
   // land on top of the space the member has already moved to.
   let loadToken = 0
 
-  async function loadMessages(bandSpaceId) {
-    const token = ++loadToken
-    isLoading.value = true
-    loadError.value = null
-    loadOlderError.value = null
+  /**
+   * Silent is a live signal refetching the newest page (#963): no spinner over a conversation that is
+   * already readable, and a failure leaves what is on screen alone rather than replacing a working
+   * pane with an error nobody asked for.
+   *
+   * It deliberately does **not** bump `loadToken`, it reads the current one the way
+   * loadOlderMessages() does. Bumping it would cancel a « charger les messages plus anciens » that is
+   * in flight, so a message arriving at the wrong moment would silently throw away the page of
+   * history the member just asked for.
+   */
+  async function loadMessages(bandSpaceId, { silent = false } = {}) {
+    const token = silent ? loadToken : ++loadToken
+    if (!silent) {
+      openBandSpaceId.value = bandSpaceId
+      isLoading.value = true
+      loadError.value = null
+      loadOlderError.value = null
+    }
 
     try {
       const response = await bandSpaceChatApi.getMessages(bandSpaceId)
@@ -61,13 +79,13 @@ export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
       totalMessages.value = knownTotal(response.totalItems)
     } catch (e) {
       console.error('Failed to load the chat:', e)
-      if (token === loadToken) {
+      if (!silent && token === loadToken) {
         messages.value = []
         totalMessages.value = 0
         loadError.value = 'Impossible de charger la discussion'
       }
     } finally {
-      if (token === loadToken) {
+      if (!silent && token === loadToken) {
         isLoading.value = false
       }
     }
@@ -104,8 +122,9 @@ export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
   }
 
   /**
-   * Appends through the merge rather than pushing, so the message is de-duplicated by `@id` the day
-   * #963 makes the same message arrive over Mercure as well.
+   * Appends through the merge rather than pushing, so the message is de-duplicated by `@id`: the
+   * sender's own signal can beat their own POST response back, because the server publishes inside the
+   * send and answers afterwards, and the refetch it triggers has then already added it (#963).
    */
   async function sendMessage(bandSpaceId, content) {
     isSending.value = true
@@ -134,7 +153,47 @@ export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
     }
   }
 
+  /**
+   * A message landed in one of this member's channels (#963).
+   *
+   * The signal carries a band space id and nothing else, so what is on screen is refetched from the
+   * API rather than patched from the payload: no message content travels over the hub. A null id is a
+   * reconnect, which means the conversation on screen, whichever it is, is stale.
+   *
+   * Exactly one notification refresh per signal, whichever branch runs. markAsRead() refreshes the
+   * badge on its way out, so refreshing it here too would race the count back to the value it had
+   * before the read landed.
+   */
+  async function handleIncomingMessage(bandSpaceId) {
+    const openId = openBandSpaceId.value
+    if (!isForTheOpenConversation(bandSpaceId, openId)) {
+      // None of this conversation is on screen, so the sidebar badge is the whole of the update.
+      await useNotificationStore().loadNotifications()
+
+      return
+    }
+
+    await loadMessages(openId, { silent: true })
+
+    // Arriving while the tab is in front is reading it, the same rule the inbox uses. In a background
+    // tab nobody has seen it, and marking it read would make the badge lie.
+    //
+    // Still on the same channel, checked again after the refetch: the member can leave it while that
+    // is in flight, and `visibilityState` cannot tell "still reading this one" from "moved on in the
+    // same visible tab". Marking it read then would clear the badge for a message nobody saw.
+    if (openBandSpaceId.value === openId && globalThis.document?.visibilityState === 'visible') {
+      await markAsRead(openId)
+
+      return
+    }
+    await useNotificationStore().loadNotifications()
+  }
+
   function clear() {
+    // Bumped so nothing already in flight lands in a pane the member has left, a silent refresh
+    // included. Chat.vue clears on unmount, which is the one moment a response has nowhere to go.
+    loadToken += 1
+    openBandSpaceId.value = null
     messages.value = []
     totalMessages.value = 0
     isLoading.value = false
@@ -157,6 +216,7 @@ export const useBandSpaceChatStore = defineStore('bandSpaceChat', () => {
     loadOlderMessages,
     sendMessage,
     markAsRead,
+    handleIncomingMessage,
     clear
   }
 })

--- a/assets/js/store/notification/userNotification.js
+++ b/assets/js/store/notification/userNotification.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { readonly, ref, watch } from 'vue'
 import userNotificationApi from '../../api/notification/userNotification.js'
 import { createNotificationStream, notificationTopic } from '../../utils/notificationStream.js'
+import { useBandSpaceChatStore } from '../bandSpace/bandSpaceChat.js'
 import { useMessageStore } from '../message/message.js'
 import { useUserSecurityStore } from '../user/security.js'
 import { useNotificationStore } from './notification.js'
@@ -117,8 +118,8 @@ export const useUserNotificationStore = defineStore('userNotification', () => {
       return userId ? [notificationTopic(userId)] : []
     },
     onSignal: (payload) => {
-      // One topic, two kinds of update, so the payload's own type says which. A null payload is a
-      // reconnect, where anything published while we were down is gone for good: refresh both.
+      // One topic, three kinds of update, so the payload's own type says which. A null payload is a
+      // reconnect, where anything published while we were down is gone for good: refresh all of them.
       const type = payload?.type ?? null
       if (type === null || type === 'notification') {
         loadCount()
@@ -128,6 +129,12 @@ export const useUserNotificationStore = defineStore('userNotification', () => {
         // inbox itself, which no-ops when it was never opened.
         useNotificationStore().loadNotifications()
         useMessageStore().handleIncomingMessage(payload?.thread_id ?? null)
+      }
+      if (type === null || type === 'band_space_message') {
+        // A Band Space channel, which the inbox above deliberately does not list (#963). The chat
+        // store refreshes the sidebar badge itself, because whether the member is looking at the
+        // conversation is also what decides whether the signal marks it read.
+        useBandSpaceChatStore().handleIncomingMessage(payload?.band_space_id ?? null)
       }
     },
     onAuthRefreshNeeded: () => useUserSecurityStore().checkAuthInfo()

--- a/assets/js/utils/messageSignal.js
+++ b/assets/js/utils/messageSignal.js
@@ -1,4 +1,19 @@
 /**
+ * Is this signal about the conversation that is on screen?
+ *
+ * A null signal id is a reconnect, or a body we could not read: we know something was missed but not
+ * what, so anything on screen is stale until proven otherwise. Naming a different conversation is the
+ * only case where the one on screen is known not to have changed.
+ *
+ * Shared by the inbox, where the id is a thread, and the Band Space chat, where it is a band space
+ * (#963): different keys, same rule, and getting the reconnect half of it wrong in one of them would
+ * leave a pane silently stale after every deploy.
+ */
+export function isForTheOpenConversation(signalId, openId) {
+  return Boolean(openId) && (!signalId || signalId === openId)
+}
+
+/**
  * What a live message signal should make the inbox do (#989).
  *
  * Separated from the store so the policy can be tested without a Pinia harness and an API double.
@@ -11,11 +26,7 @@ export function messageSignalPlan({ inboxLoaded, signalThreadId, openThreadId, t
     return { refreshInbox: false, refreshOpenThread: false, markRead: false }
   }
 
-  // A null id is a reconnect, or a body we could not read: we know something was missed but not
-  // what, so anything on screen is stale until proven otherwise. Naming a different thread is the
-  // only case where the open conversation is known not to have changed.
-  const isTheThreadOnScreen =
-    Boolean(openThreadId) && (!signalThreadId || signalThreadId === openThreadId)
+  const isTheThreadOnScreen = isForTheOpenConversation(signalThreadId, openThreadId)
 
   return {
     refreshInbox: true,

--- a/assets/js/utils/messageSignal.test.js
+++ b/assets/js/utils/messageSignal.test.js
@@ -1,6 +1,33 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { isMessageAlreadyListed, messageSignalPlan } from './messageSignal.js'
+import {
+  isForTheOpenConversation,
+  isMessageAlreadyListed,
+  messageSignalPlan
+} from './messageSignal.js'
+
+describe('isForTheOpenConversation', () => {
+  it('is false when nothing is open', () => {
+    assert.equal(isForTheOpenConversation('a-conversation', null), false)
+  })
+
+  it('is true for the conversation on screen', () => {
+    assert.equal(isForTheOpenConversation('the-open-one', 'the-open-one'), true)
+  })
+
+  it('is false for another conversation', () => {
+    assert.equal(isForTheOpenConversation('another-one', 'the-open-one'), false)
+  })
+
+  it('is true on a reconnect, which names no conversation', () => {
+    // We know something was missed but not what, so what is on screen counts as stale.
+    assert.equal(isForTheOpenConversation(null, 'the-open-one'), true)
+  })
+
+  it('is false on a reconnect with nothing open', () => {
+    assert.equal(isForTheOpenConversation(null, null), false)
+  })
+})
 
 describe('messageSignalPlan', () => {
   it('does nothing when the inbox was never opened', () => {

--- a/src/EventSubscriber/MessagePostedListener.php
+++ b/src/EventSubscriber/MessagePostedListener.php
@@ -4,16 +4,29 @@ declare(strict_types=1);
 
 namespace App\EventSubscriber;
 
+use App\Entity\BandSpace\BandSpace;
 use App\Entity\Message\Message;
 use App\Event\MessagePostedEvent;
 use App\Mercure\MercureTopic;
+use App\Service\Message\ThreadMemberResolver;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
 
 /**
- * Tells every participant's browser that the thread changed.
+ * Tells everybody in the conversation that it changed, whether it is a direct message or a Band
+ * Space channel.
+ *
+ * **One topic per recipient, each of them private**, rather than a single shared channel topic
+ * (#963). Both are one HTTP POST to the hub, since Hub::publish() sends the whole topic list as one
+ * form field, so the choice costs nothing either way at send time. What a shared topic would cost is
+ * on the subscriber side: the token would have to enumerate every space a member belongs to, so it
+ * would need reissuing on invite accept, leave, kick and account deletion, and until one of those
+ * happened a former member would keep receiving. Listing the recipients here instead means the list
+ * is computed from BandSpaceMembership at publish time, so somebody who left or was kicked is gone
+ * from the very next message, with no token to expire. The subscriber cookie stays the single topic
+ * #949 issued.
  */
 #[AsEventListener]
 readonly class MessagePostedListener
@@ -21,6 +34,7 @@ readonly class MessagePostedListener
     public function __construct(
         private HubInterface $hub,
         private LoggerInterface $logger,
+        private ThreadMemberResolver $threadMemberResolver,
     ) {
     }
 
@@ -28,10 +42,13 @@ readonly class MessagePostedListener
     {
         $message = $event->message;
         $topics = [];
-        foreach ($message->thread->messageParticipants as $participant) {
+        // The resolver, not the thread's participant rows: a channel has none, so iterating them
+        // published nothing at all for a band (#959). It answers both shapes, and for a direct
+        // message it answers with those same rows.
+        foreach ($this->threadMemberResolver->activeMembersOf($message->thread) as $member) {
             // The sender included, so a send from their laptop still updates their phone. Their own
             // tab pays one idempotent refetch for that.
-            $topics[] = MercureTopic::userNotifications((string) $participant->participant->id);
+            $topics[] = MercureTopic::userNotifications((string) $member->id);
         }
 
         if ($topics === []) {
@@ -53,14 +70,20 @@ readonly class MessagePostedListener
     }
 
     /**
-     * The thread id is here so a browser can tell the conversation it is looking at from any other and
-     * skip refetching messages it is not showing.
+     * Which conversation moved, so a browser can skip refetching one it is not showing.
+     *
+     * Two types rather than one with an extra field, because the client routes on the type and the
+     * inbox must not refetch for a channel, which it does not list. A channel is keyed by its band
+     * space and not by its thread: that is what the chat API takes, and one channel per space is a
+     * decision, not an accident (#948 parks multi-channel). A second channel is what adds an id here.
      */
     private static function tagFor(Message $message): string
     {
-        return json_encode(
-            ['type' => 'message', 'thread_id' => (string) $message->thread->id],
-            JSON_THROW_ON_ERROR,
-        );
+        $thread = $message->thread;
+        $tag = $thread->bandSpace instanceof BandSpace
+            ? ['type' => 'band_space_message', 'band_space_id' => (string) $thread->bandSpace->id]
+            : ['type' => 'message', 'thread_id' => (string) $thread->id];
+
+        return json_encode($tag, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Mercure/MercureTopic.php
+++ b/src/Mercure/MercureTopic.php
@@ -26,6 +26,10 @@ final class MercureTopic
     /**
      * Everything addressed to one user: the notification bell first, and whatever else later wants
      * to reach a signed-in person rather than a page they happen to have open.
+     *
+     * A Band Space channel rides this too rather than having a topic of its own, and deliberately:
+     * a per-space topic would have to be named in the subscriber token, so the token would need
+     * reissuing every time a roster changed. See MessagePostedListener (#963).
      */
     public static function userNotifications(string $userId): string
     {

--- a/src/Service/Message/ThreadMemberResolver.php
+++ b/src/Service/Message/ThreadMemberResolver.php
@@ -25,7 +25,7 @@ readonly class ThreadMemberResolver
     }
 
     /**
-     * Who the message is for: read-state rows, unread counts, and later the live signal.
+     * Who the message is for: read-state rows, unread counts, and the live signal (#963).
      *
      * @return User[]
      */

--- a/tests/Integration/Message/MessagePostedSignalTest.php
+++ b/tests/Integration/Message/MessagePostedSignalTest.php
@@ -4,15 +4,23 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Message;
 
+use App\Entity\BandSpace\BandSpace;
+use App\Entity\Message\MessageThread;
+use App\Entity\User;
+use App\Enum\BandSpace\MembershipStatus;
 use App\Event\MessageSentEvent;
 use App\Mercure\MercureTopic;
+use App\Repository\BandSpace\BandSpaceMembershipRepository;
 use App\Repository\Message\MessageRepository;
 use App\Service\Procedure\Message\MessageSenderProcedure;
 use App\Tests\Double\RecordingHub;
+use App\Tests\Factory\BandSpace\BandSpaceFactory;
+use App\Tests\Factory\BandSpace\BandSpaceMembershipFactory;
 use App\Tests\Factory\Message\MessageParticipantFactory;
 use App\Tests\Factory\Message\MessageThreadFactory;
 use App\Tests\Factory\Message\MessageThreadMetaFactory;
 use App\Tests\Factory\User\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -147,7 +155,125 @@ class MessagePostedSignalTest extends KernelTestCase
         );
     }
 
-    private function threadWith(\App\Entity\User ...$participants): \App\Entity\Message\MessageThread
+    public function test_a_channel_message_signals_every_active_member_and_nobody_else(): void
+    {
+        // A channel has no MessageParticipant rows at all: its members are derived from the space
+        // (#959). Before #963 that made this listener iterate an empty collection and publish nothing,
+        // so a band's conversation was the one that never went live.
+        self::bootKernel();
+        $hub = self::getContainer()->get(RecordingHub::class);
+
+        [$space, $channel, $sender, $others, $kicked, $stranger] = $this->band();
+
+        self::getContainer()->get(MessageSenderProcedure::class)->processByThread($channel, $sender, 'on répète mardi');
+
+        // The two absences by name first, so a leak is reported as "the kicked member" rather than as
+        // one uuid missing from a diff of three.
+        self::assertNotContains(MercureTopic::userNotifications((string) $kicked->id), $hub->publishedTopics());
+        self::assertNotContains(MercureTopic::userNotifications((string) $stranger->id), $hub->publishedTopics());
+        // Then the exact list, which is what catches somebody nobody thought to name.
+        self::assertSame(
+            [
+                MercureTopic::userNotifications((string) $sender->id),
+                MercureTopic::userNotifications((string) $others[0]->id),
+                MercureTopic::userNotifications((string) $others[1]->id),
+            ],
+            $hub->publishedTopics()
+        );
+
+        $update = $hub->updates[0];
+        // Without this the hub stops consulting subscriber topic selectors and hands the signal to
+        // every connected browser, whatever their token says.
+        self::assertTrue($update->isPrivate());
+        // Its own type, because the inbox does not list channels and must not refetch for one, and
+        // keyed by the space because that is what the chat API takes.
+        self::assertSame(
+            '{"type":"band_space_message","band_space_id":"' . $space->id . '"}',
+            $update->getData()
+        );
+    }
+
+    public function test_a_member_who_leaves_stops_receiving_at_once(): void
+    {
+        // The sharp edge of #963, and the reason the topic is per user rather than per space. The
+        // recipient list is computed from BandSpaceMembership at publish time, so leaving takes effect
+        // on the very next message. A shared channel topic would instead have kept delivering until
+        // the subscriber token was reissued, and "within the token lifetime" would then have been a
+        // stated security property rather than none at all.
+        self::bootKernel();
+        $hub = self::getContainer()->get(RecordingHub::class);
+
+        [, $channel, $sender, $others] = $this->band();
+        $leaver = $others[0];
+        $procedure = self::getContainer()->get(MessageSenderProcedure::class);
+
+        $procedure->processByThread($channel, $sender, 'on répète mardi');
+        self::assertContains(MercureTopic::userNotifications((string) $leaver->id), $hub->publishedTopics());
+
+        $membership = self::getContainer()->get(BandSpaceMembershipRepository::class)
+            ->findOneBy(['bandSpace' => $channel->bandSpace, 'user' => $leaver->id]);
+        self::assertNotNull($membership);
+        $membership->status = MembershipStatus::Left;
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $hub->updates = [];
+        $procedure->processByThread($channel, $sender, 'finalement jeudi');
+
+        self::assertNotContains(MercureTopic::userNotifications((string) $leaver->id), $hub->publishedTopics());
+        self::assertContains(MercureTopic::userNotifications((string) $others[1]->id), $hub->publishedTopics());
+    }
+
+    /**
+     * A band of three active members, one kicked, and one person with no membership at all.
+     *
+     * @return array{0: BandSpace, 1: MessageThread, 2: User, 3: User[], 4: User, 5: User}
+     */
+    private function band(): array
+    {
+        $space = BandSpaceFactory::new()->create(['name' => 'Les Trois Accords']);
+
+        // Pinned creation datetimes: findByBandSpace() orders by them, and the exact topic list above
+        // would otherwise flip on a faker tie.
+        $sender = $this->member($space, 'batteur', '2026-01-01 10:00:00');
+        $others = [
+            $this->member($space, 'bassiste', '2026-01-01 11:00:00'),
+            $this->member($space, 'chanteuse', '2026-01-01 12:00:00'),
+        ];
+        $kicked = $this->member($space, 'ancien', '2026-01-01 13:00:00', MembershipStatus::Kicked);
+        $stranger = UserFactory::new()->asBaseUser()->create(['username' => 'inconnu', 'email' => 'inconnu@test.com']);
+
+        return [
+            $space,
+            MessageThreadFactory::new()->forBandSpace($space)->create(),
+            $sender,
+            $others,
+            $kicked,
+            $stranger,
+        ];
+    }
+
+    private function member(
+        BandSpace $bandSpace,
+        string $username,
+        string $joinedAt,
+        MembershipStatus $status = MembershipStatus::Active,
+    ): User {
+        $user = UserFactory::new()->asBaseUser()->create([
+            'username' => $username,
+            'email' => $username . '@test.com',
+        ]);
+        BandSpaceMembershipFactory::new([
+            'bandSpace' => $bandSpace,
+            'user' => $user,
+            'status' => $status,
+            // Mutable, because that is how BandSpaceMembership maps the column.
+            'creationDatetime' => new \DateTime($joinedAt),
+        ])->create();
+
+        return $user;
+    }
+
+    private function threadWith(User ...$participants): MessageThread
     {
         $thread = MessageThreadFactory::new()->create();
         foreach ($participants as $participant) {


### PR DESCRIPTION
Closes #963. Part of #948, track D.

A Band Space channel now delivers new messages live, over the Mercure transport #949 set up and #989 already put behind the direct message inbox. Nothing about the channel was live before this: the pane only changed on a reload, and the sidebar badge was only as fresh as the bell's five minute timer.

The whole path already existed. `MessagePostedEvent` is dispatched for every message and `MessagePostedListener` publishes a small tag, never content, to each recipient's private topic. A channel published nothing for one reason: the listener fanned out over `$thread->messageParticipants`, and a channel has no participant rows by design (#959), so the topic list came out empty and the listener returned early. It now fans out over `ThreadMemberResolver::activeMembersOf()`, which answers both shapes.

## The topic model, and why it is per user

One topic per recipient, each private, rather than a single shared `/band-spaces/{id}/chat` topic.

Both are one HTTP POST to the hub either way: `Hub::publish()` sends the whole topic list as one form field, so the recipient count costs nothing at send time. What a shared topic would cost is on the subscriber side. The token would have to enumerate every space a member belongs to, so it would need reissuing on invite accept, leave, kick and account deletion, and until one of those happened a former member would keep receiving. That is concern 7 of the epic, and the per user topic answers it by not needing to widen the token at all: the subscriber cookie stays exactly the single topic #949 issued.

## Security

The hub endpoint is terminated by Caddy and never reaches the Symfony firewall, so the JWT topic selectors are the entire boundary, and the hub only consults them for updates published with `private: true`. That flag is unchanged and still asserted.

The recipient list is computed from `BandSpaceMembership` at publish time, and `findByBandSpace()` filters on `status = active`. So the answer to concern 1 is better than the issue asked for: the issue allowed for a former member to stop receiving "within the token lifetime", and here they stop on the very next message, with no token to expire and nothing to reissue. `test_a_member_who_leaves_stops_receiving_at_once` flips a membership to `Left` between two sends and pins it.

## The tag

A channel publishes `{"type":"band_space_message","band_space_id":"..."}`; a direct message keeps `{"type":"message","thread_id":"..."}`. Its own type rather than an extra field on the existing one, because the client routes on the type and the inbox, which does not list channels, must not refetch for one. Keyed by the band space rather than by the thread because that is what the chat API takes, and one channel per space is a decision rather than an accident: a second channel is what adds an id there.

## Front end

`userNotification.js` gains a `band_space_message` branch beside the existing one. The chat store gains `handleIncomingMessage`, plus a `silent` mode on `loadMessages` so a live refresh neither blanks a readable pane behind a spinner nor throws the conversation away on a transient failure.

Two subtleties worth naming, both of which bit during review:

- The silent path deliberately does not bump `loadToken`, it reads the current one the way `loadOlderMessages()` does. Bumping it would cancel a "charger les messages plus anciens" that is in flight, so a message arriving at the wrong moment would silently discard the page of history the member just asked for. `clear()` does bump it, so nothing already in flight lands in a pane the member has left.
- Marking read re-checks the open channel after the refetch. The member can leave the channel while that is in flight, and `visibilityState` cannot tell "still reading this one" from "moved on in the same visible tab", so without the re-check the badge would clear for a message nobody saw.

Exactly one notification refresh happens per signal whichever branch runs, since `markAsRead()` already refreshes the badge on its way out and doing it twice would race the count back to its pre-read value.

`isForTheOpenConversation()` is extracted from the rule `messageSignalPlan` was computing inline and is now shared by the inbox and the chat: different key, same treatment of a reconnect, and getting that half wrong in one of them would leave a pane silently stale after every deploy.

## Tests

Two added to `MessagePostedSignalTest`, which is the one place that answers who gets signalled. The first asserts the exact ordered topic list for a band of three actives, with a kicked member and a complete stranger named individually first so a leak is reported by name rather than as one uuid missing from a diff, plus `private: true` and the tag shape. The second is the leave transition above. Five cases for `isForTheOpenConversation` on the front end.

## Verified

Full suite 2713 green, PHPStan level 8 clean, 16 JS unit tests, Biome and the Vite build clean.

End to end on the dev site with two real sessions. Sitting in the chat, the message arrived with no reload and the pane auto scrolled, the badge stayed clear, and the network showed exactly `GET chat/messages`, `POST chat/read`, one `GET /api/notifications`. On another tab of the same space, the sidebar went to "Discussion (1 non lus)" live with a single `GET /api/notifications` and nothing else. No console errors.

## Known gap, not closed here

With a dead hub, a member sitting on the chat tab still sees nothing new until they navigate away and back. The fallback from #962 refreshes the badge, not the message pane, and the badge for the space being read is cleared on arrival anyway. That is unchanged behaviour, and adding a poll to the pane is scope this issue deliberately does not take.
